### PR TITLE
Add sdkVersion to PackVersionMetadata

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -54,6 +54,7 @@ export type PackVersionMetadata = Omit<
   formats: PackFormatMetadata[];
   syncTables: PackSyncTable[];
   defaultAuthentication?: AuthenticationMetadata;
+  sdkVersion?: string;
 };
 
 /** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1354,6 +1354,7 @@ export declare type PackVersionMetadata = Omit<PackVersionDefinition, "formulas"
 	formats: PackFormatMetadata[];
 	syncTables: PackSyncTable[];
 	defaultAuthentication?: AuthenticationMetadata;
+	sdkVersion?: string;
 };
 /** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
 export declare type PackMetadata = PackVersionMetadata & Pick<PackDefinition, "id" | "name" | "shortDescription" | "description" | "permissionsDescription" | "category" | "logoPath" | "exampleImages" | "exampleVideoIds" | "minimumFeatureSet" | "quotas" | "rateLimits" | "enabledConfigName" | "isSystem">;

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -38,6 +38,7 @@ export declare type PackVersionMetadata = Omit<PackVersionDefinition, 'formulas'
     formats: PackFormatMetadata[];
     syncTables: PackSyncTable[];
     defaultAuthentication?: AuthenticationMetadata;
+    sdkVersion?: string;
 };
 /** Stripped-down version of `PackDefinition` that doesn't contain formula definitions. */
 export declare type PackMetadata = PackVersionMetadata & Pick<PackDefinition, 'id' | 'name' | 'shortDescription' | 'description' | 'permissionsDescription' | 'category' | 'logoPath' | 'exampleImages' | 'exampleVideoIds' | 'minimumFeatureSet' | 'quotas' | 'rateLimits' | 'enabledConfigName' | 'isSystem'>;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -527,6 +527,7 @@ const unrefinedPackVersionMetadataSchema = zodCompleteObject({
     formulaNamespace: z.string().optional().refine(validateNamespace, {
         message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
     }),
+    sdkVersion: z.string().nonempty().optional(),
     systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
     formulas: z.array(formulaMetadataSchema).optional().default([]),
     formats: z.array(formatMetadataSchema).optional().default([]),

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -637,6 +637,7 @@ const unrefinedPackVersionMetadataSchema = zodCompleteObject<PackVersionMetadata
   formulaNamespace: z.string().optional().refine(validateNamespace, {
     message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
   }),
+  sdkVersion: z.string().nonempty().optional(),
   systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
   formulas: z.array(formulaMetadataSchema).optional().default([]),
   formats: z.array(formatMetadataSchema).optional().default([]),


### PR DESCRIPTION
For the Packs migration, we want to include the SDK version that the Pack was built with, and drop that into the `PackVersionMetadata`. So we need to include this as a field so that the Packs compiler can insert that field, and that the Coda migration workflow can read from it. 

Question: `make build` changed a bunch of `docs/` files, including creating several untracked files. Should I include those in this PR?