### PR TITLE
export zodErrorDetailToValidationError

### DIFF
--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -3,6 +3,7 @@ import type { ObjectSchema } from '../schema';
 import type { PackVersionMetadata } from '../compiled_types';
 import type { ValidationError } from './types';
 import type { VariousAuthentication } from '../types';
+import * as z from 'zod';
 export declare class PackMetadataValidationError extends Error {
     readonly originalError: Error | undefined;
     readonly validationErrors: ValidationError[] | undefined;
@@ -11,3 +12,4 @@ export declare class PackMetadataValidationError extends Error {
 export declare function validatePackVersionMetadata(metadata: Record<string, any>): Promise<PackVersionMetadata>;
 export declare function validateVariousAuthenticationMetadata(auth: any): VariousAuthentication;
 export declare function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<any, any>>;
+export declare function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[];

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -19,7 +19,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateSyncTableSchema = exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = void 0;
+exports.zodErrorDetailToValidationError = exports.validateSyncTableSchema = exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = void 0;
 const schema_1 = require("../schema");
 const types_1 = require("../types");
 const api_types_1 = require("../api_types");
@@ -140,6 +140,7 @@ function zodErrorDetailToValidationError(subError) {
         },
     ];
 }
+exports.zodErrorDetailToValidationError = zodErrorDetailToValidationError;
 function zodPathToPathString(zodPath) {
     const parts = [];
     zodPath.forEach((zodPathPart, i) => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -107,7 +107,7 @@ export function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<a
   );
 }
 
-function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[] {
+export function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[] {
   // Top-level errors for union types are totally useless, they just say "invalid input",
   // but they do record all of the specific errors when trying each element of the union,
   // so we filter out the errors that were just due to non-matches of the discriminant


### PR DESCRIPTION
so that it can be used in the coda api to explain zod validation errors. 