### PR TITLE
Disallow object types in parameter defs.

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -11,6 +11,7 @@ import type {PackFormulaResult} from './api_types';
 import type {ParamArgs} from './api_types';
 import type {ParamDef} from './api_types';
 import type {ParamDefs} from './api_types';
+import type {ParamType} from './api_types';
 import type {ParamValues} from './api_types';
 import type {RequestHandlerTemplate} from './handler_templates';
 import type {ResponseHandlerTemplate} from './handler_templates';
@@ -182,11 +183,11 @@ export function isDynamicSyncTable(syncTable: SyncTable): syncTable is GenericDy
  * @example
  * makeParameter({arrayType: Type.String, name: 'myArrayParam', description: 'My description'});
  */
-export function makeParameter<T extends Type>(definition: ParamDef<T>): ParamDef<T>;
-export function makeParameter<T extends Type>(
+export function makeParameter<T extends ParamType>(definition: ParamDef<T>): ParamDef<T>;
+export function makeParameter<T extends ParamType>(
   definition: Omit<ParamDef<ArrayType<T>>, 'type'> & {arrayType: T},
 ): ParamDef<ArrayType<T>>;
-export function makeParameter<T extends Type>(
+export function makeParameter<T extends ParamType>(
   definition: ParamDef<T> | (Omit<ParamDef<ArrayType<T>>, 'type'> & {arrayType: T}),
 ): ParamDef<T> | ParamDef<ArrayType<T>> {
   if ('arrayType' in definition) {

--- a/api_types.ts
+++ b/api_types.ts
@@ -13,6 +13,8 @@ export enum Type {
   image,
 }
 
+export type ParamType = Exclude<Type, Type.object>;
+
 export interface ArrayType<T extends Type> {
   type: 'array';
   items: T;

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -11,6 +11,7 @@ import type { PackFormulaResult } from './api_types';
 import type { ParamArgs } from './api_types';
 import type { ParamDef } from './api_types';
 import type { ParamDefs } from './api_types';
+import type { ParamType } from './api_types';
 import type { ParamValues } from './api_types';
 import type { RequestHandlerTemplate } from './handler_templates';
 import type { ResponseHandlerTemplate } from './handler_templates';
@@ -137,8 +138,8 @@ export declare function isDynamicSyncTable(syncTable: SyncTable): syncTable is G
  * @example
  * makeParameter({arrayType: Type.String, name: 'myArrayParam', description: 'My description'});
  */
-export declare function makeParameter<T extends Type>(definition: ParamDef<T>): ParamDef<T>;
-export declare function makeParameter<T extends Type>(definition: Omit<ParamDef<ArrayType<T>>, 'type'> & {
+export declare function makeParameter<T extends ParamType>(definition: ParamDef<T>): ParamDef<T>;
+export declare function makeParameter<T extends ParamType>(definition: Omit<ParamDef<ArrayType<T>>, 'type'> & {
     arrayType: T;
 }): ParamDef<ArrayType<T>>;
 export declare function makeStringParameter(name: string, description: string, args?: ParamArgs<Type.string>): ParamDef<Type.string>;

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -12,6 +12,7 @@ export declare enum Type {
     html = 5,
     image = 6
 }
+export declare type ParamType = Exclude<Type, Type.object>;
 export interface ArrayType<T extends Type> {
     type: 'array';
     items: T;

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -216,6 +216,7 @@ export declare enum Type {
 	html = 5,
 	image = 6
 }
+export declare type ParamType = Exclude<Type, Type.object>;
 export interface ArrayType<T extends Type> {
 	type: "array";
 	items: T;
@@ -553,8 +554,8 @@ export declare function isDynamicSyncTable(syncTable: SyncTable): syncTable is G
  * @example
  * makeParameter({arrayType: Type.String, name: 'myArrayParam', description: 'My description'});
  */
-export declare function makeParameter<T extends Type>(definition: ParamDef<T>): ParamDef<T>;
-export declare function makeParameter<T extends Type>(definition: Omit<ParamDef<ArrayType<T>>, "type"> & {
+export declare function makeParameter<T extends ParamType>(definition: ParamDef<T>): ParamDef<T>;
+export declare function makeParameter<T extends ParamType>(definition: Omit<ParamDef<ArrayType<T>>, "type"> & {
 	arrayType: T;
 }): ParamDef<ArrayType<T>>;
 export declare function makeStringParameter(name: string, description: string, args?: ParamArgs<Type.string>): ParamDef<Type.string>;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -274,7 +274,12 @@ const variousSupportedAuthenticationValidators = Object.entries(defaultAuthentic
 const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
 const paramDefValidator = zodCompleteObject({
     name: z.string(),
-    type: z.union([z.nativeEnum(api_types_3.Type), z.object({ type: zodDiscriminant('array'), items: z.nativeEnum(api_types_3.Type) })]),
+    type: z
+        .union([z.nativeEnum(api_types_3.Type), z.object({ type: zodDiscriminant('array'), items: z.nativeEnum(api_types_3.Type) })])
+        .refine(paramType => paramType !== api_types_3.Type.object &&
+        !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === api_types_3.Type.object), {
+        message: 'Object parameters are not currently supported.',
+    }),
     description: z.string(),
     optional: z.boolean().optional(),
     hidden: z.boolean().optional(),

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -330,7 +330,16 @@ const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
 
 const paramDefValidator = zodCompleteObject<ParamDef<any>>({
   name: z.string(),
-  type: z.union([z.nativeEnum(Type), z.object({type: zodDiscriminant('array'), items: z.nativeEnum(Type)})]),
+  type: z
+    .union([z.nativeEnum(Type), z.object({type: zodDiscriminant('array'), items: z.nativeEnum(Type)})])
+    .refine(
+      paramType =>
+        paramType !== Type.object &&
+        !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === Type.object),
+      {
+        message: 'Object parameters are not currently supported.',
+      },
+    ),
   description: z.string(),
   optional: z.boolean().optional(),
   hidden: z.boolean().optional(),


### PR DESCRIPTION
I wanted to make ParamType its own enum, so that `object` doesn't show up in the autocomplete as a selectable value, but this seems basically impossible in TypeScript. You can create an object that has a similar shape, but it will not be considered as extending `enum` and so breaks various things downstream. Spent forever on this, settling on this less-than-ideal but effective solution for the time being.

PTAL @alexd-codaio @huayang-codaio @coda/packs 