### PR TITLE
Use individual files for storing test credentials, located in the same directory as specified manifest.

### DIFF
--- a/cli/auth.ts
+++ b/cli/auth.ts
@@ -6,7 +6,6 @@ import {spawnBootstrapCommand} from './helpers';
 
 interface AuthArgs {
   manifestPath: string;
-  credentialsFile?: string;
   oauthServerPort?: number;
 }
 
@@ -15,23 +14,20 @@ import {setupAuthFromModule} from 'coda-packs-sdk/dist/testing/auth';
 
 async function main() {
   const manifestPath = process.argv[1];
-  const credentialsFile = process.argv[2] || undefined;
-  const oauthServerPort = process.argv[3] ? parseInt(process.argv[3]) : undefined;
+  const oauthServerPort = process.argv[2] ? parseInt(process.argv[2]) : undefined;
   const module = await import(manifestPath);
-  await setupAuthFromModule(module, {credentialsFile, oauthServerPort});
+  await setupAuthFromModule(manifestPath, module, {oauthServerPort});
 }
 
 void main();`;
 
-export async function handleAuth({manifestPath, credentialsFile, oauthServerPort}: Arguments<AuthArgs>) {
+export async function handleAuth({manifestPath, oauthServerPort}: Arguments<AuthArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestPath);
   if (isTypescript(manifestPath)) {
-    const tsCommand = `ts-node -e "${AUTH_BOOTSTRAP_CODE}" ${fullManifestPath} ${credentialsFile || '""'} ${
-      oauthServerPort || '""'
-    }`;
+    const tsCommand = `ts-node -e "${AUTH_BOOTSTRAP_CODE}" ${fullManifestPath} ${oauthServerPort || '""'}`;
     spawnBootstrapCommand(tsCommand);
   } else {
     const module = await import(fullManifestPath);
-    await setupAuthFromModule(module, {credentialsFile, oauthServerPort});
+    await setupAuthFromModule(fullManifestPath, module, {oauthServerPort});
   }
 }

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import {DEFAULT_CREDENTIALS_FILE} from '../testing/auth';
 import {DEFAULT_OAUTH_SERVER_PORT} from '../testing/auth';
 import type {Options} from 'yargs';
 import {handleAuth} from './auth';
@@ -32,12 +31,6 @@ if (require.main === module) {
           desc:
             'Execute the requested command in a virtual machine that mimics the environment Coda uses to execute Packs.',
         } as Options,
-        credentialsFile: {
-          alias: 'credentials_file',
-          string: true,
-          default: DEFAULT_CREDENTIALS_FILE,
-          desc: 'Path to the credentials file.',
-        } as Options,
       },
     })
     .command({
@@ -45,12 +38,6 @@ if (require.main === module) {
       describe: 'Set up authentication for a Pack',
       handler: handleAuth,
       builder: {
-        credentialsFile: {
-          alias: 'credentials_file',
-          string: true,
-          default: DEFAULT_CREDENTIALS_FILE,
-          desc: 'Path to the credentials file.',
-        } as Options,
         oauthServerPort: {
           alias: 'oauth_server_port',
           number: true,

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -2,7 +2,7 @@ import type {Arguments} from 'yargs';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
-import {getApiKey} from './helpers';
+import {getApiKey} from '../testing/auth';
 import {isCodaError} from './errors';
 import {printAndExit} from '../testing/helpers';
 import {readJSONFile} from '../testing/helpers';
@@ -27,7 +27,7 @@ export async function createPack(packName: string, codaApiEndpoint: string) {
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
   // TODO(alan): we probably want to redirect them to the `coda register`
   // flow if they don't have a Coda API token.
-  const apiKey = getApiKey();
+  const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
     printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
   }

--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -1,6 +1,5 @@
 import {Client} from '../helpers/external-api/coda';
 import path from 'path';
-import {readCredentialsFile} from '../testing/auth';
 import {spawnSync} from 'child_process';
 
 export function spawnProcess(command: string) {
@@ -8,11 +7,6 @@ export function spawnProcess(command: string) {
     shell: true,
     stdio: 'inherit',
   });
-}
-
-export function getApiKey() {
-  const credentials = readCredentialsFile();
-  return credentials?.__coda__?.apiKey;
 }
 
 export function createCodaClient(apiKey: string, protocolAndHost?: string) {

--- a/cli/publish.ts
+++ b/cli/publish.ts
@@ -8,7 +8,7 @@ import {computeSha256} from '../helpers/crypto';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
-import {getApiKey} from './helpers';
+import {getApiKey} from '../testing/auth';
 import {isCodaError} from './errors';
 import {isTestCommand} from './helpers';
 import {printAndExit} from '../testing/helpers';
@@ -34,7 +34,7 @@ export async function handlePublish({manifestFile, codaApiEndpoint}: Arguments<P
   const codaPacksSDKVersion = packageJson.version;
   codaPacksSDKVersion!;
 
-  const apiKey = getApiKey();
+  const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
     printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
   }

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -32,5 +32,5 @@ export async function handleRegister({apiToken, codaApiEndpoint}: Arguments<Regi
     const {statusCode, message} = JSON.parse(err.error);
     printAndExit(`Invalid API token provided: ${statusCode} ${message}`);
   }
-  storeCodaApiKey(apiToken);
+  storeCodaApiKey(apiToken, process.env.PWD, codaApiEndpoint);
 }

--- a/cli/set_live.ts
+++ b/cli/set_live.ts
@@ -2,7 +2,7 @@ import type {Arguments} from 'yargs';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
-import {getApiKey} from './helpers';
+import {getApiKey} from '../testing/auth';
 import {isCodaError} from './errors';
 import {printAndExit} from '../testing/helpers';
 
@@ -13,7 +13,7 @@ interface SetLiveArgs {
 }
 
 export async function handleSetLive({packId, packVersion, codaApiEndpoint}: Arguments<SetLiveArgs>) {
-  const apiKey = getApiKey();
+  const apiKey = getApiKey(codaApiEndpoint);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
 
   if (!apiKey) {

--- a/dist/cli/auth.d.ts
+++ b/dist/cli/auth.d.ts
@@ -1,8 +1,7 @@
 import type { Arguments } from 'yargs';
 interface AuthArgs {
     manifestPath: string;
-    credentialsFile?: string;
     oauthServerPort?: number;
 }
-export declare function handleAuth({ manifestPath, credentialsFile, oauthServerPort }: Arguments<AuthArgs>): Promise<void>;
+export declare function handleAuth({ manifestPath, oauthServerPort }: Arguments<AuthArgs>): Promise<void>;
 export {};

--- a/dist/cli/auth.js
+++ b/dist/cli/auth.js
@@ -29,22 +29,21 @@ import {setupAuthFromModule} from 'coda-packs-sdk/dist/testing/auth';
 
 async function main() {
   const manifestPath = process.argv[1];
-  const credentialsFile = process.argv[2] || undefined;
-  const oauthServerPort = process.argv[3] ? parseInt(process.argv[3]) : undefined;
+  const oauthServerPort = process.argv[2] ? parseInt(process.argv[2]) : undefined;
   const module = await import(manifestPath);
-  await setupAuthFromModule(module, {credentialsFile, oauthServerPort});
+  await setupAuthFromModule(manifestPath, module, {oauthServerPort});
 }
 
 void main();`;
-async function handleAuth({ manifestPath, credentialsFile, oauthServerPort }) {
+async function handleAuth({ manifestPath, oauthServerPort }) {
     const fullManifestPath = helpers_2.makeManifestFullPath(manifestPath);
     if (helpers_1.isTypescript(manifestPath)) {
-        const tsCommand = `ts-node -e "${AUTH_BOOTSTRAP_CODE}" ${fullManifestPath} ${credentialsFile || '""'} ${oauthServerPort || '""'}`;
+        const tsCommand = `ts-node -e "${AUTH_BOOTSTRAP_CODE}" ${fullManifestPath} ${oauthServerPort || '""'}`;
         helpers_3.spawnBootstrapCommand(tsCommand);
     }
     else {
         const module = await Promise.resolve().then(() => __importStar(require(fullManifestPath)));
-        await auth_1.setupAuthFromModule(module, { credentialsFile, oauthServerPort });
+        await auth_1.setupAuthFromModule(fullManifestPath, module, { oauthServerPort });
     }
 }
 exports.handleAuth = handleAuth;

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -5,8 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const auth_1 = require("../testing/auth");
-const auth_2 = require("../testing/auth");
-const auth_3 = require("./auth");
+const auth_2 = require("./auth");
 const build_1 = require("./build");
 const create_1 = require("./create");
 const execute_1 = require("./execute");
@@ -33,29 +32,17 @@ if (require.main === module) {
                 boolean: true,
                 desc: 'Execute the requested command in a virtual machine that mimics the environment Coda uses to execute Packs.',
             },
-            credentialsFile: {
-                alias: 'credentials_file',
-                string: true,
-                default: auth_1.DEFAULT_CREDENTIALS_FILE,
-                desc: 'Path to the credentials file.',
-            },
         },
     })
         .command({
         command: 'auth <manifestPath>',
         describe: 'Set up authentication for a Pack',
-        handler: auth_3.handleAuth,
+        handler: auth_2.handleAuth,
         builder: {
-            credentialsFile: {
-                alias: 'credentials_file',
-                string: true,
-                default: auth_1.DEFAULT_CREDENTIALS_FILE,
-                desc: 'Path to the credentials file.',
-            },
             oauthServerPort: {
                 alias: 'oauth_server_port',
                 number: true,
-                default: auth_2.DEFAULT_OAUTH_SERVER_PORT,
+                default: auth_1.DEFAULT_OAUTH_SERVER_PORT,
                 desc: 'Port to use for the local server that handles OAuth setup.',
             },
         },

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -4,11 +4,11 @@ exports.readPacksFile = exports.storePack = exports.createPack = exports.handleC
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
-const helpers_3 = require("./helpers");
+const auth_1 = require("../testing/auth");
 const errors_2 = require("./errors");
+const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
-const helpers_6 = require("../testing/helpers");
 const PACK_IDS_FILE = '.coda-packs.json';
 async function handleCreate({ packName, codaApiEndpoint }) {
     await createPack(packName, codaApiEndpoint);
@@ -18,15 +18,15 @@ async function createPack(packName, codaApiEndpoint) {
     const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
     // TODO(alan): we probably want to redirect them to the `coda register`
     // flow if they don't have a Coda API token.
-    const apiKey = helpers_3.getApiKey();
+    const apiKey = auth_1.getApiKey(codaApiEndpoint);
     if (!apiKey) {
-        helpers_4.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+        helpers_3.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
     }
     const codaClient = helpers_1.createCodaClient(apiKey, formattedEndpoint);
     try {
         const response = await codaClient.createPack({}, {});
         if (errors_2.isCodaError(response)) {
-            helpers_4.printAndExit(`Unable to create your pack, received error: ${errors_1.formatError(response)}`);
+            helpers_3.printAndExit(`Unable to create your pack, received error: ${errors_1.formatError(response)}`);
         }
         else {
             const packId = response.packId;
@@ -34,7 +34,7 @@ async function createPack(packName, codaApiEndpoint) {
         }
     }
     catch (err) {
-        helpers_4.printAndExit(`Unable to create your pack, received error: ${errors_1.formatError(err)}`);
+        helpers_3.printAndExit(`Unable to create your pack, received error: ${errors_1.formatError(err)}`);
     }
 }
 exports.createPack = createPack;
@@ -45,9 +45,9 @@ function storePack(packName, packId) {
 }
 exports.storePack = storePack;
 function readPacksFile() {
-    return helpers_5.readJSONFile(PACK_IDS_FILE);
+    return helpers_4.readJSONFile(PACK_IDS_FILE);
 }
 exports.readPacksFile = readPacksFile;
 function writePacksFile(allPacks) {
-    helpers_6.writeJSONFile(PACK_IDS_FILE, allPacks);
+    helpers_5.writeJSONFile(PACK_IDS_FILE, allPacks);
 }

--- a/dist/cli/execute.d.ts
+++ b/dist/cli/execute.d.ts
@@ -5,6 +5,5 @@ export interface ExecuteArgs {
     params: string[];
     fetch?: boolean;
     vm?: boolean;
-    credentialsFile?: string;
 }
-export declare function handleExecute({ manifestPath, formulaName, params, fetch, credentialsFile, vm, }: Arguments<ExecuteArgs>): Promise<void>;
+export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm }: Arguments<ExecuteArgs>): Promise<void>;

--- a/dist/cli/execute.js
+++ b/dist/cli/execute.js
@@ -13,28 +13,27 @@ async function main() {
   const manifestPath = process.argv[1];
   const useRealFetcher = process.argv[2] === 'true';
   const vm = process.argv[3] === 'true';
-  const credentialsFile = process.argv[4] || undefined;
-  const formulaName = process.argv[5];
-  const params = process.argv.slice(6);
+  const formulaName = process.argv[4];
+  const params = process.argv.slice(5);
 
   await executeFormulaOrSyncFromCLI({
     formulaName,
     params,
     manifestPath,
     vm,
-    contextOptions: {useRealFetcher, credentialsFile},
+    contextOptions: {useRealFetcher},
   });
 }
 
 void main();`;
-async function handleExecute({ manifestPath, formulaName, params, fetch, credentialsFile, vm, }) {
+async function handleExecute({ manifestPath, formulaName, params, fetch, vm }) {
     const fullManifestPath = helpers_3.makeManifestFullPath(manifestPath);
     // If the given manifest source file is a .ts file, we need to evaluate it using ts-node in the user's environment.
     // We can reasonably assume the user has ts-node if they have built a pack definition using a .ts file.
     // Otherwise, the given manifest is most likely a plain .js file or a post-build .js dist file from a TS build.
     // In the latter case, we can import the given file as a regular node (non-TS) import without any bootstrapping.
     if (helpers_2.isTypescript(manifestPath)) {
-        const tsCommand = `ts-node -e "${EXECUTE_BOOTSTRAP_CODE}" ${fullManifestPath} ${Boolean(fetch)} ${Boolean(vm)} ${credentialsFile || '""'} ${formulaName} ${params.map(helpers_1.escapeShellArg).join(' ')}`;
+        const tsCommand = `ts-node -e "${EXECUTE_BOOTSTRAP_CODE}" ${fullManifestPath} ${Boolean(fetch)} ${Boolean(vm)} ${formulaName} ${params.map(helpers_1.escapeShellArg).join(' ')}`;
         helpers_4.spawnBootstrapCommand(tsCommand);
     }
     else {
@@ -43,7 +42,7 @@ async function handleExecute({ manifestPath, formulaName, params, fetch, credent
             params,
             manifestPath,
             vm,
-            contextOptions: { useRealFetcher: fetch, credentialsFile },
+            contextOptions: { useRealFetcher: fetch },
         });
     }
 }

--- a/dist/cli/helpers.d.ts
+++ b/dist/cli/helpers.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 import { Client } from '../helpers/external-api/coda';
 export declare function spawnProcess(command: string): import("child_process").SpawnSyncReturns<Buffer>;
-export declare function getApiKey(): string | undefined;
 export declare function createCodaClient(apiKey: string, protocolAndHost?: string): Client;
 export declare function formatEndpoint(endpoint: string): string;
 export declare function isTestCommand(): boolean;

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -3,10 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.spawnBootstrapCommand = exports.escapeShellArg = exports.isTypescript = exports.makeManifestFullPath = exports.isTestCommand = exports.formatEndpoint = exports.createCodaClient = exports.getApiKey = exports.spawnProcess = void 0;
+exports.spawnBootstrapCommand = exports.escapeShellArg = exports.isTypescript = exports.makeManifestFullPath = exports.isTestCommand = exports.formatEndpoint = exports.createCodaClient = exports.spawnProcess = void 0;
 const coda_1 = require("../helpers/external-api/coda");
 const path_1 = __importDefault(require("path"));
-const auth_1 = require("../testing/auth");
 const child_process_1 = require("child_process");
 function spawnProcess(command) {
     return child_process_1.spawnSync(command, {
@@ -15,12 +14,6 @@ function spawnProcess(command) {
     });
 }
 exports.spawnProcess = spawnProcess;
-function getApiKey() {
-    var _a;
-    const credentials = auth_1.readCredentialsFile();
-    return (_a = credentials === null || credentials === void 0 ? void 0 : credentials.__coda__) === null || _a === void 0 ? void 0 : _a.apiKey;
-}
-exports.getApiKey = getApiKey;
 function createCodaClient(apiKey, protocolAndHost) {
     return new coda_1.Client(protocolAndHost !== null && protocolAndHost !== void 0 ? protocolAndHost : 'https://coda.io', apiKey);
 }

--- a/dist/cli/publish.js
+++ b/dist/cli/publish.js
@@ -30,11 +30,11 @@ const crypto_1 = require("../helpers/crypto");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
-const helpers_3 = require("./helpers");
+const auth_1 = require("../testing/auth");
 const errors_2 = require("./errors");
-const helpers_4 = require("./helpers");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
-const helpers_6 = require("../testing/helpers");
 const create_1 = require("./create");
 const request_promise_native_1 = __importDefault(require("request-promise-native"));
 const validate_1 = require("./validate");
@@ -45,28 +45,28 @@ async function handlePublish({ manifestFile, codaApiEndpoint }) {
     const bundleFilename = await build_1.build(manifestFile);
     const { manifest } = await Promise.resolve().then(() => __importStar(require(bundleFilename)));
     // Since package.json isn't in dist, we grab it from the root directory instead.
-    const packageJson = await Promise.resolve().then(() => __importStar(require(helpers_4.isTestCommand() ? '../package.json' : '../../package.json')));
+    const packageJson = await Promise.resolve().then(() => __importStar(require(helpers_3.isTestCommand() ? '../package.json' : '../../package.json')));
     const codaPacksSDKVersion = packageJson.version;
     codaPacksSDKVersion;
-    const apiKey = helpers_3.getApiKey();
+    const apiKey = auth_1.getApiKey(codaApiEndpoint);
     if (!apiKey) {
-        helpers_5.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+        helpers_4.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
     }
     const client = helpers_1.createCodaClient(apiKey, formattedEndpoint);
     const packs = create_1.readPacksFile();
     const packId = packs && packs[manifest.name];
     if (!packId) {
-        helpers_5.printAndExit(`Could not find a Pack id registered to Pack "${manifest.name}"`);
+        helpers_4.printAndExit(`Could not find a Pack id registered to Pack "${manifest.name}"`);
     }
     const packVersion = manifest.version;
     if (!packVersion) {
-        helpers_5.printAndExit(`No Pack version found for your Pack "${manifest.name}"`);
+        helpers_4.printAndExit(`No Pack version found for your Pack "${manifest.name}"`);
     }
     try {
         logger.info('Registering new Pack version...');
-        const bundle = helpers_6.readFile(bundleFilename);
+        const bundle = helpers_5.readFile(bundleFilename);
         if (!bundle) {
-            helpers_5.printAndExit(`Could not find bundle file at path ${bundleFilename}`);
+            helpers_4.printAndExit(`Could not find bundle file at path ${bundleFilename}`);
         }
         const metadata = cli_1.compilePackMetadata(manifest);
         const upload = {
@@ -77,7 +77,7 @@ async function handlePublish({ manifestFile, codaApiEndpoint }) {
         const bundleHash = crypto_1.computeSha256(uploadPayload);
         const response = await client.registerPackVersion(packId, packVersion, {}, { bundleHash });
         if (errors_2.isCodaError(response)) {
-            return helpers_5.printAndExit(`Error while registering pack version: ${errors_1.formatError(response)}`);
+            return helpers_4.printAndExit(`Error while registering pack version: ${errors_1.formatError(response)}`);
         }
         const { uploadUrl, headers } = response;
         logger.info('Validating Pack metadata...');
@@ -87,11 +87,11 @@ async function handlePublish({ manifestFile, codaApiEndpoint }) {
         logger.info('Validating upload...');
         const uploadCompleteResponse = await client.packVersionUploadComplete(packId, packVersion);
         if (errors_2.isCodaError(uploadCompleteResponse)) {
-            helpers_5.printAndExit(`Error while finalizing pack version: ${errors_1.formatError(response)}`);
+            helpers_4.printAndExit(`Error while finalizing pack version: ${errors_1.formatError(response)}`);
         }
     }
     catch (err) {
-        helpers_5.printAndExit(`Unepected error during pack upload: ${errors_1.formatError(err)}`);
+        helpers_4.printAndExit(`Unepected error during pack upload: ${errors_1.formatError(err)}`);
     }
     logger.info('Done!');
 }
@@ -104,6 +104,6 @@ async function uploadPack(uploadUrl, uploadPayload, headers) {
         });
     }
     catch (err) {
-        helpers_5.printAndExit(`Error in uploading Pack to signed url: ${errors_1.formatError(err)}`);
+        helpers_4.printAndExit(`Error in uploading Pack to signed url: ${errors_1.formatError(err)}`);
     }
 }

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -30,6 +30,6 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
         const { statusCode, message } = JSON.parse(err.error);
         helpers_3.printAndExit(`Invalid API token provided: ${statusCode} ${message}`);
     }
-    auth_1.storeCodaApiKey(apiToken);
+    auth_1.storeCodaApiKey(apiToken, process.env.PWD, codaApiEndpoint);
 }
 exports.handleRegister = handleRegister;

--- a/dist/cli/set_live.js
+++ b/dist/cli/set_live.js
@@ -4,27 +4,27 @@ exports.handleSetLive = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
-const helpers_3 = require("./helpers");
+const auth_1 = require("../testing/auth");
 const errors_2 = require("./errors");
-const helpers_4 = require("../testing/helpers");
+const helpers_3 = require("../testing/helpers");
 async function handleSetLive({ packId, packVersion, codaApiEndpoint }) {
-    const apiKey = helpers_3.getApiKey();
+    const apiKey = auth_1.getApiKey(codaApiEndpoint);
     const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
     if (!apiKey) {
-        helpers_4.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+        helpers_3.printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
     }
     const codaClient = helpers_1.createCodaClient(apiKey, formattedEndpoint);
     try {
         const response = await codaClient.setPackLiveVersion(packId, {}, { packVersion });
         if (errors_2.isCodaError(response)) {
-            helpers_4.printAndExit(`Error when setting pack live version: ${errors_1.formatError(response)}`);
+            helpers_3.printAndExit(`Error when setting pack live version: ${errors_1.formatError(response)}`);
         }
         else {
-            helpers_4.printAndExit('Success!', 0);
+            helpers_3.printAndExit('Success!', 0);
         }
     }
     catch (err) {
-        helpers_4.printAndExit(`Unexpected error while setting pack version: ${errors_1.formatError(err)}`);
+        helpers_3.printAndExit(`Unexpected error while setting pack version: ${errors_1.formatError(err)}`);
     }
 }
 exports.handleSetLive = handleSetLive;

--- a/dist/testing/auth.d.ts
+++ b/dist/testing/auth.d.ts
@@ -1,15 +1,13 @@
-import type { AllCredentials } from './auth_types';
 import type { Credentials } from './auth_types';
 import type { PackDefinition } from '../types';
 interface SetupAuthOptions {
-    credentialsFile?: string;
     oauthServerPort?: number;
 }
-export declare const DEFAULT_CREDENTIALS_FILE = ".coda/credentials.json";
 export declare const DEFAULT_OAUTH_SERVER_PORT = 3000;
-export declare function setupAuthFromModule(module: any, opts?: SetupAuthOptions): Promise<void>;
-export declare function setupAuth(packDef: PackDefinition, opts?: SetupAuthOptions): void;
-export declare function storeCredential(credentialsFile: string, packName: string, credentials: Credentials): void;
-export declare function storeCodaApiKey(apiKey: string, credentialsFile?: string): void;
-export declare function readCredentialsFile(credentialsFile?: string): AllCredentials | undefined;
+export declare function setupAuthFromModule(manifestPath: string, module: any, opts?: SetupAuthOptions): Promise<void>;
+export declare function setupAuth(manifestDir: string, packDef: PackDefinition, opts?: SetupAuthOptions): void;
+export declare function storeCredential(manifestDir: string, credentials: Credentials): void;
+export declare function getApiKey(codaApiEndpoint?: string): string | undefined;
+export declare function storeCodaApiKey(apiKey: string, projectDir?: string, codaApiEndpoint?: string): void;
+export declare function readCredentialsFile(manifestPath: string): Credentials | undefined;
 export {};

--- a/dist/testing/auth_types.d.ts
+++ b/dist/testing/auth_types.d.ts
@@ -1,9 +1,10 @@
-export interface AllCredentials {
-    __coda__?: {
-        apiKey: string;
-    };
-    packs: {
-        [name: string]: Credentials;
+export interface CredentialsFile {
+    credentials: Credentials;
+}
+export interface ApiKeyFile {
+    apiKey: string;
+    environmentApiKeys?: {
+        [host: string]: string;
     };
 }
 interface BaseCredentials {

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -11,9 +11,9 @@ export { ExecuteOptions } from './execution_helper';
 export { ExecuteSyncOptions } from './execution_helper';
 export interface ContextOptions {
     useRealFetcher?: boolean;
-    credentialsFile?: string;
+    manifestPath?: string;
 }
-export declare function executeFormulaFromPackDef(packDef: PackDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<any>;
+export declare function executeFormulaFromPackDef(packDef: PackDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any>;
 export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manifestPath, vm, contextOptions, }: {
     formulaName: string;
     params: string[];
@@ -40,7 +40,7 @@ export declare function executeFormulaOrSyncWithRawParams({ formulaName, params:
     vm?: boolean;
     executionContext: SyncExecutionContext;
 }): Promise<any>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, credentialsFile }?: ContextOptions): Promise<any[]>;
+export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any[]>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -29,10 +29,12 @@ const fetcher_2 = require("./fetcher");
 const mocks_1 = require("./mocks");
 const mocks_2 = require("./mocks");
 const helpers_2 = require("./helpers");
-async function executeFormulaFromPackDef(packDef, formulaNameWithNamespace, params, context, options, { useRealFetcher, credentialsFile } = {}) {
+const auth_1 = require("./auth");
+async function executeFormulaFromPackDef(packDef, formulaNameWithNamespace, params, context, options, { useRealFetcher, manifestPath } = {}) {
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
-        executionContext = fetcher_1.newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentialsFile);
+        const credentials = manifestPath ? auth_1.readCredentialsFile(manifestPath) : undefined;
+        executionContext = fetcher_1.newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
     }
     const formula = helper.findFormula(packDef, formulaNameWithNamespace);
     return helper.executeFormula(formula, params, executionContext || mocks_1.newMockExecutionContext(), options);
@@ -42,10 +44,12 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifestPath, 
     try {
         const module = await Promise.resolve().then(() => __importStar(require(manifestPath)));
         const manifest = helpers_1.getManifestFromModule(module);
-        const { useRealFetcher, credentialsFile } = contextOptions;
+        const { useRealFetcher } = contextOptions;
+        const credentials = useRealFetcher && manifestPath ? auth_1.readCredentialsFile(manifestPath) : undefined;
         // A sync context would work for both formula / syncFormula execution for now.
+        // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
         const executionContext = useRealFetcher
-            ? fetcher_2.newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentialsFile)
+            ? fetcher_2.newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentials)
             : mocks_2.newMockSyncExecutionContext();
         const result = vm
             ? await executeFormulaOrSyncWithRawParamsInVM({ formulaName, params, manifestPath, executionContext })
@@ -75,10 +79,11 @@ async function executeFormulaOrSyncWithRawParams({ formulaName, params: rawParam
     return helper.executeFormulaOrSyncWithRawParams(manifest, formulaName, rawParams, executionContext);
 }
 exports.executeFormulaOrSyncWithRawParams = executeFormulaOrSyncWithRawParams;
-async function executeSyncFormulaFromPackDef(packDef, syncFormulaName, params, context, options, { useRealFetcher, credentialsFile } = {}) {
+async function executeSyncFormulaFromPackDef(packDef, syncFormulaName, params, context, options, { useRealFetcher, manifestPath } = {}) {
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
-        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentialsFile);
+        const credentials = manifestPath ? auth_1.readCredentialsFile(manifestPath) : undefined;
+        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
     }
     const formula = helper.findSyncFormula(packDef, syncFormulaName);
     return helper.executeSyncFormula(formula, params, executionContext || mocks_2.newMockSyncExecutionContext(), options);

--- a/dist/testing/fetcher.d.ts
+++ b/dist/testing/fetcher.d.ts
@@ -17,5 +17,5 @@ export declare class AuthenticatingFetcher implements Fetcher {
 export declare const requestHelper: {
     makeRequest: (request: FetchRequest) => Promise<Response>;
 };
-export declare function newFetcherExecutionContext(packName: string, authDef: Authentication | undefined, credentialsFile?: string): ExecutionContext;
-export declare function newFetcherSyncExecutionContext(packName: string, authDef: Authentication | undefined, credentialsFile?: string): SyncExecutionContext;
+export declare function newFetcherExecutionContext(packName: string, authDef: Authentication | undefined, credentials?: Credentials): ExecutionContext;
+export declare function newFetcherSyncExecutionContext(packName: string, authDef: Authentication | undefined, credentials?: Credentials): SyncExecutionContext;

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -9,7 +9,6 @@ const logging_1 = require("../helpers/logging");
 const url_1 = require("url");
 const ensure_1 = require("../helpers/ensure");
 const ensure_2 = require("../helpers/ensure");
-const auth_1 = require("./auth");
 const request_promise_native_1 = __importDefault(require("request-promise-native"));
 const url_parse_1 = __importDefault(require("url-parse"));
 const uuid_1 = require("uuid");
@@ -191,9 +190,7 @@ class AuthenticatingBlobStorage {
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${uuid_1.v4()}`;
     }
 }
-function newFetcherExecutionContext(packName, authDef, credentialsFile) {
-    const allCredentials = auth_1.readCredentialsFile(credentialsFile);
-    const credentials = allCredentials === null || allCredentials === void 0 ? void 0 : allCredentials.packs[packName];
+function newFetcherExecutionContext(packName, authDef, credentials) {
     const fetcher = new AuthenticatingFetcher(authDef, credentials);
     return {
         invocationLocation: {
@@ -208,8 +205,8 @@ function newFetcherExecutionContext(packName, authDef, credentialsFile) {
     };
 }
 exports.newFetcherExecutionContext = newFetcherExecutionContext;
-function newFetcherSyncExecutionContext(packName, authDef, credentialsFile) {
-    const context = newFetcherExecutionContext(packName, authDef, credentialsFile);
+function newFetcherSyncExecutionContext(packName, authDef, credentials) {
+    const context = newFetcherExecutionContext(packName, authDef, credentials);
     return { ...context, sync: {} };
 }
 exports.newFetcherSyncExecutionContext = newFetcherSyncExecutionContext;

--- a/testing/auth_types.ts
+++ b/testing/auth_types.ts
@@ -1,8 +1,11 @@
-export interface AllCredentials {
-  __coda__?: {apiKey: string};
-  packs: {
-    [name: string]: Credentials;
-  };
+export interface CredentialsFile {
+  credentials: Credentials;
+}
+
+export interface ApiKeyFile {
+  apiKey: string;
+  // Codan-only overrides for storing API keys for other environments.
+  environmentApiKeys?: {[host: string]: string};
 }
 
 interface BaseCredentials {

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -7,7 +7,7 @@ import type {PackDefinition} from '../types';
 import type {ParamDefs} from '../api_types';
 import type {ParamValues} from '../api_types';
 import type {SyncExecutionContext} from '../api_types';
-import { build as buildBundle } from '../cli/build';
+import {build as buildBundle} from '../cli/build';
 import {getManifestFromModule} from './helpers';
 import * as helper from './execution_helper';
 import * as ivmHelper from './ivm_helper';
@@ -16,13 +16,14 @@ import {newFetcherSyncExecutionContext} from './fetcher';
 import {newMockExecutionContext} from './mocks';
 import {newMockSyncExecutionContext} from './mocks';
 import {print} from './helpers';
+import {readCredentialsFile} from './auth';
 
 export {ExecuteOptions} from './execution_helper';
 export {ExecuteSyncOptions} from './execution_helper';
 
 export interface ContextOptions {
   useRealFetcher?: boolean;
-  credentialsFile?: string;
+  manifestPath?: string;
 }
 
 export async function executeFormulaFromPackDef(
@@ -31,11 +32,12 @@ export async function executeFormulaFromPackDef(
   params: ParamValues<ParamDefs>,
   context?: ExecutionContext,
   options?: ExecuteOptions,
-  {useRealFetcher, credentialsFile}: ContextOptions = {},
+  {useRealFetcher, manifestPath}: ContextOptions = {},
 ) {
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
-    executionContext = newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentialsFile);
+    const credentials = manifestPath ? readCredentialsFile(manifestPath) : undefined;
+    executionContext = newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
   }
 
   const formula = helper.findFormula(packDef, formulaNameWithNamespace);
@@ -55,14 +57,16 @@ export async function executeFormulaOrSyncFromCLI({
   vm?: boolean;
   contextOptions?: ContextOptions;
 }) {
-  try {    
+  try {
     const module = await import(manifestPath);
     const manifest = getManifestFromModule(module);
-    const {useRealFetcher, credentialsFile} = contextOptions;
+    const {useRealFetcher} = contextOptions;
 
+    const credentials = useRealFetcher && manifestPath ? readCredentialsFile(manifestPath) : undefined;
     // A sync context would work for both formula / syncFormula execution for now.
-    const executionContext = useRealFetcher 
-      ? newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentialsFile) 
+    // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
+    const executionContext = useRealFetcher
+      ? newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentials)
       : newMockSyncExecutionContext();
 
     const result = vm
@@ -103,7 +107,7 @@ export async function executeFormulaOrSyncWithRawParamsInVM({
   params: string[];
   manifestPath: string;
   executionContext?: SyncExecutionContext;
-}) {  
+}) {
   const bundlePath = await buildBundle(manifestPath, 'esbuild');
 
   const ivmContext = await ivmHelper.setupIvmContext(bundlePath, executionContext);
@@ -125,12 +129,7 @@ export async function executeFormulaOrSyncWithRawParams({
 }) {
   const manifest = getManifestFromModule(module);
 
-  return helper.executeFormulaOrSyncWithRawParams(
-    manifest,
-    formulaName,
-    rawParams,
-    executionContext,
-  );  
+  return helper.executeFormulaOrSyncWithRawParams(manifest, formulaName, rawParams, executionContext);
 }
 
 export async function executeSyncFormulaFromPackDef(
@@ -139,11 +138,12 @@ export async function executeSyncFormulaFromPackDef(
   params: ParamValues<ParamDefs>,
   context?: SyncExecutionContext,
   options?: ExecuteSyncOptions,
-  {useRealFetcher, credentialsFile}: ContextOptions = {},
+  {useRealFetcher, manifestPath}: ContextOptions = {},
 ) {
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
-    executionContext = newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentialsFile);
+    const credentials = manifestPath ? readCredentialsFile(manifestPath) : undefined;
+    executionContext = newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
   }
 
   const formula = helper.findSyncFormula(packDef, syncFormulaName);

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -17,7 +17,6 @@ import {URL} from 'url';
 import type {WebBasicCredentials} from './auth_types';
 import {ensureNonEmptyString} from '../helpers/ensure';
 import {ensureUnreachable} from '../helpers/ensure';
-import {readCredentialsFile} from './auth';
 import requestPromise from 'request-promise-native';
 import urlParse from 'url-parse';
 import {v4} from 'uuid';
@@ -54,7 +53,7 @@ export class AuthenticatingFetcher implements Fetcher {
     if (responseBody && responseBody.length >= MaxContentLengthBytes) {
       throw new Error(`Response body is too large for Coda. Body is ${responseBody.length} bytes.`);
     }
-        
+
     try {
       const contentType = response.headers['content-type'];
       if (contentType && contentType.includes('text/xml')) {
@@ -239,10 +238,8 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
 export function newFetcherExecutionContext(
   packName: string,
   authDef: Authentication | undefined,
-  credentialsFile?: string,
+  credentials?: Credentials,
 ): ExecutionContext {
-  const allCredentials = readCredentialsFile(credentialsFile);
-  const credentials = allCredentials?.packs[packName];
   const fetcher = new AuthenticatingFetcher(authDef, credentials);
   return {
     invocationLocation: {
@@ -260,9 +257,9 @@ export function newFetcherExecutionContext(
 export function newFetcherSyncExecutionContext(
   packName: string,
   authDef: Authentication | undefined,
-  credentialsFile?: string,
+  credentials?: Credentials,
 ): SyncExecutionContext {
-  const context = newFetcherExecutionContext(packName, authDef, credentialsFile);
+  const context = newFetcherExecutionContext(packName, authDef, credentials);
   return {...context, sync: {}};
 }
 


### PR DESCRIPTION
I still need to install this in a dummy project and test it out for real.

I also need to rewrite all of the packs-examples integration tests and documentation :(

PTAL @huayang-codaio @alan-codaio @coda-hq/ecosystem 