### PR TITLE
create separate ivm context for each sync formula execution

### DIFF
--- a/development.ts
+++ b/development.ts
@@ -4,7 +4,6 @@
 
 export type {ContextOptions} from './testing/execution';
 export type {ExecuteOptions} from './testing/execution';
-export type {ExecuteSyncOptions} from './testing/execution';
 export {executeFormulaFromPackDef} from './testing/execution';
 export {executeMetadataFormula} from './testing/execution';
 export {executeSyncFormulaFromPackDef} from './testing/execution';

--- a/dist/development.d.ts
+++ b/dist/development.d.ts
@@ -1,6 +1,5 @@
 export type { ContextOptions } from './testing/execution';
 export type { ExecuteOptions } from './testing/execution';
-export type { ExecuteSyncOptions } from './testing/execution';
 export { executeFormulaFromPackDef } from './testing/execution';
 export { executeMetadataFormula } from './testing/execution';
 export { executeSyncFormulaFromPackDef } from './testing/execution';

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="node" />
 import type { ExecuteOptions } from './execution_helper';
-import type { ExecuteSyncOptions } from './execution_helper';
 import type { ExecutionContext } from '../api_types';
 import type { MetadataContext } from '../api';
 import type { MetadataFormula } from '../api';
@@ -8,9 +7,9 @@ import type { PackVersionDefinition } from '../types';
 import type { ParamDefs } from '../api_types';
 import type { ParamValues } from '../api_types';
 import type { SyncExecutionContext } from '../api_types';
+import type { SyncFormulaResult } from '../api';
 import util from 'util';
 export { ExecuteOptions } from './execution_helper';
-export { ExecuteSyncOptions } from './execution_helper';
 export interface ContextOptions {
     useRealFetcher?: boolean;
     manifestPath?: string;
@@ -51,7 +50,7 @@ export declare function executeFormulaOrSyncWithRawParams({ formulaName, params:
     vm?: boolean;
     executionContext: SyncExecutionContext;
 }): Promise<any>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteSyncOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any[]>;
+export declare function executeSyncFormulaFromPackDef(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<SyncFormulaResult<any>>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;

--- a/dist/testing/execution_helper.d.ts
+++ b/dist/testing/execution_helper.d.ts
@@ -9,14 +9,10 @@ export interface ExecuteOptions {
     validateParams?: boolean;
     validateResult?: boolean;
 }
-export interface ExecuteSyncOptions extends ExecuteOptions {
-    maxIterations?: number;
-}
-export declare function executeSyncFormulaWithoutValidation(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context: SyncExecutionContext, maxIterations?: number): Promise<any[]>;
 export declare function executeFormulaOrSyncWithRawParams(manifest: PackVersionDefinition, formulaName: string, rawParams: string[], context: SyncExecutionContext): Promise<any>;
 export declare function executeFormulaOrSync(manifest: PackVersionDefinition, formulaName: string, params: ParamValues<ParamDefs>, context: SyncExecutionContext): Promise<any>;
 export declare function executeFormula(formula: Formula, params: ParamValues<ParamDefs>, context: ExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult }?: ExecuteOptions): Promise<any>;
-export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult, maxIterations: maxIterations, }?: ExecuteSyncOptions): Promise<any[]>;
+export declare function executeSyncFormula(formula: GenericSyncFormula, params: ParamValues<ParamDefs>, context: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult }?: ExecuteOptions): Promise<import("../api").SyncFormulaResult<any>>;
 export declare function findFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula;
 export declare function findSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula;
 export declare function tryFindFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula | undefined;

--- a/dist/testing/execution_helper.js
+++ b/dist/testing/execution_helper.js
@@ -1,32 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.wrapError = exports.tryFindSyncFormula = exports.tryFindFormula = exports.findSyncFormula = exports.findFormula = exports.executeSyncFormula = exports.executeFormula = exports.executeFormulaOrSync = exports.executeFormulaOrSyncWithRawParams = exports.executeSyncFormulaWithoutValidation = void 0;
+exports.wrapError = exports.tryFindSyncFormula = exports.tryFindFormula = exports.findSyncFormula = exports.findFormula = exports.executeSyncFormula = exports.executeFormula = exports.executeFormulaOrSync = exports.executeFormulaOrSyncWithRawParams = void 0;
 const coercion_1 = require("./coercion");
 const ensure_1 = require("../helpers/ensure");
 const validation_1 = require("./validation");
 const validation_2 = require("./validation");
-const MaxSyncIterations = 100;
-async function executeSyncFormulaWithoutValidation(formula, params, context, maxIterations = MaxSyncIterations) {
-    const result = [];
-    let iterations = 1;
-    do {
-        if (iterations > maxIterations) {
-            throw new Error(`Sync is still running after ${maxIterations} iterations, this is likely due to an infinite loop. If more iterations are needed, use the maxIterations option.`);
-        }
-        let response;
-        try {
-            response = await formula.execute(params, context);
-        }
-        catch (err) {
-            throw wrapError(err);
-        }
-        result.push(...response.result);
-        context.sync.continuation = response.continuation;
-        iterations++;
-    } while (context.sync.continuation);
-    return result;
-}
-exports.executeSyncFormulaWithoutValidation = executeSyncFormulaWithoutValidation;
 async function executeFormulaOrSyncWithRawParams(manifest, formulaName, rawParams, context) {
     try {
         const formula = tryFindFormula(manifest, formulaName);
@@ -83,13 +61,13 @@ async function executeFormula(formula, params, context, { validateParams: should
     return result;
 }
 exports.executeFormula = executeFormula;
-async function executeSyncFormula(formula, params, context, { validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true, maxIterations: maxIterations = MaxSyncIterations, } = {}) {
+async function executeSyncFormula(formula, params, context, { validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true } = {}) {
     if (shouldValidateParams) {
         validation_1.validateParams(formula, params);
     }
-    const result = await executeSyncFormulaWithoutValidation(formula, params, context, maxIterations);
+    const result = await formula.execute(params, context);
     if (shouldValidateResult) {
-        validation_2.validateResult(formula, result);
+        validation_2.validateResult(formula, result.result);
     }
     return result;
 }

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -43,7 +43,7 @@ describe('Execution', () => {
 
   it('executes a sync formula by name', async () => {
     const result = await executeSyncFormulaFromPackDef(fakePack, 'Students', ['Smith']);
-    assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
+    assert.deepEqual(result, {result: [{Name: 'Alice'}, {Name: 'Bob'}], continuation: {page: 2}});
   });
 
   it('executes a formula by name with VM', async () => {
@@ -61,14 +61,7 @@ describe('Execution', () => {
       params: ['Smith'],
       bundlePath,
     });
-    assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
-  });
-
-  it('error when maxIterations exceeded', async () => {
-    await testHelper.willBeRejectedWith(
-      executeSyncFormulaFromPackDef(fakePack, 'Students', ['Smith'], undefined, {maxIterations: 1}),
-      /Sync is still running after 1 iterations, this is likely due to an infinite loop. If more iterations are needed, use the maxIterations option./,
-    );
+    assert.deepEqual(result, {result: [{Name: 'Alice'}, {Name: 'Bob'}], continuation: {page: 2}});
   });
 
   describe('execution errors', () => {

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -65,6 +65,7 @@ export function validateResult<ResultT extends any>(formula: TypedPackFormula, r
   if (maybeError) {
     throw ResultValidationException.fromErrors(formula.name, [maybeError]);
   }
+
   if (isObjectPackFormula(formula)) {
     // We've already validated that the result type is valid by this point.
     validateObjectResult(formula, result as Record<string, unknown>);


### PR DESCRIPTION
https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/Bugs-Feature-requests_suyN0#Open-Bugs_tu6FU/r26

This PR fixes the bug and further narrows the gap between the lambda execution and the sdk execution. Instead of having IVM thunk to iterate though all the pages, now it's the sdk iterating the pages and thunk only executes a single request. 

Now if a pack author uses a global variable to store page number, it's going to fail in the CLI execution (with VM).

Testing:

```
➜  packs-sdk git:(hg-sync-cli) node_modules/.bin/ts-node cli/coda.ts execute test/packs/fake.ts Students Smith  --vm
[
  { Name: 'Alice' },
  { Name: 'Bob' },
  { Name: 'Chris' },
  { Name: 'Diana' }
]
➜  packs-sdk git:(hg-sync-cli) node_modules/.bin/ts-node cli/coda.ts execute test/packs/fake.ts Students Smith      
[
  { Name: 'Alice' },
  { Name: 'Bob' },
  { Name: 'Chris' },
  { Name: 'Diana' }
]

```