### PR TITLE
Silence VSCode complaining about non-existent global assert.

### DIFF
--- a/test/handler_templates_test.ts
+++ b/test/handler_templates_test.ts
@@ -1,3 +1,4 @@
+import './test_helper';
 import {ValueType} from '../schema';
 import {generateObjectResponseHandler} from '../handler_templates';
 import {generateRequestHandler} from '../handler_templates';
@@ -109,8 +110,18 @@ describe('handler templates', () => {
         },
       });
       assert.deepEqual(
-        handler({headers: {}, body: [{some_thing: 42, cool_thing: 123}, {cool: 456, some_thing: 321}], status: 200}),
-        [{someThing: 42, cool_thing: 123}, {cool: 456, someThing: 321}] as any,
+        handler({
+          headers: {},
+          body: [
+            {some_thing: 42, cool_thing: 123},
+            {cool: 456, some_thing: 321},
+          ],
+          status: 200,
+        }),
+        [
+          {someThing: 42, cool_thing: 123},
+          {cool: 456, someThing: 321},
+        ] as any,
       );
     });
 

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -1,4 +1,4 @@
-import {PackId} from '../types';
+import './test_helper';
 import {schema} from '../index';
 
 const CODA_DEBUG_PACK_ID = 1009;

--- a/test/test_helper.ts
+++ b/test/test_helper.ts
@@ -1,0 +1,1 @@
+import './types';

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,5 +1,4 @@
 import 'chai';
-import 'sinon';
 
 declare global {
   const assert: Chai.AssertStatic;


### PR DESCRIPTION
No idea what's going on here. The globals seem properly declared in an ambient module, and that module seems to be included properly in `tsconfig.json` via `"include": ["./*.d.ts", ...]`.

VSCode seems to stop complaining as soon as the module with the global declarations is imported anywhere in the project. But you can't import an ambient module, so I can't import it from globals.d.ts, so my workaround is just to move it to a regular module, and then start using the test_helper pattern so these seemingly useless imports don't seem as odd.

Definitely open to other solutions.

PTAL @nigelellis @vaskevich CC @adeneui @kr-project/ecosystem 