### PR TITLE
Return executeSyncFormulaFromPackDef to its original behavior of running the sync in a loop to preserve backwards compatibility.

### DIFF
--- a/development.ts
+++ b/development.ts
@@ -7,6 +7,7 @@ export type {ExecuteOptions} from './testing/execution';
 export {executeFormulaFromPackDef} from './testing/execution';
 export {executeMetadataFormula} from './testing/execution';
 export {executeSyncFormulaFromPackDef} from './testing/execution';
+export {executeSyncFormulaFromPackDefSingleIteration} from './testing/execution';
 
 // TODO(huayang): this needs to be documented in README once it's ready to be used efficiently.
 export {executeFormulaOrSyncWithVM} from './testing/execution';

--- a/dist/development.d.ts
+++ b/dist/development.d.ts
@@ -3,6 +3,7 @@ export type { ExecuteOptions } from './testing/execution';
 export { executeFormulaFromPackDef } from './testing/execution';
 export { executeMetadataFormula } from './testing/execution';
 export { executeSyncFormulaFromPackDef } from './testing/execution';
+export { executeSyncFormulaFromPackDefSingleIteration } from './testing/execution';
 export { executeFormulaOrSyncWithVM } from './testing/execution';
 export type { MockExecutionContext } from './testing/mocks';
 export type { MockSyncExecutionContext } from './testing/mocks';

--- a/dist/development.js
+++ b/dist/development.js
@@ -3,16 +3,18 @@
 //
 // These are kept separate from index.ts to avoid these utilities winding up in pack bundles.
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.newMockSyncExecutionContext = exports.newMockExecutionContext = exports.newJsonFetchResponse = exports.executeFormulaOrSyncWithVM = exports.executeSyncFormulaFromPackDef = exports.executeMetadataFormula = exports.executeFormulaFromPackDef = void 0;
+exports.newMockSyncExecutionContext = exports.newMockExecutionContext = exports.newJsonFetchResponse = exports.executeFormulaOrSyncWithVM = exports.executeSyncFormulaFromPackDefSingleIteration = exports.executeSyncFormulaFromPackDef = exports.executeMetadataFormula = exports.executeFormulaFromPackDef = void 0;
 var execution_1 = require("./testing/execution");
 Object.defineProperty(exports, "executeFormulaFromPackDef", { enumerable: true, get: function () { return execution_1.executeFormulaFromPackDef; } });
 var execution_2 = require("./testing/execution");
 Object.defineProperty(exports, "executeMetadataFormula", { enumerable: true, get: function () { return execution_2.executeMetadataFormula; } });
 var execution_3 = require("./testing/execution");
 Object.defineProperty(exports, "executeSyncFormulaFromPackDef", { enumerable: true, get: function () { return execution_3.executeSyncFormulaFromPackDef; } });
-// TODO(huayang): this needs to be documented in README once it's ready to be used efficiently.
 var execution_4 = require("./testing/execution");
-Object.defineProperty(exports, "executeFormulaOrSyncWithVM", { enumerable: true, get: function () { return execution_4.executeFormulaOrSyncWithVM; } });
+Object.defineProperty(exports, "executeSyncFormulaFromPackDefSingleIteration", { enumerable: true, get: function () { return execution_4.executeSyncFormulaFromPackDefSingleIteration; } });
+// TODO(huayang): this needs to be documented in README once it's ready to be used efficiently.
+var execution_5 = require("./testing/execution");
+Object.defineProperty(exports, "executeFormulaOrSyncWithVM", { enumerable: true, get: function () { return execution_5.executeFormulaOrSyncWithVM; } });
 var mocks_1 = require("./testing/mocks");
 Object.defineProperty(exports, "newJsonFetchResponse", { enumerable: true, get: function () { return mocks_1.newJsonFetchResponse; } });
 var mocks_2 = require("./testing/mocks");

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -50,7 +50,24 @@ export declare function executeFormulaOrSyncWithRawParams({ formulaName, params:
     vm?: boolean;
     executionContext: SyncExecutionContext;
 }): Promise<any>;
-export declare function executeSyncFormulaFromPackDef(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<SyncFormulaResult<any>>;
+/**
+ * Executes multiple iterations of a sync formula in a loop until there is no longer
+ * a `continuation` returned, aggregating each page of results and returning an array
+ * with results of all iterations combined and flattened.
+ *
+ * NOTE: This currently runs all the iterations in a simple loop, which does not
+ * adequately simulate the fact that in a real execution environment each iteration
+ * will be run in a completely isolated environment, with absolutely no sharing
+ * of state or global variables between iterations.
+ *
+ * For now, use `coda execute --vm` to simulate that level of isolation.
+ */
+export declare function executeSyncFormulaFromPackDef(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<any[]>;
+/**
+ * Executes a single sync iteration, and returns the return value from the sync formula
+ * including the continuation, for inspection.
+ */
+export declare function executeSyncFormulaFromPackDefSingleIteration(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<SyncFormulaResult<any>>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -43,7 +43,7 @@ describe('Execution', () => {
 
   it('executes a sync formula by name', async () => {
     const result = await executeSyncFormulaFromPackDef(fakePack, 'Students', ['Smith']);
-    assert.deepEqual(result, {result: [{Name: 'Alice'}, {Name: 'Bob'}], continuation: {page: 2}});
+    assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
   });
 
   it('executes a formula by name with VM', async () => {


### PR DESCRIPTION
I'm trying to bump the SDK in the packs repo and the change in functionality of executeSyncFormulaFromPackDef is breaking a bunch of tests there, that rely on the fact that it runs a sync to completion. It will also break packs-examples, and possibly customers who bothered to write unittests (don't know if there are any).

It is fair that it's probably more useful to test a single iteration and be able to inspect the returned continuation, and sidestep the fact that we don't run the loops in isolation in the context of a unittest or integration test yet. But I'd rather not have this be a breaking change and have to fix all those tests and tell users to do the same, we can try to have this use the VM too when it's ready.

PTAL @huayang-codaio @alan-codaio @coda/packs 