### PR TITLE
Have TypeDoc use main as the revision for source code links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ snippets:
 
 .PHONY: typedoc
 typedoc:
-	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected
+	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main
 
 .PHONY: docs
 docs: snippets typedoc

--- a/docs/classes/packdefinitionbuilder.html
+++ b/docs/classes/packdefinitionbuilder.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L47">builder.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L47">builder.ts:47</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.defaultAuthentication</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L42">builder.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L42">builder.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formats</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L38">builder.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L38">builder.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L45">builder.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L45">builder.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formulas</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L37">builder.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L37">builder.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.networkDomains</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L40">builder.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L40">builder.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.syncTables</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L39">builder.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L39">builder.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.systemConnectionAuthentication</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L43">builder.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L43">builder.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L176">builder.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L176">builder.ts:176</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L156">builder.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L156">builder.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L90">builder.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L90">builder.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,7 +375,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L253">builder.ts:253</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L253">builder.ts:253</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L116">builder.ts:116</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L116">builder.ts:116</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -473,7 +473,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L272">builder.ts:272</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L272">builder.ts:272</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -513,7 +513,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L226">builder.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L226">builder.ts:226</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -553,7 +553,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L195">builder.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L195">builder.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/statuscodeerror.html
+++ b/docs/classes/statuscodeerror.html
@@ -108,7 +108,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Error.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L65">api.ts:65</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L65">api.ts:65</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L65">api.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L65">api.ts:65</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/uservisibleerror.html
+++ b/docs/classes/uservisibleerror.html
@@ -119,7 +119,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Error.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L56">api.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L56">api.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">internal<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Error</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L56">api.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L56">api.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>User<wbr>Visible<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L55">api.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L55">api.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/authenticationtype.html
+++ b/docs/enums/authenticationtype.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">AWSSignature4<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;AWSSignature4&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L38">types.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L38">types.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">Coda<wbr>Api<wbr>Header<wbr>Bearer<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CodaApiHeaderBearerToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L39">types.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L39">types.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">Custom<wbr>Header<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CustomHeaderToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L33">types.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L33">types.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">Header<wbr>Bearer<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;HeaderBearerToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L32">types.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L32">types.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">Multi<wbr>Query<wbr>Param<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;MultiQueryParamToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L35">types.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L35">types.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;None&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L31">types.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L31">types.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">OAuth2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;OAuth2&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L36">types.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L36">types.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">Query<wbr>Param<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;QueryParamToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L34">types.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L34">types.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">Various<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Various&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L40">types.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L40">types.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Basic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;WebBasic&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L37">types.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L37">types.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/connectionrequirement.html
+++ b/docs/enums/connectionrequirement.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;none&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L261">api_types.ts:261</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L261">api_types.ts:261</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;optional&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L262">api_types.ts:262</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L262">api_types.ts:262</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;required&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L263">api_types.ts:263</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L263">api_types.ts:263</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/defaultconnectiontype.html
+++ b/docs/enums/defaultconnectiontype.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">Proxy<wbr>Actions<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L46">types.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L46">types.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L45">types.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L45">types.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Shared<wbr>Data<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L44">types.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L44">types.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/featureset.html
+++ b/docs/enums/featureset.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Basic&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L255">types.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L255">types.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Enterprise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Enterprise&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L258">types.ts:258</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L258">types.ts:258</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pro<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Pro&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L256">types.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L256">types.ts:256</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Team<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Team&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L257">types.ts:257</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L257">types.ts:257</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/networkconnection.html
+++ b/docs/enums/networkconnection.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;none&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L268">api_types.ts:268</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L268">api_types.ts:268</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;optional&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L269">api_types.ts:269</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269">api_types.ts:269</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;required&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L270">api_types.ts:270</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L270">api_types.ts:270</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/packcategory.html
+++ b/docs/enums/packcategory.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">CRM<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CRM&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L11">types.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L11">types.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Calendar<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Calendar&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L12">types.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L12">types.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Communication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Communication&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L13">types.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L13">types.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Data<wbr>Storage<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;DataStorage&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L14">types.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L14">types.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Design<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Design&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L15">types.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L15">types.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Financial<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Financial&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L16">types.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L16">types.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fun<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Fun&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L17">types.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L17">types.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">Geo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Geo&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L18">types.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L18">types.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">IT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;IT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L19">types.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L19">types.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">Mathematics<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Mathematics&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L20">types.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L20">types.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">Organization<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L21">types.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L21">types.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">Recruiting<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Recruiting&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L22">types.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L22">types.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">Shopping<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Shopping&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L23">types.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L23">types.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">Social<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Social&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L24">types.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L24">types.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sports<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sports&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L25">types.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L25">types.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">Travel<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Travel&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L26">types.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L26">types.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">Weather<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Weather&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L27">types.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L27">types.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/parametertype.html
+++ b/docs/enums/parametertype.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;boolean&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L88">api_types.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L88">api_types.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;booleanArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L95">api_types.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L95">api_types.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L89">api_types.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L89">api_types.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;dateArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L96">api_types.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L96">api_types.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;html&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L90">api_types.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L90">api_types.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;htmlArray&#x60;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L97">api_types.ts:97</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L97">api_types.ts:97</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;image&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L91">api_types.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L91">api_types.ts:91</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;imageArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L98">api_types.ts:98</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L98">api_types.ts:98</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L87">api_types.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L87">api_types.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;numberArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L94">api_types.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L94">api_types.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;string&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L86">api_types.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L86">api_types.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;stringArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L93">api_types.ts:93</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L93">api_types.ts:93</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/postsetuptype.html
+++ b/docs/enums/postsetuptype.html
@@ -84,7 +84,7 @@
 					<div class="tsd-signature tsd-kind-icon">Set<wbr>Endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SetEndPoint&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L64">types.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L64">types.ts:64</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/precanneddaterange.html
+++ b/docs/enums/precanneddaterange.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Everything<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;everything&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L385">api_types.ts:385</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L385">api_types.ts:385</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last30<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_30_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L358">api_types.ts:358</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358">api_types.ts:358</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last3<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_3_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L361">api_types.ts:361</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L361">api_types.ts:361</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last6<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_6_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L362">api_types.ts:362</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L362">api_types.ts:362</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last7<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_7_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L357">api_types.ts:357</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L357">api_types.ts:357</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L360">api_types.ts:360</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L360">api_types.ts:360</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L359">api_types.ts:359</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359">api_types.ts:359</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L363">api_types.ts:363</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L363">api_types.ts:363</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next30<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_30_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L378">api_types.ts:378</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L378">api_types.ts:378</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next3<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_3_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L381">api_types.ts:381</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L381">api_types.ts:381</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next6<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_6_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L382">api_types.ts:382</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L382">api_types.ts:382</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next7<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_7_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L377">api_types.ts:377</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L377">api_types.ts:377</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L380">api_types.ts:380</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L380">api_types.ts:380</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L379">api_types.ts:379</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379">api_types.ts:379</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L383">api_types.ts:383</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383">api_types.ts:383</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L369">api_types.ts:369</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L369">api_types.ts:369</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Month<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_month_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L370">api_types.ts:370</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L370">api_types.ts:370</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L367">api_types.ts:367</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L367">api_types.ts:367</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Week<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_week_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L368">api_types.ts:368</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368">api_types.ts:368</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L373">api_types.ts:373</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L373">api_types.ts:373</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Year<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_year_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L371">api_types.ts:371</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L371">api_types.ts:371</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">Today<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;today&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L366">api_types.ts:366</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L366">api_types.ts:366</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -328,7 +328,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tomorrow<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;tomorrow&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L376">api_types.ts:376</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L376">api_types.ts:376</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">Year<wbr>ToDate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;year_to_date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L372">api_types.ts:372</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L372">api_types.ts:372</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -348,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">Yesterday<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;yesterday&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L356">api_types.ts:356</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L356">api_types.ts:356</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/quotalimittype.html
+++ b/docs/enums/quotalimittype.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Action<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Action&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L262">types.ts:262</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L262">types.ts:262</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Getter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Getter&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L263">types.ts:263</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L263">types.ts:263</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Metadata&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L265">types.ts:265</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L265">types.ts:265</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sync<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sync&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L264">types.ts:264</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L264">types.ts:264</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/schema.attributionnodetype.html
+++ b/docs/enums/schema.attributionnodetype.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L205">schema.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L205">schema.ts:205</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Link<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L204">schema.ts:204</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L204">schema.ts:204</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L203">schema.ts:203</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L203">schema.ts:203</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/schema.currencyformat.html
+++ b/docs/enums/schema.currencyformat.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">Accounting<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;accounting&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L95">schema.ts:95</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L95">schema.ts:95</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Currency<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;currency&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L94">schema.ts:94</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L94">schema.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Financial<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;financial&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L96">schema.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L96">schema.ts:96</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/schema.durationunit.html
+++ b/docs/enums/schema.durationunit.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L144">schema.ts:144</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L144">schema.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hours<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;hours&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L145">schema.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L145">schema.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Minutes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;minutes&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L146">schema.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L146">schema.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Seconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;seconds&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L147">schema.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L147">schema.ts:147</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/schema.valuehinttype.html
+++ b/docs/enums/schema.valuehinttype.html
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">Attachment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;attachment&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L41">schema.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L41">schema.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">Currency<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;currency&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L33">schema.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L33">schema.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L27">schema.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L27">schema.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;datetime&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L29">schema.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L29">schema.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;duration&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L30">schema.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L30">schema.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">Embed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;embed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L38">schema.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L38">schema.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;html&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L37">schema.ts:37</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L37">schema.ts:37</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;image&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L34">schema.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L34">schema.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<wbr>Attachment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;imageAttachment&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L40">schema.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L40">schema.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">Markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;markdown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L36">schema.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L36">schema.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<div class="tsd-signature tsd-kind-icon">Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;percent&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L32">schema.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L32">schema.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 					<div class="tsd-signature tsd-kind-icon">Person<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;person&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L31">schema.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L31">schema.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -230,7 +230,7 @@
 					<div class="tsd-signature tsd-kind-icon">Reference<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;reference&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L39">schema.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L39">schema.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -240,7 +240,7 @@
 					<div class="tsd-signature tsd-kind-icon">Scale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;scale&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L43">schema.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L43">schema.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<div class="tsd-signature tsd-kind-icon">Slider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;slider&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L42">schema.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L42">schema.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;time&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L28">schema.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L28">schema.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;url&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L35">schema.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L35">schema.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/schema.valuetype.html
+++ b/docs/enums/schema.valuetype.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;array&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L19">schema.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L19">schema.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;boolean&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L16">schema.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L16">schema.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L17">schema.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L17">schema.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;object&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L20">schema.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L20">schema.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;string&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L18">schema.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L18">schema.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/syncinterval.html
+++ b/docs/enums/syncinterval.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Daily<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Daily&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L270">types.ts:270</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L270">types.ts:270</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Every<wbr>Ten<wbr>Minutes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;EveryTenMinutes&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L272">types.ts:272</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L272">types.ts:272</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hourly<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Hourly&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L271">types.ts:271</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L271">types.ts:271</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Manual<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Manual&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L269">types.ts:269</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L269">types.ts:269</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/type.html
+++ b/docs/enums/type.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L10">api_types.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L10">api_types.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L11">api_types.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L11">api_types.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L12">api_types.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L12">api_types.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L13">api_types.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L13">api_types.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L8">api_types.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L8">api_types.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">object<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L9">api_types.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L9">api_types.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">string<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L7">api_types.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L7">api_types.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/arraytype.html
+++ b/docs/interfaces/arraytype.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L20">api_types.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L20">api_types.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;array&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L19">api_types.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L19">api_types.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/dynamicsynctabledef.html
+++ b/docs/interfaces/dynamicsynctabledef.html
@@ -131,7 +131,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="synctabledef.html">SyncTableDef</a>.<a href="synctabledef.html#entityname">entityName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L86">api.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L86">api.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Display<wbr>Url<span class="tsd-signature-symbol">:</span> <a href="../modules.html#metadataformula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L102">api.ts:102</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L102">api.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">:</span> <a href="../modules.html#metadataformula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L101">api.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L101">api.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="synctabledef.html">SyncTableDef</a>.<a href="synctabledef.html#getschema">getSchema</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L100">api.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L100">api.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="synctabledef.html">SyncTableDef</a>.<a href="synctabledef.html#getter">getter</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L84">api.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L84">api.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Dynamic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L99">api.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L99">api.ts:99</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">list<wbr>Dynamic<wbr>Urls<span class="tsd-signature-symbol">:</span> <a href="../modules.html#metadataformula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L103">api.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L103">api.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="synctabledef.html">SyncTableDef</a>.<a href="synctabledef.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L82">api.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L82">api.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="synctabledef.html">SyncTableDef</a>.<a href="synctabledef.html#schema">schema</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L83">api.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L83">api.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/emptyformuladef.html
+++ b/docs/interfaces/emptyformuladef.html
@@ -118,7 +118,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.cacheTtlSecs</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L235">api_types.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235">api_types.ts:235</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.connectionRequirement</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L227">api_types.ts:227</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227">api_types.ts:227</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L201">api_types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L201">api_types.ts:201</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.examples</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L216">api_types.ts:216</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L216">api_types.ts:216</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.extraOAuthScopes</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L257">api_types.ts:257</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257">api_types.ts:257</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isAction</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L222">api_types.ts:222</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222">api_types.ts:222</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isExperimental</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L241">api_types.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241">api_types.ts:241</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -237,7 +237,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isSystem</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L247">api_types.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247">api_types.ts:247</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L196">api_types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L196">api_types.ts:196</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.network</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L230">api_types.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L230">api_types.ts:230</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.parameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L206">api_types.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L206">api_types.ts:206</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RequestHandlerTemplate</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L347">api.ts:347</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L347">api.ts:347</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.varargParameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L211">api_types.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L211">api_types.ts:211</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/executioncontext.html
+++ b/docs/interfaces/executioncontext.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L335">api_types.ts:335</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L335">api_types.ts:335</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">fetcher<span class="tsd-signature-symbol">:</span> <a href="fetcher.html" class="tsd-signature-type" data-tsd-kind="Interface">Fetcher</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L332">api_types.ts:332</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L332">api_types.ts:332</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">invocation<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>docId<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>protocolAndHost<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L336">api_types.ts:336</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L336">api_types.ts:336</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">invocation<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L344">api_types.ts:344</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L344">api_types.ts:344</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="logger.html" class="tsd-signature-type" data-tsd-kind="Interface">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L334">api_types.ts:334</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L334">api_types.ts:334</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Sync</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L345">api_types.ts:345</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L345">api_types.ts:345</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">temporary<wbr>Blob<wbr>Storage<span class="tsd-signature-symbol">:</span> <a href="temporaryblobstorage.html" class="tsd-signature-type" data-tsd-kind="Interface">TemporaryBlobStorage</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L333">api_types.ts:333</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L333">api_types.ts:333</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">timezone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L340">api_types.ts:340</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340">api_types.ts:340</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/externalpackversionmetadata.html
+++ b/docs/interfaces/externalpackversionmetadata.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>deferConnectionSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>endpointDomain<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>params<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-symbol">{ </span>description<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>postSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">PostSetupMetadata</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>requiresEndpointUrl<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>shouldAutoAuthSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>type<span class="tsd-signature-symbol">: </span><a href="../enums/authenticationtype.html" class="tsd-signature-type" data-tsd-kind="Enumeration">AuthenticationType</a><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L96">compiled_types.ts:96</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L96">compiled_types.ts:96</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">formats<span class="tsd-signature-symbol">:</span> <a href="format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L109">compiled_types.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L109">compiled_types.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">formulas<span class="tsd-signature-symbol">:</span> <a href="../modules.html#externalpackformulas" class="tsd-signature-type" data-tsd-kind="Type alias">ExternalPackFormulas</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L108">compiled_types.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L108">compiled_types.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">instructions<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L105">compiled_types.ts:105</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L105">compiled_types.ts:105</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.networkDomains</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Tables<span class="tsd-signature-symbol">:</span> <a href="../modules.html#packsynctable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L110">compiled_types.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L110">compiled_types.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.version</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/fetcher.html
+++ b/docs/interfaces/fetcher.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L307">api_types.ts:307</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L307">api_types.ts:307</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/fetchrequest.html
+++ b/docs/interfaces/fetchrequest.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L288">api_types.ts:288</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288">api_types.ts:288</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">cache<wbr>Ttl<wbr>Secs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L292">api_types.ts:292</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292">api_types.ts:292</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">disable<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L296">api_types.ts:296</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L296">api_types.ts:296</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">form<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L289">api_types.ts:289</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289">api_types.ts:289</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L290">api_types.ts:290</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L290">api_types.ts:290</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Binary<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L294">api_types.ts:294</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294">api_types.ts:294</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;GET&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PATCH&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;POST&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PUT&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;DELETE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L286">api_types.ts:286</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L286">api_types.ts:286</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L287">api_types.ts:287</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287">api_types.ts:287</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/fetchresponse.html
+++ b/docs/interfaces/fetchresponse.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L302">api_types.ts:302</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L302">api_types.ts:302</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L303">api_types.ts:303</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303">api_types.ts:303</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L301">api_types.ts:301</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L301">api_types.ts:301</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/format.html
+++ b/docs/interfaces/format.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L246">types.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L246">types.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L245">types.ts:245</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L245">types.ts:245</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>NoConnection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L248">types.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L248">types.ts:248</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">instructions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L249">types.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L249">types.ts:249</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L250">types.ts:250</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L250">types.ts:250</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L244">types.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L244">types.ts:244</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">placeholder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L251">types.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/logger.html
+++ b/docs/interfaces/logger.html
@@ -100,7 +100,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L325">api_types.ts:325</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L325">api_types.ts:325</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L328">api_types.ts:328</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328">api_types.ts:328</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L326">api_types.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L326">api_types.ts:326</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L324">api_types.ts:324</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324">api_types.ts:324</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L327">api_types.ts:327</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L327">api_types.ts:327</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/metadataformulaobjectresulttype.html
+++ b/docs/interfaces/metadataformulaobjectresulttype.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">display<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L629">api.ts:629</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L629">api.ts:629</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Children<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L631">api.ts:631</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L631">api.ts:631</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L630">api.ts:630</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L630">api.ts:630</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/network.html
+++ b/docs/interfaces/network.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<span class="tsd-signature-symbol">:</span> <a href="../enums/networkconnection.html" class="tsd-signature-type" data-tsd-kind="Enumeration">NetworkConnection</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L277">api_types.ts:277</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277">api_types.ts:277</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Side<wbr>Effect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L275">api_types.ts:275</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275">api_types.ts:275</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">requires<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L276">api_types.ts:276</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L276">api_types.ts:276</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/oauth2authentication.html
+++ b/docs/interfaces/oauth2authentication.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">additional<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L150">types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L150">types.ts:150</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">authorization<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L146">types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L146">types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.defaultConnectionType</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L75">types.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L75">types.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.endpointDomain</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L84">types.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L84">types.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L154">types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L154">types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L70">types.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L70">types.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionUserId</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L71">types.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L71">types.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.instructionsUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L78">types.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L78">types.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.postSetup</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L87">types.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L87">types.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.requiresEndpointUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L81">types.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L81">types.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">scopes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L148">types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L148">types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L149">types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L149">types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Query<wbr>Param<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L157">types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L157">types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -256,7 +256,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L147">types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L147">types.ts:147</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/authenticationtype.html#oauth2" class="tsd-signature-type" data-tsd-kind="Enumeration member">OAuth2</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L145">types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L145">types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/packdefinition.html
+++ b/docs/interfaces/packdefinition.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">category<span class="tsd-signature-symbol">:</span> <a href="../enums/packcategory.html" class="tsd-signature-type" data-tsd-kind="Enumeration">PackCategory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L335">types.ts:335</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L335">types.ts:335</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#defaultauthentication">defaultAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L308">types.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L308">types.ts:308</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L333">types.ts:333</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L333">types.ts:333</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">enabled<wbr>Config<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L337">types.ts:337</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L337">types.ts:337</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Images<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L338">types.ts:338</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L338">types.ts:338</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Video<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L339">types.ts:339</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L339">types.ts:339</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#formats">formats</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L319">types.ts:319</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#formulanamespace">formulaNamespace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#formulas">formulas</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L318">types.ts:318</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L318">types.ts:318</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L330">types.ts:330</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L330">types.ts:330</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>System<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L346">types.ts:346</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L346">types.ts:346</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">logo<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L336">types.ts:336</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L336">types.ts:336</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimum<wbr>Feature<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../enums/featureset.html" class="tsd-signature-type" data-tsd-kind="Enumeration">FeatureSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L340">types.ts:340</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L340">types.ts:340</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L331">types.ts:331</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L331">types.ts:331</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -284,7 +284,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#networkdomains">networkDomains</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -294,7 +294,7 @@
 					<div class="tsd-signature tsd-kind-icon">permissions<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L334">types.ts:334</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L334">types.ts:334</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">quotas<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>Basic<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Enterprise<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Pro<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Team<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L341">types.ts:341</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L341">types.ts:341</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<wbr>Limits<span class="tsd-signature-symbol">:</span> <a href="ratelimits.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimits</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L342">types.ts:342</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L342">types.ts:342</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -324,7 +324,7 @@
 					<div class="tsd-signature tsd-kind-icon">short<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L332">types.ts:332</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L332">types.ts:332</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#synctables">syncTables</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L320">types.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#systemconnectionauthentication">systemConnectionAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L313">types.ts:313</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L313">types.ts:313</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="packversiondefinition.html">PackVersionDefinition</a>.<a href="packversiondefinition.html#version">version</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/packformatmetadata.html
+++ b/docs/interfaces/packformatmetadata.html
@@ -104,7 +104,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L246">types.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L246">types.ts:246</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L245">types.ts:245</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L245">types.ts:245</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.hasNoConnection</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L248">types.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L248">types.ts:248</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.instructions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L249">types.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L249">types.ts:249</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L27">compiled_types.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L27">compiled_types.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L244">types.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L244">types.ts:244</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.placeholder</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L251">types.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/packformuladef.html
+++ b/docs/interfaces/packformuladef.html
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.cacheTtlSecs</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L235">api_types.ts:235</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235">api_types.ts:235</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.connectionRequirement</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L227">api_types.ts:227</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227">api_types.ts:227</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L201">api_types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L201">api_types.ts:201</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.examples</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L216">api_types.ts:216</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L216">api_types.ts:216</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.extraOAuthScopes</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L257">api_types.ts:257</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257">api_types.ts:257</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isAction</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L222">api_types.ts:222</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222">api_types.ts:222</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isExperimental</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L241">api_types.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241">api_types.ts:241</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isSystem</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L247">api_types.ts:247</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247">api_types.ts:247</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L196">api_types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L196">api_types.ts:196</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -278,7 +278,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.network</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L230">api_types.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L230">api_types.ts:230</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.parameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L206">api_types.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L206">api_types.ts:206</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.varargParameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L211">api_types.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L211">api_types.ts:211</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L324">api.ts:324</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L324">api.ts:324</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/packversiondefinition.html
+++ b/docs/interfaces/packversiondefinition.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#authentication" class="tsd-signature-type" data-tsd-kind="Type alias">Authentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L308">types.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L308">types.ts:308</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">formats<span class="tsd-signature-symbol">:</span> <a href="format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L319">types.ts:319</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">formulas<span class="tsd-signature-symbol">:</span> <a href="packformulas.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulas</a><span class="tsd-signature-symbol"> | </span><a href="../modules.html#formula" class="tsd-signature-type" data-tsd-kind="Type alias">Formula</a><span class="tsd-signature-symbol">&lt;</span><a href="../modules.html#paramdefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L318">types.ts:318</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L318">types.ts:318</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<wbr>Domains<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Tables<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncTable</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L320">types.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">system<wbr>Connection<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#systemauthentication" class="tsd-signature-type" data-tsd-kind="Type alias">SystemAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L313">types.ts:313</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L313">types.ts:313</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/paramdef.html
+++ b/docs/interfaces/paramdef.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">autocomplete<span class="tsd-signature-symbol">:</span> <a href="../modules.html#metadataformula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L164">api_types.ts:164</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L164">api_types.ts:164</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Value<span class="tsd-signature-symbol">:</span> <a href="../modules.html#defaultvaluetype" class="tsd-signature-type" data-tsd-kind="Type alias">DefaultValueType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L168">api_types.ts:168</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L168">api_types.ts:168</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L145">api_types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L145">api_types.ts:145</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">hidden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L151">api_types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L151">api_types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L137">api_types.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L137">api_types.ts:137</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L150">api_types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L150">api_types.ts:150</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L141">api_types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L141">api_types.ts:141</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/quota.html
+++ b/docs/interfaces/quota.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Sync<wbr>Interval<span class="tsd-signature-symbol">:</span> <a href="../enums/syncinterval.html" class="tsd-signature-type" data-tsd-kind="Enumeration">SyncInterval</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L283">types.ts:283</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L283">types.ts:283</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">monthly<wbr>Limits<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>Action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Getter<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Metadata<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Sync<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L281">types.ts:281</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L281">types.ts:281</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<span class="tsd-signature-symbol">:</span> <a href="syncquota.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncQuota</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L284">types.ts:284</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L284">types.ts:284</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ratelimit.html
+++ b/docs/interfaces/ratelimit.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Seconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L289">types.ts:289</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L289">types.ts:289</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">operations<wbr>Per<wbr>Interval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L288">types.ts:288</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L288">types.ts:288</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ratelimits.html
+++ b/docs/interfaces/ratelimits.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">overall<span class="tsd-signature-symbol">:</span> <a href="ratelimit.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L293">types.ts:293</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L293">types.ts:293</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">per<wbr>Connection<span class="tsd-signature-symbol">:</span> <a href="ratelimit.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L294">types.ts:294</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L294">types.ts:294</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.arrayschema.html
+++ b/docs/interfaces/schema.arrayschema.html
@@ -111,7 +111,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L162">schema.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L162">schema.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuetype.html#array" class="tsd-signature-type" data-tsd-kind="Enumeration member">Array</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L161">schema.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L161">schema.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.booleanschema.html
+++ b/docs/interfaces/schema.booleanschema.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuetype.html#boolean" class="tsd-signature-type" data-tsd-kind="Enumeration member">Boolean</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L79">schema.ts:79</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L79">schema.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.currencyschema.html
+++ b/docs/interfaces/schema.currencyschema.html
@@ -106,7 +106,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L100">schema.ts:100</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L100">schema.ts:100</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">currency<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L102">schema.ts:102</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L102">schema.ts:102</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.currencyformat.html" class="tsd-signature-type" data-tsd-kind="Enumeration">CurrencyFormat</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L103">schema.ts:103</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L103">schema.ts:103</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L101">schema.ts:101</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L101">schema.ts:101</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.dateschema.html
+++ b/docs/interfaces/schema.dateschema.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuehinttype.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L124">schema.ts:124</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L124">schema.ts:124</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L126">schema.ts:126</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L126">schema.ts:126</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.datetimeschema.html
+++ b/docs/interfaces/schema.datetimeschema.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuehinttype.html#datetime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L136">schema.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L136">schema.ts:136</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<wbr>Format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L138">schema.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L138">schema.ts:138</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L140">schema.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L140">schema.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.durationschema.html
+++ b/docs/interfaces/schema.durationschema.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.stringschema.html">StringSchema</a>.<a href="schema.stringschema.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L157">schema.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L157">schema.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.stringschema.html">StringSchema</a>.<a href="schema.stringschema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Unit<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.durationunit.html" class="tsd-signature-type" data-tsd-kind="Enumeration">DurationUnit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L152">schema.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L152">schema.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L151">schema.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L151">schema.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.stringschema.html">StringSchema</a>.<a href="schema.stringschema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L156">schema.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L156">schema.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.identity.html
+++ b/docs/interfaces/schema.identity.html
@@ -104,7 +104,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.identitydefinition.html">IdentityDefinition</a>.<a href="schema.identitydefinition.html#attribution">attribution</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L179">schema.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L179">schema.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.identitydefinition.html">IdentityDefinition</a>.<a href="schema.identitydefinition.html#dynamicurl">dynamicUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L178">schema.ts:178</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L178">schema.ts:178</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.identitydefinition.html">IdentityDefinition</a>.<a href="schema.identitydefinition.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L177">schema.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L177">schema.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.identitydefinition.html">IdentityDefinition</a>.<a href="schema.identitydefinition.html#packid">packId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L185">schema.ts:185</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L185">schema.ts:185</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.identitydefinition.html
+++ b/docs/interfaces/schema.identitydefinition.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">attribution<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AttributionNode</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L179">schema.ts:179</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L179">schema.ts:179</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">dynamic<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L178">schema.ts:178</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L178">schema.ts:178</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L177">schema.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L177">schema.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">pack<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L181">schema.ts:181</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L181">schema.ts:181</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.numberschema.html
+++ b/docs/interfaces/schema.numberschema.html
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuehinttype.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#datetime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#percent" class="tsd-signature-type" data-tsd-kind="Enumeration member">Percent</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#currency" class="tsd-signature-type" data-tsd-kind="Enumeration member">Currency</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#slider" class="tsd-signature-type" data-tsd-kind="Enumeration member">Slider</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#scale" class="tsd-signature-type" data-tsd-kind="Enumeration member">Scale</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L84">schema.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L84">schema.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuetype.html#number" class="tsd-signature-type" data-tsd-kind="Enumeration member">Number</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.numericschema.html
+++ b/docs/interfaces/schema.numericschema.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L88">schema.ts:88</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L88">schema.ts:88</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L89">schema.ts:89</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L89">schema.ts:89</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">use<wbr>Thousands<wbr>Separator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L90">schema.ts:90</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L90">schema.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.objectschema.html
+++ b/docs/interfaces/schema.objectschema.html
@@ -119,7 +119,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L193">schema.ts:193</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L193">schema.ts:193</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#featured">featured</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L194">schema.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L194">schema.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#id">id</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L191">schema.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L191">schema.ts:191</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#identity">identity</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L199">schema.ts:199</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L199">schema.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#primary">primary</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L192">schema.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L192">schema.ts:192</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#properties">properties</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L190">schema.ts:190</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L190">schema.ts:190</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.objectschemadefinition.html">ObjectSchemaDefinition</a>.<a href="schema.objectschemadefinition.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L189">schema.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L189">schema.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.objectschemadefinition.html
+++ b/docs/interfaces/schema.objectschemadefinition.html
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuehinttype.html#person" class="tsd-signature-type" data-tsd-kind="Enumeration member">Person</a><span class="tsd-signature-symbol"> | </span><a href="../enums/schema.valuehinttype.html#reference" class="tsd-signature-type" data-tsd-kind="Enumeration member">Reference</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L193">schema.ts:193</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L193">schema.ts:193</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">featured<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">L</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L194">schema.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L194">schema.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">K</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L191">schema.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L191">schema.ts:191</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">identity<span class="tsd-signature-symbol">:</span> <a href="schema.identitydefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">IdentityDefinition</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L195">schema.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L195">schema.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">K</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L192">schema.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L192">schema.ts:192</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">properties<span class="tsd-signature-symbol">:</span> <a href="../modules/schema.html#objectschemaproperties" class="tsd-signature-type" data-tsd-kind="Type alias">ObjectSchemaProperties</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">L</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L190">schema.ts:190</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L190">schema.ts:190</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuetype.html#object" class="tsd-signature-type" data-tsd-kind="Enumeration member">Object</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L189">schema.ts:189</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L189">schema.ts:189</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.objectschemaproperty.html
+++ b/docs/interfaces/schema.objectschemaproperty.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L166">schema.ts:166</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L166">schema.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L167">schema.ts:167</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L167">schema.ts:167</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.scaleschema.html
+++ b/docs/interfaces/schema.scaleschema.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L114">schema.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L114">schema.ts:114</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L116">schema.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L116">schema.ts:116</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L115">schema.ts:115</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L115">schema.ts:115</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.sliderschema.html
+++ b/docs/interfaces/schema.sliderschema.html
@@ -106,7 +106,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#codatype">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L107">schema.ts:107</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L107">schema.ts:107</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L109">schema.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L109">schema.ts:109</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L108">schema.ts:108</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L108">schema.ts:108</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">step<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L110">schema.ts:110</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L110">schema.ts:110</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="schema.numberschema.html">NumberSchema</a>.<a href="schema.numberschema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.stringschema.html
+++ b/docs/interfaces/schema.stringschema.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L157">schema.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L157">schema.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuetype.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">String</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L156">schema.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L156">schema.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/schema.timeschema.html
+++ b/docs/interfaces/schema.timeschema.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/schema.valuehinttype.html#time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L130">schema.ts:130</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L130">schema.ts:130</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L132">schema.ts:132</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L132">schema.ts:132</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/simpleautocompleteoption.html
+++ b/docs/interfaces/simpleautocompleteoption.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">display<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L680">api.ts:680</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L680">api.ts:680</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L681">api.ts:681</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L681">api.ts:681</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/syncexecutioncontext.html
+++ b/docs/interfaces/syncexecutioncontext.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#endpoint">endpoint</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L335">api_types.ts:335</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L335">api_types.ts:335</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#fetcher">fetcher</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L332">api_types.ts:332</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L332">api_types.ts:332</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#invocationlocation">invocationLocation</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L336">api_types.ts:336</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L336">api_types.ts:336</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -149,7 +149,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#invocationtoken">invocationToken</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L344">api_types.ts:344</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L344">api_types.ts:344</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L334">api_types.ts:334</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L334">api_types.ts:334</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#sync">sync</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L349">api_types.ts:349</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L349">api_types.ts:349</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#temporaryblobstorage">temporaryBlobStorage</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L333">api_types.ts:333</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L333">api_types.ts:333</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="executioncontext.html">ExecutionContext</a>.<a href="executioncontext.html#timezone">timezone</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L340">api_types.ts:340</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340">api_types.ts:340</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/syncformularesult.html
+++ b/docs/interfaces/syncformularesult.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">continuation<span class="tsd-signature-symbol">:</span> <a href="continuation.html" class="tsd-signature-type" data-tsd-kind="Interface">Continuation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L404">api.ts:404</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L404">api.ts:404</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ResultT</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L403">api.ts:403</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L403">api.ts:403</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/syncquota.html
+++ b/docs/interfaces/syncquota.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Interval<span class="tsd-signature-symbol">:</span> <a href="../enums/syncinterval.html" class="tsd-signature-type" data-tsd-kind="Enumeration">SyncInterval</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L276">types.ts:276</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L276">types.ts:276</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Row<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L277">types.ts:277</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L277">types.ts:277</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/synctabledef.html
+++ b/docs/interfaces/synctabledef.html
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">entity<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L86">api.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L86">api.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Schema<span class="tsd-signature-symbol">:</span> <a href="../modules.html#metadataformula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L85">api.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L85">api.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">getter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">L</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">SchemaT</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L84">api.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L84">api.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L82">api.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L82">api.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">schema<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SchemaT</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L83">api.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L83">api.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/temporaryblobstorage.html
+++ b/docs/interfaces/temporaryblobstorage.html
@@ -97,7 +97,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L312">api_types.ts:312</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L312">api_types.ts:312</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L311">api_types.ts:311</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311">api_types.ts:311</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/variousauthentication.html
+++ b/docs/interfaces/variousauthentication.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/authenticationtype.html#various" class="tsd-signature-type" data-tsd-kind="Enumeration member">Various</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L177">types.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L177">types.ts:177</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/webbasicauthentication.html
+++ b/docs/interfaces/webbasicauthentication.html
@@ -106,7 +106,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.defaultConnectionType</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L75">types.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L75">types.ts:75</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.endpointDomain</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L84">types.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L84">types.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L70">types.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L70">types.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionUserId</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L71">types.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L71">types.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.instructionsUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L78">types.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L78">types.ts:78</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -161,7 +161,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.postSetup</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L87">types.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L87">types.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.requiresEndpointUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L81">types.ts:81</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L81">types.ts:81</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/authenticationtype.html#webbasic" class="tsd-signature-type" data-tsd-kind="Enumeration member">WebBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L161">types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L161">types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">ux<wbr>Config<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>placeholderPassword<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>placeholderUsername<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>usernameOnly<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L162">types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L162">types.ts:162</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/variousauthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">VariousAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CodaApiBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/oauth2authentication.html" class="tsd-signature-type" data-tsd-kind="Interface">OAuth2Authentication</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/webbasicauthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L180">types.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L180">types.ts:180</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -386,7 +386,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<wbr>Pack<wbr>Definition<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/packversiondefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackVersionDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;version&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L297">types.ts:297</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L297">types.ts:297</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -396,7 +396,7 @@
 					<div class="tsd-signature tsd-kind-icon">Default<wbr>Value<wbr>Type&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/arraytype.html" class="tsd-signature-type" data-tsd-kind="Interface">ArrayType</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/type.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">date</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="enums/precanneddaterange.html" class="tsd-signature-type" data-tsd-kind="Enumeration">PrecannedDateRange</a><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L188">api_types.ts:188</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L188">api_types.ts:188</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -412,7 +412,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Object<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ObjectPackFormulaMetadata</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L83">compiled_types.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L83">compiled_types.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -422,7 +422,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Format<span class="tsd-signature-symbol">:</span> <a href="interfaces/format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L85">compiled_types.ts:85</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L85">compiled_types.ts:85</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -432,7 +432,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Format<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="interfaces/packformatmetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormatMetadata</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L86">compiled_types.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L86">compiled_types.ts:86</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -442,7 +442,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <a href="modules.html#packformulametadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L84">compiled_types.ts:84</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L84">compiled_types.ts:84</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -452,7 +452,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Formulas<span class="tsd-signature-symbol">:</span> <a href="interfaces/packformulasmetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulasMetadata</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#packformulametadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L82">compiled_types.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L82">compiled_types.ts:82</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -462,7 +462,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="interfaces/externalpackversionmetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">ExternalPackVersionMetadata</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="modules.html#packmetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackMetadata</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;id&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;name&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;shortDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;description&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;permissionsDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;category&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;logoPath&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleImages&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleVideoIds&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;minimumFeatureSet&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;quotas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;rateLimits&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;isSystem&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L114">compiled_types.ts:114</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L114">compiled_types.ts:114</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -477,7 +477,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="modules.html#packsynctable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L87">compiled_types.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L87">compiled_types.ts:87</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -487,7 +487,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fetch<wbr>Method<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><span class="tsd-signature-type">ValidFetchMethods</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L282">api_types.ts:282</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282">api_types.ts:282</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -497,7 +497,7 @@
 					<div class="tsd-signature tsd-kind-icon">Formula&lt;ParamDefsT&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NumericPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">StringPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">BooleanPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">ObjectPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><a href="modules/schema.html#schema-1" class="tsd-signature-type" data-tsd-kind="Type alias">Schema</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L379">api.ts:379</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L379">api.ts:379</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -513,7 +513,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Dynamic<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="interfaces/dynamicsynctabledef.html" class="tsd-signature-type" data-tsd-kind="Interface">DynamicSyncTableDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#paramdefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L156">api.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L156">api.ts:156</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -530,7 +530,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#paramdefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L138">api.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L138">api.ts:138</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -547,7 +547,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Formula<wbr>Result<span class="tsd-signature-symbol">:</span> <a href="interfaces/syncformularesult.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncFormulaResult</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L144">api.ts:144</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L144">api.ts:144</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -564,7 +564,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="interfaces/synctabledef.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncTableDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#paramdefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L150">api.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L150">api.ts:150</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -581,7 +581,7 @@
 					<div class="tsd-signature tsd-kind-icon">Logger<wbr>Param<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L321">api_types.ts:321</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L321">api_types.ts:321</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -591,7 +591,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Context<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L640">api.ts:640</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L640">api.ts:640</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -609,7 +609,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ObjectPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/type.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">string</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/type.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">string</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L643">api.ts:643</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L643">api.ts:643</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -619,7 +619,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Formula<wbr>Result<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/metadataformulaobjectresulttype.html" class="tsd-signature-type" data-tsd-kind="Interface">MetadataFormulaObjectResultType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L642">api.ts:642</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L642">api.ts:642</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -629,7 +629,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="modules.html#typedpackformula" class="tsd-signature-type" data-tsd-kind="Type alias">TypedPackFormula</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;execute&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L388">api.ts:388</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L388">api.ts:388</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -639,7 +639,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TypeMap</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="modules.html#packformularesult" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaResult</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L71">api_types.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L71">api_types.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -649,7 +649,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TypeMap</span><span class="tsd-signature-symbol">, </span><a href="enums/type.html#object" class="tsd-signature-type" data-tsd-kind="Enumeration member">object</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="modules.html#packformulavalue" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaValue</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L70">api_types.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L70">api_types.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -659,7 +659,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L8">types.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L8">types.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -669,7 +669,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="modules.html#packversionmetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackVersionMetadata</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/packdefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;id&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;name&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;shortDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;description&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;permissionsDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;category&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;logoPath&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleImages&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleVideoIds&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;minimumFeatureSet&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;quotas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;rateLimits&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;enabledConfigName&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;isSystem&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L60">compiled_types.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L60">compiled_types.ts:60</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -684,7 +684,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">SyncTable</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;getter&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getName&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getSchema&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;listDynamicUrls&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getDisplayUrl&quot;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>getDisplayUrl<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getName<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getSchema<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getter<span class="tsd-signature-symbol">: </span><a href="modules.html#packformulametadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">; </span>hasDynamicSchema<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>isDynamic<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>listDynamicUrls<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L13">compiled_types.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L13">compiled_types.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -694,7 +694,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Version<wbr>Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/packversiondefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackVersionDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;formulas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;formats&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;defaultAuthentication&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;syncTables&quot;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>defaultAuthentication<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">AuthenticationMetadata</span><span class="tsd-signature-symbol">; </span>formats<span class="tsd-signature-symbol">: </span><a href="interfaces/packformatmetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormatMetadata</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>formulas<span class="tsd-signature-symbol">: </span><a href="interfaces/packformulasmetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulasMetadata</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#packformulametadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>syncTables<span class="tsd-signature-symbol">: </span><a href="modules.html#packsynctable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/compiled_types.ts#L48">compiled_types.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L48">compiled_types.ts:48</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -709,7 +709,7 @@
 					<div class="tsd-signature tsd-kind-icon">Param<wbr>Defs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">...</span><a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L173">api_types.ts:173</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L173">api_types.ts:173</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -719,7 +719,7 @@
 					<div class="tsd-signature tsd-kind-icon">Param<wbr>Values&lt;ParamDefsT&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">infer </span> T<span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L183">api_types.ts:183</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L183">api_types.ts:183</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -735,7 +735,7 @@
 					<div class="tsd-signature tsd-kind-icon">Params<wbr>List<span class="tsd-signature-symbol">:</span> <a href="interfaces/paramdef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L175">api_types.ts:175</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L175">api_types.ts:175</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -745,7 +745,7 @@
 					<div class="tsd-signature tsd-kind-icon">System<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/webbasicauthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L210">types.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L210">types.ts:210</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -755,7 +755,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <a href="modules.html#formula" class="tsd-signature-type" data-tsd-kind="Type alias">Formula</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#genericsyncformula" class="tsd-signature-type" data-tsd-kind="Type alias">GenericSyncFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L385">api.ts:385</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L385">api.ts:385</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -765,7 +765,7 @@
 					<div class="tsd-signature tsd-kind-icon">Various<wbr>Supported<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/webbasicauthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/types.ts#L233">types.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L233">types.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -782,7 +782,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/ensure.ts#L25">helpers/ensure.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L25">helpers/ensure.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -808,7 +808,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L705">api.ts:705</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L705">api.ts:705</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -846,7 +846,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/ensure.ts#L14">helpers/ensure.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L14">helpers/ensure.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -878,7 +878,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/ensure.ts#L7">helpers/ensure.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L7">helpers/ensure.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -904,7 +904,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/ensure.ts#L3">helpers/ensure.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L3">helpers/ensure.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -930,7 +930,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/url.ts#L17">helpers/url.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L17">helpers/url.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -958,7 +958,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api_types.ts#L23">api_types.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L23">api_types.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -981,7 +981,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L173">api.ts:173</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L173">api.ts:173</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1004,7 +1004,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L390">api.ts:390</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L390">api.ts:390</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1027,7 +1027,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L394">api.ts:394</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L394">api.ts:394</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1050,7 +1050,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L398">api.ts:398</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L398">api.ts:398</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1073,7 +1073,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L169">api.ts:169</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L169">api.ts:169</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1105,7 +1105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/url.ts#L27">helpers/url.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L27">helpers/url.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1136,7 +1136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L977">api.ts:977</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L977">api.ts:977</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1197,7 +1197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L1057">api.ts:1057</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L1057">api.ts:1057</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1226,7 +1226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L498">api.ts:498</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L498">api.ts:498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1299,7 +1299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L652">api.ts:652</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L652">api.ts:652</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1330,7 +1330,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L197">api.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L197">api.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1372,7 +1372,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L722">api.ts:722</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L722">api.ts:722</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1395,7 +1395,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L896">api.ts:896</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L896">api.ts:896</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1449,7 +1449,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L1028">api.ts:1028</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L1028">api.ts:1028</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1481,7 +1481,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L308">api.ts:308</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L308">api.ts:308</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1504,7 +1504,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/builder.ts#L32">builder.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L32">builder.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1540,7 +1540,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/api.ts#L684">api.ts:684</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L684">api.ts:684</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1566,7 +1566,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/helpers/url.ts#L5">helpers/url.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L5">helpers/url.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/schema.html
+++ b/docs/modules/schema.html
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Object<wbr>Schema<span class="tsd-signature-symbol">:</span> <a href="../interfaces/schema.objectschema.html" class="tsd-signature-type" data-tsd-kind="Interface">ObjectSchema</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L174">schema.ts:174</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L174">schema.ts:174</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<wbr>Hint<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="schema.html#numberhintvaluetypes" class="tsd-signature-type" data-tsd-kind="Variable">NumberHintValueTypes</a><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L71">schema.ts:71</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L71">schema.ts:71</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<wbr>Hint<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="schema.html#objecthintvaluetypes" class="tsd-signature-type" data-tsd-kind="Variable">ObjectHintValueTypes</a><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L72">schema.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L72">schema.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<wbr>Schema<wbr>Properties&lt;K&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K2</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="schema.html#schema-1" class="tsd-signature-type" data-tsd-kind="Type alias">Schema</a><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/schema.objectschemaproperty.html" class="tsd-signature-type" data-tsd-kind="Interface">ObjectSchemaProperty</a><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L170">schema.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L170">schema.ts:170</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schema<span class="tsd-signature-symbol">:</span> <a href="../interfaces/schema.booleanschema.html" class="tsd-signature-type" data-tsd-kind="Interface">BooleanSchema</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/schema.numberschema.html" class="tsd-signature-type" data-tsd-kind="Interface">NumberSchema</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/schema.stringschema.html" class="tsd-signature-type" data-tsd-kind="Interface">StringSchema</a><span class="tsd-signature-symbol"> | </span><a href="../interfaces/schema.arrayschema.html" class="tsd-signature-type" data-tsd-kind="Interface">ArraySchema</a><span class="tsd-signature-symbol"> | </span><a href="schema.html#genericobjectschema" class="tsd-signature-type" data-tsd-kind="Type alias">GenericObjectSchema</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L230">schema.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L230">schema.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schema<wbr>Type&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="../interfaces/schema.booleanschema.html" class="tsd-signature-type" data-tsd-kind="Interface">BooleanSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="../interfaces/schema.numberschema.html" class="tsd-signature-type" data-tsd-kind="Interface">NumberSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="../interfaces/schema.stringschema.html" class="tsd-signature-type" data-tsd-kind="Interface">StringSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">StringHintTypeToSchemaType</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;codaType&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="../interfaces/schema.arrayschema.html" class="tsd-signature-type" data-tsd-kind="Interface">ArraySchema</a><span class="tsd-signature-symbol"> ? </span><a href="schema.html#schematype" class="tsd-signature-type" data-tsd-kind="Type alias">SchemaType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;items&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="schema.html#genericobjectschema" class="tsd-signature-type" data-tsd-kind="Type alias">GenericObjectSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">PickOptional</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="schema.html#schematype" class="tsd-signature-type" data-tsd-kind="Type alias">SchemaType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> extends </span><span class="tsd-signature-symbol">{ </span>required<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L249">schema.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L249">schema.ts:249</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<wbr>Hint<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><a href="schema.html#stringhintvaluetypes" class="tsd-signature-type" data-tsd-kind="Variable">StringHintValueTypes</a><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L70">schema.ts:70</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L70">schema.ts:70</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">Valid<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L264">schema.ts:264</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L264">schema.ts:264</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<wbr>Hint<wbr>Value<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">readonly </span><span class="tsd-signature-symbol">[</span><a href="../enums/schema.valuehinttype.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#datetime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#percent" class="tsd-signature-type" data-tsd-kind="Enumeration member">Percent</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#currency" class="tsd-signature-type" data-tsd-kind="Enumeration member">Currency</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#slider" class="tsd-signature-type" data-tsd-kind="Enumeration member">Slider</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#scale" class="tsd-signature-type" data-tsd-kind="Enumeration member">Scale</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L59">schema.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L59">schema.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -251,7 +251,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<wbr>Hint<wbr>Value<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">readonly </span><span class="tsd-signature-symbol">[</span><a href="../enums/schema.valuehinttype.html#person" class="tsd-signature-type" data-tsd-kind="Enumeration member">Person</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#reference" class="tsd-signature-type" data-tsd-kind="Enumeration member">Reference</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L68">schema.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L68">schema.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 					<div class="tsd-signature tsd-kind-icon">Placeholder<wbr>Identity<wbr>Pack<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">-1</span><span class="tsd-signature-symbol"> = -1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L300">schema.ts:300</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L300">schema.ts:300</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -271,7 +271,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<wbr>Hint<wbr>Value<wbr>Types<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">readonly </span><span class="tsd-signature-symbol">[</span><a href="../enums/schema.valuehinttype.html#attachment" class="tsd-signature-type" data-tsd-kind="Enumeration member">Attachment</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#datetime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#duration" class="tsd-signature-type" data-tsd-kind="Enumeration member">Duration</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#embed" class="tsd-signature-type" data-tsd-kind="Enumeration member">Embed</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#html" class="tsd-signature-type" data-tsd-kind="Enumeration member">Html</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#image" class="tsd-signature-type" data-tsd-kind="Enumeration member">Image</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#imageattachment" class="tsd-signature-type" data-tsd-kind="Enumeration member">ImageAttachment</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#markdown" class="tsd-signature-type" data-tsd-kind="Enumeration member">Markdown</a><span class="tsd-signature-symbol">, </span><a href="../enums/schema.valuehinttype.html#url" class="tsd-signature-type" data-tsd-kind="Enumeration member">Url</a><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L46">schema.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L46">schema.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L266">schema.ts:266</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L266">schema.ts:266</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L236">schema.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L236">schema.ts:236</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L232">schema.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L232">schema.ts:232</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -357,7 +357,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L226">schema.ts:226</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L226">schema.ts:226</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L302">schema.ts:302</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L302">schema.ts:302</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -421,7 +421,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L399">schema.ts:399</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L399">schema.ts:399</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -447,7 +447,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L296">schema.ts:296</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L296">schema.ts:296</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -476,7 +476,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L361">schema.ts:361</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L361">schema.ts:361</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -505,7 +505,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/0598aa7/schema.ts#L356">schema.ts:356</a></li>
+									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L356">schema.ts:356</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>


### PR DESCRIPTION
This should make typedoc output much more stable. And is more correct.

PTAL @huayang-codaio @patrick-codaio @coda/packs 