### PR TITLE
Remove deprecated oauth client id and client secret env var names from SDK.

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -801,8 +801,6 @@ export interface OAuth2Authentication extends BaseAuthentication {
 	additionalParams?: {
 		[key: string]: any;
 	};
-	clientIdEnvVarName: string;
-	clientSecretEnvVarName: string;
 	endpointKey?: string;
 	tokenQueryParam?: string;
 }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -226,8 +226,6 @@ const defaultAuthenticationValidators = {
         scopes: z.array(z.string()).optional(),
         tokenPrefix: z.string().optional(),
         additionalParams: z.record(z.any()).optional(),
-        clientIdEnvVarName: z.string().optional(),
-        clientSecretEnvVarName: z.string().optional(),
         endpointKey: z.string().optional(),
         tokenQueryParam: z.string().optional(),
         ...baseAuthenticationValidators,

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -119,8 +119,6 @@ export interface OAuth2Authentication extends BaseAuthentication {
     additionalParams?: {
         [key: string]: any;
     };
-    clientIdEnvVarName: string;
-    clientSecretEnvVarName: string;
     endpointKey?: string;
     tokenQueryParam?: string;
 }

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -850,9 +850,6 @@ describe('Auth', () => {
           type: AuthenticationType.OAuth2,
           authorizationUrl: 'https://auth-url.com',
           tokenUrl: 'https://token-url.com',
-
-          clientIdEnvVarName: 'ignored',
-          clientSecretEnvVarName: 'ignored',
         });
         setupReadline(['some-client-id', 'some-client-secret']);
         doSetupAuth(pack);
@@ -875,8 +872,6 @@ describe('Auth', () => {
           authDef: {
             additionalParams: undefined,
             authorizationUrl: 'https://auth-url.com',
-            clientIdEnvVarName: 'ignored',
-            clientSecretEnvVarName: 'ignored',
             scopes: undefined,
             tokenUrl: 'https://token-url.com',
             type: 'OAuth2',
@@ -895,9 +890,6 @@ describe('Auth', () => {
           tokenPrefix: 'SomePrefix',
           scopes: ['scope1', 'scope2'],
           additionalParams: {foo: 'bar'},
-
-          clientIdEnvVarName: 'ignored',
-          clientSecretEnvVarName: 'ignored',
         });
         setupReadline(['some-client-id', 'some-client-secret']);
         doSetupAuth(pack);
@@ -920,8 +912,6 @@ describe('Auth', () => {
           authDef: {
             additionalParams: {foo: 'bar'},
             authorizationUrl: 'https://auth-url.com',
-            clientIdEnvVarName: 'ignored',
-            clientSecretEnvVarName: 'ignored',
             scopes: ['scope1', 'scope2'],
             tokenUrl: 'https://token-url.com',
             type: 'OAuth2',
@@ -938,9 +928,6 @@ describe('Auth', () => {
             type: AuthenticationType.OAuth2,
             authorizationUrl: 'https://auth-url.com',
             tokenUrl: 'https://token-url.com',
-
-            clientIdEnvVarName: 'ignored',
-            clientSecretEnvVarName: 'ignored',
           },
           {name: 'Fake Pack'},
         );

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -820,8 +820,6 @@ describe('Pack metadata Validation', () => {
           scopes: ['scope 1', 'scope 2'],
           tokenPrefix: 'some-prefix',
           additionalParams: {foo: 'bar'},
-          clientIdEnvVarName: 'deprecated',
-          clientSecretEnvVarName: 'deprecated',
           endpointKey: 'some-key',
           tokenQueryParam: 'some-param',
           postSetup: [
@@ -843,8 +841,6 @@ describe('Pack metadata Validation', () => {
           type: AuthenticationType.OAuth2,
           authorizationUrl: 'some-url',
           tokenUrl: 'some-url',
-          clientIdEnvVarName: 'deprecated',
-          clientSecretEnvVarName: 'deprecated',
         },
       });
       await validateJson(metadata);

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -276,8 +276,6 @@ const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> 
     scopes: z.array(z.string()).optional(),
     tokenPrefix: z.string().optional(),
     additionalParams: z.record(z.any()).optional(),
-    clientIdEnvVarName: z.string().optional(), // Deprecated
-    clientSecretEnvVarName: z.string().optional(), // Deprecated
     endpointKey: z.string().optional(),
     tokenQueryParam: z.string().optional(),
     ...baseAuthenticationValidators,

--- a/types.ts
+++ b/types.ts
@@ -147,9 +147,6 @@ export interface OAuth2Authentication extends BaseAuthentication {
   scopes?: string[];
   tokenPrefix?: string;
   additionalParams?: {[key: string]: any};
-  // TODO(oleg): store secrets somewhere better, like in AWS Secrets Manager.
-  clientIdEnvVarName: string;
-  clientSecretEnvVarName: string;
 
   // Some OAuth providers will return the API domain with the OAuth response.
   // This is the key in the OAuth response json body that points to the endpoint.


### PR DESCRIPTION
Long live the OAuth server.

PTAL @huayang-codaio @coda/packs 