### PR TITLE
fix a few things found in testing

### DIFF
--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -45,6 +45,6 @@ export function getPackAuth(packDef: PackVersionDefinition): Authentication | un
 }
 
 export async function importManifest(bundleFilename: string): Promise<PackVersionDefinition> {
-  const module = await import(bundleFilename);
+  const module = await import(path.resolve(bundleFilename));
   return module.pack || module.manifest;
 }

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -68,7 +68,7 @@ function getPackAuth(packDef) {
 }
 exports.getPackAuth = getPackAuth;
 async function importManifest(bundleFilename) {
-    const module = await Promise.resolve().then(() => __importStar(require(bundleFilename)));
+    const module = await Promise.resolve().then(() => __importStar(require(path_1.default.resolve(bundleFilename))));
     return module.pack || module.manifest;
 }
 exports.importManifest = importManifest;

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -71,7 +71,6 @@ async function handleUpload({ manifestFile, codaApiEndpoint, notes }) {
         helpers_5.printAndExit(`No Pack version declared for this Pack`);
     }
     try {
-        logger.info('Registering new Pack version...');
         const bundle = helpers_6.readFile(bundlePath);
         if (!bundle) {
             helpers_5.printAndExit(`Could not find bundle file at path ${bundlePath}`);
@@ -89,13 +88,14 @@ async function handleUpload({ manifestFile, codaApiEndpoint, notes }) {
         };
         const uploadPayload = JSON.stringify(upload);
         const bundleHash = crypto_1.computeSha256(uploadPayload);
+        logger.info('Validating Pack metadata...');
+        await validate_1.validateMetadata(metadata);
+        logger.info('Registering new Pack version...');
         const registerResponse = await client.registerPackVersion(packId, packVersion, {}, { bundleHash });
         if (errors_2.isCodaError(registerResponse)) {
             return helpers_5.printAndExit(`Error while registering pack version: ${errors_1.formatError(registerResponse)}`);
         }
         const { uploadUrl, headers } = registerResponse;
-        logger.info('Validating Pack metadata...');
-        await validate_1.validateMetadata(metadata);
         logger.info('Uploading Pack...');
         await uploadPack(uploadUrl, uploadPayload, headers);
         logger.info('Validating upload...');

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -140,8 +140,8 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, }) {
     fs_1.default.copyFileSync(tempBundlePath, bundlePath);
     fs_1.default.copyFileSync(`${tempBundlePath}.map`, bundleSourceMapPath);
     return {
-        bundlePath,
         intermediateOutputDirectory,
+        bundlePath,
         bundleSourceMapPath,
     };
 }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -433,9 +433,7 @@ const genericObjectSchema = z.lazy(() => zodCompleteObject({
             message: 'Invalid name. Identity names can only contain alphanumeric characters, underscores, and dashes, and no spaces.',
         }),
         dynamicUrl: z.string().optional(),
-        attribution: z
-            .union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema])
-            .optional(),
+        attribution: z.array(z.union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema])).optional(),
     }).optional(),
     properties: z.record(objectPropertyUnionSchema),
 })
@@ -586,8 +584,14 @@ function validateFormulas(schema) {
         for (const format of data.formats || []) {
             const formula = formulas.find(f => f.name === format.formulaName);
             if (formula) {
-                if (((_a = formula.parameters) === null || _a === void 0 ? void 0 : _a.length) !== 1) {
+                if (!((_a = formula.parameters) === null || _a === void 0 ? void 0 : _a.length)) {
                     return false;
+                }
+                const [_, ...extraParams] = formula.parameters;
+                for (const extraParam of extraParams) {
+                    if (!extraParam.optional) {
+                        return false;
+                    }
                 }
             }
             // Ignore the else case of formula not found, that will be validated already above.
@@ -596,7 +600,7 @@ function validateFormulas(schema) {
     }, {
         // Annoying that the we can't be more precise and identify in the message which format had the issue;
         // these error messages are static.
-        message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+        message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
         path: ['formats'],
     });
 }

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1213,7 +1213,7 @@ describe('Pack metadata Validation', () => {
         const err = await validateJsonAndAssertFails(metadata);
         assert.deepEqual(err.validationErrors, [
           {
-            message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+            message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
             path: 'formats',
           },
         ]);
@@ -1242,7 +1242,7 @@ describe('Pack metadata Validation', () => {
         const err = await validateJsonAndAssertFails(metadata);
         assert.deepEqual(err.validationErrors, [
           {
-            message: 'Formats can only be implemented using formulas that take exactly one parameter.',
+            message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
             path: 'formats',
           },
         ]);

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -170,8 +170,8 @@ export async function compilePackBundle({
   fs.copyFileSync(`${tempBundlePath}.map`, bundleSourceMapPath);
 
   return {
-    bundlePath,
     intermediateOutputDirectory,
+    bundlePath,
     bundleSourceMapPath,
   }
 }


### PR DESCRIPTION
A few fixes of the sdk while I am verifying v1 packs compatibility. 
- import takes either a relative path or an absolute path, but not something like `bundle.js`
- we should validate before registering a pack version, instead of in the reverse order.
- `attribution` is an array instead of an object. 
- formats should allow a formula with one required parameter and a few optional ones. 

PTAL @coda/packs 