### PR TITLE
add shouldAutoAuthSetup in compiled types for browser

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -70,6 +70,7 @@ export interface ExternalPackMetadata extends BasePackMetadata {
       getOptionsFormula: PackFormulaMetadata;
     }>;
     deferConnectionSetup?: boolean;
+    shouldAutoAuthSetup?: boolean;
   };
   instructionsUrl?: string;
 

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -51,6 +51,7 @@ export interface ExternalPackMetadata extends BasePackMetadata {
             getOptionsFormula: PackFormulaMetadata;
         }>;
         deferConnectionSetup?: boolean;
+        shouldAutoAuthSetup?: boolean;
     };
     instructionsUrl?: string;
     formulas?: ExternalPackFormulas;


### PR DESCRIPTION
looks like this is the derived type that the browser reads so need to add here too for it to be picked up. The other spot only added it to be specified in the `packs` repo.


@kr-project/monetization / 