### PR TITLE
Add definition for ExternalPackMetadata to this repo

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -1,6 +1,7 @@
 import {$Omit} from './type_utils';
 import {$OmitNested} from './type_utils';
 import {Authentication} from './types';
+import {AuthenticationType} from './types';
 import {Format} from './types';
 import {PackDefinition} from './types';
 import {TypedPackFormula} from './api';
@@ -15,11 +16,36 @@ export interface PackFormulasMetadata {
   [namespace: string]: PackFormulaMetadata[];
 }
 
-export type PackMetadata = $Omit<
-  PackDefinition,
-  'formulas' | 'formats' | 'defaultAuthentication' | 'legacyFormulasLoader'
-> & {
+/** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
+export type PackMetadata = $Omit<PackDefinition, 'formulas' | 'formats' | 'defaultAuthentication'> & {
   formulas: PackFormulasMetadata;
   formats: PackFormatMetadata[];
   defaultAuthentication?: $OmitNested<Authentication, 'getConnectionNameFormula', 'execute'>;
 };
+
+// Re-exported values for use in browser code.
+
+export type ExternalPackAuthenticationType = AuthenticationType;
+export type ExternalPackFormulas = PackFormulasMetadata;
+export type ExternalPackFormula = PackFormulaMetadata;
+export type ExternalPackFormat = Format;
+
+type BasePackMetadata = $Omit<
+  PackMetadata,
+  'enabledConfigName' | 'defaultAuthentication' | 'systemConnectionAuthentication' | 'formulas' | 'formats'
+>;
+
+/** Further stripped-down version of `PackMetadata` that contains only what the browser needs. */
+export interface ExternalPackMetadata extends BasePackMetadata {
+  authentication: {
+    type: ExternalPackAuthenticationType;
+    params?: Array<{name: string; description: string}>;
+    requiresEndpointUrl: boolean;
+    endpointDomain?: string;
+  };
+  instructionsUrl?: string;
+
+  // User-facing components
+  formulas?: ExternalPackFormulas;
+  formats?: ExternalPackFormat[];
+}

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -1,6 +1,7 @@
 import { $Omit } from './type_utils';
 import { $OmitNested } from './type_utils';
 import { Authentication } from './types';
+import { AuthenticationType } from './types';
 import { Format } from './types';
 import { PackDefinition } from './types';
 import { TypedPackFormula } from './api';
@@ -11,8 +12,30 @@ export interface PackFormatMetadata extends $Omit<Format, 'matchers'> {
 export interface PackFormulasMetadata {
     [namespace: string]: PackFormulaMetadata[];
 }
-export declare type PackMetadata = $Omit<PackDefinition, 'formulas' | 'formats' | 'defaultAuthentication' | 'legacyFormulasLoader'> & {
+/** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
+export declare type PackMetadata = $Omit<PackDefinition, 'formulas' | 'formats' | 'defaultAuthentication'> & {
     formulas: PackFormulasMetadata;
     formats: PackFormatMetadata[];
     defaultAuthentication?: $OmitNested<Authentication, 'getConnectionNameFormula', 'execute'>;
 };
+export declare type ExternalPackAuthenticationType = AuthenticationType;
+export declare type ExternalPackFormulas = PackFormulasMetadata;
+export declare type ExternalPackFormula = PackFormulaMetadata;
+export declare type ExternalPackFormat = Format;
+declare type BasePackMetadata = $Omit<PackMetadata, 'enabledConfigName' | 'defaultAuthentication' | 'systemConnectionAuthentication' | 'formulas' | 'formats'>;
+/** Further stripped-down version of `PackMetadata` that contains only what the browser needs. */
+export interface ExternalPackMetadata extends BasePackMetadata {
+    authentication: {
+        type: ExternalPackAuthenticationType;
+        params?: Array<{
+            name: string;
+            description: string;
+        }>;
+        requiresEndpointUrl: boolean;
+        endpointDomain?: string;
+    };
+    instructionsUrl?: string;
+    formulas?: ExternalPackFormulas;
+    formats?: ExternalPackFormat[];
+}
+export {};


### PR DESCRIPTION
Instead of generating the Packs manifest on demand, we'll instead just serve individual Pack definitions off S3, and precompile the external metadata for use by browsers during the deploy stage.

This PR just adds the external types we'll be using here.

PTAL @chrisleck
FYI @kr-project/foundation 