### PR TITLE
Add upload validation support for boolean formulas.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -346,6 +346,14 @@ const stringPackFormulaSchema = zodCompleteObject({
         description: z.string().optional(),
     }).optional(),
 });
+const booleanPackFormulaSchema = zodCompleteObject({
+    ...commonPackFormulaSchema,
+    resultType: zodDiscriminant(api_types_3.Type.boolean),
+    schema: zodCompleteObject({
+        type: zodDiscriminant(schema_5.ValueType.Boolean),
+        description: z.string().optional(),
+    }).optional(),
+});
 // TODO(jonathan): Use zodCompleteObject on these after exporting these types.
 const textAttributionNodeSchema = z.object({
     type: zodDiscriminant(schema_1.AttributionNodeType.Text),
@@ -459,7 +467,12 @@ const objectPackFormulaSchema = zodCompleteObject({
     // schema for objects, but that doesn't seem like a use case we actually want to support.
     schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
 });
-const formulaMetadataSchema = z.union([numericPackFormulaSchema, stringPackFormulaSchema, objectPackFormulaSchema]);
+const formulaMetadataSchema = z.union([
+    numericPackFormulaSchema,
+    stringPackFormulaSchema,
+    booleanPackFormulaSchema,
+    objectPackFormulaSchema,
+]);
 const formatMetadataSchema = zodCompleteObject({
     name: z.string(),
     formulaNamespace: z.string(),

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -19,6 +19,7 @@ import {createFakePack} from './test_utils';
 import {createFakePackFormulaMetadata} from './test_utils';
 import {createFakePackVersionMetadata} from './test_utils';
 import {makeDynamicSyncTable} from '../api';
+import {makeFormula} from '../api';
 import {makeMetadataFormula} from '../api';
 import {makeNumericFormula} from '../api';
 import {makeNumericParameter} from '../api';
@@ -155,7 +156,8 @@ describe('Pack metadata Validation', () => {
     }
 
     it('valid number formula', async () => {
-      const formula = makeNumericFormula({
+      const formula = makeFormula({
+        resultType: ValueType.Number,
         name: 'MyFormula',
         description: 'My description',
         examples: [],
@@ -170,12 +172,86 @@ describe('Pack metadata Validation', () => {
     });
 
     it('valid string formula', async () => {
-      const formula = makeStringFormula({
+      const formula = makeFormula({
+        resultType: ValueType.String,
         name: 'MyFormula',
         description: 'My description',
         examples: [],
         parameters: [makeStringParameter('myParam', 'param description')],
         execute: () => '',
+      });
+      const metadata = createFakePackVersionMetadata({
+        formulas: [formulaToMetadata(formula)],
+        formulaNamespace: 'MyNamespace',
+      });
+      await validateJson(metadata);
+    });
+
+    it('valid boolean formula', async () => {
+      const formula = makeFormula({
+        resultType: ValueType.Boolean,
+        name: 'MyFormula',
+        description: 'My description',
+        examples: [],
+        parameters: [makeStringParameter('myParam', 'param description')],
+        execute: () => true,
+      });
+      const metadata = createFakePackVersionMetadata({
+        formulas: [formulaToMetadata(formula)],
+        formulaNamespace: 'MyNamespace',
+      });
+      await validateJson(metadata);
+    });
+
+    it('valid scalar array formula', async () => {
+      const formula = makeFormula({
+        resultType: ValueType.Array,
+        items: {type: ValueType.String},
+        name: 'MyFormula',
+        description: 'My description',
+        examples: [],
+        parameters: [makeStringParameter('myParam', 'param description')],
+        execute: () => ['hello'],
+      });
+      const metadata = createFakePackVersionMetadata({
+        formulas: [formulaToMetadata(formula)],
+        formulaNamespace: 'MyNamespace',
+      });
+      await validateJson(metadata);
+    });
+
+    it('valid object array formula', async () => {
+      const formula = makeFormula({
+        resultType: ValueType.Array,
+        items: makeObjectSchema({
+          type: ValueType.Object,
+          properties: {foo: {type: ValueType.String}},
+        }),
+        name: 'MyFormula',
+        description: 'My description',
+        examples: [],
+        parameters: [makeStringParameter('myParam', 'param description')],
+        execute: () => ['hello'],
+      });
+      const metadata = createFakePackVersionMetadata({
+        formulas: [formulaToMetadata(formula)],
+        formulaNamespace: 'MyNamespace',
+      });
+      await validateJson(metadata);
+    });
+
+    it('valid object formula', async () => {
+      const formula = makeFormula({
+        resultType: ValueType.Object,
+        schema: makeObjectSchema({
+          type: ValueType.Object,
+          properties: {foo: {type: ValueType.String}},
+        }),
+        name: 'MyFormula',
+        description: 'My description',
+        examples: [],
+        parameters: [makeStringParameter('myParam', 'param description')],
+        execute: () => ['hello'],
       });
       const metadata = createFakePackVersionMetadata({
         formulas: [formulaToMetadata(formula)],

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2,6 +2,7 @@ import type {AWSSignature4Authentication} from '../types';
 import type {ArraySchema} from '../schema';
 import {AttributionNodeType} from '../schema';
 import {AuthenticationType} from '../types';
+import type {BooleanPackFormula} from '../api';
 import type {BooleanSchema} from '../schema';
 import type {CodaApiBearerTokenAuthentication} from '../types';
 import {ConnectionRequirement} from '../api_types';
@@ -418,6 +419,15 @@ const stringPackFormulaSchema = zodCompleteObject<Omit<StringPackFormula<any>, '
   }).optional(),
 });
 
+const booleanPackFormulaSchema = zodCompleteObject<Omit<BooleanPackFormula<any>, 'execute'>>({
+  ...commonPackFormulaSchema,
+  resultType: zodDiscriminant(Type.boolean),
+  schema: zodCompleteObject<BooleanSchema>({
+    type: zodDiscriminant(ValueType.Boolean),
+    description: z.string().optional(),
+  }).optional(),
+});
+
 // TODO(jonathan): Use zodCompleteObject on these after exporting these types.
 
 const textAttributionNodeSchema = z.object({
@@ -554,7 +564,12 @@ const objectPackFormulaSchema = zodCompleteObject<Omit<ObjectPackFormula<any, an
   schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
 });
 
-const formulaMetadataSchema = z.union([numericPackFormulaSchema, stringPackFormulaSchema, objectPackFormulaSchema]);
+const formulaMetadataSchema = z.union([
+  numericPackFormulaSchema,
+  stringPackFormulaSchema,
+  booleanPackFormulaSchema,
+  objectPackFormulaSchema,
+]);
 
 const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
   name: z.string(),


### PR DESCRIPTION
Addresses https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/Bugs-Feature-requests_suyN0#Open-Bugs_tu6FU/r42&modal=true

I think array formulas already worked (that's what sync tables are based on), they were part of the object formula def type, but added tests to verify.

PTAL @huayang-codaio @coda/packs 