### PR TITLE
Validate that column format defs can only use formulas with exactly one parameter.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -548,6 +548,25 @@ function validateFormulas(schema) {
         message: 'Could not find a formula for one or more matchers. Check that the "formulaName" for each matcher ' +
             'matches the name of a formula defined in this pack.',
         path: ['formats'],
+    })
+        .refine(data => {
+        var _a;
+        const formulas = (data.formulas || []);
+        for (const format of data.formats || []) {
+            const formula = formulas.find(f => f.name === format.formulaName);
+            if (formula) {
+                if (((_a = formula.parameters) === null || _a === void 0 ? void 0 : _a.length) !== 1) {
+                    return false;
+                }
+            }
+            // Ignore the else case of formula not found, that will be validated already above.
+        }
+        return true;
+    }, {
+        // Annoying that the we can't be more precise and identify in the message which format had the issue;
+        // these error messages are static.
+        message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+        path: ['formats'],
     });
 }
 // We temporarily allow our legacy packs to provide non-versioned data until we sufficiently migrate them.

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -803,6 +803,64 @@ describe('Pack metadata Validation', () => {
           },
         ]);
       });
+
+      it('formula uses more than one parameter', async () => {
+        const formula = makeStringFormula({
+          name: 'MyFormula',
+          description: 'My description',
+          examples: [],
+          parameters: [makeStringParameter('p1', ''), makeStringParameter('p2', '')],
+          execute: () => '',
+        });
+        const metadata = createFakePackVersionMetadata({
+          formulas: [formulaToMetadata(formula)],
+          formulaNamespace: 'MyNamespace',
+          formats: [
+            {
+              name: 'MyFormat',
+              formulaNamespace: 'MyNamespace',
+              formulaName: 'MyFormula',
+              matchers: ['some-regex'],
+            },
+          ],
+        });
+        const err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+            path: 'formats',
+          },
+        ]);
+      });
+
+      it('formula uses no parameters', async () => {
+        const formula = makeStringFormula({
+          name: 'MyFormula',
+          description: 'My description',
+          examples: [],
+          parameters: [],
+          execute: () => '',
+        });
+        const metadata = createFakePackVersionMetadata({
+          formulas: [formulaToMetadata(formula)],
+          formulaNamespace: 'MyNamespace',
+          formats: [
+            {
+              name: 'MyFormat',
+              formulaNamespace: 'MyNamespace',
+              formulaName: 'MyFormula',
+              matchers: ['some-regex'],
+            },
+          ],
+        });
+        const err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+            path: 'formats',
+          },
+        ]);
+      });
     });
   });
 

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -25,6 +25,7 @@ import type {ObjectSchema} from '../schema';
 import type {ObjectSchemaProperty} from '../schema';
 import {PackCategory} from '../types';
 import type {PackFormatMetadata} from '../compiled_types';
+import type {PackFormulaMetadata} from '../api';
 import type {PackVersionMetadata} from '../compiled_types';
 import type {ParamDef} from '../api_types';
 import type {ParamDefs} from '../api_types';
@@ -644,7 +645,7 @@ function validateFormulas(schema: z.ZodObject<any>) {
     )
     .refine(
       data => {
-        const formulas = (data.formulas || []) as PackFormatMetadata[];
+        const formulas = (data.formulas || []) as PackFormulaMetadata[];
         const formulaNames = new Set(formulas.map(f => f.name));
         for (const format of data.formats || []) {
           if (!formulaNames.has(format.formulaName)) {
@@ -659,6 +660,27 @@ function validateFormulas(schema: z.ZodObject<any>) {
         message:
           'Could not find a formula for one or more matchers. Check that the "formulaName" for each matcher ' +
           'matches the name of a formula defined in this pack.',
+        path: ['formats'],
+      },
+    )
+    .refine(
+      data => {
+        const formulas = (data.formulas || []) as PackFormulaMetadata[];
+        for (const format of data.formats || []) {
+          const formula = formulas.find(f => f.name === format.formulaName);
+          if (formula) {
+            if (formula.parameters?.length !== 1) {
+              return false;
+            }
+          }
+          // Ignore the else case of formula not found, that will be validated already above.
+        }
+        return true;
+      },
+      {
+        // Annoying that the we can't be more precise and identify in the message which format had the issue;
+        // these error messages are static.
+        message: 'Formats can only be implemented using formulas that take exactly one parameter.',
         path: ['formats'],
       },
     );


### PR DESCRIPTION
QA caught this, tried to create a column format using a formula that accept two params and it didn't work in practice.

Pretty sure column formats are designed only to be used with exactly one input, right?

PTAL @alexd-codaio @coda/packs 