### PR TITLE
Remove boolean primary

### DIFF
--- a/dist/samples/npm.js
+++ b/dist/samples/npm.js
@@ -59,7 +59,7 @@ exports.packageSchema = schema_2.makeSyncObjectSchema({
     primary: 'url',
     featured: ['package', 'downloadCount'],
     properties: {
-        package: { type: schema_1.ValueType.String, primary: true },
+        package: { type: schema_1.ValueType.String },
         url: { type: schema_1.ValueType.String, id: true },
         author: exports.personSchema,
         downloadCount: { type: schema_1.ValueType.Number },

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -38,7 +38,6 @@ export interface ArraySchema extends BaseSchema {
 }
 export interface ObjectSchemaProperty {
     id?: boolean;
-    primary?: boolean;
     fromKey?: string;
     required?: boolean;
 }

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -103,9 +103,8 @@ function normalizeSchema(schema) {
         for (const key of Object.keys(schema.properties)) {
             const normalizedKey = pascalcase_1.default(key);
             const props = schema.properties[key];
-            const { primary: primaryKey, required, fromKey } = props;
+            const { required, fromKey } = props;
             normalized[normalizedKey] = Object.assign(normalizeSchema(props), {
-                primary: primaryKey,
                 required,
                 fromKey: fromKey || (normalizedKey !== key ? key : undefined),
             });

--- a/samples/npm.ts
+++ b/samples/npm.ts
@@ -57,7 +57,7 @@ export const packageSchema = makeSyncObjectSchema({
   primary: 'url',
   featured: ['package', 'downloadCount'],
   properties: {
-    package: {type: ValueType.String, primary: true},
+    package: {type: ValueType.String},
     url: {type: ValueType.String, id: true},
     author: personSchema,
     downloadCount: {type: ValueType.Number},

--- a/schema.ts
+++ b/schema.ts
@@ -29,8 +29,7 @@ type StringHintTypes =
   | ValueType.Html
   | ValueType.Image
   | ValueType.Markdown
-  | ValueType.Url
-  ;
+  | ValueType.Url;
 export type NumberHintTypes = ValueType.Date | ValueType.Percent | ValueType.Currency;
 
 export type ObjectHintTypes = ValueType.Person;
@@ -61,7 +60,6 @@ export interface ArraySchema extends BaseSchema {
 export interface ObjectSchemaProperty {
   // TODO(alexd): Remove these once we've hoisted these up.
   id?: boolean;
-  primary?: boolean;
   fromKey?: string;
   required?: boolean;
 }
@@ -214,9 +212,8 @@ export function normalizeSchema<T extends Schema>(schema: T): T {
     for (const key of Object.keys(schema.properties)) {
       const normalizedKey = pascalcase(key);
       const props = schema.properties[key];
-      const {primary: primaryKey, required, fromKey} = props as ObjectSchemaProperty;
+      const {required, fromKey} = props as ObjectSchemaProperty;
       normalized[normalizedKey] = Object.assign(normalizeSchema(props), {
-        primary: primaryKey,
         required,
         fromKey: fromKey || (normalizedKey !== key ? key : undefined),
       });

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -67,7 +67,7 @@ describe('Schema', () => {
         id: 'name',
         primary: 'name',
         properties: {
-          name: {type: schema.ValueType.String, primary: true},
+          name: {type: schema.ValueType.String},
           another: anotherSchema,
           yetAnother: schema.makeObjectSchema({
             type: schema.ValueType.Object,


### PR DESCRIPTION
PTAL @adeneui @codajonathan FYI @harisiva 

As discussed deprecating the boolean primary field. Will shortly send out PRs removing all usages of this field from `packs` and `experimental` and bumping the versions there. 

