### PR TITLE
Don't add empty string for missing optional params

### DIFF
--- a/dist/handler_templates.js
+++ b/dist/handler_templates.js
@@ -10,10 +10,18 @@ const ensure_1 = require("./helpers/ensure");
 const schema_1 = require("./schema");
 const schema_2 = require("./schema");
 const url_1 = require("./helpers/url");
-function generateParamMap(keys, nameToValueMap) {
+function generateParamMap(keys, nameToValueMap, optionalNames) {
     const map = {};
     keys.forEach(key => {
-        map[key] = nameToValueMap[key] || '';
+        let val = nameToValueMap[key];
+        if (typeof val === 'undefined') {
+            if (optionalNames && optionalNames.has(key)) {
+                return;
+            }
+            // Never pass undefined;
+            val = '';
+        }
+        map[key] = val;
     });
     return map;
 }
@@ -83,7 +91,7 @@ function generateRequestHandler(request, parameters) {
             body = clone_1.default(bodyTemplate);
         }
         if (hasBodyParams) {
-            const currentBodyParams = generateParamMap(ensure_1.ensureExists(bodyParams), nameMapping);
+            const currentBodyParams = generateParamMap(ensure_1.ensureExists(bodyParams), nameMapping, optionalNames);
             // Merge the param if needed.
             body = body ? Object.assign(Object.assign({}, body), currentBodyParams) : currentBodyParams;
         }

--- a/handler_templates.ts
+++ b/handler_templates.ts
@@ -37,10 +37,18 @@ interface ParamMap {
   [name: string]: PackFormulaValue;
 }
 
-function generateParamMap(keys: string[], nameToValueMap: ParamMap): ParamMap {
+function generateParamMap(keys: string[], nameToValueMap: ParamMap, optionalNames?: Set<string>): ParamMap {
   const map: ParamMap = {};
   keys.forEach(key => {
-    map[key] = nameToValueMap[key] || '';
+    let val = nameToValueMap[key];
+    if (typeof val === 'undefined') {
+      if (optionalNames && optionalNames.has(key)) {
+        return;
+      }
+      // Never pass undefined;
+      val = '';
+    }
+    map[key] = val;
   });
   return map;
 }
@@ -132,7 +140,7 @@ export function generateRequestHandler<ParamDefsT extends ParamDefs>(
       body = clone(bodyTemplate);
     }
     if (hasBodyParams) {
-      const currentBodyParams = generateParamMap(ensureExists(bodyParams), nameMapping);
+      const currentBodyParams = generateParamMap(ensureExists(bodyParams), nameMapping, optionalNames);
       // Merge the param if needed.
       body = body ? {...body, ...currentBodyParams} : currentBodyParams;
     }


### PR DESCRIPTION
Addresses https://staging.coda.io/d/LED-2020_dxkM9wrI5Y9/Bugs-Nits_suApB#Bugs-and-Nits_tuKYn/r419&modal=true

Intercom was failing requests with: `'400 - "{\\"type\\":\\"error.list\\",\\"request_id\\":\\"0009kh1nes7dp0hpctd0\\",\\"errors\\":[{\\"code\\":\\"parameter_invalid\\",\\"message\\":\\"Value:  not of type Requisite::Boolean\\"}]}"'`

There's an optional `unsubscribed_from_emails` param on this request. If the coda user set this everything worked. But if they didn't we'd add an empty string for the param, and intercom would reject the request because it couldn't parse the empty string as a boolean.

We already did this for URL params, just not for body params: https://github.com/kr-project/packs-sdk/blob/0b1b0b66713d2887237a8a8d91e8e48d733eb0ad/handler_templates.ts#L55

PTAL @codajonathan @kr-project/ecosystem 