### PR TITLE
Add video (youtube) ids to the pack definition

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -193,6 +193,7 @@ export interface PackDefinition {
     enabledConfigName?: string;
     defaultAuthentication?: Authentication;
     exampleImages?: string[];
+    exampleVideoIds?: string[];
     /**
      * If specified, this pack requires system credentials to be set up via Coda's admin console in order to work when no
      * explicit connection is specified by the user.

--- a/types.ts
+++ b/types.ts
@@ -229,6 +229,7 @@ export interface PackDefinition {
   enabledConfigName?: string;
   defaultAuthentication?: Authentication;
   exampleImages?: string[];
+  exampleVideoIds?: string[];
   /**
    * If specified, this pack requires system credentials to be set up via Coda's admin console in order to work when no
    * explicit connection is specified by the user.


### PR DESCRIPTION
This is so we can get the intro videos showing up in addition to the sample images