### PR TITLE
Add formulaNamespace to PackMetadata

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -28,6 +28,7 @@ export interface PackFormulasMetadata {
 /** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
 export type PackMetadata = Omit<PackDefinition, 'formulas' | 'formats' | 'defaultAuthentication' | 'syncTables'> & {
   // TODO: @alan-fang once all packs are using formulaNamespace, delete PackFormulasMetadata.
+  formulaNamespace?: string;
   formulas: PackFormulasMetadata | PackFormulaMetadata[];
   formats: PackFormatMetadata[];
   syncTables: PackSyncTable[];

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -22,6 +22,7 @@ export interface PackFormulasMetadata {
 }
 /** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
 export declare type PackMetadata = Omit<PackDefinition, 'formulas' | 'formats' | 'defaultAuthentication' | 'syncTables'> & {
+    formulaNamespace?: string;
     formulas: PackFormulasMetadata | PackFormulaMetadata[];
     formats: PackFormatMetadata[];
     syncTables: PackSyncTable[];


### PR DESCRIPTION
There are a bunch of tests in my experimental PR that broke due to not having the formulaNamespace in the ExternalPackDefinition, so I think this is the right way to fix it? Not sure though, can discuss more if I'm wrong here.