### PR TITLE
Add an isSystem flags for packs we use implicitly like Google Docs.

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -321,6 +321,10 @@ export interface PackDefinition {
     formats?: Format[];
     policies?: Policy[];
     syncTables?: SyncTable[];
+    /**
+     * Whether this is a pack that will be used by Coda internally and not exposed directly to users.
+     */
+    isSystem?: boolean;
 }
 export interface ProviderDefinition {
     id: ProviderId;

--- a/types.ts
+++ b/types.ts
@@ -378,6 +378,10 @@ export interface PackDefinition {
   formats?: Format[];
   policies?: Policy[];
   syncTables?: SyncTable[];
+  /**
+   * Whether this is a pack that will be used by Coda internally and not exposed directly to users.
+   */
+  isSystem?: boolean;
 }
 
 export interface ProviderDefinition {


### PR DESCRIPTION
People are finding and installing the Google Docs pack directly, which results in them setting up a shared connection instead of a private connection. This gives collaborators access to their doc list and the ability to import content from those docs. We should just hide implementation-only packs like this from the gallery.

PTAL @adeneui @kr-project/ecosystem 