### PR TITLE
Add object rewrite functions for makeSyncTable functions

### DIFF
--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -109,7 +109,7 @@ export declare function makeStringFormula<ParamDefsT extends ParamDefs>(definiti
 export declare type GetConnectionNameFormula = StringPackFormula<[ParamDef<Type.string>, ParamDef<Type.string>]>;
 export declare function makeGetConnectionNameFormula(execute: (context: ExecutionContext, codaUserName: string, authParams: string) => Promise<string> | string): GetConnectionNameFormula;
 export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({ response, ...definition }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
-export declare function makeSyncTable<K extends string, ParamDefsT extends ParamDefs, SchemaT extends SyncObjectSchema<K>>(name: string, schema: SchemaT, { schema: formulaSchema, ...definition }: SyncFormulaDef<K, ParamDefsT, SchemaT>): SyncTable<K, SchemaT>;
+export declare function makeSyncTable<K extends string, ParamDefsT extends ParamDefs, SchemaT extends SyncObjectSchema<K>>(name: string, schema: SchemaT, { schema: formulaSchema, execute: wrappedExecute, ...definition }: SyncFormulaDef<K, ParamDefsT, SchemaT>): SyncTable<K, SchemaT>;
 export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs, ResultT extends Schema>({ response, ...definition }: ObjectArrayFormulaDef<ParamDefsT, ResultT>): {
     request: RequestHandlerTemplate;
     name: string;

--- a/dist/api.js
+++ b/dist/api.js
@@ -190,11 +190,22 @@ function makeObjectFormula(_a) {
 }
 exports.makeObjectFormula = makeObjectFormula;
 function makeSyncTable(name, schema, _a) {
-    var { schema: formulaSchema } = _a, definition = __rest(_a, ["schema"]);
+    var { schema: formulaSchema, execute: wrappedExecute } = _a, definition = __rest(_a, ["schema", "execute"]);
+    formulaSchema = schema_1.normalizeSchema(formulaSchema);
+    const responseHandler = handler_templates_1.generateObjectResponseHandler({ schema: formulaSchema, excludeExtraneous: true });
+    const execute = function exec(params, context) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const { result, continuation } = yield wrappedExecute(params, context);
+            return {
+                result: responseHandler({ body: ensure_1.ensureExists(result), status: 200, headers: {} }),
+                continuation,
+            };
+        });
+    };
     return {
         name,
         schema: schema_1.normalizeSchema(schema),
-        getter: Object.assign({}, definition, { schema: schema_1.normalizeSchema(formulaSchema), isSyncFormula: true, resultType: api_types_1.Type.object }),
+        getter: Object.assign({}, definition, { execute, schema: formulaSchema, isSyncFormula: true, resultType: api_types_1.Type.object }),
     };
 }
 exports.makeSyncTable = makeSyncTable;


### PR DESCRIPTION
@vaskevich, @harisiva TBR

Realized that my object key normalization functions are not present on the sync table functions