### PR TITLE
Allow object formulas that return arrays.

### DIFF
--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1,4 +1,5 @@
 import {testHelper} from './test_helper';
+import type {ArraySchema} from '../schema';
 import {AuthenticationType} from '../types';
 import {DefaultConnectionType} from '../types';
 import type {GenericObjectSchema} from '../schema';
@@ -18,6 +19,7 @@ import {makeNumericFormula} from '../api';
 import {makeNumericParameter} from '../api';
 import {makeObjectFormula} from '../api';
 import {makeObjectSchema} from '../schema';
+import {makeSchema} from '../schema';
 import {makeStringFormula} from '../api';
 import {makeStringParameter} from '../api';
 import {makeSyncTable} from '../api';
@@ -491,17 +493,18 @@ describe('Pack metadata Validation', () => {
               'alphanumeric characters, underscores, and dashes, and no spaces.',
             path: 'syncTables[0].schema.identity.name',
           },
-          // TODO(alan): figure out how to obscure this error.
           {
-            message: 'Invalid input',
-            path: 'syncTables[0].getter.schema.items',
+            message:
+              'Invalid name. Identity names can only contain ' +
+              'alphanumeric characters, underscores, and dashes, and no spaces.',
+            path: 'syncTables[0].getter.schema.items.identity.name',
           },
         ]);
       });
     });
 
     describe('object schemas', () => {
-      function metadataForFormulaWithObjectSchema(schema: GenericObjectSchema): PackVersionMetadata {
+      function metadataForFormulaWithObjectSchema(schema: GenericObjectSchema | ArraySchema): PackVersionMetadata {
         const formula = makeObjectFormula({
           name: 'MyFormula',
           description: 'My description',
@@ -533,6 +536,29 @@ describe('Pack metadata Validation', () => {
             date: {type: ValueType.String, codaType: ValueType.Date},
           },
         });
+        await validateJson(metadata);
+      });
+
+      it('valid object formula with array schema', async () => {
+        const itemSchema = makeObjectSchema({
+          type: ValueType.Object,
+          id: 'id',
+          primary: 'primary',
+          identity: {
+            packId: 123,
+            name: 'IdentityName',
+          },
+          properties: {
+            id: {type: ValueType.Number, fromKey: 'foo', required: true},
+            primary: {type: ValueType.String},
+            date: {type: ValueType.String, codaType: ValueType.Date},
+          },
+        });
+        const arraySchema = makeSchema({
+          type: ValueType.Array,
+          items: itemSchema,
+        });
+        const metadata = metadataForFormulaWithObjectSchema(arraySchema);
         await validateJson(metadata);
       });
 


### PR DESCRIPTION
I was trying verify that the example packs in the packs-examples repo actually worked if you tried to upload them, and of course the very first one I try (Dictionary) runs into a validation error that produces no actionable messages :(

It turns out it's because that example formula is declared to return an array of objects, and our validator didn't accept that. The typing and naming are weird, it appears that we really do use makeObjectFormula() in our existing packs to encompass returning both a single object and an array of objects, but this does seem kind of confusing.

Anyway, this fixes the validator. The validator change broke a bunch of the error output we expect in tests, which seemed to be due to objects that have nested unions. So I adapted the error mapping function to recursively fix find and fix union errors. As a bonus, this seemed to eliminate one of the unexplained duplicate error messages.

PTAL @alan-codaio @coda-hq/ecosystem 