### PR TITLE
[Sandbox] Export sync function return type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -61,6 +61,7 @@ export type { ParamsList } from './api_types';
 export { PrecannedDateRange } from './api_types';
 export { StatusCodeError } from './api';
 export type { SyncExecutionContext } from './api_types';
+export type { SyncFormulaResult } from './api';
 export type { SyncTableDef } from './api';
 export type { TemporaryBlobStorage } from './api_types';
 export { Type } from './api_types';

--- a/index.ts
+++ b/index.ts
@@ -68,6 +68,7 @@ export type {ParamsList} from './api_types';
 export {PrecannedDateRange} from './api_types';
 export {StatusCodeError} from './api';
 export type {SyncExecutionContext} from './api_types';
+export type {SyncFormulaResult} from './api';
 export type {SyncTableDef} from './api';
 export type {TemporaryBlobStorage} from './api_types';
 export {Type} from './api_types';


### PR DESCRIPTION
Would like to include this type in the result payload in the lambda bootstrap script.

PTAL @codajonathan @huayang-coda @alan-fang 