### PR TITLE
Claim ids for internal Shutterstock pack.

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -94,7 +94,8 @@ export declare enum PackId {
     FedEx = 1070,
     UPS = 1071,
     SlackChannels = 1072,
-    USPS = 1073
+    USPS = 1073,
+    Shutterstock = 1074
 }
 export declare enum ProviderId {
     Airtable = 2001,
@@ -149,7 +150,8 @@ export declare enum ProviderId {
     YouTube = 2050,
     FedEx = 2051,
     UPS = 2052,
-    USPS = 2053
+    USPS = 2053,
+    Shutterstock = 2054
 }
 export declare enum AuthenticationType {
     None = "None",

--- a/dist/types.js
+++ b/dist/types.js
@@ -96,6 +96,7 @@ var PackId;
     PackId[PackId["UPS"] = 1071] = "UPS";
     PackId[PackId["SlackChannels"] = 1072] = "SlackChannels";
     PackId[PackId["USPS"] = 1073] = "USPS";
+    PackId[PackId["Shutterstock"] = 1074] = "Shutterstock";
 })(PackId = exports.PackId || (exports.PackId = {}));
 var ProviderId;
 (function (ProviderId) {
@@ -152,6 +153,7 @@ var ProviderId;
     ProviderId[ProviderId["FedEx"] = 2051] = "FedEx";
     ProviderId[ProviderId["UPS"] = 2052] = "UPS";
     ProviderId[ProviderId["USPS"] = 2053] = "USPS";
+    ProviderId[ProviderId["Shutterstock"] = 2054] = "Shutterstock";
 })(ProviderId = exports.ProviderId || (exports.ProviderId = {}));
 var AuthenticationType;
 (function (AuthenticationType) {

--- a/types.ts
+++ b/types.ts
@@ -97,6 +97,7 @@ export enum PackId {
   UPS = 1071,
   SlackChannels = 1072,
   USPS = 1073,
+  Shutterstock = 1074,
 }
 
 export enum ProviderId {
@@ -153,6 +154,7 @@ export enum ProviderId {
   FedEx = 2051,
   UPS = 2052,
   USPS = 2053,
+  Shutterstock = 2054,
 }
 
 export enum AuthenticationType {


### PR DESCRIPTION
My plan is to have a CMS-in-Coda where it shows a preview of the photo to be licensed, the reviewer (me/Glenn/Al/Justin) presses a button that executes a pack action to license the image, which produces a download url, and another button to use that download url as the cover photo for the section, which will call the API, which will actually ingest the photo.

I'll make this internal-only behind a flag, but since Shutterstock uses OAuth there's no reason why we couldn't actually launch this at some point.

PTAL @adeneui @kr-project/ecosystem 