### PR TITLE
Show a default error message if no union members match. Create a utility to validate schemas.

### DIFF
--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -1,3 +1,5 @@
+import type { ArraySchema } from '../schema';
+import type { ObjectSchema } from '../schema';
 import type { PackVersionMetadata } from '../compiled_types';
 import type { ValidationError } from './types';
 import type { VariousAuthentication } from '../types';
@@ -8,3 +10,4 @@ export declare class PackMetadataValidationError extends Error {
 }
 export declare function validatePackVersionMetadata(metadata: Record<string, any>): Promise<PackVersionMetadata>;
 export declare function validateVariousAuthenticationMetadata(auth: any): VariousAuthentication;
+export declare function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<any, any>>;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -19,7 +19,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = void 0;
+exports.validateSyncTableSchema = exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = void 0;
 const schema_1 = require("../schema");
 const types_1 = require("../types");
 const types_2 = require("../types");
@@ -67,6 +67,15 @@ function validateVariousAuthenticationMetadata(auth) {
     throw new PackMetadataValidationError('Various authentication failed validation', validated.error, validated.error.errors.flatMap(zodErrorDetailToValidationError));
 }
 exports.validateVariousAuthenticationMetadata = validateVariousAuthenticationMetadata;
+// Note: This is called within Coda for validating the result of getSchema calls for dynamic sync tables.
+function validateSyncTableSchema(schema) {
+    const validated = arrayPropertySchema.safeParse(schema);
+    if (validated.success) {
+        return validated.data;
+    }
+    throw new PackMetadataValidationError('Schema failed validation', validated.error, validated.error.errors.flatMap(zodErrorDetailToValidationError));
+}
+exports.validateSyncTableSchema = validateSyncTableSchema;
 function zodErrorDetailToValidationError(subError) {
     var _a;
     // Top-level errors for union types are totally useless, they just say "invalid input",
@@ -112,6 +121,9 @@ function zodErrorDetailToValidationError(subError) {
                     }
                 }
             }
+        }
+        if (underlyingErrors.length === 0) {
+            return [{ path: zodPathToPathString(subError.path), message: 'Could not find any valid schema for this value.' }];
         }
         return underlyingErrors;
     }


### PR DESCRIPTION
Trying to better detect invalid schemas. Right now we're relying on TypeScript to enforce our type hints properly, e.g. that you do `{type: ValueType.String, codaType: ValueType.DateTime}` rather than `{type: ValueType.DateTime}`.

Today, if you do this in a static sync table, we'll detect it, but we'll just throw an exception with no path and no message, so it's not actionable. We don't validate this at all for dynamic sync tables, so you'll be able to create a dynamic sync table with one of these invalid schemas that will just fail mysteriously at runtime with dataType errors in the formula language. So I'm going to explicitly call validation on dynamic schemas.

PTAL @alan-codaio @coda/packs 