### PR TITLE
Freeze url-parse at 1.4.7 for now.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,10 @@ updates:
       day: 'tuesday'
     open-pull-requests-limit: 50
     reviewers:
-      - "coda-hq/ecosystem"
+      - 'coda-hq/ecosystem'
+    ignore:
+      # This version broke parsing of relative urls without a base, removing the leading slash.
+      # This breaks the implementation of withQueryParams() if used with a relative url.
+      # We suspect they will need to undo these behavior in a future version.
+      - dependency-name: 'url-parse'
+        versions: ['1.5.0']

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "request-promise-native": "^1.0.9",
     "sinon": "9.2.4",
     "string-template": "^1.0.0",
-    "url-parse": "^1.4.7",
+    "url-parse": "~1.4.7",
     "uuid": "^8.3.2",
     "webpack": "^5.22.0",
     "xml2js": "^0.4.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,7 +3037,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@^1.4.7:
+url-parse@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
This was actually caught by dependabot trying to update the same package in the `packs` repo: https://github.com/coda-hq/packs/pull/2183.

Because the SDK declares url-parse as `^1.4.7`, when dependabot tried to bump the same package in the packs repo, it bumped the version that the SDK was transitively using because the new version number was compatible with our declaration.

It turns out that that new version is totally busted, it breaks parsing of relative urls, removing the leading slash. This broke `withQueryParams()` within the SDK and any code in the `packs` repo that uses url-parse directly.

I think they're going to break a ton of people and are going to need to roll this back.

PTAL @huayang-coda @alan-fang @coda-hq/ecosystem 