### PR TITLE
Change 'coda validate' to build first.

### DIFF
--- a/cli/validate.ts
+++ b/cli/validate.ts
@@ -1,6 +1,7 @@
 import type {Arguments} from 'yargs';
 import type {PackMetadata} from '../compiled_types';
 import type {PackMetadataValidationError} from '../testing/upload_validation';
+import {build} from './build';
 import {makeManifestFullPath} from './helpers';
 import {printAndExit} from '../testing/helpers';
 import {validatePackVersionMetadata} from '../testing/upload_validation';
@@ -11,7 +12,8 @@ interface ValidateArgs {
 
 export async function handleValidate({manifestFile}: Arguments<ValidateArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestFile);
-  const {manifest} = await import(fullManifestPath);
+  const bundleFilename = await build(fullManifestPath);
+  const {manifest} = await import(bundleFilename);
   return validateMetadata(manifest);
 }
 

--- a/dist/cli/validate.js
+++ b/dist/cli/validate.js
@@ -20,12 +20,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validateMetadata = exports.handleValidate = void 0;
+const build_1 = require("./build");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("../testing/helpers");
 const upload_validation_1 = require("../testing/upload_validation");
 async function handleValidate({ manifestFile }) {
     const fullManifestPath = helpers_1.makeManifestFullPath(manifestFile);
-    const { manifest } = await Promise.resolve().then(() => __importStar(require(fullManifestPath)));
+    const bundleFilename = await build_1.build(fullManifestPath);
+    const { manifest } = await Promise.resolve().then(() => __importStar(require(bundleFilename)));
     return validateMetadata(manifest);
 }
 exports.handleValidate = handleValidate;


### PR DESCRIPTION
Tried this today and it didn't work, TS was complaining about imports. We fixed all the other commands to build first and then import but I guess we missed this one.

PTAL @alan-codaio @coda/packs 