### PR TITLE
Fix typos on fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,11 +643,10 @@ Use the `makeDynamicSyncTable()` wrapper function. It takes an object with the f
   {
     ...
     execute: async (params, context) => {
-      const request: coda.FetchRequest = {
+      const response = await context.fetcher.fetch({
         method: 'GET',
-        dynamicUrl: context.sync.dynamicUrl,
-      };
-      const response = await context.fetcher.fetch(request);
+        url: context.sync.dynamicUrl,
+      });
       ...
     },
   }


### PR DESCRIPTION
Copied this code and pasted it into Monaco on the adhoc. Got a couple of build errors. 

1. Missing semicolon
2. Type coercion was required (not entirely sure about this one).

PTAL @patrick-codaio 

Thanks,
Hari.