### PR TITLE
register execution context in the isolated-vm context

### DIFF
--- a/cli/execute_bundle.ts
+++ b/cli/execute_bundle.ts
@@ -17,6 +17,6 @@ export async function handleExecuteBundle({
     bundlePath,
     formulaName,
     params,
-    _contextOptions: {useRealFetcher: fetch, credentialsFile},
+    contextOptions: {useRealFetcher: fetch, credentialsFile},
   });
 }

--- a/dist/cli/execute_bundle.js
+++ b/dist/cli/execute_bundle.js
@@ -7,7 +7,7 @@ async function handleExecuteBundle({ bundlePath, formulaName, params, fetch, cre
         bundlePath,
         formulaName,
         params,
-        _contextOptions: { useRealFetcher: fetch, credentialsFile },
+        contextOptions: { useRealFetcher: fetch, credentialsFile },
     });
 }
 exports.handleExecuteBundle = handleExecuteBundle;

--- a/dist/testing/bundle_execution.d.ts
+++ b/dist/testing/bundle_execution.d.ts
@@ -2,9 +2,9 @@ import type { ContextOptions } from './execution';
 import type { Context as IVMContext } from 'isolated-vm';
 import type { Isolate } from 'isolated-vm';
 export declare function registerBundle(isolate: Isolate, context: IVMContext, path: string, stubName: string): Promise<void>;
-export declare function executeFormulaOrSyncFromBundle({ bundlePath, formulaName, params: rawParams, _contextOptions, }: {
+export declare function executeFormulaOrSyncFromBundle({ bundlePath, formulaName, params: rawParams, contextOptions: executionContextOptions, }: {
     bundlePath: string;
     formulaName: string;
     params: string[];
-    _contextOptions?: ContextOptions;
+    contextOptions?: ContextOptions;
 }): Promise<void>;


### PR DESCRIPTION
This PR sets up the execution context in the ivm context by copying over basic properties and mapping back fetcher/blobmanager/logger methods. 

```
> coda execute-bundle dist/bundles/1009/0.1.7/bundle.js Debug::ServerVersionHash prod
eba732f24d8e
```