### PR TITLE
Add a date range parameter (in the form of a data array) to the fake NPM pack for testing

### DIFF
--- a/dist/samples/npm.js
+++ b/dist/samples/npm.js
@@ -181,7 +181,10 @@ const FakeNpmDefinitionFake = {
             name: 'SyncPackages',
             description: 'Pull down NPM packages.',
             examples: [],
-            parameters: [api_8.makeStringParameter('search', 'Search string', { defaultValue: 'oy-vey' })],
+            parameters: [
+                api_8.makeStringParameter('search', 'Search string', { defaultValue: 'oy-vey' }),
+                api_3.makeDateArrayParameter('dateRange', 'Date range', { optional: true }),
+            ],
             network: { hasSideEffect: false, hasConnection: false },
             execute: ([search], context, continuation) => __awaiter(this, void 0, void 0, function* () {
                 const url = url_1.withQueryParams(`https://npmjs.com/api/packages/${search}`, { continuation });
@@ -201,7 +204,6 @@ const FakeNpmDefinitionFake = {
                         return result.body;
                     })),
                 }),
-                api_3.makeDateArrayParameter('dateRange', 'Date range', { optional: true }),
             ],
             network: { hasSideEffect: false, hasConnection: false },
             execute: ([pack], context, continuation) => __awaiter(this, void 0, void 0, function* () {

--- a/samples/npm.ts
+++ b/samples/npm.ts
@@ -181,7 +181,10 @@ const FakeNpmDefinitionFake: FakePackDefinition = {
       name: 'SyncPackages',
       description: 'Pull down NPM packages.',
       examples: [],
-      parameters: [makeStringParameter('search', 'Search string', {defaultValue: 'oy-vey'})],
+      parameters: [
+        makeStringParameter('search', 'Search string', {defaultValue: 'oy-vey'}),
+        makeDateArrayParameter('dateRange', 'Date range', {optional: true}),
+      ],
       network: {hasSideEffect: false, hasConnection: false},
       execute: async ([search], context, continuation) => {
         const url = withQueryParams(`https://npmjs.com/api/packages/${search}`, {continuation});
@@ -201,7 +204,6 @@ const FakeNpmDefinitionFake: FakePackDefinition = {
             return result.body;
           }),
         }),
-        makeDateArrayParameter('dateRange', 'Date range', {optional: true}),
       ],
       network: {hasSideEffect: false, hasConnection: false},
       execute: async ([pack], context, continuation) => {


### PR DESCRIPTION
The only change here is the line `makeDateArrayParameter('dateRange', 'Date range', {optional: true}),`, the rest are auto-formatter updates.

Ideally I'd like to stop doing this and use fake/mock packs in experimental, but that's too big of a can of worms to open at the moment.

PTAL @kr-project/ecosystem 