### PR TITLE
Make formula examples optional. Remove logoPath from Format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,11 +910,7 @@ interface MyFormulaResponse {
 
 ## Assets
 
-The `PackDefinition` asks you to specify a `logoPath` to a logo image for your pack.
-This should be a `png` or `svg` in a subdirectory called `assets`.
-
-This should be a square image ideally at least 200 pixels per side and with
-a transparent background.
+Assets like your pack's logo should be uploaded via the Pack management UI.
 
 ## Reference
 

--- a/api_types.ts
+++ b/api_types.ts
@@ -114,7 +114,7 @@ export type DefaultValueType<T extends UnionType> = T extends ArrayType<Type.dat
 export interface CommonPackFormulaDef<T extends ParamDefs> {
   readonly name: string;
   readonly description: string;
-  readonly examples: Array<{params: PackFormulaValue[]; result: PackFormulaResult}>;
+  readonly examples?: Array<{params: PackFormulaValue[]; result: PackFormulaResult}>;
   readonly parameters: T;
   readonly varargParameters?: ParamDefs;
   readonly network?: Network;
@@ -143,13 +143,7 @@ export interface Network {
 }
 
 // Fetcher APIs
-const ValidFetchMethods = [
-  'GET',
-  'PATCH',
-  'POST',
-  'PUT',
-  'DELETE',
-] as const;
+const ValidFetchMethods = ['GET', 'PATCH', 'POST', 'PUT', 'DELETE'] as const;
 export type FetchMethodType = typeof ValidFetchMethods[number];
 
 // Copied from https://developer.mozilla.org/en-US/docs/Web/API/Request

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -271,10 +271,10 @@ export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs,
     request: RequestHandlerTemplate;
     description: string;
     name: string;
-    examples: {
+    examples?: {
         params: import("./api_types").PackFormulaValue[];
         result: PackFormulaResult;
-    }[];
+    }[] | undefined;
     parameters: ParamDefsT;
     varargParameters?: ParamDefs | undefined;
     network?: import("./api_types").Network | undefined;

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -56,7 +56,7 @@ export declare type DefaultValueType<T extends UnionType> = T extends ArrayType<
 export interface CommonPackFormulaDef<T extends ParamDefs> {
     readonly name: string;
     readonly description: string;
-    readonly examples: Array<{
+    readonly examples?: Array<{
         params: PackFormulaValue[];
         result: PackFormulaResult;
     }>;

--- a/dist/api_types.js
+++ b/dist/api_types.js
@@ -46,13 +46,7 @@ var NetworkConnection;
     NetworkConnection["Required"] = "required";
 })(NetworkConnection = exports.NetworkConnection || (exports.NetworkConnection = {}));
 // Fetcher APIs
-const ValidFetchMethods = [
-    'GET',
-    'PATCH',
-    'POST',
-    'PUT',
-    'DELETE',
-];
+const ValidFetchMethods = ['GET', 'PATCH', 'POST', 'PUT', 'DELETE'];
 // A mapping exists in coda that allows these to show up in the UI.
 // If adding new values here, add them to that mapping and vice versa.
 var PrecannedDateRange;

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -241,7 +241,7 @@ export declare type DefaultValueType<T extends UnionType> = T extends ArrayType<
 export interface CommonPackFormulaDef<T extends ParamDefs> {
 	readonly name: string;
 	readonly description: string;
-	readonly examples: Array<{
+	readonly examples?: Array<{
 		params: PackFormulaValue[];
 		result: PackFormulaResult;
 	}>;
@@ -639,10 +639,10 @@ export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs,
 	request: RequestHandlerTemplate;
 	description: string;
 	name: string;
-	examples: {
+	examples?: {
 		params: PackFormulaValue[];
 		result: PackFormulaResult;
-	}[];
+	}[] | undefined;
 	parameters: ParamDefsT;
 	varargParameters?: ParamDefs | undefined;
 	network?: Network | undefined;
@@ -803,7 +803,6 @@ export interface Format {
 	formulaName: string;
 	hasNoConnection?: boolean;
 	instructions?: string;
-	logoPath?: string;
 	matchers?: RegExp[];
 	placeholder?: string;
 }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -276,10 +276,12 @@ const commonPackFormulaSchema = {
         .string()
         .refine(validateFormulaName, { message: 'Formula names can only contain alphanumeric characters and underscores.' }),
     description: z.string(),
-    examples: z.array(z.object({
+    examples: z
+        .array(z.object({
         params: z.union([primitiveUnion, z.array(primitiveUnion)]),
         result: z.any(),
-    })),
+    }))
+        .optional(),
     parameters: z.array(paramDefValidator),
     varargParameters: z.array(paramDefValidator).optional(),
     network: zodCompleteObject({
@@ -425,7 +427,6 @@ const formatMetadataSchema = zodCompleteObject({
     formulaName: z.string(),
     hasNoConnection: z.boolean().optional(),
     instructions: z.string().optional(),
-    logoPath: z.string().optional(),
     placeholder: z.string().optional(),
     matchers: z.array(z.string()),
 });

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -150,7 +150,6 @@ export interface Format {
     formulaName: string;
     hasNoConnection?: boolean;
     instructions?: string;
-    logoPath?: string;
     matchers?: RegExp[];
     placeholder?: string;
 }

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -49,7 +49,7 @@ describe('Pack metadata Validation', () => {
 
   it('wrong top-level types', async () => {
     const metadata = 'asdf';
-    const err = await validateJsonAndAssertFails((metadata as unknown) as Record<string, any>);
+    const err = await validateJsonAndAssertFails(metadata as unknown as Record<string, any>);
     assert.deepEqual(err.validationErrors, [{path: '', message: 'Expected object, received string'}]);
   });
 
@@ -230,7 +230,7 @@ describe('Pack metadata Validation', () => {
         {connection: NetworkConnection.None},
         {connection: NetworkConnection.Optional},
         {connection: NetworkConnection.Required},
-        {hasSideEffect: true, connection: NetworkConnection.Optional},        
+        {hasSideEffect: true, connection: NetworkConnection.Optional},
       ];
       for (const network of networks) {
         const formula = makeStringFormula({
@@ -430,7 +430,6 @@ describe('Pack metadata Validation', () => {
         assert.deepEqual(invalidFormulaErrors.validationErrors, [
           {path: 'syncTables[0].getter.name', message: 'Required'},
           {path: 'syncTables[0].getter.description', message: 'Required'},
-          {path: 'syncTables[0].getter.examples', message: 'Required'},
           {path: 'syncTables[0].getter.parameters', message: 'Required'},
         ]);
       });
@@ -848,13 +847,17 @@ describe('Pack metadata Validation', () => {
   describe('validateVariousAuthenticationMetadata', () => {
     it('succeeds', () => {
       assert.ok(validateVariousAuthenticationMetadata({type: AuthenticationType.None}));
-      assert.ok(validateVariousAuthenticationMetadata({
-        type: AuthenticationType.HeaderBearerToken,
-      }));
-      assert.ok(validateVariousAuthenticationMetadata({
-        type: AuthenticationType.CustomHeaderToken,
-        headerName: 'MyHeader',
-      }));
+      assert.ok(
+        validateVariousAuthenticationMetadata({
+          type: AuthenticationType.HeaderBearerToken,
+        }),
+      );
+      assert.ok(
+        validateVariousAuthenticationMetadata({
+          type: AuthenticationType.CustomHeaderToken,
+          headerName: 'MyHeader',
+        }),
+      );
     });
 
     it('fails on invalid auth type', () => {
@@ -862,21 +865,26 @@ describe('Pack metadata Validation', () => {
     });
 
     it('fails on invalid auth type', () => {
-      assert.throws(() => validateVariousAuthenticationMetadata({
-        type: AuthenticationType.CustomHeaderToken,
-      }));
-      assert.throws(() => validateVariousAuthenticationMetadata({
-        type: AuthenticationType.CustomHeaderToken,
-        headerName: {
-          not: 'a string',
-        },
-      }));
-      assert.throws(() => validateVariousAuthenticationMetadata({
-        type: AuthenticationType.CustomHeaderToken,
-        headerName: 'MyHeader',
-        evilData: 0xDEADBEEF,
-      }));
+      assert.throws(() =>
+        validateVariousAuthenticationMetadata({
+          type: AuthenticationType.CustomHeaderToken,
+        }),
+      );
+      assert.throws(() =>
+        validateVariousAuthenticationMetadata({
+          type: AuthenticationType.CustomHeaderToken,
+          headerName: {
+            not: 'a string',
+          },
+        }),
+      );
+      assert.throws(() =>
+        validateVariousAuthenticationMetadata({
+          type: AuthenticationType.CustomHeaderToken,
+          headerName: 'MyHeader',
+          evilData: 0xdeadbeef,
+        }),
+      );
     });
-
   });
 });

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -290,7 +290,7 @@ const systemAuthenticationTypes: {[key in SystemAuthenticationTypes]: true} = {
   [AuthenticationType.QueryParamToken]: true,
   [AuthenticationType.WebBasic]: true,
   [AuthenticationType.AWSSignature4]: true,
-}
+};
 
 const systemAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
   .filter(([authType]) => authType in systemAuthenticationTypes)
@@ -303,7 +303,7 @@ const variousSupportedAuthenticationTypes: {[key in VariousSupportedAuthenticati
   [AuthenticationType.QueryParamToken]: true,
   [AuthenticationType.WebBasic]: true,
   [AuthenticationType.None]: true,
-}
+};
 
 const variousSupportedAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
   .filter(([authType]) => authType in variousSupportedAuthenticationTypes)
@@ -326,12 +326,14 @@ const commonPackFormulaSchema = {
     .string()
     .refine(validateFormulaName, {message: 'Formula names can only contain alphanumeric characters and underscores.'}),
   description: z.string(),
-  examples: z.array(
-    z.object({
-      params: z.union([primitiveUnion, z.array(primitiveUnion)]),
-      result: z.any(),
-    }),
-  ),
+  examples: z
+    .array(
+      z.object({
+        params: z.union([primitiveUnion, z.array(primitiveUnion)]),
+        result: z.any(),
+      }),
+    )
+    .optional(),
   parameters: z.array(paramDefValidator),
   varargParameters: z.array(paramDefValidator).optional(),
   network: zodCompleteObject<Network>({
@@ -504,7 +506,6 @@ const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
   formulaName: z.string(),
   hasNoConnection: z.boolean().optional(),
   instructions: z.string().optional(),
-  logoPath: z.string().optional(), // Should move to the UI somehow
   placeholder: z.string().optional(),
   matchers: z.array(z.string()),
 });

--- a/types.ts
+++ b/types.ts
@@ -217,7 +217,6 @@ export interface Format {
   formulaName: string;
   hasNoConnection?: boolean;
   instructions?: string;
-  logoPath?: string;
   matchers?: RegExp[];
   placeholder?: string;
 }


### PR DESCRIPTION
It's annoying that examples are required, nobody uses them and just puts and empty list, which makes the boilerplate for a basic formula bulkier.

Our Format object allows you to specify a different logo if you don't want to use the pack logo, but it looks like we don't have a single instance where we use a different logo. We have no plans to tackle the complexity of supporting UI uploads of format-specific assets, so I just want to rip this out.

PTAL @alexd-codaio @huayang-codaio @alan-codaio @coda-hq/ecosystem 