### PR TITLE
Fix invalid zod import usage.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -31,7 +31,6 @@ const types_5 = require("../types");
 const schema_4 = require("../schema");
 const api_types_1 = require("../api_types");
 const schema_5 = require("../schema");
-const ZodParsedType_1 = require("zod/lib/cjs/ZodParsedType");
 const ensure_1 = require("../helpers/ensure");
 const object_utils_1 = require("../helpers/object_utils");
 const z = __importStar(require("zod"));
@@ -81,8 +80,8 @@ function zodErrorDetailToValidationError(subError) {
     const { path: zodPath, message } = subError;
     const path = zodPathToPathString(zodPath);
     const isMissingRequiredFieldError = subError.code === z.ZodIssueCode.invalid_type &&
-        subError.received === ZodParsedType_1.ZodParsedType.undefined &&
-        subError.expected.toString() !== ZodParsedType_1.ZodParsedType.undefined;
+        subError.received === 'undefined' &&
+        subError.expected.toString() !== 'undefined';
     return {
         path,
         message: isMissingRequiredFieldError ? `Missing required field ${path}.` : message,

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -34,7 +34,6 @@ import {Type} from '../api_types';
 import type {ValidationError} from './types';
 import {ValueType} from '../schema';
 import type {WebBasicAuthentication} from '../types';
-import {ZodParsedType} from 'zod/lib/cjs/ZodParsedType';
 import {assertCondition} from '../helpers/ensure';
 import {isNil} from '../helpers/object_utils';
 import * as z from 'zod';
@@ -97,8 +96,8 @@ function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError 
   const path = zodPathToPathString(zodPath);
   const isMissingRequiredFieldError =
     subError.code === z.ZodIssueCode.invalid_type &&
-    subError.received === ZodParsedType.undefined &&
-    subError.expected.toString() !== ZodParsedType.undefined;
+    subError.received === 'undefined' &&
+    subError.expected.toString() !== 'undefined';
 
   return {
     path,


### PR DESCRIPTION
I think `ZodParsedType` is just a type, so it can't be used as any object. Don't know why TS isn't catching this. Also the import from zod/lib/... is also invalid for some reason (in addition to it not being recommended to import things other than from index) and that is likely the source of the issue when running `coda`.

PTAL @alan-codaio @coda-hq/ecosystem 