### PR TITLE
More user-friendly errors coda 'coda upload' and 'coda validate'

### DIFF
--- a/cli/validate.ts
+++ b/cli/validate.ts
@@ -1,6 +1,7 @@
 import type {Arguments} from 'yargs';
 import type {PackMetadata} from '../compiled_types';
 import type {PackMetadataValidationError} from '../testing/upload_validation';
+import type {ValidationError} from '../testing/types';
 import {build} from './build';
 import {makeManifestFullPath} from './helpers';
 import {printAndExit} from '../testing/helpers';
@@ -22,7 +23,14 @@ export async function validateMetadata(metadata: PackMetadata) {
     await validatePackVersionMetadata(metadata);
   } catch (e: any) {
     const packMetadataValidationError = e as PackMetadataValidationError;
-    const validationErrors = packMetadataValidationError.validationErrors?.map(error => error.message).join('\n');
+    const validationErrors = packMetadataValidationError.validationErrors?.map(makeErrorMessage).join('\n');
     printAndExit(`${e.message}: \n${validationErrors}`);
   }
+}
+
+function makeErrorMessage({path, message}: ValidationError): string {
+  if (path) {
+    return `Error in field at path "${path}": ${message}`;
+  }
+  return message;
 }

--- a/dist/cli/validate.js
+++ b/dist/cli/validate.js
@@ -38,8 +38,14 @@ async function validateMetadata(metadata) {
     }
     catch (e) {
         const packMetadataValidationError = e;
-        const validationErrors = (_a = packMetadataValidationError.validationErrors) === null || _a === void 0 ? void 0 : _a.map(error => error.message).join('\n');
+        const validationErrors = (_a = packMetadataValidationError.validationErrors) === null || _a === void 0 ? void 0 : _a.map(makeErrorMessage).join('\n');
         helpers_2.printAndExit(`${e.message}: \n${validationErrors}`);
     }
 }
 exports.validateMetadata = validateMetadata;
+function makeErrorMessage({ path, message }) {
+    if (path) {
+        return `Error in field at path "${path}": ${message}`;
+    }
+    return message;
+}


### PR DESCRIPTION
Before:

```
Pack metadata failed validation:
Required
Required
```

After:

```
Pack metadata failed validation:
Error in field at path "defaultAuthentication.authorizationUrl": Required
Error in field at path "defaultAuthentication.tokenUrl": Required
```

I'm open to making this much nicer too if people have ideas.

PTAL @alan-codaio @patrick-codaio @coda/packs 