### PR TITLE
Don't import file on coda build

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -22,11 +22,9 @@ export async function handleBuild({manifestFile, compiler}: Arguments<BuildArgs>
 }
 
 export async function build(manifestFile: string, compiler?: string): Promise<string> {
-  // TODO(alan): surface more helpful error messages when import manifestFile fails.
-  const {manifest} = await import(manifestFile);
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coda-packs-'));
 
-  const bundleFilename = path.join(tempDir, `bundle-${manifest.id}-${manifest.version}.js`);
+  const bundleFilename = path.join(tempDir, `bundle.js`);
   const logger = new ConsoleLogger();
 
   switch (compiler) {

--- a/dist/cli/build.js
+++ b/dist/cli/build.js
@@ -39,10 +39,8 @@ async function handleBuild({ manifestFile, compiler }) {
 }
 exports.handleBuild = handleBuild;
 async function build(manifestFile, compiler) {
-    // TODO(alan): surface more helpful error messages when import manifestFile fails.
-    const { manifest } = await Promise.resolve().then(() => __importStar(require(manifestFile)));
     const tempDir = fs_1.default.mkdtempSync(path_1.default.join(os_1.default.tmpdir(), 'coda-packs-'));
-    const bundleFilename = path_1.default.join(tempDir, `bundle-${manifest.id}-${manifest.version}.js`);
+    const bundleFilename = path_1.default.join(tempDir, `bundle.js`);
     const logger = new logging_1.ConsoleLogger();
     switch (compiler) {
         case Compiler.webpack:


### PR DESCRIPTION
The bundled file was only temporarily used so there's no need to name it with the manifest id and version anyways.