### PR TITLE
Allow node versions higher than 14, rather than pegging to v14 only.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "private": true,
   "engines": {
-    "node": "14.x"
+    "node": ">=14.x"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
There was no reason to require 14 before, I think it was just leftover from some copy-paste from ages ago.

If you've already been using an environment built on v14 and you want to try another version using `nvm use`, make sure to do `npm rebuild` to recreate all of the node_modules using the new node version.

PTAL @huayang-codaio @alan-codaio @patrick-codaio @coda/ecosystem 