### PR TITLE
Increase the max iterations of a sync in coda execute before we throw an error thinking it's a runaway sync.

### DIFF
--- a/dist/testing/execution_helper.js
+++ b/dist/testing/execution_helper.js
@@ -5,7 +5,7 @@ const coercion_1 = require("./coercion");
 const ensure_1 = require("../helpers/ensure");
 const validation_1 = require("./validation");
 const validation_2 = require("./validation");
-async function executeSyncFormulaWithoutValidation(formula, params, context, maxIterations = 3) {
+async function executeSyncFormulaWithoutValidation(formula, params, context, maxIterations = 100) {
     const result = [];
     let iterations = 1;
     do {

--- a/dist/testing/execution_helper_bundle.js
+++ b/dist/testing/execution_helper_bundle.js
@@ -2787,7 +2787,7 @@ function validateArray(result, schema, context) {
 }
 
 // testing/execution_helper.ts
-async function executeSyncFormulaWithoutValidation(formula, params, context, maxIterations = 3) {
+async function executeSyncFormulaWithoutValidation(formula, params, context, maxIterations = 100) {
   const result = [];
   let iterations = 1;
   do {

--- a/testing/execution_helper.ts
+++ b/testing/execution_helper.ts
@@ -24,7 +24,7 @@ export async function executeSyncFormulaWithoutValidation(
   formula: GenericSyncFormula,
   params: ParamValues<ParamDefs>,
   context: SyncExecutionContext,
-  maxIterations: number = 3,
+  maxIterations: number = 100,
 ) {
   const result = [];
   let iterations = 1;


### PR DESCRIPTION
Partner was hitting this on a valid sync they were trying to test, the default is too low. Really we should have a flag for this but I just want to unblock them quickly.

PTAL @coda/packs 