### PR TITLE
Better type for mock sync execution context.

### DIFF
--- a/dist/testing/mocks.d.ts
+++ b/dist/testing/mocks.d.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from '../api_types';
 import type { FetchResponse } from '../api_types';
-import type { SyncExecutionContext } from '../api_types';
+import type { Sync } from '../api_types';
 import sinon from 'sinon';
 export interface MockExecutionContext extends ExecutionContext {
     fetcher: {
@@ -11,7 +11,10 @@ export interface MockExecutionContext extends ExecutionContext {
         storeBlob: sinon.SinonStub;
     };
 }
-export declare function newMockSyncExecutionContext(): SyncExecutionContext;
+export interface MockSyncExecutionContext extends MockExecutionContext {
+    readonly sync: Sync;
+}
+export declare function newMockSyncExecutionContext(): MockSyncExecutionContext;
 export declare function newMockExecutionContext(): MockExecutionContext;
 export declare function newJsonFetchResponse<T>(body: T, status?: number, headers?: {
     [header: string]: string | string[] | undefined;

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -1,6 +1,6 @@
 import type {ExecutionContext} from '../api_types';
 import type {FetchResponse} from '../api_types';
-import type {SyncExecutionContext} from '../api_types';
+import type {Sync} from '../api_types';
 import sinon from 'sinon';
 import {v4} from 'uuid';
 
@@ -14,7 +14,11 @@ export interface MockExecutionContext extends ExecutionContext {
   };
 }
 
-export function newMockSyncExecutionContext(): SyncExecutionContext {
+export interface MockSyncExecutionContext extends MockExecutionContext {
+  readonly sync: Sync;
+}
+
+export function newMockSyncExecutionContext(): MockSyncExecutionContext {
   return {...newMockExecutionContext(), sync: {}};
 }
 


### PR DESCRIPTION
Need to extend of the mock context so that you set up mock fetcher responses when writing tests.

PTAL @alan-fang @huayang-coda @kr-project/ecosystem 