### PR TITLE
Add a reference property type

### DIFF
--- a/dist/samples/npm.js
+++ b/dist/samples/npm.js
@@ -67,7 +67,7 @@ exports.packageSchema = schema_3.makeObjectSchema({
         downloadCount: { type: schema_1.ValueType.Number },
         versions: {
             type: schema_1.ValueType.Array,
-            items: schema_2.makeReferenceSchemaFromObjectSchema(exports.versionSchema, ['url']),
+            items: schema_2.makeReferenceSchemaFromObjectSchema(exports.versionSchema),
         },
     },
 });

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -105,7 +105,7 @@ export declare function generateSchema(obj: ValidTypes): Schema;
 export declare function makeSchema<T extends Schema>(schema: T): T;
 export declare function makeObjectSchema<K extends string, L extends string>(schema: ObjectSchema<K, L>): ObjectSchema<K, L>;
 export declare function normalizeSchema<T extends Schema>(schema: T): T;
-export declare function makeReferenceSchemaFromObjectSchema(schema: GenericObjectSchema, referencePropertyNames: string[]): GenericObjectSchema;
+export declare function makeReferenceSchemaFromObjectSchema(schema: GenericObjectSchema): GenericObjectSchema;
 export declare enum SchemaIdPrefix {
     Identity = "I"
 }

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -4,6 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const ensure_1 = require("./helpers/ensure");
+const ensure_2 = require("./helpers/ensure");
 const pascalcase_1 = __importDefault(require("pascalcase"));
 // Defines a subset of the JSON Object schema for use in annotating API results.
 // http://json-schema.org/latest/json-schema-core.html#rfc.section.8.2
@@ -72,7 +73,7 @@ function generateSchema(obj) {
     else if (typeof obj === 'number') {
         return { type: ValueType.Number };
     }
-    return ensure_1.ensureUnreachable(obj);
+    return ensure_2.ensureUnreachable(obj);
 }
 exports.generateSchema = generateSchema;
 function makeSchema(schema) {
@@ -117,20 +118,23 @@ function normalizeSchema(schema) {
 }
 exports.normalizeSchema = normalizeSchema;
 // Convenience for creating a reference object schema from an existing schema for the
-// object. Copies over the id and primary from the schema, and the subset of properties
-// specified that are required to form a valid reference.
-function makeReferenceSchemaFromObjectSchema(schema, referencePropertyNames) {
-    const { type, id, primary, properties } = schema;
-    const referenceProperties = {};
-    for (const key of Object.keys(properties)) {
-        if (referencePropertyNames.includes(key)) {
-            referenceProperties[key] = properties[key];
-        }
+// object. Copies over the identity, id, and primary from the schema, and the subset of
+// properties indicated by the id and primary.
+// A reference schema can always be defined directly, but if you already have an object
+// schema it provides better code reuse to derive a reference schema instead.
+function makeReferenceSchemaFromObjectSchema(schema) {
+    const { type, id, primary, identity, properties } = schema;
+    ensure_1.ensureExists(identity);
+    const validId = ensure_1.ensureExists(id);
+    const referenceProperties = { [validId]: properties[validId] };
+    if (primary && primary !== id) {
+        referenceProperties[primary] = properties[primary];
     }
     return {
         codaType: ValueType.Reference,
         type,
         id,
+        identity,
         primary,
         properties: referenceProperties,
     };

--- a/samples/npm.ts
+++ b/samples/npm.ts
@@ -65,7 +65,7 @@ export const packageSchema = makeObjectSchema({
     downloadCount: {type: ValueType.Number},
     versions: {
       type: ValueType.Array,
-      items: makeReferenceSchemaFromObjectSchema(versionSchema, ['url']),
+      items: makeReferenceSchemaFromObjectSchema(versionSchema),
     },
   },
 });


### PR DESCRIPTION
Add an explicit schema property type for references. Create a convenience function for generating reference property objects from existing object schema properties, which isn't require for creating a reference schema, but makes for better code reuse.

There's a companion PR for experimental that I'm sending now too where you can see this in action.

PTAL @ggoldsh @adeneui @harisiva 