### PR TITLE
Revert "Remove Policy from SDK."

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -7,6 +7,7 @@ export type { Format } from './types';
 export { PackCategory } from './types';
 export type { PackDefinition } from './types';
 export type { PackId } from './types';
+export type { Policy } from './types';
 export type { ProviderDefinition } from './types';
 export type { ProviderId } from './types';
 export type { Quota } from './types';

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -143,6 +143,10 @@ export interface Format {
     matchers?: RegExp[];
     placeholder?: string;
 }
+export interface Policy {
+    name: string;
+    url: string;
+}
 export declare enum FeatureSet {
     Basic = "Basic",
     Pro = "Pro",
@@ -207,6 +211,7 @@ export interface PackDefinition {
     systemConnectionAuthentication?: SystemAuthentication;
     formulas?: PackFormulas | TypedStandardFormula[];
     formats?: Format[];
+    policies?: Policy[];
     syncTables?: SyncTable[];
     /**
      * Whether this is a pack that will be used by Coda internally and not exposed directly to users.

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export type {Format} from './types';
 export {PackCategory} from './types';
 export type {PackDefinition} from './types';
 export type {PackId} from './types';
+export type {Policy} from './types';
 export type {ProviderDefinition} from './types';
 export type {ProviderId} from './types';
 export type {Quota} from './types';

--- a/types.ts
+++ b/types.ts
@@ -196,6 +196,11 @@ export interface Format {
   placeholder?: string;
 }
 
+export interface Policy {
+  name: string;
+  url: string;
+}
+
 export enum FeatureSet {
   Basic = 'Basic',
   Pro = 'Pro',
@@ -266,6 +271,7 @@ export interface PackDefinition {
   // User-facing components
   formulas?: PackFormulas | TypedStandardFormula[];
   formats?: Format[];
+  policies?: Policy[];
   syncTables?: SyncTable[];
   /**
    * Whether this is a pack that will be used by Coda internally and not exposed directly to users.


### PR DESCRIPTION
Temporarily reverts kr-project/packs-sdk#728. We need to first migrate all packs away from using policy, so that make validate in packs stops detecting policy and complaining. Then we can remove it again.