### PR TITLE
revert narrowing to GenericObjectSChema from object formula typing

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1,4 +1,4 @@
-import {ArraySchema, GenericObjectSchema, StringHintTypes} from './schema';
+import {ArraySchema, StringHintTypes} from './schema';
 import {ArrayType} from './api_types';
 import {CommonPackFormulaDef} from './api_types';
 import {ExecutionContext} from './api_types';
@@ -244,7 +244,7 @@ type StringPackFormula<ParamDefsT extends ParamDefs, ResultT extends StringHintT
   schema?: StringSchema<ResultT>;
 };
 
-export type ObjectPackFormula<ParamDefsT extends ParamDefs, SchemaT extends GenericObjectSchema> = Formula<
+export type ObjectPackFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema> = Formula<
   ParamDefsT,
   SchemaType<SchemaT>
 > & {
@@ -254,10 +254,10 @@ export type ObjectPackFormula<ParamDefsT extends ParamDefs, SchemaT extends Gene
 export type TypedPackFormula =
   | NumericPackFormula<ParamDefs>
   | StringPackFormula<ParamDefs, any>
-  | ObjectPackFormula<ParamDefs, GenericObjectSchema>
+  | ObjectPackFormula<ParamDefs, Schema>
   | GenericSyncFormula;
 
-type TypedObjectPackFormula = ObjectPackFormula<ParamDefs, GenericObjectSchema>;
+type TypedObjectPackFormula = ObjectPackFormula<ParamDefs, Schema>;
 export type PackFormulaMetadata = Omit<TypedPackFormula, 'execute'>;
 export type ObjectPackFormulaMetadata = Omit<TypedObjectPackFormula, 'execute'>;
 export function isObjectPackFormula(fn: PackFormulaMetadata): fn is ObjectPackFormulaMetadata {
@@ -442,7 +442,7 @@ function isResponseExampleTemplate(obj: any): obj is {example: SchemaType<any>} 
   return obj && obj.example;
 }
 
-export function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends GenericObjectSchema>({
+export function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({
   response,
   ...definition // tslint:disable-line: trailing-comma
 }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT> {

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -1,4 +1,4 @@
-import { ArraySchema, GenericObjectSchema, StringHintTypes } from './schema';
+import { ArraySchema, StringHintTypes } from './schema';
 import { ArrayType } from './api_types';
 import { CommonPackFormulaDef } from './api_types';
 import { ExecutionContext } from './api_types';
@@ -98,11 +98,11 @@ declare type NumericPackFormula<ParamDefsT extends ParamDefs> = Formula<ParamDef
 declare type StringPackFormula<ParamDefsT extends ParamDefs, ResultT extends StringHintTypes = StringHintTypes> = Formula<ParamDefsT, SchemaType<StringSchema<ResultT>>> & {
     schema?: StringSchema<ResultT>;
 };
-export declare type ObjectPackFormula<ParamDefsT extends ParamDefs, SchemaT extends GenericObjectSchema> = Formula<ParamDefsT, SchemaType<SchemaT>> & {
+export declare type ObjectPackFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema> = Formula<ParamDefsT, SchemaType<SchemaT>> & {
     schema?: SchemaT;
 };
-export declare type TypedPackFormula = NumericPackFormula<ParamDefs> | StringPackFormula<ParamDefs, any> | ObjectPackFormula<ParamDefs, GenericObjectSchema> | GenericSyncFormula;
-declare type TypedObjectPackFormula = ObjectPackFormula<ParamDefs, GenericObjectSchema>;
+export declare type TypedPackFormula = NumericPackFormula<ParamDefs> | StringPackFormula<ParamDefs, any> | ObjectPackFormula<ParamDefs, Schema> | GenericSyncFormula;
+declare type TypedObjectPackFormula = ObjectPackFormula<ParamDefs, Schema>;
 export declare type PackFormulaMetadata = Omit<TypedPackFormula, 'execute'>;
 export declare type ObjectPackFormulaMetadata = Omit<TypedObjectPackFormula, 'execute'>;
 export declare function isObjectPackFormula(fn: PackFormulaMetadata): fn is ObjectPackFormulaMetadata;
@@ -140,7 +140,7 @@ export interface SimpleAutocompleteOption {
 export declare function simpleAutocomplete(search: string | undefined, options: Array<string | SimpleAutocompleteOption>): Promise<MetadataFormulaObjectResultType[]>;
 export declare function autocompleteSearchObjects<T>(search: string, objs: T[], displayKey: keyof T, valueKey: keyof T): Promise<MetadataFormulaObjectResultType[]>;
 export declare function makeSimpleAutocompleteMetadataFormula(options: Array<string | SimpleAutocompleteOption>): MetadataFormula;
-export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends GenericObjectSchema>({ response, ...definition }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
+export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({ response, ...definition }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
 export declare function makeSyncTable<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>>(name: string, schema: SchemaT, { execute: wrappedExecute, ...definition }: SyncFormulaDef<K, L, ParamDefsT, SchemaT>, getSchema?: MetadataFormula, entityName?: string): SyncTableDef<K, L, ParamDefsT, SchemaT>;
 export declare function makeDynamicSyncTable<K extends string, L extends string, ParamDefsT extends ParamDefs>({ packId, name, getName, getSchema, getDisplayUrl, formula, listDynamicUrls, entityName, }: {
     packId: number;


### PR DESCRIPTION
running into some typing issues that we can figure out async, rolling this back for now and will do explicit cast in `experimental`. Verified type errors go away in `packs` repo

@codajonathan 