### PR TITLE
Wrap fetcher errors with a more helpful message.

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -141,7 +141,7 @@ function spawnProcess(command: string) {
   // Hack to allow us to run this CLI tool for testing purposes from within this repo, without
   // needing it installed as an npm package.
   if (process.argv[1].endsWith('coda.ts')) {
-    cmd = command.replace('coda-packs-sdk/dist', '.');
+    cmd = command.replace('coda-packs-sdk/dist', process.env.PWD!);
   }
 
   return spawnSync(cmd, {

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -149,7 +149,7 @@ function spawnProcess(command) {
     // Hack to allow us to run this CLI tool for testing purposes from within this repo, without
     // needing it installed as an npm package.
     if (process.argv[1].endsWith('coda.ts')) {
-        cmd = command.replace('coda-packs-sdk/dist', '.');
+        cmd = command.replace('coda-packs-sdk/dist', process.env.PWD);
     }
     return child_process_1.spawnSync(cmd, {
         shell: true,

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -26,8 +26,8 @@ export declare function executeFormulaOrSyncFromCLI({ formulaName, params: rawPa
     module: any;
     contextOptions?: ContextOptions;
 }): Promise<void>;
-export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<any[]>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<any[]>;
+export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<any[] | Error>;
+export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<any[] | Error>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;


### PR DESCRIPTION
If you run `coda execute` on a formula that uses the fetcher but you forget to add the `--fetch` flag, you get a mysterious and unhelpful message. This at least explains the situation and tells you what you likely need to do.

I actually think we may want to invert the behavior of the flag, and change it to --no_fetch or --mock_fetcher. I think it might be counterintuitive for developers that they have to do something extra to get things to work for real. May be worth the risk of people accidentally running an action formula for real.

Before:

```
TypeError: Cannot read property 'body' of undefined
    at /home/admin/src/packs-examples/examples/dictionary/formulas.ts:21:32
    at Generator.next (<anonymous>)
    at fulfilled (/home/admin/src/packs-examples/examples/dictionary/formulas.ts:24:58)
```

After:

```
TypeError: Cannot read property 'body' of undefined
This means your formula was invoked with a mock fetcher that had no response configured.
This usually means you invoked your formula from the commandline with `coda execute` but forgot to add the --fetch flag to actually fetch from the remote API.
    at /home/admin/src/packs-examples/examples/dictionary/formulas.ts:21:32
    at Generator.next (<anonymous>)
    at fulfilled (/home/admin/src/packs-examples/examples/dictionary/formulas.ts:24:58)
```

PTAL @huayang-coda @alan-fang @coda-hq/ecosystem 