### PR TITLE
Require only a PackVersionDefinition instead of a PackDefinition in test execution helpers.

### DIFF
--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -3,7 +3,7 @@ import type { ExecuteSyncOptions } from './execution_helper';
 import type { ExecutionContext } from '../api_types';
 import type { MetadataContext } from '../api';
 import type { MetadataFormula } from '../api';
-import type { PackDefinition } from '../types';
+import type { PackVersionDefinition } from '../types';
 import type { ParamDefs } from '../api_types';
 import type { ParamValues } from '../api_types';
 import type { SyncExecutionContext } from '../api_types';
@@ -13,7 +13,7 @@ export interface ContextOptions {
     useRealFetcher?: boolean;
     manifestPath?: string;
 }
-export declare function executeFormulaFromPackDef(packDef: PackDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any>;
+export declare function executeFormulaFromPackDef(packDef: PackVersionDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any>;
 export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manifestPath, vm, contextOptions, }: {
     formulaName: string;
     params: string[];
@@ -40,7 +40,7 @@ export declare function executeFormulaOrSyncWithRawParams({ formulaName, params:
     vm?: boolean;
     executionContext: SyncExecutionContext;
 }): Promise<any>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any[]>;
+export declare function executeSyncFormulaFromPackDef(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any[]>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -35,7 +35,7 @@ async function executeFormulaFromPackDef(packDef, formulaNameWithNamespace, para
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
         const credentials = getCredentials(manifestPath);
-        executionContext = fetcher_1.newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
+        executionContext = fetcher_1.newFetcherExecutionContext(packDef.defaultAuthentication, credentials);
     }
     const formula = helper.findFormula(packDef, formulaNameWithNamespace);
     return helper.executeFormula(formula, params, executionContext || mocks_1.newMockExecutionContext(), options);
@@ -50,7 +50,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifestPath, 
         // A sync context would work for both formula / syncFormula execution for now.
         // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
         const executionContext = useRealFetcher
-            ? fetcher_2.newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentials)
+            ? fetcher_2.newFetcherSyncExecutionContext(manifest.defaultAuthentication, credentials)
             : mocks_2.newMockSyncExecutionContext();
         const result = vm
             ? await executeFormulaOrSyncWithRawParamsInVM({ formulaName, params, manifestPath, executionContext })
@@ -84,7 +84,7 @@ async function executeSyncFormulaFromPackDef(packDef, syncFormulaName, params, c
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
         const credentials = getCredentials(manifestPath);
-        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
+        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.defaultAuthentication, credentials);
     }
     const formula = helper.findSyncFormula(packDef, syncFormulaName);
     return helper.executeSyncFormula(formula, params, executionContext || mocks_2.newMockSyncExecutionContext(), options);

--- a/dist/testing/execution_helper.d.ts
+++ b/dist/testing/execution_helper.d.ts
@@ -1,6 +1,6 @@
 import type { ExecutionContext } from '../api_types';
 import type { GenericSyncFormula } from '../api';
-import type { PackDefinition } from '../types';
+import type { PackVersionDefinition } from '../types';
 import type { ParamDefs } from '../api_types';
 import type { ParamValues } from '../api_types';
 import type { SyncExecutionContext } from '../api_types';
@@ -13,12 +13,12 @@ export interface ExecuteSyncOptions extends ExecuteOptions {
     maxIterations?: number;
 }
 export declare function executeSyncFormulaWithoutValidation(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context: SyncExecutionContext, maxIterations?: number): Promise<any[]>;
-export declare function executeFormulaOrSyncWithRawParams(manifest: PackDefinition, formulaName: string, rawParams: string[], context: SyncExecutionContext): Promise<any>;
-export declare function executeFormulaOrSync(manifest: PackDefinition, formulaName: string, params: ParamValues<ParamDefs>, context: SyncExecutionContext): Promise<any>;
+export declare function executeFormulaOrSyncWithRawParams(manifest: PackVersionDefinition, formulaName: string, rawParams: string[], context: SyncExecutionContext): Promise<any>;
+export declare function executeFormulaOrSync(manifest: PackVersionDefinition, formulaName: string, params: ParamValues<ParamDefs>, context: SyncExecutionContext): Promise<any>;
 export declare function executeFormula(formula: TypedStandardFormula, params: ParamValues<ParamDefs>, context: ExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult }?: ExecuteOptions): Promise<any>;
 export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<any[]>;
-export declare function findFormula(packDef: PackDefinition, formulaNameWithNamespace: string): TypedStandardFormula;
-export declare function findSyncFormula(packDef: PackDefinition, syncFormulaName: string): GenericSyncFormula;
-export declare function tryFindFormula(packDef: PackDefinition, formulaNameWithNamespace: string): TypedStandardFormula | undefined;
-export declare function tryFindSyncFormula(packDef: PackDefinition, syncFormulaName: string): GenericSyncFormula | undefined;
+export declare function findFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): TypedStandardFormula;
+export declare function findSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula;
+export declare function tryFindFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): TypedStandardFormula | undefined;
+export declare function tryFindSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula | undefined;
 export declare function wrapError(err: Error): Error;

--- a/dist/testing/execution_helper.js
+++ b/dist/testing/execution_helper.js
@@ -38,7 +38,7 @@ async function executeFormulaOrSyncWithRawParams(manifest, formulaName, rawParam
             const params = coercion_1.coerceParams(syncFormula, rawParams);
             return await executeSyncFormula(syncFormula, params, context);
         }
-        throw new Error(`Pack definition for ${manifest.name} has no formula or sync called ${formulaName}.`);
+        throw new Error(`Pack definition has no formula or sync called ${formulaName}.`);
     }
     catch (err) {
         throw wrapError(err);
@@ -55,7 +55,7 @@ async function executeFormulaOrSync(manifest, formulaName, params, context) {
         if (syncFormula) {
             return await executeSyncFormula(syncFormula, params, context);
         }
-        throw new Error(`Pack definition for ${manifest.name} has no formula or sync called ${formulaName}.`);
+        throw new Error(`Pack definition has no formula or sync called ${formulaName}.`);
     }
     catch (err) {
         throw wrapError(err);
@@ -93,7 +93,7 @@ exports.executeSyncFormula = executeSyncFormula;
 function findFormula(packDef, formulaNameWithNamespace) {
     const packFormulas = packDef.formulas;
     if (!packFormulas) {
-        throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formulas.`);
+        throw new Error(`Pack definition has no formulas.`);
     }
     const [namespace, name] = formulaNameWithNamespace.includes('::')
         ? formulaNameWithNamespace.split('::')
@@ -103,19 +103,19 @@ function findFormula(packDef, formulaNameWithNamespace) {
     }
     const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
     if (!formulas || !formulas.length) {
-        throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formulas for namespace "${namespace}".`);
+        throw new Error(`Pack definition has no formulas for namespace "${namespace}".`);
     }
     for (const formula of formulas) {
         if (formula.name === name) {
             return formula;
         }
     }
-    throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formula "${name}" in namespace "${namespace}".`);
+    throw new Error(`Pack definition has no formula "${name}" in namespace "${namespace}".`);
 }
 exports.findFormula = findFormula;
 function findSyncFormula(packDef, syncFormulaName) {
     if (!packDef.syncTables) {
-        throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no sync tables.`);
+        throw new Error(`Pack definition has no sync tables.`);
     }
     for (const syncTable of packDef.syncTables) {
         const syncFormula = syncTable.getter;
@@ -123,7 +123,7 @@ function findSyncFormula(packDef, syncFormulaName) {
             return syncFormula;
         }
     }
-    throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no sync formula "${syncFormulaName}" in its sync tables.`);
+    throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
 }
 exports.findSyncFormula = findSyncFormula;
 function tryFindFormula(packDef, formulaNameWithNamespace) {

--- a/dist/testing/execution_helper_bundle.js
+++ b/dist/testing/execution_helper_bundle.js
@@ -2763,7 +2763,7 @@ async function executeFormulaOrSyncWithRawParams(manifest, formulaName, rawParam
       const params = coerceParams(syncFormula, rawParams);
       return await executeSyncFormula(syncFormula, params, context);
     }
-    throw new Error(`Pack definition for ${manifest.name} has no formula or sync called ${formulaName}.`);
+    throw new Error(`Pack definition has no formula or sync called ${formulaName}.`);
   } catch (err) {
     throw wrapError(err);
   }
@@ -2778,7 +2778,7 @@ async function executeFormulaOrSync(manifest, formulaName, params, context) {
     if (syncFormula) {
       return await executeSyncFormula(syncFormula, params, context);
     }
-    throw new Error(`Pack definition for ${manifest.name} has no formula or sync called ${formulaName}.`);
+    throw new Error(`Pack definition has no formula or sync called ${formulaName}.`);
   } catch (err) {
     throw wrapError(err);
   }
@@ -2815,7 +2815,7 @@ async function executeSyncFormula(formula, params, context, {
 function findFormula(packDef, formulaNameWithNamespace) {
   const packFormulas = packDef.formulas;
   if (!packFormulas) {
-    throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formulas.`);
+    throw new Error(`Pack definition has no formulas.`);
   }
   const [namespace, name] = formulaNameWithNamespace.includes("::") ? formulaNameWithNamespace.split("::") : [ensureExists(packDef.formulaNamespace), formulaNameWithNamespace];
   if (!(namespace && name)) {
@@ -2823,18 +2823,18 @@ function findFormula(packDef, formulaNameWithNamespace) {
   }
   const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
   if (!formulas || !formulas.length) {
-    throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formulas for namespace "${namespace}".`);
+    throw new Error(`Pack definition has no formulas for namespace "${namespace}".`);
   }
   for (const formula of formulas) {
     if (formula.name === name) {
       return formula;
     }
   }
-  throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no formula "${name}" in namespace "${namespace}".`);
+  throw new Error(`Pack definition has no formula "${name}" in namespace "${namespace}".`);
 }
 function findSyncFormula(packDef, syncFormulaName) {
   if (!packDef.syncTables) {
-    throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no sync tables.`);
+    throw new Error(`Pack definition has no sync tables.`);
   }
   for (const syncTable of packDef.syncTables) {
     const syncFormula = syncTable.getter;
@@ -2842,7 +2842,7 @@ function findSyncFormula(packDef, syncFormulaName) {
       return syncFormula;
     }
   }
-  throw new Error(`Pack definition for ${packDef.name} (id ${packDef.id}) has no sync formula "${syncFormulaName}" in its sync tables.`);
+  throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
 }
 function tryFindFormula(packDef, formulaNameWithNamespace) {
   try {

--- a/dist/testing/fetcher.d.ts
+++ b/dist/testing/fetcher.d.ts
@@ -17,5 +17,5 @@ export declare class AuthenticatingFetcher implements Fetcher {
 export declare const requestHelper: {
     makeRequest: (request: FetchRequest) => Promise<Response>;
 };
-export declare function newFetcherExecutionContext(packName: string, authDef: Authentication | undefined, credentials?: Credentials): ExecutionContext;
-export declare function newFetcherSyncExecutionContext(packName: string, authDef: Authentication | undefined, credentials?: Credentials): SyncExecutionContext;
+export declare function newFetcherExecutionContext(authDef: Authentication | undefined, credentials?: Credentials): ExecutionContext;
+export declare function newFetcherSyncExecutionContext(authDef: Authentication | undefined, credentials?: Credentials): SyncExecutionContext;

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -193,7 +193,7 @@ class AuthenticatingBlobStorage {
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${uuid_1.v4()}`;
     }
 }
-function newFetcherExecutionContext(packName, authDef, credentials) {
+function newFetcherExecutionContext(authDef, credentials) {
     const fetcher = new AuthenticatingFetcher(authDef, credentials);
     return {
         invocationLocation: {
@@ -208,8 +208,8 @@ function newFetcherExecutionContext(packName, authDef, credentials) {
     };
 }
 exports.newFetcherExecutionContext = newFetcherExecutionContext;
-function newFetcherSyncExecutionContext(packName, authDef, credentials) {
-    const context = newFetcherExecutionContext(packName, authDef, credentials);
+function newFetcherSyncExecutionContext(authDef, credentials) {
+    const context = newFetcherExecutionContext(authDef, credentials);
     return { ...context, sync: {} };
 }
 exports.newFetcherSyncExecutionContext = newFetcherSyncExecutionContext;

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -24,7 +24,6 @@ import {newMockExecutionContext} from '../testing/mocks';
 import sinon from 'sinon';
 
 describe('Execution', () => {
-
   it('executes a formula by name', async () => {
     const result = await executeFormulaFromPackDef(fakePack, 'Fake::Square', [5]);
     assert.equal(result, 25);
@@ -41,12 +40,20 @@ describe('Execution', () => {
   });
 
   it('executes a formula by name with VM', async () => {
-    const result = await executeFormulaOrSyncWithVM({formulaName: 'Fake::Square', params: [5], manifestPath: `${__dirname}/packs/fake`});
+    const result = await executeFormulaOrSyncWithVM({
+      formulaName: 'Fake::Square',
+      params: [5],
+      manifestPath: `${__dirname}/packs/fake`,
+    });
     assert.equal(result, 25);
   });
 
   it('executes a sync formula by name with VM', async () => {
-    const result = await executeFormulaOrSyncWithVM({formulaName: 'Students', params: ['Smith'], manifestPath: `${__dirname}/packs/fake`});
+    const result = await executeFormulaOrSyncWithVM({
+      formulaName: 'Students',
+      params: ['Smith'],
+      manifestPath: `${__dirname}/packs/fake`,
+    });
     assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
   });
 
@@ -70,28 +77,28 @@ describe('Execution', () => {
     it('no formulas', async () => {
       await testHelper.willBeRejectedWith(
         executeFormulaFromPackDef(createFakePack({formulas: undefined}), 'Foo::Bar', []),
-        /Pack definition for Fake Pack \(id 424242\) has no formulas./,
+        /Pack definition has no formulas./,
       );
     });
 
     it('malformed formula name', async () => {
       await testHelper.willBeRejectedWith(
         executeFormulaFromPackDef(fakePack, 'malformed', []),
-        /Pack definition for Fake Pack \(id 424242\) has no formula "malformed" in namespace "Fake"./,
+        /Pack definition has no formula "malformed" in namespace "Fake"./,
       );
     });
 
     it('bad namespace', async () => {
       await testHelper.willBeRejectedWith(
         executeFormulaFromPackDef(fakePack, 'Foo::Bar', []),
-        /Pack definition for Fake Pack \(id 424242\) has no formula "Bar" in namespace "Foo"./,
+        /Pack definition has no formula "Bar" in namespace "Foo"./,
       );
     });
 
     it('non-existent formula', async () => {
       await testHelper.willBeRejectedWith(
         executeFormulaFromPackDef(fakePack, 'Fake::Foo', []),
-        /Pack definition for Fake Pack \(id 424242\) has no formula "Foo" in namespace "Fake"./,
+        /Pack definition has no formula "Foo" in namespace "Fake"./,
       );
     });
   });
@@ -307,14 +314,14 @@ describe('Execution', () => {
     it('no sync tables', async () => {
       await testHelper.willBeRejectedWith(
         executeSyncFormulaFromPackDef(createFakePack({formulas: undefined, syncTables: undefined}), 'Bar', []),
-        /Pack definition for Fake Pack \(id 424242\) has no sync tables./,
+        /Pack definition has no sync tables./,
       );
     });
 
     it('non-existent sync formula', async () => {
       await testHelper.willBeRejectedWith(
         executeSyncFormulaFromPackDef(fakePack, 'Foo', []),
-        /Pack definition for Fake Pack \(id 424242\) has no sync formula "Foo" in its sync tables./,
+        /Pack definition has no sync formula "Foo" in its sync tables./,
       );
     });
   });

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -3,7 +3,7 @@ import type {ExecuteSyncOptions} from './execution_helper';
 import type {ExecutionContext} from '../api_types';
 import type {MetadataContext} from '../api';
 import type {MetadataFormula} from '../api';
-import type {PackDefinition} from '../types';
+import type {PackVersionDefinition} from '../types';
 import type {ParamDefs} from '../api_types';
 import type {ParamValues} from '../api_types';
 import type {SyncExecutionContext} from '../api_types';
@@ -28,7 +28,7 @@ export interface ContextOptions {
 }
 
 export async function executeFormulaFromPackDef(
-  packDef: PackDefinition,
+  packDef: PackVersionDefinition,
   formulaNameWithNamespace: string,
   params: ParamValues<ParamDefs>,
   context?: ExecutionContext,
@@ -38,7 +38,7 @@ export async function executeFormulaFromPackDef(
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
     const credentials = getCredentials(manifestPath);
-    executionContext = newFetcherExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
+    executionContext = newFetcherExecutionContext(packDef.defaultAuthentication, credentials);
   }
 
   const formula = helper.findFormula(packDef, formulaNameWithNamespace);
@@ -67,7 +67,7 @@ export async function executeFormulaOrSyncFromCLI({
     // A sync context would work for both formula / syncFormula execution for now.
     // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
     const executionContext = useRealFetcher
-      ? newFetcherSyncExecutionContext(manifest.name, manifest.defaultAuthentication, credentials)
+      ? newFetcherSyncExecutionContext(manifest.defaultAuthentication, credentials)
       : newMockSyncExecutionContext();
 
     const result = vm
@@ -134,7 +134,7 @@ export async function executeFormulaOrSyncWithRawParams({
 }
 
 export async function executeSyncFormulaFromPackDef(
-  packDef: PackDefinition,
+  packDef: PackVersionDefinition,
   syncFormulaName: string,
   params: ParamValues<ParamDefs>,
   context?: SyncExecutionContext,
@@ -144,7 +144,7 @@ export async function executeSyncFormulaFromPackDef(
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
     const credentials = getCredentials(manifestPath);
-    executionContext = newFetcherSyncExecutionContext(packDef.name, packDef.defaultAuthentication, credentials);
+    executionContext = newFetcherSyncExecutionContext(packDef.defaultAuthentication, credentials);
   }
 
   const formula = helper.findSyncFormula(packDef, syncFormulaName);

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -241,7 +241,6 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
 }
 
 export function newFetcherExecutionContext(
-  packName: string,
   authDef: Authentication | undefined,
   credentials?: Credentials,
 ): ExecutionContext {
@@ -260,11 +259,10 @@ export function newFetcherExecutionContext(
 }
 
 export function newFetcherSyncExecutionContext(
-  packName: string,
   authDef: Authentication | undefined,
   credentials?: Credentials,
 ): SyncExecutionContext {
-  const context = newFetcherExecutionContext(packName, authDef, credentials);
+  const context = newFetcherExecutionContext(authDef, credentials);
   return {...context, sync: {}};
 }
 


### PR DESCRIPTION
Now that we only ask that you write a PackVersionDefinition, our TS needs to accept those in all of our testing/execution helpers.

PTAL @huayang-codaio @alan-codaio @coda-hq/ecosystem 