### PR TITLE
Use an absolute path in the setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ npm install --save git+ssh://github.com/kr-project/packs-sdk.git
 Update your path so you can easily use the `coda` commandline (CLI) that ships with the SDK:
 
 ```bash
-export PATH=./node_modules/.bin:$PATH
+# Make sure to run this from the root directory of your project.
+export PATH=$(pwd)/node_modules/.bin:$PATH
 ```
 
 (Globally-installed npm packages link CLI scripts into your system path. Locally installed packages


### PR DESCRIPTION
Punit tried to run `coda` from other directories and it didn't work because the command had him add a relative directory to his path.

There are a few other things that may not work when run from the root directory, I think it's fine if we can't fix them all but we should probably try to detect and report that as the error.

PTAL @huayang-coda @alan-fang @coda-hq/ecosystem 