### PR TITLE
remove source-root from sourcemap

### DIFF
--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -29,7 +29,16 @@ export async function handleUpload({manifestFile, codaApiEndpoint, notes}: Argum
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
   const logger = new ConsoleLogger();
   logger.info('Building Pack bundle...');
-  const {bundlePath, bundleSourceMapPath} = await compilePackBundle({manifestPath: manifestFile});
+
+  // we need to generate the bundle file in the working directory instead of a temp directory in
+  // order to set source map right. The source map tool chain isn't smart enough to resolve a
+  // relative path in the end.
+  const {bundlePath, bundleSourceMapPath} = await compilePackBundle({
+    manifestPath: manifestFile,
+    outputDirectory: './',
+    intermediateOutputDirectory: './',
+  });
+
   const manifest = await importManifest(bundlePath);
 
   // Since package.json isn't in dist, we grab it from the root directory instead.

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -45,7 +45,14 @@ async function handleUpload({ manifestFile, codaApiEndpoint, notes }) {
     const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
     const logger = new logging_1.ConsoleLogger();
     logger.info('Building Pack bundle...');
-    const { bundlePath, bundleSourceMapPath } = await compile_1.compilePackBundle({ manifestPath: manifestFile });
+    // we need to generate the bundle file in the working directory instead of a temp directory in
+    // order to set source map right. The source map tool chain isn't smart enough to resolve a
+    // relative path in the end.
+    const { bundlePath, bundleSourceMapPath } = await compile_1.compilePackBundle({
+        manifestPath: manifestFile,
+        outputDirectory: './',
+        intermediateOutputDirectory: './',
+    });
     const manifest = await helpers_3.importManifest(bundlePath);
     // Since package.json isn't in dist, we grab it from the root directory instead.
     const packageJson = await Promise.resolve().then(() => __importStar(require(helpers_4.isTestCommand() ? '../package.json' : '../../package.json')));

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -64,7 +64,6 @@ async function uglifyBundle({ outputDirectory, lastBundleFilename, outputBundleF
             url: `${outputBundleFilename}.map`,
             content: sourcemap,
             includeSources: true,
-            root: `${process.cwd()}/`,
         },
     });
     if (uglifyOutput.error) {
@@ -86,7 +85,7 @@ async function buildWithES({ manifestPath, outputDirectory, outputBundleFilename
         format: 'cjs',
         platform: 'node',
         minify: false,
-        sourcemap: 'inline',
+        sourcemap: 'both',
     };
     await esbuild.build(options);
 }
@@ -128,7 +127,7 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, }) {
     // which uses gifcodec, which calls process.nextTick on the global level.
     // maybe we just need to get rid of jimp and resize-optimize-images instead.
     await loadIntoVM(tempBundlePath);
-    if (!outputDirectory) {
+    if (!outputDirectory || outputDirectory === intermediateOutputDirectory) {
         return {
             bundlePath: path_1.default.join(intermediateOutputDirectory, bundleFilename),
             intermediateOutputDirectory,

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -69,7 +69,6 @@ async function uglifyBundle({
         url: `${outputBundleFilename}.map`,
         content: sourcemap,
         includeSources: true,
-        root: `${process.cwd()}/`,
       },
     }
   );
@@ -100,7 +99,7 @@ async function buildWithES({
     format: 'cjs',
     platform: 'node',
     minify: false,  // don't minify here since browserify doesn't minify anyway.
-    sourcemap: 'inline',
+    sourcemap: 'both',
   };
   
   await esbuild.build(options);
@@ -155,7 +154,7 @@ export async function compilePackBundle({
   // maybe we just need to get rid of jimp and resize-optimize-images instead.
   await loadIntoVM(tempBundlePath);
 
-  if (!outputDirectory) {
+  if (!outputDirectory || outputDirectory === intermediateOutputDirectory) {
     return {
       bundlePath: path.join(intermediateOutputDirectory, bundleFilename),
       intermediateOutputDirectory,


### PR DESCRIPTION
three changes:
1. I misunderstood source map root. it's actually causing a leak of the current compile directory without giving us any benefits. removing it. 
2. generate both inline / external source maps for node for the purpose of debugging. 
3. if the bundle was to be uploaded, it needs to be generated in the current directory to generate the correct source map path. Honest it's a limitation of the source map tool chain. Even though some compiler supports setting a base path, it's not supported by the others.