### PR TITLE
Generalize PostSetup

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -46,14 +46,15 @@ export interface NoAuthentication {
     type: AuthenticationType.None;
 }
 export interface SetEndpoint {
+    type: PostSetupType.SetEndpoint;
     name: 'endpoint';
     description: string;
     getOptionsFormula: MetadataFormula;
 }
 export declare enum PostSetupType {
-    SetEndpoint = 0
+    SetEndpoint = "SetEndPoint"
 }
-export declare type PostSetup = PostSetupType;
+export declare type PostSetup = SetEndpoint;
 interface BaseAuthentication {
     getConnectionName?: MetadataFormula;
     getConnectionUserId?: MetadataFormula;

--- a/dist/types.js
+++ b/dist/types.js
@@ -41,7 +41,7 @@ var DefaultConnectionType;
 })(DefaultConnectionType = exports.DefaultConnectionType || (exports.DefaultConnectionType = {}));
 var PostSetupType;
 (function (PostSetupType) {
-    PostSetupType[PostSetupType["SetEndpoint"] = 0] = "SetEndpoint";
+    PostSetupType["SetEndpoint"] = "SetEndPoint";
 })(PostSetupType = exports.PostSetupType || (exports.PostSetupType = {}));
 var FeatureSet;
 (function (FeatureSet) {

--- a/types.ts
+++ b/types.ts
@@ -52,16 +52,18 @@ export interface NoAuthentication {
 }
 
 export interface SetEndpoint {
+  type: PostSetupType.SetEndpoint;
+  // TODO: Remove after experimental uses `type`.
   name: 'endpoint';
   description: string;
   getOptionsFormula: MetadataFormula;
 }
 
 export enum PostSetupType {
-  SetEndpoint,
+  SetEndpoint = 'SetEndPoint',
 }
 
-export type PostSetup = PostSetupType;
+export type PostSetup = SetEndpoint;
 
 interface BaseAuthentication {
   getConnectionName?: MetadataFormula;


### PR DESCRIPTION
Generalizes PostSetup to handle different post setup options without changing Pack definitions themselves. Then when we add a new post-setup step, we just add it to the Union type `PostSetup` and add the appropriate wiring in experimental.