### PR TITLE
Endpoint URL configuration

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -87,6 +87,7 @@ interface BaseAuthentication {
     getConnectionNameFormula?: GetConnectionNameFormula;
     defaultConnectionType?: DefaultConnectionType;
     instructionsUrl?: string;
+    requiresEndpointUrl?: boolean;
 }
 /**
  * A pack or formula which uses standard bearer token header authentication:

--- a/types.ts
+++ b/types.ts
@@ -99,6 +99,9 @@ interface BaseAuthentication {
 
   // link to help article, etc. if more instructions needed explaining how to install the pack
   instructionsUrl?: string;
+
+  // Does this authentication instance require a custom endpoint url?
+  requiresEndpointUrl?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add support for custom endpoint URL - this is a booelan flag on the base auth configuration.   

Basic idea (per discusion w/Oleg) is that we:
  - Packs needing customer endpoints set this value to `true` in their default auth config
  - Our Packs auth config UX will show a endpointUrl text box when true and pass this value into `ExternalConnectionManager::addConnection` using the existing (optional) `endpoint` argument
   - We extend the formula exec `context` with an `endpoint` property so this become accessible to the formula execution where a Packs implementor can then use it to build the correct URL

