### PR TITLE
Test for zod stripping extraneous child fields.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -142,7 +142,6 @@ function zodPathToPathString(zodPath) {
 function zodCompleteObject(shape) {
     return z.object(shape);
 }
-// TODO(jonathan): Migrate all schemas to strict validation.
 function zodCompleteStrictObject(shape) {
     return z.strictObject(shape);
 }

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -9,6 +9,7 @@ import type {PackFormulaMetadata} from '../api';
 import type {PackMetadataValidationError} from '../testing/upload_validation';
 import type {PackVersionMetadata} from '../compiled_types';
 import {PostSetupType} from '../types';
+import type {StringFormulaDef} from '../api';
 import type {TypedStandardFormula} from '../api';
 import {ValueType} from '../schema';
 import {createFakePack} from './test_utils';
@@ -60,12 +61,24 @@ describe('Pack metadata Validation', () => {
   });
 
   it('extraneous fields are omitted', async () => {
-    const metadata = createFakePackVersionMetadata();
+    const metadata = createFakePackVersionMetadata({
+      formulaNamespace: 'namespace',
+      formulas: [
+        makeStringFormula({
+          extraneous: 'evil long string',
+          name: 'formula',
+          description: '',
+          execute: () => '',
+          parameters: [],
+        } as StringFormulaDef<any>),
+      ],
+    });
     const result = await validateJson({
       ...metadata,
       extraneous: 'long evil string',
     });
     assert.notInclude(Object.keys(result), 'extraneous');
+    assert.notInclude(Object.keys((result.formulas as PackFormulaMetadata[])[0]), 'extraneous');
   });
 
   it('formula namespace required when formulas present', async () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -176,7 +176,6 @@ function zodCompleteObject<O, T extends ZodCompleteShape<O> = ZodCompleteShape<R
   return z.object<T>(shape);
 }
 
-// TODO(jonathan): Migrate all schemas to strict validation.
 function zodCompleteStrictObject<O, T extends ZodCompleteShape<O> = ZodCompleteShape<Required<O>>>(shape: T) {
   return z.strictObject<T>(shape);
 }


### PR DESCRIPTION
I had suggested that we should probably convert all of our zod schema validators to `.strict()` so that they disallowed extraneous fields, as Alex was doing this for the Various auth validation.

I have since remembered that I think in zod 3, zod switched from being strict by default to allowing but simply removing extraneous fields by default, and that's the behavior we're relying on. I think we actually might need this behavior for some of our union type validation.

So I don't think we need to worry about strictness checks, zod will automatically remove any unvalidated fields from the parsed object. So just adding a test here to verify that this is indeed happening for child objects too.

PTAL @alexd-codaio @alan-codaio @coda-hq/ecosystem 