### PR TITLE
Allow running the coda CLI directly while doing development in the packs-sdk repo.

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -97,7 +97,14 @@ function isTypescript(path: string): boolean {
 }
 
 function spawnProcess(command: string) {
-  spawnSync(command, {
+  let cmd = command;
+  // Hack to allow us to run this CLI tool for testing purposes from within this repo, without
+  // needing it installed as an npm package.
+  if (process.argv[1].endsWith('coda.ts')) {
+    cmd = command.replace('packs-sdk/dist', '.');
+  }
+
+  spawnSync(cmd, {
     shell: true,
     stdio: 'inherit',
   });

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -111,7 +111,13 @@ function isTypescript(path) {
     return path.toLowerCase().endsWith('.ts');
 }
 function spawnProcess(command) {
-    child_process_1.spawnSync(command, {
+    let cmd = command;
+    // Hack to allow us to run this CLI tool for testing purposes from within this repo, without
+    // needing it installed as an npm package.
+    if (process.argv[1].endsWith('coda.ts')) {
+        cmd = command.replace('packs-sdk/dist', '.');
+    }
+    child_process_1.spawnSync(cmd, {
         shell: true,
         stdio: 'inherit',
     });


### PR DESCRIPTION
As I'm building out functionality for the CLI, it's helpful to be able to run it from the packs-sdk repo with the sample pack definitions while doing development. This hack is a little gross but it's small and very useful, and should actually allow us to write tests that make sure this main file actually execute properly, even with the ts-node weirdness.

PTAL @huayang-coda @kr-project/ecosystem 