### PR TITLE
Turn off yargs automatic parsing of numberic args.

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -123,6 +123,7 @@ function escapeShellArg(arg: string): string {
 if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   yargs
+    .parserConfiguration({'parse-numbers': false})
     .command({
       command: 'execute <manifestPath> <formulaName> [params..]',
       describe: 'Execute a formula',

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -131,6 +131,7 @@ function escapeShellArg(arg) {
 if (require.main === module) {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     yargs_1.default
+        .parserConfiguration({ 'parse-numbers': false })
         .command({
         command: 'execute <manifestPath> <formulaName> [params..]',
         describe: 'Execute a formula',


### PR DESCRIPTION
Without this, if a CLI arg looks like number, yargs will parse it as a number automagically. This was breaking our shell escaper and could break other logic down the line, that's expecting all incoming CLI args to be strings that we'll coerce ourselves. It only does this for numbers and not other value types like booleans, and based on the bug reports seems surprising to many other users too.

PTAL @huayang-coda @kr-project/ecosystem 