### PR TITLE
Validate pack version identifiers.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -383,7 +383,6 @@ const formatMetadataSchema = zodCompleteObject({
 const unrefinedPackVersionMetadataSchema = zodCompleteObject({
     version: z
         .string()
-        .nonempty()
         .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".'),
     defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
     networkDomains: z.array(z.string()).optional(),

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -82,7 +82,7 @@ describe('Pack metadata Validation', () => {
   });
 
   it('invalid versions', async () => {
-    for (const version of ['foo', 'unversioned', '-1', '1.0.0.0', '1.0.0-beta']) {
+    for (const version of ['', 'foo', 'unversioned', '-1', '1.0.0.0', '1.0.0-beta']) {
       const metadata = createFakePackVersionMetadata({version});
       const err = await validateJsonAndAssertFails(metadata);
       assert.deepEqual(err.validationErrors, [

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -455,7 +455,6 @@ const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
 const unrefinedPackVersionMetadataSchema = zodCompleteObject<PackVersionMetadata>({
   version: z
     .string()
-    .nonempty()
     .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".'),
   defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
   networkDomains: z.array(z.string()).optional(),


### PR DESCRIPTION
Previously we'd accept arbitrary strings as version identifiers. This just makes sure we only accept valid semantic version identifiers.

PTAL @huayang-codaio @alan-codaio @coda-hq/ecosystem 