### PR TITLE
change back to use ivm script

### DIFF
--- a/dist/testing/bundle_execution.d.ts
+++ b/dist/testing/bundle_execution.d.ts
@@ -1,6 +1,7 @@
 import type { ContextOptions } from './execution';
 import type { Context as IVMContext } from 'isolated-vm';
-export declare function registerBundle(context: IVMContext, path: string, stubName: string): Promise<void>;
+import ivm from 'isolated-vm';
+export declare function registerBundle(isolate: ivm.Isolate, context: IVMContext, path: string, stubName: string): Promise<void>;
 export declare function executeFormulaOrSyncFromBundle({ bundlePath, formulaName, params: rawParams, contextOptions: executionContextOptions, }: {
     bundlePath: string;
     formulaName: string;

--- a/test/bundle_execution_helper_test.ts
+++ b/test/bundle_execution_helper_test.ts
@@ -34,6 +34,6 @@ describe('Bundle Execution Helper', () => {
     const jail = ivmContext.global;
     await jail.set('test', undefined, {copy: true});
   
-    await registerBundle(ivmContext, outputFilePath, 'test');
+    await registerBundle(isolate, ivmContext, outputFilePath, 'test');
   });
 });


### PR DESCRIPTION
Sorry I quickly regret after merging https://github.com/coda-hq/packs-sdk/pull/875. It's impossible to live without error stack. 

After playing with a few ideas, I figured out that manually wrapping the script source with a closure could avoid the variables leak to global scope in the ivm script execution. 
