### PR TITLE
Add endpointUrl to ExecutionContext

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -126,4 +126,5 @@ export interface Fetcher {
 
 export interface ExecutionContext {
   readonly fetcher?: Fetcher;
+  readonly endpoint?: string;
 }

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -83,5 +83,6 @@ export interface Fetcher {
 }
 export interface ExecutionContext {
     readonly fetcher?: Fetcher;
+    readonly endpoint?: string;
 }
 export {};


### PR DESCRIPTION
For packs with custom endpoints, we need to provide the endpoint URL to the pack implementor in the execution context.   

There are two reasons for this - both of which I'm running into with Discourse (the 1st pack that uses custom endpoints):
1. If the Pack is parsing URLs, the implementor needs to validate the URL parsed is for the target connection endpoint.  For example, parsing a URL `https://siteA.com/topic/123` to infer a topic #123 and then sending it over a connection links to say `https://siteB.com/...` would be incorrect and could easily lead to Coda returning incorrect results.
2. For API results returning HTML content, this content typically returns relative paths for `<img/>` and `<a/>` elements.   The site endpoint URL is required so these links can be expanded to be fully qualified.


@adeneui / @chrisleck / @vaskevich PTAL
