### PR TITLE
Add optional getConnectionUserId formula for Pack connection metadata

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -179,6 +179,7 @@ export interface PostSetup {
 interface BaseAuthentication {
     getConnectionNameFormula?: GetConnectionNameFormula;
     getConnectionName?: MetadataFormula;
+    getConnectionUserId?: MetadataFormula;
     defaultConnectionType?: DefaultConnectionType;
     instructionsUrl?: string;
     requiresEndpointUrl?: boolean;

--- a/types.ts
+++ b/types.ts
@@ -188,6 +188,7 @@ interface BaseAuthentication {
   // TODO(alexd): Remove this once we duplicate all the connection name stuff.
   getConnectionNameFormula?: GetConnectionNameFormula;
   getConnectionName?: MetadataFormula;
+  getConnectionUserId?: MetadataFormula;
 
   // Specifies a set of defaults for allowing pack authors to decide what the "normal"
   // configuration of authentication for this pack should look like.


### PR DESCRIPTION
Adding ability for a Pack to define the external userId which will be consumed along with the connection name and stored in the external connection manager.   I'll be using this as a mechanism to implement pack connection enumeration for user data redaction (mainly in Zoom but general purpose for other cases).   Basic approach is outlined [here](https://staging.coda.io/d/Zoom-Pack-Publishing_dB5WNVZMCnn/Implementing-Zooms-Compliance-Flow_su5nh#_lud4Z).

@adeneui / @codajonathan PTAL