### PR TITLE
Fixes for publish/validate.

### DIFF
--- a/cli/publish.ts
+++ b/cli/publish.ts
@@ -41,9 +41,9 @@ interface PublishArgs {
 export async function handlePublish({manifestFile, codaApiEndpoint}: Arguments<PublishArgs>) {
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
   const logger = new ConsoleLogger();
-  const {manifest} = await import(manifestFile);
   logger.info('Building Pack bundle...');
   const bundleFilename = await build(manifestFile);
+  const {manifest} = await import(bundleFilename);
 
   // Since package.json isn't in dist, we grab it from the root directory instead.
   const packageJson = await import(isTestCommand() ? '../package.json' : '../../package.json');

--- a/cli/validate.ts
+++ b/cli/validate.ts
@@ -1,4 +1,5 @@
 import type {Arguments} from 'yargs';
+import type {PackDefinition} from '../types';
 import type {PackMetadataValidationError} from '../testing/upload_validation';
 import {printAndExit} from '../testing/helpers';
 import {validatePackMetadata} from '../testing/upload_validation';
@@ -8,11 +9,11 @@ interface ValidateArgs {
 }
 
 export async function handleValidate({manifestFile}: Arguments<ValidateArgs>) {
-  return validateMetadata(manifestFile);
+  const {manifest} = await import(manifestFile);
+  return validateMetadata(manifest);
 }
 
-export async function validateMetadata(manifestFile: string) {
-  const {manifest} = await import(manifestFile);
+export async function validateMetadata(manifest: PackDefinition) {
   try {
     await validatePackMetadata(manifest);
   } catch (e: any) {

--- a/dist/cli/publish.js
+++ b/dist/cli/publish.js
@@ -40,9 +40,9 @@ const validate_1 = require("./validate");
 async function handlePublish({ manifestFile, codaApiEndpoint }) {
     const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
     const logger = new logging_1.ConsoleLogger();
-    const { manifest } = await Promise.resolve().then(() => __importStar(require(manifestFile)));
     logger.info('Building Pack bundle...');
     const bundleFilename = await build_1.build(manifestFile);
+    const { manifest } = await Promise.resolve().then(() => __importStar(require(bundleFilename)));
     // Since package.json isn't in dist, we grab it from the root directory instead.
     const packageJson = await Promise.resolve().then(() => __importStar(require(helpers_4.isTestCommand() ? '../package.json' : '../../package.json')));
     const codaPacksSDKVersion = packageJson.version;

--- a/dist/cli/validate.d.ts
+++ b/dist/cli/validate.d.ts
@@ -1,7 +1,8 @@
 import type { Arguments } from 'yargs';
+import type { PackDefinition } from '../types';
 interface ValidateArgs {
     manifestFile: string;
 }
 export declare function handleValidate({ manifestFile }: Arguments<ValidateArgs>): Promise<void>;
-export declare function validateMetadata(manifestFile: string): Promise<void>;
+export declare function validateMetadata(manifest: PackDefinition): Promise<void>;
 export {};

--- a/dist/cli/validate.js
+++ b/dist/cli/validate.js
@@ -23,12 +23,12 @@ exports.validateMetadata = exports.handleValidate = void 0;
 const helpers_1 = require("../testing/helpers");
 const upload_validation_1 = require("../testing/upload_validation");
 async function handleValidate({ manifestFile }) {
-    return validateMetadata(manifestFile);
+    const { manifest } = await Promise.resolve().then(() => __importStar(require(manifestFile)));
+    return validateMetadata(manifest);
 }
 exports.handleValidate = handleValidate;
-async function validateMetadata(manifestFile) {
+async function validateMetadata(manifest) {
     var _a;
-    const { manifest } = await Promise.resolve().then(() => __importStar(require(manifestFile)));
     try {
         await upload_validation_1.validatePackMetadata(manifest);
     }


### PR DESCRIPTION
* Only try to import the post-compiled manifest (solves all kinds of issues with TS vs JS, ES6-style imports, etc)
* Bug in bundle validation

PTAL @alan-codaio @coda-hq/ecosystem 