### PR TITLE
Add endpoint to ExecutionContext constructors

### DIFF
--- a/dist/testing/mocks.d.ts
+++ b/dist/testing/mocks.d.ts
@@ -14,8 +14,8 @@ export interface MockExecutionContext extends ExecutionContext {
 export interface MockSyncExecutionContext extends MockExecutionContext {
     readonly sync: Sync;
 }
-export declare function newMockSyncExecutionContext(endpoint?: string): MockSyncExecutionContext;
-export declare function newMockExecutionContext(endpoint?: string): MockExecutionContext;
+export declare function newMockSyncExecutionContext(overrides?: Partial<MockSyncExecutionContext>): MockSyncExecutionContext;
+export declare function newMockExecutionContext(overrides?: Partial<MockExecutionContext>): MockExecutionContext;
 export declare function newJsonFetchResponse<T>(body: T, status?: number, headers?: {
     [header: string]: string | string[] | undefined;
 }): FetchResponse<T>;

--- a/dist/testing/mocks.js
+++ b/dist/testing/mocks.js
@@ -6,26 +6,19 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.newJsonFetchResponse = exports.newMockExecutionContext = exports.newMockSyncExecutionContext = void 0;
 const sinon_1 = __importDefault(require("sinon"));
 const uuid_1 = require("uuid");
-function newMockSyncExecutionContext(endpoint) {
-    return Object.assign(Object.assign({}, newMockExecutionContext(endpoint)), { sync: {} });
+function newMockSyncExecutionContext(overrides) {
+    return Object.assign(Object.assign(Object.assign({}, newMockExecutionContext()), { sync: {} }), overrides);
 }
 exports.newMockSyncExecutionContext = newMockSyncExecutionContext;
-function newMockExecutionContext(endpoint) {
-    return {
-        invocationLocation: {
+function newMockExecutionContext(overrides) {
+    return Object.assign({ invocationLocation: {
             protocolAndHost: 'https://coda.io',
-        },
-        timezone: 'America/Los_Angeles',
-        invocationToken: uuid_1.v4(),
-        fetcher: {
+        }, timezone: 'America/Los_Angeles', invocationToken: uuid_1.v4(), fetcher: {
             fetch: sinon_1.default.stub(),
-        },
-        temporaryBlobStorage: {
+        }, temporaryBlobStorage: {
             storeUrl: sinon_1.default.stub(),
             storeBlob: sinon_1.default.stub(),
-        },
-        endpoint,
-    };
+        } }, overrides);
 }
 exports.newMockExecutionContext = newMockExecutionContext;
 function newJsonFetchResponse(body, status = 200, headers) {

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -18,11 +18,11 @@ export interface MockSyncExecutionContext extends MockExecutionContext {
   readonly sync: Sync;
 }
 
-export function newMockSyncExecutionContext(endpoint?: string): MockSyncExecutionContext {
-  return {...newMockExecutionContext(endpoint), sync: {}};
+export function newMockSyncExecutionContext(overrides?: Partial<MockSyncExecutionContext>): MockSyncExecutionContext {
+  return {...newMockExecutionContext(), sync: {}, ...overrides};
 }
 
-export function newMockExecutionContext(endpoint?: string): MockExecutionContext {
+export function newMockExecutionContext(overrides?: Partial<MockExecutionContext>): MockExecutionContext {
   return {
     invocationLocation: {
       protocolAndHost: 'https://coda.io',
@@ -36,7 +36,7 @@ export function newMockExecutionContext(endpoint?: string): MockExecutionContext
       storeUrl: sinon.stub(),
       storeBlob: sinon.stub(),
     },
-    endpoint,
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
I was going to add some tests to the Jira pack since I'm already working here, but it uses the `ExecutionContext.endpoint`. 

I don't have too much context on the other fields so I didn't add them in, but if there's no heavy opposition I can take those on too as a follow-up.