### PR TITLE
Add an exports file for development-only utilities.

### DIFF
--- a/development.ts
+++ b/development.ts
@@ -1,0 +1,17 @@
+// Exports for development-related code.
+//
+// These are kept separate from index.ts to avoid these utilities winding up in pack bundles.
+
+export type {ContextOptions} from './testing/execution';
+export type {ExecuteOptions} from './testing/execution';
+export type {ExecuteSyncOptions} from './testing/execution';
+export {executeFormula} from './testing/execution';
+export {executeFormulaFromPackDef} from './testing/execution';
+export {executeSyncFormula} from './testing/execution';
+export {executeSyncFormulaFromPackDef} from './testing/execution';
+
+export type {MockExecutionContext} from './testing/mocks';
+export type {MockSyncExecutionContext} from './testing/mocks';
+export {newJsonFetchResponse} from './testing/mocks';
+export {newMockExecutionContext} from './testing/mocks';
+export {newMockSyncExecutionContext} from './testing/mocks';

--- a/dist/development.d.ts
+++ b/dist/development.d.ts
@@ -1,0 +1,12 @@
+export type { ContextOptions } from './testing/execution';
+export type { ExecuteOptions } from './testing/execution';
+export type { ExecuteSyncOptions } from './testing/execution';
+export { executeFormula } from './testing/execution';
+export { executeFormulaFromPackDef } from './testing/execution';
+export { executeSyncFormula } from './testing/execution';
+export { executeSyncFormulaFromPackDef } from './testing/execution';
+export type { MockExecutionContext } from './testing/mocks';
+export type { MockSyncExecutionContext } from './testing/mocks';
+export { newJsonFetchResponse } from './testing/mocks';
+export { newMockExecutionContext } from './testing/mocks';
+export { newMockSyncExecutionContext } from './testing/mocks';

--- a/dist/development.js
+++ b/dist/development.js
@@ -1,0 +1,20 @@
+"use strict";
+// Exports for development-related code.
+//
+// These are kept separate from index.ts to avoid these utilities winding up in pack bundles.
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.newMockSyncExecutionContext = exports.newMockExecutionContext = exports.newJsonFetchResponse = exports.executeSyncFormulaFromPackDef = exports.executeSyncFormula = exports.executeFormulaFromPackDef = exports.executeFormula = void 0;
+var execution_1 = require("./testing/execution");
+Object.defineProperty(exports, "executeFormula", { enumerable: true, get: function () { return execution_1.executeFormula; } });
+var execution_2 = require("./testing/execution");
+Object.defineProperty(exports, "executeFormulaFromPackDef", { enumerable: true, get: function () { return execution_2.executeFormulaFromPackDef; } });
+var execution_3 = require("./testing/execution");
+Object.defineProperty(exports, "executeSyncFormula", { enumerable: true, get: function () { return execution_3.executeSyncFormula; } });
+var execution_4 = require("./testing/execution");
+Object.defineProperty(exports, "executeSyncFormulaFromPackDef", { enumerable: true, get: function () { return execution_4.executeSyncFormulaFromPackDef; } });
+var mocks_1 = require("./testing/mocks");
+Object.defineProperty(exports, "newJsonFetchResponse", { enumerable: true, get: function () { return mocks_1.newJsonFetchResponse; } });
+var mocks_2 = require("./testing/mocks");
+Object.defineProperty(exports, "newMockExecutionContext", { enumerable: true, get: function () { return mocks_2.newMockExecutionContext; } });
+var mocks_3 = require("./testing/mocks");
+Object.defineProperty(exports, "newMockSyncExecutionContext", { enumerable: true, get: function () { return mocks_3.newMockSyncExecutionContext; } });


### PR DESCRIPTION
Consolidate testing utilities into one file for sane imports by downstream users, like the `packs` repo. It's still funky to have `dist` in the import path, we can perhaps fix that before we would launch something like this, if we decide to have a separate repo for the published npm package. For instance, if we bazel-ify the packs-sdk repo, the recommend publishing pattern is to copy your generated files to a separate repo for npm. In which case, we can adjust the file layout at publish time to eliminate `dist`.

PTAL @huayang-coda @kr-project/ecosystem 