### PR TITLE
Validate that networkDomains is provided if authentication is declared.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -548,7 +548,8 @@ const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSc
     quotas: z.any().optional(),
     rateLimits: z.any().optional(),
     isSystem: z.boolean().optional(),
-})).refine(data => {
+}))
+    .refine(data => {
     var _a;
     for (const syncTable of data.syncTables) {
         if (!((_a = syncTable.schema) === null || _a === void 0 ? void 0 : _a.identity)) {
@@ -562,4 +563,14 @@ const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSc
     return true;
 }, {
     message: "Cannot have a sync table property with the same name as the sync table's schema identity.",
+})
+    .refine(data => {
+    var _a;
+    const usesAuthentication = (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) ||
+        data.systemConnectionAuthentication;
+    return !usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length);
+}, {
+    message: 'This pack uses authentication but did not declare a network domain. ' +
+        "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+    path: ['networkDomains'],
 });

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -29,6 +29,7 @@ export const FakePack: PackDefinition = deepFreeze({
 
 export const FakePackVersionMetadata: PackVersionMetadata = deepFreeze({
   ...BaseFakePack,
+  networkDomains: ['example.com'],
   defaultAuthentication: {
     type: AuthenticationType.QueryParamToken,
     paramName: 'authToken',

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -897,6 +897,57 @@ describe('Pack metadata Validation', () => {
         },
       ]);
     });
+
+    it('missing networkDomains when specifying authentication', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: undefined,
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            "This pack uses authentication but did not declare a network domain. Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+          path: 'networkDomains',
+        },
+      ]);
+    });
+
+    it('empty networkDomains when specifying authentication', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: [],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            "This pack uses authentication but did not declare a network domain. Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+          path: 'networkDomains',
+        },
+      ]);
+    });
+
+    it('missing networkDomains when specifying system authentication', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: undefined,
+        systemConnectionAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            "This pack uses authentication but did not declare a network domain. Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+          path: 'networkDomains',
+        },
+      ]);
+    });
   });
 
   describe('validateVariousAuthenticationMetadata', () => {


### PR DESCRIPTION
I don't think there's any valid reason a pack would declare authentication but not hit the network and hence need networkDomains. So just thought of this this morning to try to catch these kinds of errors before runtime.

PTAL @betty-codaio @huayang-codaio @coda/packs 