### PR TITLE
Do not allow sync schemas to have missing properties

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -389,6 +389,10 @@ export function makeSyncTable<
     {schema: formulaSchema, execute: wrappedExecute, ...definition}: SyncFormulaDef<K, L, ParamDefsT, SchemaT>,
 ): SyncTable<K, L, SchemaT> {
   formulaSchema = normalizeSchema(formulaSchema);
+  const {identity, id, primary} = schema;
+  if (!(primary && id && identity)) {
+    throw new Error(`Sync table schemas should have defined properties for identity, id and primary`);
+  }
   const responseHandler = generateObjectResponseHandler({schema: formulaSchema, excludeExtraneous: true});
   const execute = async function exec(
     params: ParamValues<ParamDefsT>,

--- a/dist/api.js
+++ b/dist/api.js
@@ -220,6 +220,10 @@ exports.makeObjectFormula = makeObjectFormula;
 function makeSyncTable(name, schema, _a) {
     var { schema: formulaSchema, execute: wrappedExecute } = _a, definition = __rest(_a, ["schema", "execute"]);
     formulaSchema = schema_1.normalizeSchema(formulaSchema);
+    const { identity, id, primary } = schema;
+    if (!(primary && id && identity)) {
+        throw new Error(`Sync table schemas should have defined properties for identity, id and primary`);
+    }
     const responseHandler = handler_templates_1.generateObjectResponseHandler({ schema: formulaSchema, excludeExtraneous: true });
     const execute = function exec(params, context, input) {
         return __awaiter(this, void 0, void 0, function* () {


### PR DESCRIPTION
@ggoldsh, @codajonathan PTAL

I was unable to hack TS to make these required, but this should be good enough for now.