### PR TITLE
Add endpointKey to OAuth2 params

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -118,6 +118,7 @@ export interface OAuth2Authentication extends BaseAuthentication {
     clientIdEnvVarName: string;
     clientSecretEnvVarName: string;
     signingSecretEnvVarName?: string;
+    endpointKey?: string;
 }
 export interface WebBasicAuthentication extends BaseAuthentication {
     type: AuthenticationType.WebBasic;

--- a/types.ts
+++ b/types.ts
@@ -146,6 +146,10 @@ export interface OAuth2Authentication extends BaseAuthentication {
   clientIdEnvVarName: string;
   clientSecretEnvVarName: string;
   signingSecretEnvVarName?: string;
+
+  // Some OAuth providers will return the API domain with the OAuth response.
+  // This is the key in the OAuth response json body that points to the endpoint.
+  endpointKey?: string;
 }
 
 export interface WebBasicAuthentication extends BaseAuthentication {


### PR DESCRIPTION
For Salesforce, the API domain (i.e. endpoint) is returned in the OAuth response. 

I am aware that there's an existing post-oauth page that was for similar but different purpose. It's easier to simply check an endpoint key instead of adding on top of post-auth page. 