### PR TITLE
Omit extraneous 'response' from compiled object formulas

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -228,10 +228,10 @@ function isResponseExampleTemplate(obj: any): obj is {example: SchemaType<any>} 
   return obj && obj.example;
 }
 
-export function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>(
-  definition: ObjectResultFormulaDef<ParamDefsT, SchemaT>,
-): ObjectPackFormula<ParamDefsT, SchemaT> {
-  const {response} = definition;
+export function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({
+  response,
+  ...definition // tslint:disable-line: trailing-comma
+}: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT> {
   let schema: Schema | undefined;
   if (response) {
     if (isResponseHandlerTemplate(response)) {
@@ -270,10 +270,11 @@ export function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends 
   }) as ObjectPackFormula<ParamDefsT, SchemaT>;
 }
 
-export function makeTranslateObjectFormula<ParamDefsT extends ParamDefs, ResultT extends Schema>(
-  definition: ObjectArrayFormulaDef<ParamDefsT, ResultT>,
-) {
-  const {request, response, parameters} = definition;
+export function makeTranslateObjectFormula<ParamDefsT extends ParamDefs, ResultT extends Schema>({
+  response,
+  ...definition // tslint:disable-line: trailing-comma
+}: ObjectArrayFormulaDef<ParamDefsT, ResultT>) {
+  const {request, parameters} = definition;
   response.schema = normalizeSchema(response.schema) as ResultT;
   const {onError} = response;
   const requestHandler = generateRequestHandler(request, parameters);

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -79,8 +79,21 @@ export declare function makeNumericFormula<ParamDefsT extends ParamDefs>(definit
 export declare function makeStringFormula<ParamDefsT extends ParamDefs>(definition: StringFormulaDef<ParamDefsT>): StringPackFormula<ParamDefsT>;
 export declare type GetConnectionNameFormula = StringPackFormula<[ParamDef<Type.string>, ParamDef<Type.string>]>;
 export declare function makeGetConnectionNameFormula(execute: (context: ExecutionContext, codaUserName: string, authParams: string) => Promise<string> | string): GetConnectionNameFormula;
-export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>(definition: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
-export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs, ResultT extends Schema>(definition: ObjectArrayFormulaDef<ParamDefsT, ResultT>): ObjectArrayFormulaDef<ParamDefsT, ResultT> & {
+export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({ response, ...definition }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
+export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs, ResultT extends Schema>({ response, ...definition }: ObjectArrayFormulaDef<ParamDefsT, ResultT>): {
+    request: RequestHandlerTemplate;
+    description: string;
+    name: string;
+    examples: {
+        params: import("./api_types").PackFormulaValue[];
+        result: PackFormulaResult;
+    }[];
+    parameters: ParamDefsT;
+    varargParameters?: [ParamDef<any>, ...ParamDef<any>[]] | never[] | undefined;
+    network?: import("./api_types").Network | undefined;
+    cacheTtlSecs?: number | undefined;
+    isExperimental?: boolean | undefined;
+} & {
     execute: (params: ParamValues<ParamDefsT>, context: ExecutionContext) => Promise<SchemaType<ResultT>>;
     resultType: Type;
     schema: ResultT;

--- a/dist/api.js
+++ b/dist/api.js
@@ -7,6 +7,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const api_types_1 = require("./api_types");
 const api_types_2 = require("./api_types");
@@ -123,8 +132,9 @@ function isResponseHandlerTemplate(obj) {
 function isResponseExampleTemplate(obj) {
     return obj && obj.example;
 }
-function makeObjectFormula(definition) {
-    const { response } = definition;
+function makeObjectFormula(_a) {
+    var { response } = _a, definition = __rest(_a, ["response"]) // tslint:disable-line: trailing-comma
+    ;
     let schema;
     if (response) {
         if (isResponseHandlerTemplate(response)) {
@@ -166,8 +176,10 @@ function makeObjectFormula(definition) {
     });
 }
 exports.makeObjectFormula = makeObjectFormula;
-function makeTranslateObjectFormula(definition) {
-    const { request, response, parameters } = definition;
+function makeTranslateObjectFormula(_a) {
+    var { response } = _a, definition = __rest(_a, ["response"]) // tslint:disable-line: trailing-comma
+    ;
+    const { request, parameters } = definition;
     response.schema = schema_1.normalizeSchema(response.schema);
     const { onError } = response;
     const requestHandler = handler_templates_2.generateRequestHandler(request, parameters);


### PR DESCRIPTION
This is causing diffs with some diff policy work I'm doing. `response` doesn't actually exist on the resulting definitions, but TS doesn't check for extraneous types.

PTAL @chrisleck 