### PR TITLE
Rename coda-hq to coda

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
       day: 'tuesday'
     open-pull-requests-limit: 50
     reviewers:
-      - "coda-hq/ecosystem"
+      - "coda/ecosystem"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coda-hq/ecosystem
+* @coda/ecosystem

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ in which case, make sure that you have TypeScript and **ts-node** installed.
 The simplest way to get started with the SDK is to install it globally:
 
 ```bash
-npm install --global git+ssh://github.com/coda-hq/packs-sdk.git
+npm install --global git+ssh://github.com/coda/packs-sdk.git
 ```
 
 #### Single-Project Install (Recommended)
@@ -98,7 +98,7 @@ Create a new project directory if you haven't already and initialize your projec
 # Initialize npm and follow prompts.
 npm init
 # Install the Coda Packs SDK locally in your project
-npm install --save git+ssh://github.com/coda-hq/packs-sdk.git
+npm install --save git+ssh://github.com/coda/packs-sdk.git
 ```
 
 Update your path so you can easily use the `coda` commandline (CLI) that ships with the SDK:
@@ -189,7 +189,7 @@ See the [Authentication](#authentication) section about how to set this up.
 
 ## Examples
 
-See our examples repo https://github.com/coda-hq/packs-examples for several examples of complete
+See our examples repo https://github.com/coda/packs-examples for several examples of complete
 pack definitions of various levels of complexity.
 
 ## Core Concepts

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coda-hq/packs-sdk"
+    "url": "https://github.com/coda/packs-sdk"
   },
   "dependencies": {
     "@types/sinon": "^10.0.0",


### PR DESCRIPTION
Per discussion from https://codaproject.slack.com/archives/G01K0R0BAPR/p1620658218002900 rename the coda-hq org to coda

