### PR TITLE
Add setLive cli command

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -10,6 +10,7 @@ import {handleExecute} from './execute';
 import {handleInit} from './init';
 import {handlePublish} from './publish';
 import {handleRegister} from './register';
+import {handleSetLive} from './set_live';
 import {handleValidate} from './validate';
 import yargs from 'yargs';
 
@@ -28,7 +29,8 @@ if (require.main === module) {
         } as Options,
         vm: {
           boolean: true,
-          desc: 'Execute the requested command in a virtual machine that mimics the environment Coda uses to execute Packs.',
+          desc:
+            'Execute the requested command in a virtual machine that mimics the environment Coda uses to execute Packs.',
         } as Options,
         credentialsFile: {
           alias: 'credentials_file',
@@ -114,6 +116,18 @@ if (require.main === module) {
       command: 'validate <manifestFile>',
       describe: 'Validate your Pack definition',
       handler: handleValidate,
+    })
+    .command({
+      command: 'setLive <packId> <packVersion>',
+      describe: 'Set the Pack version that is installable for users.',
+      builder: {
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: 'https://coda.io',
+        } as Options,
+      },
+      handler: handleSetLive,
     })
     .demandCommand()
     .strict()

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -33,7 +33,7 @@ export async function createPack(packName: string, codaApiEndpoint: string) {
   const codaClient = createCodaClient(apiKey, formattedEndpoint);
   let packId: number;
   try {
-    const response = await codaClient.createPack();
+    const response = await codaClient.createPack({}, {});
     packId = response.packId;
   } catch (err) {
     // TODO(alan): pressure test with errors

--- a/cli/set_live.ts
+++ b/cli/set_live.ts
@@ -1,0 +1,30 @@
+import type {Arguments} from 'yargs';
+import {createCodaClient} from './helpers';
+import {formatEndpoint} from './helpers';
+import {getApiKey} from './helpers';
+import {printAndExit} from '../testing/helpers';
+
+interface SetLiveArgs {
+  packId: number;
+  packVersion: string;
+  codaApiEndpoint: string;
+}
+
+export async function handleSetLive({packId, packVersion, codaApiEndpoint}: Arguments<SetLiveArgs>) {
+  const apiKey = getApiKey();
+  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
+
+  if (!apiKey) {
+    printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+  }
+
+  const codaClient = createCodaClient(apiKey, formattedEndpoint);
+  try {
+    await codaClient.setPackLiveVersion(packId, {}, {packVersion});
+  } catch (err) {
+    const {statusCode, message} = JSON.parse(err.error);
+    printAndExit(`Could not set the pack version: ${statusCode} ${message}`);
+  }
+
+  printAndExit('Success!');
+}

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -13,6 +13,7 @@ const execute_1 = require("./execute");
 const init_1 = require("./init");
 const publish_1 = require("./publish");
 const register_1 = require("./register");
+const set_live_1 = require("./set_live");
 const validate_1 = require("./validate");
 const yargs_1 = __importDefault(require("yargs"));
 if (require.main === module) {
@@ -116,6 +117,18 @@ if (require.main === module) {
         command: 'validate <manifestFile>',
         describe: 'Validate your Pack definition',
         handler: validate_1.handleValidate,
+    })
+        .command({
+        command: 'setLive <packId> <packVersion>',
+        describe: 'Set the Pack version that is installable for users.',
+        builder: {
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: 'https://coda.io',
+            },
+        },
+        handler: set_live_1.handleSetLive,
     })
         .demandCommand()
         .strict()

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -23,7 +23,7 @@ async function createPack(packName, codaApiEndpoint) {
     const codaClient = helpers_1.createCodaClient(apiKey, formattedEndpoint);
     let packId;
     try {
-        const response = await codaClient.createPack();
+        const response = await codaClient.createPack({}, {});
         packId = response.packId;
     }
     catch (err) {

--- a/dist/cli/set_live.d.ts
+++ b/dist/cli/set_live.d.ts
@@ -1,0 +1,8 @@
+import type { Arguments } from 'yargs';
+interface SetLiveArgs {
+    packId: number;
+    packVersion: string;
+    codaApiEndpoint: string;
+}
+export declare function handleSetLive({ packId, packVersion, codaApiEndpoint }: Arguments<SetLiveArgs>): Promise<void>;
+export {};

--- a/dist/cli/set_live.js
+++ b/dist/cli/set_live.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleSetLive = void 0;
+const helpers_1 = require("./helpers");
+const helpers_2 = require("./helpers");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("../testing/helpers");
+async function handleSetLive({ packId, packVersion, codaApiEndpoint }) {
+    const apiKey = helpers_3.getApiKey();
+    const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
+    if (!apiKey) {
+        helpers_4.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+    }
+    const codaClient = helpers_1.createCodaClient(apiKey, formattedEndpoint);
+    try {
+        await codaClient.setPackLiveVersion(packId, {}, { packVersion });
+    }
+    catch (err) {
+        const { statusCode, message } = JSON.parse(err.error);
+        helpers_4.printAndExit(`Could not set the pack version: ${statusCode} ${message}`);
+    }
+    helpers_4.printAndExit('Success!');
+}
+exports.handleSetLive = handleSetLive;

--- a/dist/helpers/external-api/coda.d.ts
+++ b/dist/helpers/external-api/coda.d.ts
@@ -3,7 +3,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: d7c3f53287ba26554cc58614e4870ec5bfd5328139ef564e67517bd0411267a6
+ * Hash: c6876c1f07a4e420a1a6542ebec6cff3a9be3c4e3a9bf481065fa87d7893d5f5
  */
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
@@ -59,6 +59,7 @@ export declare class Client {
         useColumnNames?: boolean;
         valueFormat?: types.PublicApiValueFormat;
         visibleOnly?: boolean;
+        syncToken?: string;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiRowList>;
@@ -111,7 +112,11 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiGetWorkspaceRoleActivity>;
-    createPack(params?: {}): Promise<types.PublicApiCreatePackResponse>;
+    createPack(params: {} | undefined, payload: types.PublicApiCreatePackRequest): Promise<types.PublicApiCreatePackResponse>;
+    updatePack(packId: number, params: {} | undefined, payload: types.PublicApiUpdatePackRequest): Promise<types.PublicApiPack>;
     registerPackVersion(packId: number, packVersion: string, params?: {}): Promise<types.PublicApiPackVersionUploadInfo>;
     packVersionUploadComplete(packId: number, packVersion: string, params?: {}): Promise<types.PublicApiCreatePackVersionResponse>;
+    setPackLiveVersion(packId: number, params: {} | undefined, payload: types.PublicApiSetPackLiveVersion): Promise<types.PublicApiSetPackLiveVersionResponse>;
+    addPackPermission(packId: number, params: {} | undefined, payload: types.PublicApiAddPackPermissionRequest): Promise<types.PublicApiAddPackPermissionResponse>;
+    deletePackPermission(packId: number, permissionId: string, params?: {}): Promise<types.PublicApiDeletePackPermissionResponse>;
 }

--- a/dist/helpers/external-api/coda.js
+++ b/dist/helpers/external-api/coda.js
@@ -5,7 +5,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: d7c3f53287ba26554cc58614e4870ec5bfd5328139ef564e67517bd0411267a6
+ * Hash: c6876c1f07a4e420a1a6542ebec6cff3a9be3c4e3a9bf481065fa87d7893d5f5
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Client = void 0;
@@ -577,7 +577,7 @@ class Client {
         });
         return response.json();
     }
-    async createPack(params = {}) {
+    async createPack(params = {}, payload) {
         const allParams = {
             ...params,
         };
@@ -589,6 +589,23 @@ class Client {
                 'User-Agent': this.userAgent,
             },
             method: 'POST',
+            body: JSON.stringify(payload),
+        });
+        return response.json();
+    }
+    async updatePack(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = url_1.withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
+        const response = await fetch(codaUrl, {
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent,
+            },
+            method: 'PATCH',
+            body: JSON.stringify(payload),
         });
         return response.json();
     }
@@ -619,6 +636,53 @@ class Client {
                 'User-Agent': this.userAgent,
             },
             method: 'POST',
+        });
+        return response.json();
+    }
+    async setPackLiveVersion(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = url_1.withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}/liveVersion`, allParams);
+        const response = await fetch(codaUrl, {
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent,
+            },
+            method: 'PUT',
+            body: JSON.stringify(payload),
+        });
+        return response.json();
+    }
+    async addPackPermission(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = url_1.withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions`, allParams);
+        const response = await fetch(codaUrl, {
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent,
+            },
+            method: 'PUT',
+            body: JSON.stringify(payload),
+        });
+        return response.json();
+    }
+    async deletePackPermission(packId, permissionId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = url_1.withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions/${permissionId}`, allParams);
+        const response = await fetch(codaUrl, {
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent,
+            },
+            method: 'DELETE',
         });
         return response.json();
     }

--- a/dist/helpers/external-api/v1.d.ts
+++ b/dist/helpers/external-api/v1.d.ts
@@ -1,8 +1,8 @@
 /**
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
-export declare const OpenApiSpecHash = "d7c3f53287ba26554cc58614e4870ec5bfd5328139ef564e67517bd0411267a6";
-export declare const OpenApiSpecVersion = "1.1.0";
+export declare const OpenApiSpecHash = "c6876c1f07a4e420a1a6542ebec6cff3a9be3c4e3a9bf481065fa87d7893d5f5";
+export declare const OpenApiSpecVersion = "1.2.0";
 /**
  * A constant identifying the type of the resource.
  */
@@ -22,7 +22,8 @@ export declare enum PublicApiType {
     MutationStatus = "mutationStatus",
     Workspace = "workspace",
     Pack = "pack",
-    PackVersion = "packVersion"
+    PackVersion = "packVersion",
+    PackAclPermissions = "packAclPermissions"
 }
 /**
  * Type of principal.
@@ -549,6 +550,19 @@ export interface PublicApiDocumentMutateResponse {
     requestId: string;
 }
 /**
+ * Detail about why a particular field failed request validation.
+ */
+export interface PublicApiValidationError {
+    /**
+     * A path indicating the affected field, in OGNL notation.
+     */
+    path: string;
+    /**
+     * An error message.
+     */
+    message: string;
+}
+/**
  * Reference to a table or view.
  */
 export interface PublicApiTableReference {
@@ -773,6 +787,13 @@ export declare type PublicApiDateColumnFormat = PublicApiSimpleColumnFormat & {
     format?: string;
 };
 /**
+ * Format of an email column.
+ */
+export declare type PublicApiEmailColumnFormat = PublicApiSimpleColumnFormat & {
+    iconOnly?: boolean;
+    suggestedDomains?: string;
+};
+/**
  * Format of a time column.
  */
 export declare type PublicApiTimeColumnFormat = PublicApiSimpleColumnFormat & {
@@ -860,7 +881,7 @@ export declare type PublicApiScaleColumnFormat = PublicApiSimpleColumnFormat & {
 /**
  * Format of a column.
  */
-export declare type PublicApiColumnFormat = PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
+export declare type PublicApiColumnFormat = PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiEmailColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
 /**
  * Format type of the column
  */
@@ -875,6 +896,7 @@ export declare enum PublicApiColumnFormatType {
     DateTime = "dateTime",
     Time = "time",
     Duration = "duration",
+    Email = "email",
     Slider = "slider",
     Scale = "scale",
     Image = "image",
@@ -883,6 +905,7 @@ export declare enum PublicApiColumnFormatType {
     Checkbox = "checkbox",
     Select = "select",
     PackObject = "packObject",
+    Reaction = "reaction",
     Other = "other"
 }
 /**
@@ -997,6 +1020,7 @@ export interface PublicApiRowList {
     href?: string;
     nextPageToken?: PublicApiNextPageToken;
     nextPageLink?: PublicApiNextPageLink & string;
+    nextSyncToken?: PublicApiNextSyncToken;
 }
 /**
  * A Coda result or entity expressed as a primitive type.
@@ -1220,7 +1244,12 @@ export interface PublicApiRowsUpsert {
 /**
  * The result of a rows insert/upsert operation.
  */
-export declare type PublicApiRowsUpsertResult = PublicApiDocumentMutateResponse;
+export declare type PublicApiRowsUpsertResult = PublicApiDocumentMutateResponse & {
+    /**
+     * Row IDs for rows that will be added. Only applicable when keyColumns is not set or empty.
+     */
+    addedRowIds?: string[];
+};
 /**
  * The result of a row deletion.
  */
@@ -1235,7 +1264,8 @@ export declare type PublicApiRowDeleteResult = PublicApiDocumentMutateResponse &
  */
 export declare enum PublicApiRowsSortBy {
     CreatedAt = "createdAt",
-    Natural = "natural"
+    Natural = "natural",
+    UpdatedAt = "updatedAt"
 }
 /**
  * The format that cell values are returned as.
@@ -1372,7 +1402,8 @@ export declare enum PublicApiControlType {
     Multiselect = "multiselect",
     Select = "select",
     Scale = "scale",
-    Slider = "slider"
+    Slider = "slider",
+    Reaction = "reaction"
 }
 /**
  * Info about the user.
@@ -1416,6 +1447,11 @@ export declare type PublicApiNextPageToken = string;
  * If specified, a link that can be used to fetch the next page of results.
  */
 export declare type PublicApiNextPageLink = string;
+/**
+ * If specified, an opaque token that can be passed back later to retrieve new results that match the parameters specified when the sync token was created.
+ *
+ */
+export declare type PublicApiNextSyncToken = string;
 /**
  * Info about a resolved link to an API resource.
  */
@@ -1738,39 +1774,151 @@ export interface PublicApiDocAnalyticsCollection {
     nextPageLink?: PublicApiNextPageLink & string;
 }
 /**
- * Info about a pack that was just created.
+ * Payload for creating a Pack.
+ */
+export interface PublicApiCreatePackRequest {
+    /**
+     * The parent workspace for the Pack. If unspecified, the user's default workspace will be used.
+     */
+    workspaceId?: string;
+}
+/**
+ * Info about a Pack that was just created.
  */
 export interface PublicApiCreatePackResponse {
     /**
-     * The id assigned to the newly-created pack.
+     * The ID assigned to the newly-created Pack.
      */
     packId: number;
 }
 /**
- * Information indicating where to upload the pack version definition.
+ * Payload for updating a Pack.
+ */
+export interface PublicApiUpdatePackRequest {
+    /**
+     * Rate limit in Pack settings.
+     */
+    overallRateLimit?: {
+        /**
+         * The rate limit interval in seconds.
+         */
+        intervalSeconds: number;
+        /**
+         * The maximum number of Pack operations that can be performed in a given interval.
+         */
+        operationsPerInterval: number;
+    } | null;
+    /**
+     * Rate limit in Pack settings.
+     */
+    perConnectionRateLimit?: {
+        /**
+         * The rate limit interval in seconds.
+         */
+        intervalSeconds: number;
+        /**
+         * The maximum number of Pack operations that can be performed in a given interval.
+         */
+        operationsPerInterval: number;
+    } | null;
+}
+/**
+ * Metadata of a Pack.
+ */
+export interface PublicApiPack {
+    /**
+     * ID of the Pack.
+     */
+    id: number;
+    overallRateLimit?: PublicApiPackRateLimit;
+    perConnectionRateLimit?: PublicApiPackRateLimit;
+}
+/**
+ * Rate limit in Pack settings.
+ */
+export interface PublicApiPackRateLimit {
+    /**
+     * The rate limit interval in seconds.
+     */
+    intervalSeconds: number;
+    /**
+     * The maximum number of Pack operations that can be performed in a given interval.
+     */
+    operationsPerInterval: number;
+}
+/**
+ * Information indicating where to upload the Pack version definition.
  */
 export interface PublicApiPackVersionUploadInfo {
     /**
-     * A signed url to be used for uploading a pack version definition.
+     * A signed url to be used for uploading a Pack version definition.
      */
     uploadUrl: string;
 }
 /**
- * Confirmation of successful pack version creation.
+ * Payload for setting a Pack version live.
+ */
+export interface PublicApiSetPackLiveVersion {
+    /**
+     * The version of the Pack.
+     */
+    packVersion: string;
+}
+/**
+ * Confirmation of successful Pack version creation.
  */
 export interface PublicApiCreatePackVersionResponse {
 }
 /**
- * An error when trying to create a new pack version.
+ * Confirmation of successfully setting a Pack version live.
  */
-export declare type PublicApiCreatePackVersionError = PublicApiInvalidMetadataError | PublicApiInvalidSemanticVersionError;
-/**
- * An error indicating that the pack version contained unparseable or invalid metadata.
- */
-export interface PublicApiInvalidMetadataError {
+export interface PublicApiSetPackLiveVersionResponse {
 }
 /**
- * An error indicating that the new semantic version is incompatible with the changes in the new pack definition.
+ * Type of Pack permissions.
  */
-export interface PublicApiInvalidSemanticVersionError {
+export declare enum PublicApiPackAclType {
+    User = "user",
+    Workspace = "workspace",
+    Anyone = "anyone"
+}
+/**
+ * Access type for a Pack.
+ */
+export declare enum PublicApiPackAcl {
+    View = "view",
+    Test = "test",
+    Edit = "edit"
+}
+export interface PublicApiPackUserAcl {
+    type: 'user';
+    packAcl: PublicApiPackAcl;
+    email: string;
+}
+export interface PublicApiPackWorkspaceAcl {
+    type: 'workspace';
+    packAcl: PublicApiPackAcl;
+    workspaceId: string;
+}
+export interface PublicApiPackGlobalAcl {
+    type: 'anyone';
+    packAcl: PublicApiPackAcl;
+}
+/**
+ * Payload for upserting Pack permissions.
+ */
+export declare type PublicApiAddPackPermissionRequest = PublicApiPackUserAcl | PublicApiPackWorkspaceAcl | PublicApiPackGlobalAcl;
+/**
+ * Confirmation of successfully upserting a Pack permission.
+ */
+export interface PublicApiAddPackPermissionResponse {
+    /**
+     * The ID of the permission created or updated.
+     */
+    permissionId: string;
+}
+/**
+ * Confirmation of successfully deleting a Pack permission.
+ */
+export interface PublicApiDeletePackPermissionResponse {
 }

--- a/dist/helpers/external-api/v1.js
+++ b/dist/helpers/external-api/v1.js
@@ -3,10 +3,10 @@
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
+exports.PublicApiPackAcl = exports.PublicApiPackAclType = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
 /* eslint-disable */
-exports.OpenApiSpecHash = 'd7c3f53287ba26554cc58614e4870ec5bfd5328139ef564e67517bd0411267a6';
-exports.OpenApiSpecVersion = '1.1.0';
+exports.OpenApiSpecHash = 'c6876c1f07a4e420a1a6542ebec6cff3a9be3c4e3a9bf481065fa87d7893d5f5';
+exports.OpenApiSpecVersion = '1.2.0';
 /**
  * A constant identifying the type of the resource.
  */
@@ -28,6 +28,7 @@ var PublicApiType;
     PublicApiType["Workspace"] = "workspace";
     PublicApiType["Pack"] = "pack";
     PublicApiType["PackVersion"] = "packVersion";
+    PublicApiType["PackAclPermissions"] = "packAclPermissions";
 })(PublicApiType = exports.PublicApiType || (exports.PublicApiType = {}));
 /**
  * Type of principal.
@@ -144,6 +145,7 @@ var PublicApiColumnFormatType;
     PublicApiColumnFormatType["DateTime"] = "dateTime";
     PublicApiColumnFormatType["Time"] = "time";
     PublicApiColumnFormatType["Duration"] = "duration";
+    PublicApiColumnFormatType["Email"] = "email";
     PublicApiColumnFormatType["Slider"] = "slider";
     PublicApiColumnFormatType["Scale"] = "scale";
     PublicApiColumnFormatType["Image"] = "image";
@@ -152,6 +154,7 @@ var PublicApiColumnFormatType;
     PublicApiColumnFormatType["Checkbox"] = "checkbox";
     PublicApiColumnFormatType["Select"] = "select";
     PublicApiColumnFormatType["PackObject"] = "packObject";
+    PublicApiColumnFormatType["Reaction"] = "reaction";
     PublicApiColumnFormatType["Other"] = "other";
 })(PublicApiColumnFormatType = exports.PublicApiColumnFormatType || (exports.PublicApiColumnFormatType = {}));
 /**
@@ -181,6 +184,7 @@ var PublicApiRowsSortBy;
 (function (PublicApiRowsSortBy) {
     PublicApiRowsSortBy["CreatedAt"] = "createdAt";
     PublicApiRowsSortBy["Natural"] = "natural";
+    PublicApiRowsSortBy["UpdatedAt"] = "updatedAt";
 })(PublicApiRowsSortBy = exports.PublicApiRowsSortBy || (exports.PublicApiRowsSortBy = {}));
 /**
  * The format that cell values are returned as.
@@ -205,6 +209,7 @@ var PublicApiControlType;
     PublicApiControlType["Select"] = "select";
     PublicApiControlType["Scale"] = "scale";
     PublicApiControlType["Slider"] = "slider";
+    PublicApiControlType["Reaction"] = "reaction";
 })(PublicApiControlType = exports.PublicApiControlType || (exports.PublicApiControlType = {}));
 /**
  * Determines how the objects returned are sorted
@@ -224,3 +229,21 @@ var PublicApiWorkspaceUserRole;
     PublicApiWorkspaceUserRole["DocMaker"] = "DocMaker";
     PublicApiWorkspaceUserRole["Editor"] = "Editor";
 })(PublicApiWorkspaceUserRole = exports.PublicApiWorkspaceUserRole || (exports.PublicApiWorkspaceUserRole = {}));
+/**
+ * Type of Pack permissions.
+ */
+var PublicApiPackAclType;
+(function (PublicApiPackAclType) {
+    PublicApiPackAclType["User"] = "user";
+    PublicApiPackAclType["Workspace"] = "workspace";
+    PublicApiPackAclType["Anyone"] = "anyone";
+})(PublicApiPackAclType = exports.PublicApiPackAclType || (exports.PublicApiPackAclType = {}));
+/**
+ * Access type for a Pack.
+ */
+var PublicApiPackAcl;
+(function (PublicApiPackAcl) {
+    PublicApiPackAcl["View"] = "view";
+    PublicApiPackAcl["Test"] = "test";
+    PublicApiPackAcl["Edit"] = "edit";
+})(PublicApiPackAcl = exports.PublicApiPackAcl || (exports.PublicApiPackAcl = {}));

--- a/helpers/external-api/coda.ts
+++ b/helpers/external-api/coda.ts
@@ -4,14 +4,13 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: d7c3f53287ba26554cc58614e4870ec5bfd5328139ef564e67517bd0411267a6
+ * Hash: c6876c1f07a4e420a1a6542ebec6cff3a9be3c4e3a9bf481065fa87d7893d5f5
  */
 
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
 import {withQueryParams} from '../url';
 import * as types from './v1';
-
 export class Client {
   private readonly protocolAndHost: string;
   private readonly apiKey: string;
@@ -376,6 +375,7 @@ export class Client {
       useColumnNames?: boolean;
       valueFormat?: types.PublicApiValueFormat;
       visibleOnly?: boolean;
+      syncToken?: string;
       limit?: number;
       pageToken?: string;
     } = {},
@@ -825,7 +825,10 @@ export class Client {
     return response.json();
   }
 
-  async createPack(params: {} = {}): Promise<types.PublicApiCreatePackResponse> {
+  async createPack(
+    params: {} = {},
+    payload: types.PublicApiCreatePackRequest,
+  ): Promise<types.PublicApiCreatePackResponse> {
     const allParams = {
       ...params,
     };
@@ -837,6 +840,28 @@ export class Client {
         'User-Agent': this.userAgent,
       },
       method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    return response.json();
+  }
+
+  async updatePack(
+    packId: number,
+    params: {} = {},
+    payload: types.PublicApiUpdatePackRequest,
+  ): Promise<types.PublicApiPack> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
+    const response = await fetch(codaUrl, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        'User-Agent': this.userAgent,
+      },
+      method: 'PATCH',
+      body: JSON.stringify(payload),
     });
     return response.json();
   }
@@ -883,6 +908,71 @@ export class Client {
         'User-Agent': this.userAgent,
       },
       method: 'POST',
+    });
+    return response.json();
+  }
+
+  async setPackLiveVersion(
+    packId: number,
+    params: {} = {},
+    payload: types.PublicApiSetPackLiveVersion,
+  ): Promise<types.PublicApiSetPackLiveVersionResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}/liveVersion`, allParams);
+    const response = await fetch(codaUrl, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        'User-Agent': this.userAgent,
+      },
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+    return response.json();
+  }
+
+  async addPackPermission(
+    packId: number,
+    params: {} = {},
+    payload: types.PublicApiAddPackPermissionRequest,
+  ): Promise<types.PublicApiAddPackPermissionResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions`, allParams);
+    const response = await fetch(codaUrl, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        'User-Agent': this.userAgent,
+      },
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    });
+    return response.json();
+  }
+
+  async deletePackPermission(
+    packId: number,
+    permissionId: string,
+    params: {} = {},
+  ): Promise<types.PublicApiDeletePackPermissionResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/packs/${packId}/permissions/${permissionId}`,
+      allParams,
+    );
+    const response = await fetch(codaUrl, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        'User-Agent': this.userAgent,
+      },
+      method: 'DELETE',
     });
     return response.json();
   }


### PR DESCRIPTION
https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/Tasks_sugs3#V2-Tasks_tu4y4/r23&modal=true

Adds a new command: `coda setLive <packId> <packVersion>` to hit the endpoint to set a pack version live. The actual changes are pretty minimal, but there's extra files since I copied over our Typescript SDK client helper. (and some random lint changes)