### PR TITLE
Make the Fetcher and TemporaryBlobStorage required.

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -173,8 +173,8 @@ export interface Sync {
 }
 
 export interface ExecutionContext {
-  readonly fetcher?: Fetcher;
-  readonly temporaryBlobStorage?: TemporaryBlobStorage;
+  readonly fetcher: Fetcher;
+  readonly temporaryBlobStorage: TemporaryBlobStorage;
   readonly endpoint?: string;
   readonly invocationLocation: {
     protocolAndHost: string;

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -115,8 +115,8 @@ export interface Sync {
     dynamicUrl?: string;
 }
 export interface ExecutionContext {
-    readonly fetcher?: Fetcher;
-    readonly temporaryBlobStorage?: TemporaryBlobStorage;
+    readonly fetcher: Fetcher;
+    readonly temporaryBlobStorage: TemporaryBlobStorage;
     readonly endpoint?: string;
     readonly invocationLocation: {
         protocolAndHost: string;


### PR DESCRIPTION
I patched this in to `experimental` and TS was happy, as expected we only ever populate an ExecutionContext with values for these.

PTAL @huayang-coda @vaskevich @kr-project/ecosystem 