### PR TITLE
Make formulaNamespace optional

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -202,6 +202,9 @@ export interface PackDefinition {
         [featureSet in FeatureSet]: Quota;
     }>;
     rateLimits?: RateLimits;
+    /**
+     * Required if formulas is specified.
+     */
     formulaNamespace?: string;
     /**
      * If specified, this pack requires system credentials to be set up via Coda's admin console in order to work when no

--- a/types.ts
+++ b/types.ts
@@ -260,7 +260,11 @@ export interface PackDefinition {
   minimumFeatureSet?: FeatureSet;
   quotas?: Partial<{[featureSet in FeatureSet]: Quota}>;
   rateLimits?: RateLimits;
+  /**
+   * Required if formulas is specified.
+   */
   formulaNamespace?: string;
+
   /**
    * If specified, this pack requires system credentials to be set up via Coda's admin console in order to work when no
    * explicit connection is specified by the user.


### PR DESCRIPTION
@codajonathan I think this makes sense based on the feedback from the last PR. No point in requiring a formulaNamespace for packs without formulas. 