### PR TITLE
Bump zod from 3.0.0-alpha.4 to 3.0.0-alpha.30

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -58,21 +58,12 @@ function zodErrorDetailToValidationError(subError) {
     if (subError.code === z.ZodIssueCode.invalid_union) {
         const underlyingErrors = [];
         for (const unionError of subError.unionErrors) {
-            const isNonmatchedUnionMember = unionError.issues.some(issue => issue.code === z.ZodIssueCode.invalid_literal_value);
-            // Skip any errors that are nested with an "invalid literal" error that is usually
-            // a failed discriminant match; we don't care about reporting any errors from this union
-            // member if the discriminant didn't match.
-            if (isNonmatchedUnionMember) {
-                continue;
-            }
             for (const unionIssue of unionError.issues) {
-                if (unionIssue.code !== z.ZodIssueCode.invalid_literal_value) {
-                    const error = {
-                        path: zodPathToPathString(unionIssue.path),
-                        message: unionIssue.message,
-                    };
-                    underlyingErrors.push(error);
-                }
+                const error = {
+                    path: zodPathToPathString(unionIssue.path),
+                    message: unionIssue.message,
+                };
+                underlyingErrors.push(error);
             }
         }
         return underlyingErrors;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack": "^5.27.2",
     "xml2js": "^0.4.23",
     "yargs": "^16.2.0",
-    "zod": "^3.0.0-alpha.4"
+    "zod": "^3.0.0-alpha.30"
   },
   "devDependencies": {
     "@types/chai": "^4.2.15",

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -70,23 +70,12 @@ function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError 
   if (subError.code === z.ZodIssueCode.invalid_union) {
     const underlyingErrors: ValidationError[] = [];
     for (const unionError of subError.unionErrors) {
-      const isNonmatchedUnionMember = unionError.issues.some(
-        issue => issue.code === z.ZodIssueCode.invalid_literal_value,
-      );
-      // Skip any errors that are nested with an "invalid literal" error that is usually
-      // a failed discriminant match; we don't care about reporting any errors from this union
-      // member if the discriminant didn't match.
-      if (isNonmatchedUnionMember) {
-        continue;
-      }
       for (const unionIssue of unionError.issues) {
-        if (unionIssue.code !== z.ZodIssueCode.invalid_literal_value) {
-          const error: ValidationError = {
-            path: zodPathToPathString(unionIssue.path),
-            message: unionIssue.message,
-          };
-          underlyingErrors.push(error);
-        }
+        const error: ValidationError = {
+          path: zodPathToPathString(unionIssue.path),
+          message: unionIssue.message,
+        };
+        underlyingErrors.push(error);
       }
     }
     return underlyingErrors;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3288,7 +3288,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.0.0-alpha.4:
-  version "3.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.0.0-alpha.4.tgz#530efd89f292c5840f9d8b0854427948b0314649"
-  integrity sha512-pOtx1/JRT4NQ3K0wlnVAFDMY6Kvsb0xIMZvAaVzZBDUFKUS6OgZtrztcpI5NqCB4KMexcbgXgKxgpOpia9SFSw==
+zod@^3.0.0-alpha.30:
+  version "3.0.0-alpha.30"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.0.0-alpha.30.tgz#1300055e77bb1e7e5979486815aabe9d3b1c7b80"
+  integrity sha512-B2Pz+P0hZkdo9HzAT9oysa6CsA9/X3Bg0ZZzheTqb7X3aSI8jspcFxo5s9s319Sa00wm0XyY3GpTQZsUu5/Cmg==


### PR DESCRIPTION
Looks like the `invalid_literal_value` error was removed entirely in https://github.com/colinhacks/zod/commit/3712ba3491900d7eb8d8074080a3e597e138be17.