### PR TITLE
Update packs-sdk to node 12.17 to match experimental tooling.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:12.16-buster
+      - image: circleci/node:12.17-buster
 
     working_directory: ~/repo
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "private": true,
   "engines": {
-    "node": "^12.16.0"
+    "node": "^12.17.0"
   },
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
It looks like experimental has bumped to node 12.17, and since our packs tooling relies on experimental stuff is breaking due to the mismatch. We just need to bump these version first in the SDK and then in the packs repo.

PTAL @adeneui @matthewtebbs-codaio @kr-project/ecosystem 