### PR TITLE
Introduce an ImageAttachment SDK type.

### DIFF
--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -19,11 +19,12 @@ export declare enum ValueType {
     Html = "html",
     Embed = "embed",
     Reference = "reference",
+    ImageAttachment = "imageAttachment",
     Attachment = "attachment",
     Slider = "slider",
     Scale = "scale"
 }
-export declare type StringHintTypes = ValueType.Attachment | ValueType.Date | ValueType.Time | ValueType.DateTime | ValueType.Duration | ValueType.Embed | ValueType.Html | ValueType.Image | ValueType.Markdown | ValueType.Url;
+export declare type StringHintTypes = ValueType.Attachment | ValueType.Date | ValueType.Time | ValueType.DateTime | ValueType.Duration | ValueType.Embed | ValueType.Html | ValueType.Image | ValueType.ImageAttachment | ValueType.Markdown | ValueType.Url;
 export declare type NumberHintTypes = ValueType.Date | ValueType.Time | ValueType.DateTime | ValueType.Percent | ValueType.Currency | ValueType.Slider | ValueType.Scale;
 export declare type ObjectHintTypes = ValueType.Person | ValueType.Reference;
 interface BaseSchema {

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -30,6 +30,7 @@ var ValueType;
     ValueType["Html"] = "html";
     ValueType["Embed"] = "embed";
     ValueType["Reference"] = "reference";
+    ValueType["ImageAttachment"] = "imageAttachment";
     ValueType["Attachment"] = "attachment";
     ValueType["Slider"] = "slider";
     ValueType["Scale"] = "scale";

--- a/schema.ts
+++ b/schema.ts
@@ -27,6 +27,7 @@ export enum ValueType {
   Html = 'html',
   Embed = 'embed',
   Reference = 'reference',
+  ImageAttachment = 'imageAttachment',
   Attachment = 'attachment',
   Slider = 'slider',
   Scale = 'scale',
@@ -41,6 +42,7 @@ export type StringHintTypes =
   | ValueType.Embed
   | ValueType.Html
   | ValueType.Image
+  | ValueType.ImageAttachment
   | ValueType.Markdown
   | ValueType.Url;
 export type NumberHintTypes =


### PR DESCRIPTION
I think we need to do a specific phasing to roll this out:

1. Update experimental to map this new type identically to how ValueType.Attachment is used today.
2. Wait for that to be pushed everywhere.
3. Update the pack defs to find-and-replace ValueType.Attachment->ValueType.ImageAttachment, wait for deployment.
4. Change experimental to map ValueType.Attachment to the new file attachment column format.

I'm happy to do step 3 in a few days after the experimental changes have been pushed.

PTAL @bhuang14 @adeneui @kr-project/ecosystem 