### PR TITLE
make format.formulaNamespace optional

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -134,7 +134,7 @@ export declare type Authentication = NoAuthentication | HeaderBearerTokenAuthent
 export declare type SystemAuthentication = HeaderBearerTokenAuthentication | CustomHeaderTokenAuthentication | QueryParamTokenAuthentication | MultiQueryParamTokenAuthentication | WebBasicAuthentication | AWSSignature4Authentication;
 export interface Format {
     name: string;
-    formulaNamespace: string;
+    formulaNamespace?: string;
     formulaName: string;
     hasNoConnection?: boolean;
     instructions?: string;

--- a/types.ts
+++ b/types.ts
@@ -186,7 +186,7 @@ export type SystemAuthentication =
 
 export interface Format {
   name: string;
-  formulaNamespace: string;
+  formulaNamespace?: string;
   formulaName: string;
   hasNoConnection?: boolean;
   instructions?: string;


### PR DESCRIPTION
I think I need to merge this before removing it entirely because https://github.com/kr-project/packs/pull/2117 fails on `make validate-version-changes` with:

```
Error: Missing a finding for property "formulaNamespace". Is this a new property?
    at getFinding (/home/circleci/repo/tools/validator/diff_pack_metadata.ts:707:11)
    at getFindingsForDiff (/home/circleci/repo/tools/validator/diff_pack_metadata.ts:694:21)
    at diffFormats (/home/circleci/repo/tools/validator/diff_pack_metadata.ts:415:28)
    at Object.diffPackMetadata (/home/circleci/repo/tools/validator/diff_pack_metadata.ts:351:3)
    at diffMetadata (/home/circleci/repo/tools/validator/diff_packs.ts:87:20)
    at diffProposedPackVersion (/home/circleci/repo/tools/validator/diff_packs.ts:66:7)
    at Object.diffPacks (/home/circleci/repo/tools/validator/diff_packs.ts:31:7)
    at /home/circleci/repo/tools/validator/main.ts:39:5
    at Generator.next (<anonymous>)
    at /home/circleci/repo/tools/validator/main.ts:8:71
make: *** [Makefile:175: validate-version-changes] Error 1
```