### PR TITLE
Start updating the SDK package version as changes are made.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coda-packs-sdk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "license": "UNLICENSED",
   "private": true,
   "engines": {


### PR DESCRIPTION
We should start bumping the version number on the SDK as we make changes to its functionality. This will allow better communication with partners about what version they need to be on to get certain features, and will make the sdk_version column that we track in pack_versions useful. Obviously once we go to prod, we'll have to do this for sure.

For now, let's use patch version for normal changes and minor version for breaking changes, during this pre-launch period, aiming to hit 1.0.0 at prod beta.

PTAL @coda/packs 