### PR TITLE
Update CLI to install devDependencies and only folder contents

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -113,7 +113,7 @@ async function handleInit() {
     spawnProcess(installCommand);
   }
 
-  const installDevDependenciesCommand = `npm install --save-dev @types/chai@4.2.14 @types/mocha@8.2.0 @types/node@14.14.20 @types/sinon@9.0.10 chai@4.2.0 mocha@8.2.0 sinon@9.2.2 ts-node@9.1.1 typescript@4.1.3`;
+  const installDevDependenciesCommand = `npm install --save-dev @types/chai @types/mocha @types/node @types/sinon chai mocha sinon ts-node typescript`;
   spawnProcess(installDevDependenciesCommand);
 
   const copyCommand = `cp -r node_modules/coda-packs-examples/examples/template/* ${process.cwd()}`;

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -125,7 +125,7 @@ function handleInit() {
             const installCommand = `npm install https://74a1ea8b58ba756a7173dd2e0a2fbee9be66151a:x-oauth-basic@github.com/kr-project/packs-examples`;
             spawnProcess(installCommand);
         }
-        const installDevDependenciesCommand = `npm install --save-dev @types/chai@4.2.14 @types/mocha@8.2.0 @types/node@14.14.20 @types/sinon@9.0.10 chai@4.2.0 mocha@8.2.0 sinon@9.2.2 ts-node@9.1.1 typescript@4.1.3`;
+        const installDevDependenciesCommand = `npm install --save-dev @types/chai @types/mocha @types/node @types/sinon chai mocha sinon ts-node typescript`;
         spawnProcess(installDevDependenciesCommand);
         const copyCommand = `cp -r node_modules/coda-packs-examples/examples/template/* ${process.cwd()}`;
         spawnProcess(copyCommand);


### PR DESCRIPTION
`coda init` will now also install the necessary npm packages for developing a pack, and will save them as dev dependencies in your project folder. Also, will no longer copy the template folder but only its underlying contents.

Not sure if we should adhere strictly to the versions in packs-examples, or if just installing the latest versions are ok.