### PR TITLE
Fix erroneously throwing an error when checking a boolean property

### DIFF
--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -100,9 +100,7 @@ function checkPropertyTypeAndCodaType(schema, result, validationContext) {
     switch (schema.type) {
         case schema_1.ValueType.Boolean: {
             const resultValidationError = checkType(typeof result === 'boolean', 'boolean', result);
-            if (resultValidationError) {
-                return errors;
-            }
+            return resultValidationError ? errors : [];
         }
         case schema_1.ValueType.Number: {
             const resultValidationError = checkType(typeof result === 'number', 'number', result);

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -17,6 +17,7 @@ describe('Property validation in objects', () => {
     primary: 'date',
     id: 'date',
     properties: {
+      bool: {type: ValueType.Boolean},
       date: {type: ValueType.String, codaType: ValueType.Date},
       url: {type: ValueType.String, codaType: ValueType.Url},
       slider: {
@@ -55,6 +56,19 @@ describe('Property validation in objects', () => {
       },
     },
     identity: {packId: FakePack.id, name: 'Events'},
+  });
+
+  const fakeBooleanFormula = makeObjectFormula({
+    name: 'Boolean',
+    description: 'Returns the boolean you passed in.',
+    examples: [],
+    parameters: [makeBooleanParameter('boolParam', 'Pass in a boolean (malformed is ok)')],
+    execute: async ([boolParam]) => {
+      return {bool: boolParam};
+    },
+    response: {
+      schema: fakeSchema,
+    },
   });
 
   const fakeDateFormula = makeObjectFormula({
@@ -140,8 +154,20 @@ describe('Property validation in objects', () => {
 
   const fakePack = createFakePack({
     formulas: {
-      Fake: [fakeDateFormula, fakeSliderFormula, fakeScaleFormula, fakeUrlFormula, fakeArrayFormula, fakePeopleFormula],
+      Fake: [
+        fakeBooleanFormula,
+        fakeDateFormula,
+        fakeSliderFormula,
+        fakeScaleFormula,
+        fakeUrlFormula,
+        fakeArrayFormula,
+        fakePeopleFormula,
+      ],
     },
+  });
+
+  it('validates boolean', async () => {
+    await executeFormulaFromPackDef(fakePack, 'Fake::Boolean', [true]);
   });
 
   it('validates correct date string', async () => {

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -137,9 +137,7 @@ function checkPropertyTypeAndCodaType<ResultT extends any>(
   switch (schema.type) {
     case ValueType.Boolean: {
       const resultValidationError = checkType(typeof result === 'boolean', 'boolean', result);
-      if (resultValidationError) {
-        return errors;
-      }
+      return resultValidationError ? errors : [];
     }
     case ValueType.Number: {
       const resultValidationError = checkType(typeof result === 'number', 'number', result);


### PR DESCRIPTION
This was causing all boolean checking to fail, because the switch statement didn't terminate in the `ValueType.Boolean` block. 🤦‍♂️