### PR TITLE
Enforce network domains in the simulated fetcher.

### DIFF
--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -35,7 +35,7 @@ async function executeFormulaFromPackDef(packDef, formulaNameWithNamespace, para
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
         const credentials = getCredentials(manifestPath);
-        executionContext = fetcher_1.newFetcherExecutionContext(packDef.defaultAuthentication, credentials);
+        executionContext = fetcher_1.newFetcherExecutionContext(packDef.defaultAuthentication, packDef.networkDomains, credentials);
     }
     const formula = helper.findFormula(packDef, formulaNameWithNamespace);
     return helper.executeFormula(formula, params, executionContext || mocks_1.newMockExecutionContext(), options);
@@ -50,7 +50,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifestPath, 
         // A sync context would work for both formula / syncFormula execution for now.
         // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
         const executionContext = useRealFetcher
-            ? fetcher_2.newFetcherSyncExecutionContext(manifest.defaultAuthentication, credentials)
+            ? fetcher_2.newFetcherSyncExecutionContext(manifest.defaultAuthentication, manifest.networkDomains, credentials)
             : mocks_2.newMockSyncExecutionContext();
         const result = vm
             ? await executeFormulaOrSyncWithRawParamsInVM({ formulaName, params, manifestPath, executionContext })
@@ -84,7 +84,7 @@ async function executeSyncFormulaFromPackDef(packDef, syncFormulaName, params, c
     let executionContext = context;
     if (!executionContext && useRealFetcher) {
         const credentials = getCredentials(manifestPath);
-        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.defaultAuthentication, credentials);
+        executionContext = fetcher_2.newFetcherSyncExecutionContext(packDef.defaultAuthentication, packDef.networkDomains, credentials);
     }
     const formula = helper.findSyncFormula(packDef, syncFormulaName);
     return helper.executeSyncFormula(formula, params, executionContext || mocks_2.newMockSyncExecutionContext(), options);

--- a/dist/testing/fetcher.d.ts
+++ b/dist/testing/fetcher.d.ts
@@ -8,14 +8,16 @@ import type { Response } from 'request';
 import type { SyncExecutionContext } from '../api_types';
 export declare class AuthenticatingFetcher implements Fetcher {
     private readonly _authDef;
+    private readonly _networkDomains;
     private readonly _credentials;
-    constructor(authDef: Authentication | undefined, credentials: Credentials | undefined);
+    constructor(authDef: Authentication | undefined, networkDomains: string[] | undefined, credentials: Credentials | undefined);
     fetch<T = any>(request: FetchRequest): Promise<FetchResponse<T>>;
     private _applyAuthentication;
     private _applyAndValidateEndpoint;
+    private _validateHost;
 }
 export declare const requestHelper: {
     makeRequest: (request: FetchRequest) => Promise<Response>;
 };
-export declare function newFetcherExecutionContext(authDef: Authentication | undefined, credentials?: Credentials): ExecutionContext;
-export declare function newFetcherSyncExecutionContext(authDef: Authentication | undefined, credentials?: Credentials): SyncExecutionContext;
+export declare function newFetcherExecutionContext(authDef: Authentication | undefined, networkDomains: string[] | undefined, credentials?: Credentials): ExecutionContext;
+export declare function newFetcherSyncExecutionContext(authDef: Authentication | undefined, networkDomains: string[] | undefined, credentials?: Credentials): SyncExecutionContext;

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -38,7 +38,7 @@ export async function executeFormulaFromPackDef(
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
     const credentials = getCredentials(manifestPath);
-    executionContext = newFetcherExecutionContext(packDef.defaultAuthentication, credentials);
+    executionContext = newFetcherExecutionContext(packDef.defaultAuthentication, packDef.networkDomains, credentials);
   }
 
   const formula = helper.findFormula(packDef, formulaNameWithNamespace);
@@ -67,7 +67,7 @@ export async function executeFormulaOrSyncFromCLI({
     // A sync context would work for both formula / syncFormula execution for now.
     // TODO(jonathan): Pass the right context, just to set user expectations correctly for runtime values.
     const executionContext = useRealFetcher
-      ? newFetcherSyncExecutionContext(manifest.defaultAuthentication, credentials)
+      ? newFetcherSyncExecutionContext(manifest.defaultAuthentication, manifest.networkDomains, credentials)
       : newMockSyncExecutionContext();
 
     const result = vm
@@ -144,7 +144,11 @@ export async function executeSyncFormulaFromPackDef(
   let executionContext = context;
   if (!executionContext && useRealFetcher) {
     const credentials = getCredentials(manifestPath);
-    executionContext = newFetcherSyncExecutionContext(packDef.defaultAuthentication, credentials);
+    executionContext = newFetcherSyncExecutionContext(
+      packDef.defaultAuthentication,
+      packDef.networkDomains,
+      credentials,
+    );
   }
 
   const formula = helper.findSyncFormula(packDef, syncFormulaName);


### PR DESCRIPTION
This is already enforced in the lambda fetcher, just making sure our SDK simulator mimics the same behavior.

PTAL @huayang-codaio @alan-codaio @coda-hq/ecosystem 