### PR TITLE
Allow explicit caching of requests

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -64,8 +64,8 @@ export type PackFormulaResult = $Values<TypeMap> | ConcreteArrayTypes;
 export type TypeOf<T extends PackFormulaResult> = T extends number
   ? Type.number
   : (T extends string
-      ? Type.string
-      : (T extends boolean ? Type.boolean : (T extends Date ? Type.date : (T extends object ? Type.object : never))));
+    ? Type.string
+    : (T extends boolean ? Type.boolean : (T extends Date ? Type.date : (T extends object ? Type.object : never))));
 
 export interface ParamDef<T extends UnionType> {
   name: string;
@@ -119,6 +119,8 @@ export interface FetchRequest {
   body?: string;
   form?: {[key: string]: string};
   headers?: {[header: string]: string};
+  // Allows explicit caching of the results of this request.
+  cacheTtlSecs?: number;
 }
 
 // Copied from https://developer.mozilla.org/en-US/docs/Web/API/Response

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -76,6 +76,7 @@ export interface FetchRequest {
     headers?: {
         [header: string]: string;
     };
+    cacheTtlSecs?: number;
 }
 export interface FetchResponse<T extends any = any> {
     status: number;


### PR DESCRIPTION
@codajonathan, @harisiva, @ggoldsh PTAL

Today we cache the underlying HTTP requests at the same cache TTL as the formula. Since sync formulas have no TTL this means none of the fan-out requests are cached which is not a good idea.