### PR TITLE
Add option to disable authentication

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -148,6 +148,8 @@ export interface FetchRequest {
   cacheTtlSecs?: number;
   // Allows binary responses.
   isBinaryResponse?: boolean;
+  // Disable authentication
+  disableAuthentication?: boolean;
 }
 
 // Copied from https://developer.mozilla.org/en-US/docs/Web/API/Response

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -90,6 +90,7 @@ export interface FetchRequest {
     };
     cacheTtlSecs?: number;
     isBinaryResponse?: boolean;
+    disableAuthentication?: boolean;
 }
 export interface FetchResponse<T extends any = any> {
     status: number;


### PR DESCRIPTION
Facebook's pages APIs return specific auth tokens to use for each page you want to access. Adding this lets the facebook pack disable our auth header and add its own.

Experimental implementation: https://github.com/kr-project/experimental/pull/49831
Facebook packs usage: https://github.com/kr-project/packs/pull/1961

PTAL @codajonathan 
CC @kr-project/ecosystem 