### PR TITLE
add update-config CLI

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -9,6 +9,7 @@ import {handleExecute} from './execute';
 import {handleInit} from './init';
 import {handleRegister} from './register';
 import {handleRelease} from './release';
+import { handleUpdateConfig } from './update_config';
 import {handleUpload} from './upload';
 import {handleValidate} from './validate';
 import yargs from 'yargs';
@@ -149,6 +150,20 @@ if (require.main === module) {
         },
       },
       handler: handleRelease,
+    })
+    .command({
+      command: 'update-config <manifestFile>',
+      describe:
+        'Update the pack title, description, short description, and image assets from ' +
+        'the manifest. This only applies to the full PackDefinition exports.',
+      builder: {
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: DEFAULT_API_ENDPOINT,
+        },
+      },
+      handler: handleUpdateConfig,
     })
     .demandCommand()
     .strict()

--- a/cli/update_config.ts
+++ b/cli/update_config.ts
@@ -1,0 +1,10 @@
+import type {Arguments} from 'yargs';
+
+interface UpdateConfigArgs {
+  manifestFile: string;
+  codaApiEndpoint: string;
+}
+
+export async function handleUpdateConfig({
+}: Arguments<UpdateConfigArgs>) {
+}

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -13,6 +13,7 @@ const execute_1 = require("./execute");
 const init_1 = require("./init");
 const register_1 = require("./register");
 const release_1 = require("./release");
+const update_config_1 = require("./update_config");
 const upload_1 = require("./upload");
 const validate_1 = require("./validate");
 const yargs_1 = __importDefault(require("yargs"));
@@ -150,6 +151,19 @@ if (require.main === module) {
             },
         },
         handler: release_1.handleRelease,
+    })
+        .command({
+        command: 'update-config <manifestFile>',
+        describe: 'Update the pack title, description, short description, and image assets from ' +
+            'the manifest. This only applies to the full PackDefinition exports.',
+        builder: {
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: config_storage_1.DEFAULT_API_ENDPOINT,
+            },
+        },
+        handler: update_config_1.handleUpdateConfig,
     })
         .demandCommand()
         .strict()

--- a/dist/cli/update_config.d.ts
+++ b/dist/cli/update_config.d.ts
@@ -1,0 +1,7 @@
+import type { Arguments } from 'yargs';
+interface UpdateConfigArgs {
+    manifestFile: string;
+    codaApiEndpoint: string;
+}
+export declare function handleUpdateConfig({}: Arguments<UpdateConfigArgs>): Promise<void>;
+export {};

--- a/dist/cli/update_config.js
+++ b/dist/cli/update_config.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleUpdateConfig = void 0;
+async function handleUpdateConfig({}) {
+}
+exports.handleUpdateConfig = handleUpdateConfig;


### PR DESCRIPTION
I want to get some feedback first before moving forward with this. 

The context is that when we upload v1 packs, the pack name, description, short description, image assets are specified in the repo with the full PackDefinition. We'll need to update the Pack database to update these fields accordingly. 

There are two ways I considered:
- add a custom hook/script in the `packs` repo to update these fields. 
- or just add this method to the packs sdk. 
  - could be in the CLI if any CLI user may potentially use this format.
  - or just a testing/ helper. 
