### PR TITLE
Update CustomHeaderTokenAuthentication to allow the pack to specify the token prefix optionally

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -197,11 +197,12 @@ export interface CodaApiBearerTokenAuthentication extends BaseAuthentication {
 }
 /**
  * A pack or formula which uses standard bearer token header authentication:
- * {"Authorization": "Bearer <token here>"}
+ * {"HeaderNameHere": "OptionalTokenPrefixHere <token here>"}
  */
 export interface CustomHeaderTokenAuthentication extends BaseAuthentication {
     type: AuthenticationType.CustomHeaderToken;
     headerName: string;
+    tokenPrefix?: string;
 }
 /**
  * A pack or formula which includes a token in a query parameter (bad for security).

--- a/types.ts
+++ b/types.ts
@@ -222,11 +222,12 @@ export interface CodaApiBearerTokenAuthentication extends BaseAuthentication {
 
 /**
  * A pack or formula which uses standard bearer token header authentication:
- * {"Authorization": "Bearer <token here>"}
+ * {"HeaderNameHere": "OptionalTokenPrefixHere <token here>"}
  */
 export interface CustomHeaderTokenAuthentication extends BaseAuthentication {
   type: AuthenticationType.CustomHeaderToken;
   headerName: string;
+  tokenPrefix?: string;
 }
 
 /**


### PR DESCRIPTION
Looks like we're not currently using this auth type anywhere, but it's needed for OpsGenie: 
https://docs.opsgenie.com/docs/authentication

PTAL @nigelellis 