### PR TITLE
include host and docId in execution context

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -135,6 +135,8 @@ export interface Fetcher {
 export interface ExecutionContext {
   readonly fetcher?: Fetcher;
   readonly endpoint?: string;
-  readonly protocolAndHost: string;
-  readonly docId?: string;
+  readonly invocationLocation: {
+    protocolAndHost: string;
+    docId?: string;
+  };
 }

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -90,7 +90,9 @@ export interface Fetcher {
 export interface ExecutionContext {
     readonly fetcher?: Fetcher;
     readonly endpoint?: string;
-    readonly protocolAndHost: string;
-    readonly docId?: string;
+    readonly invocationLocation: {
+        protocolAndHost: string;
+        docId?: string;
+    };
 }
 export {};


### PR DESCRIPTION
Pass in host and docId instead of doc url @adeneui 