### PR TITLE
allow Various Auth to exempt from the network domains check.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -642,7 +642,15 @@ const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSc
     var _a;
     const usesAuthentication = (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) ||
         data.systemConnectionAuthentication;
-    return !usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length);
+    if (!usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length)) {
+        return true;
+    }
+    // Various is an internal authentication type that's only applicable to whitelisted Pack Ids. 
+    // Skipping validation here to let it exempt from network domains.
+    if (data.defaultAuthentication.type === types_1.AuthenticationType.Various) {
+        return true;
+    }
+    return false;
 }, {
     message: 'This pack uses authentication but did not declare a network domain. ' +
         "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1480,6 +1480,15 @@ describe('Pack metadata Validation', () => {
       ]);
     });
 
+    it('various auth type exempt from networkDomains requirement', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.Various,
+        },
+      });
+      await validateJson(metadata);
+    });
+
     it('missing networkDomains when specifying system authentication', async () => {
       const metadata = createFakePackVersionMetadata({
         networkDomains: undefined,

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -778,8 +778,18 @@ const legacyPackMetadataSchema = validateFormulas(
     data => {
       const usesAuthentication =
         (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) ||
-        data.systemConnectionAuthentication;
-      return !usesAuthentication || data.networkDomains?.length;
+        data.systemConnectionAuthentication;      
+      if (!usesAuthentication || data.networkDomains?.length) {
+        return true;
+      }
+      
+      // Various is an internal authentication type that's only applicable to whitelisted Pack Ids. 
+      // Skipping validation here to let it exempt from network domains.
+      if (data.defaultAuthentication.type === AuthenticationType.Various) {
+        return true;
+      }
+
+      return false;
     },
     {
       message:


### PR DESCRIPTION
I am not sure about this. Feedbacks welcome.

Basically we have the following packs which use networks but don't specify network domains for a reason. 

Shopify, phabricator, okta, discourse and SFDC could be mostly using custom domains. These Packs are all live in production..

The Web Pack is Various auth type. 

```
packs/shopify/main/manifest.ts
packs/phacility/phabricator/manifest.ts
packs/okta/main/manifest.ts
packs/discourse/main/manifest.ts
packs/salesforce/main/manifest.ts
packs/coda/web/manifest.ts
```

How do we want to migrate them to the v2 packs platform? I don't feel like we should allow external packs to use `requiresEndpointUrl` or `Various` auth type. 

Maybe we say if this is an internal pack and it uses `requiresEndpointUrl` or `Various` auth type, it's exempted from networkDomains restriction? 

But how do we decide if it's an internal pack? Esp from the CLI.

PTAL @jonathan-codaio @alexd-codaio 