### PR TITLE
add bundle-path parameter to executeFormulaOrSyncWithVM

### DIFF
--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -23,11 +23,10 @@ export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manif
     dynamicUrl?: string;
     contextOptions?: ContextOptions;
 }): Promise<void>;
-export declare function executeFormulaOrSyncWithVM({ formulaName, params, manifestPath, bundlePath, executionContext, }: {
+export declare function executeFormulaOrSyncWithVM({ formulaName, params, bundlePath, executionContext, }: {
     formulaName: string;
     params: ParamValues<ParamDefs>;
-    manifestPath?: string;
-    bundlePath?: string;
+    bundlePath: string;
     executionContext?: SyncExecutionContext;
 }): Promise<any>;
 export declare function executeFormulaOrSyncWithRawParamsInVM({ formulaName, params: rawParams, manifestPath, executionContext, }: {

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -21,7 +21,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.executeMetadataFormula = exports.executeSyncFormulaFromPackDef = exports.executeFormulaOrSyncWithRawParams = exports.executeFormulaOrSyncWithRawParamsInVM = exports.executeFormulaOrSyncWithVM = exports.executeFormulaOrSyncFromCLI = exports.executeFormulaFromPackDef = void 0;
 const build_1 = require("../cli/build");
-const ensure_1 = require("../helpers/ensure");
 const helpers_1 = require("../cli/helpers");
 const helper = __importStar(require("./execution_helper"));
 const ivmHelper = __importStar(require("./ivm_helper"));
@@ -64,13 +63,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
     }
 }
 exports.executeFormulaOrSyncFromCLI = executeFormulaOrSyncFromCLI;
-async function executeFormulaOrSyncWithVM({ formulaName, params, manifestPath, bundlePath, executionContext = mocks_2.newMockSyncExecutionContext(), }) {
-    if (!manifestPath && !bundlePath) {
-        throw new Error('Expecting either manifestPath or bundlePath but both are undefined.');
-    }
-    if (!bundlePath) {
-        bundlePath = await build_1.build(ensure_1.ensureExists(manifestPath));
-    }
+async function executeFormulaOrSyncWithVM({ formulaName, params, bundlePath, executionContext = mocks_2.newMockSyncExecutionContext(), }) {
     const ivmContext = await ivmHelper.setupIvmContext(bundlePath, executionContext);
     return ivmHelper.executeFormulaOrSync(ivmContext, formulaName, params);
 }

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -5,6 +5,7 @@ import type {Schema} from '../schema';
 import type {TypedStandardFormula} from '../api';
 import {ValueType} from '../schema';
 import {assertCondition} from '../helpers/ensure';
+import {build as buildBundle} from '../cli/build';
 import {createFakePack} from './test_utils';
 import {executeFormulaFromPackDef} from '../testing/execution';
 import {executeFormulaOrSyncWithVM} from '../testing/execution';
@@ -24,6 +25,12 @@ import {newMockExecutionContext} from '../testing/mocks';
 import sinon from 'sinon';
 
 describe('Execution', () => {
+  let bundlePath: string;
+
+  before(async () => {  
+    bundlePath = await buildBundle(`${__dirname}/packs/fake`);
+  });
+
   it('executes a formula by name', async () => {
     const result = await executeFormulaFromPackDef(fakePack, 'Fake::Square', [5]);
     assert.equal(result, 25);
@@ -43,7 +50,7 @@ describe('Execution', () => {
     const result = await executeFormulaOrSyncWithVM({
       formulaName: 'Fake::Square',
       params: [5],
-      manifestPath: `${__dirname}/packs/fake`,
+      bundlePath,
     });
     assert.equal(result, 25);
   });
@@ -52,7 +59,7 @@ describe('Execution', () => {
     const result = await executeFormulaOrSyncWithVM({
       formulaName: 'Students',
       params: ['Smith'],
-      manifestPath: `${__dirname}/packs/fake`,
+      bundlePath,
     });
     assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
   });

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -9,7 +9,6 @@ import type {ParamDefs} from '../api_types';
 import type {ParamValues} from '../api_types';
 import type {SyncExecutionContext} from '../api_types';
 import {build as buildBundle} from '../cli/build';
-import { ensureExists } from '../helpers/ensure';
 import {getPackAuth} from '../cli/helpers';
 import * as helper from './execution_helper';
 import * as ivmHelper from './ivm_helper';
@@ -99,24 +98,14 @@ export async function executeFormulaOrSyncFromCLI({
 export async function executeFormulaOrSyncWithVM({
   formulaName,
   params,
-  manifestPath,
   bundlePath,
   executionContext = newMockSyncExecutionContext(),
 }: {
   formulaName: string;
   params: ParamValues<ParamDefs>;
-  manifestPath?: string;
-  bundlePath?: string;
+  bundlePath: string;
   executionContext?: SyncExecutionContext;
 }) {
-  if (!manifestPath && !bundlePath) {
-    throw new Error('Expecting either manifestPath or bundlePath but both are undefined.');
-  }
-  
-  if (!bundlePath) {
-    bundlePath = await buildBundle(ensureExists(manifestPath));
-  }
-
   const ivmContext = await ivmHelper.setupIvmContext(bundlePath, executionContext);
 
   return ivmHelper.executeFormulaOrSync(ivmContext, formulaName, params);


### PR DESCRIPTION
allow passing bundlepath instead of the manifest path to the testing helper. 

this is useful to avoid compiling the bundle for each test case. 