### PR TITLE
Add support for endpointDomain enforcement

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -118,6 +118,7 @@ interface BaseAuthentication {
     defaultConnectionType?: DefaultConnectionType;
     instructionsUrl?: string;
     requiresEndpointUrl?: boolean;
+    endpointDomain?: string;
 }
 /**
  * A pack or formula which uses standard bearer token header authentication:

--- a/types.ts
+++ b/types.ts
@@ -132,6 +132,9 @@ interface BaseAuthentication {
 
   // Does this authentication instance require a custom endpoint url?
   requiresEndpointUrl?: boolean;
+
+  // Root endpoint domain for multi-tenant services - for example set to "example.com" for "https://mysite.example.com"
+  endpointDomain?: string;
 }
 
 /**


### PR DESCRIPTION
Adds property to track required endpoint domain for auth when using custom endpoints.    Used for sites such as Shoplify, Jira, etc. which host tenants with a pattern of `https://tenant.endpoint-dom`.   We'll be using this for Shoplify which would define config as:

```js
{
  requiredEndpointUrl: true,
  endpointDomain: 'myshoplify.com',
}
```

This would then allow the user to configure an endpoint Url such as https://coda-toys.myshoplify.com.   Work coming in experimental to wire this up.

FYI @vaskevich @adeneui @chrisleck 