### PR TITLE
Validate formula names.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -231,7 +231,9 @@ const paramDefValidator = zodCompleteObject({
     defaultValue: z.unknown(),
 });
 const commonPackFormulaSchema = {
-    name: z.string(),
+    name: z
+        .string()
+        .refine(validateFormulaName, { message: 'Formula names can only contain alphanumeric characters and underscores.' }),
     description: z.string(),
     examples: z.array(z.object({
         params: z.union([primitiveUnion, z.array(primitiveUnion)]),
@@ -431,14 +433,22 @@ const unrefinedPackVersionMetadataSchema = zodCompleteObject({
     formats: z.array(formatMetadataSchema).optional().default([]),
     syncTables: z.array(syncTableSchema).optional().default([]),
 });
+// The following largely copied from tokens.ts for parsing formula names.
+const letterChar = String.raw `\p{L}`;
+const numberChar = String.raw `\p{N}`;
+const wordChar = String.raw `${letterChar}${numberChar}_`;
+const regexLetterChar = String.raw `[${letterChar}]`;
+const regexWordChar = String.raw `[${wordChar}]`;
+const regexFormulaNameStr = String.raw `^${regexLetterChar}(?:${regexWordChar}+)?$`;
+const regexFormulaName = new RegExp(regexFormulaNameStr, 'u');
 function validateNamespace(namespace) {
-    if (!namespace) {
+    if (typeof namespace === 'undefined') {
         return true;
     }
-    // Technically we accept unicode characters in namespaces and formulas in general.
-    // We can borrow the unicode parsing from tokens.ts, but given that this is just temporary
-    // and we're about to delete namespaces, restrict to ascii for now for simplicity.
-    return /^\w+$/.test(namespace);
+    return validateFormulaName(namespace);
+}
+function validateFormulaName(value) {
+    return regexFormulaName.test(value);
 }
 function validateFormulas(schema) {
     return schema

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -161,6 +161,45 @@ describe('Pack metadata Validation', () => {
       await validateJson(metadata);
     });
 
+    it('valid formula names', async () => {
+      for (const name of ['foo', 'Foo', 'foo_bar', 'Foo123', 'føø']) {
+        const formula = makeNumericFormula({
+          name,
+          description: 'My description',
+          examples: [],
+          parameters: [],
+          execute: () => 1,
+        });
+        const metadata = createFakePackVersionMetadata({
+          formulas: [formulaToMetadata(formula)],
+          formulaNamespace: 'MyNamespace',
+        });
+        await validateJson(metadata);
+      }
+    });
+
+    it('invalid formula names', async () => {
+      for (const name of ['_foo', 'foo-bar', 'foo bar', '2foo']) {
+        const formula = makeNumericFormula({
+          name,
+          examples: [],
+          description: 'desc',
+          parameters: [],
+        } as any);
+        const metadata = createFakePackVersionMetadata({
+          formulas: [formulaToMetadata(formula)],
+          formulaNamespace: 'MyNamespace',
+        });
+        const err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: 'Formula names can only contain alphanumeric characters and underscores.',
+            path: 'formulas[0].name',
+          },
+        ]);
+      }
+    });
+
     it('valid string formula with examples', async () => {
       const formula = makeStringFormula({
         name: 'MyFormula',
@@ -220,7 +259,7 @@ describe('Pack metadata Validation', () => {
 
     it('invalid numeric formula', async () => {
       const formula = makeNumericFormula({
-        name: '',
+        name: 'MyFormula',
         examples: [],
         parameters: [makeNumericParameter('myParam', 'param description')],
       } as any);
@@ -273,7 +312,7 @@ describe('Pack metadata Validation', () => {
             return '';
           }),
           formula: {
-            name: 'Sync table',
+            name: 'SyncTable',
             description: 'Sync table',
             examples: [],
             parameters: [],
@@ -368,7 +407,7 @@ describe('Pack metadata Validation', () => {
             return '';
           }),
           formula: {
-            name: 'Sync table',
+            name: 'SyncTable',
             description: 'Sync table',
             examples: [],
             parameters: [],


### PR DESCRIPTION
Last PR just validated namespaces, but Al pointed out that we weren't validating formula names either 😱 . Took the opportunity to better align our validation with what the formula parser actually does on the `coda` side, in particular allowing unicode characters. It seems like `\w` handle unicode characters just fine though, so not sure if the fanciness is really needed.

PTAL @alan-codaio @coda-hq/ecosystem 