### PR TITLE
Relax the return type for execute when used in makeObjectFormula to account for fromKey mappings.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -288,7 +288,7 @@ export type SyncFormula<
   L extends string,
   ParamDefsT extends ParamDefs,
   SchemaT extends ObjectSchema<K, L>
-> = SyncFormulaDef<ParamDefsT> & {
+> = Omit<SyncFormulaDef<ParamDefsT>, 'execute'> & {
   execute(
     params: ParamValues<ParamDefsT>,
     context: SyncExecutionContext,

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -117,7 +117,7 @@ export interface SyncFormulaResult<ResultT extends object> {
 interface SyncFormulaDef<ParamsT extends ParamDefs> extends CommonPackFormulaDef<ParamsT> {
     execute(params: ParamValues<ParamsT>, context: SyncExecutionContext): Promise<SyncFormulaResult<object>>;
 }
-export declare type SyncFormula<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>> = SyncFormulaDef<ParamDefsT> & {
+export declare type SyncFormula<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>> = Omit<SyncFormulaDef<ParamDefsT>, 'execute'> & {
     execute(params: ParamValues<ParamDefsT>, context: SyncExecutionContext): Promise<SyncFormulaResult<SchemaType<SchemaT>>>;
     resultType: TypeOf<SchemaType<SchemaT>>;
     isSyncFormula: true;

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -26,8 +26,8 @@ export declare function executeFormulaOrSyncFromCLI({ formulaName, params: rawPa
     module: any;
     contextOptions?: ContextOptions;
 }): Promise<void>;
-export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<object[]>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<object[]>;
+export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<any[]>;
+export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<any[]>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;


### PR DESCRIPTION
There's a bug in our pack `execute` return type inference that's currently blocking a PR. The fancy typing we have on object formula definitions declares a return type for `execute` that matches the object property names from the response schema. But we have `fromKey` which allows you to provide arbitrary key name mappings that will be applied _after_ `execute` has run. So in essence, you can return pretty much any object from a wrapped `execute` and it can match the response schema provided that your `fromKey` declarations do the right thing.

I think this means that we should just declare the return type of `execute` for wrapped object formulas to be `object`. Unless there's some way to incorporate the `fromKey` value in the return type inference. But that's a bridge too far for my tastes.

This only came up now because we added validation for reference schemas that the id and name values are required so I had to mark some schema fields for existing packs as required. If you have a required field with a `fromKey` mapping, you'll hit this error:

```
const mySchema = makeObjectSchema({
  type: ValueType.Object,
  properties: {foo: {type: ValueType.String, required: true, fromKey: 'bar'},
});

const myFormula = makeObjectFormula({
  ...
  execute: () => {
    // Valid return value since `bar` will get mapped to `foo` because of `fromKey`.
    // But TS complains because it wants `foo` to exist on the return value.
   // TS flags `execute` as having an invalid return type.
    return {'bar': 'hello'};
  },
  response: {schema: mySchema},
});
```

This fix leaves the final typing for an object formula unchanged. The pack definition will still have a formula whose `execute` returns something that matches the schema. But if you use `makeObjectFormula()` to create a wrapped execute that does key mappings, the `execute` you provide to the wrapper can return any object.

PTAL @adeneui @vaskevich @kr-project/ecosystem 