### PR TITLE
Make the pack version optional

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -190,6 +190,7 @@ export interface RateLimits {
     overall?: RateLimit;
     perConnection?: RateLimit;
 }
+export declare type BasicPackDefinition = Omit<PackVersionDefinition, 'version'>;
 /**
  * The definition of the contents of a Pack at a specific version. This is the
  * heart of the implementation of a Pack.

--- a/types.ts
+++ b/types.ts
@@ -264,6 +264,8 @@ export interface RateLimits {
   perConnection?: RateLimit;
 }
 
+export type BasicPackDefinition = Omit<PackVersionDefinition, 'version'>;
+
 /**
  * The definition of the contents of a Pack at a specific version. This is the
  * heart of the implementation of a Pack.


### PR DESCRIPTION
Making the version optional since we auto-generate in the web editor and throw if it's undefined from the cli (where we don't auto-generate)

![image](https://user-images.githubusercontent.com/42978433/120719583-87f53800-c498-11eb-8cc7-dbae20e95ffb.png)
^no red squiggly

PTAL @jonathan-codaio / @huayang-codaio / @alan-codaio / @patrick-codaio 