### PR TITLE
Add action prompt when dev certs are rejected

### DIFF
--- a/cli/create.ts
+++ b/cli/create.ts
@@ -9,6 +9,7 @@ import {isCodaError} from './errors';
 import * as path from 'path';
 import {printAndExit} from '../testing/helpers';
 import {storePackId} from './config_storage';
+import {tryParseSystemError} from './errors';
 
 interface CreateArgs {
   manifestFile: string;
@@ -53,7 +54,8 @@ export async function createPack(
     const packId = response.packId;
     storePackId(manifestDir, packId, codaApiEndpoint);
     return printAndExit(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
-  } catch (err) {
-    return printAndExit(`Unable to create your pack, received error: ${formatError(err)}`);
+} catch (err) {
+    const errors = [`Unable to create your pack, received error: ${formatError(err)}`, tryParseSystemError(err)];
+    return printAndExit(errors.join('\n'));
   }
 }

--- a/cli/errors.ts
+++ b/cli/errors.ts
@@ -9,6 +9,13 @@ export function isCodaError(value: any): value is CodaError {
   return value && 'statusCode' in value && typeof value.statusCode === 'number' && value.statusCode >= 400;
 }
 
+export function tryParseSystemError(error: any) {
+  if (error.errno === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+    return 'Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.';
+  }
+  return '';
+}
+
 export function formatError(obj: any): string {
   return util.inspect(obj, false, null, true);
 }

--- a/cli/errors.ts
+++ b/cli/errors.ts
@@ -10,6 +10,7 @@ export function isCodaError(value: any): value is CodaError {
 }
 
 export function tryParseSystemError(error: any) {
+  // NB(alan): this should only be hit for Coda developers trying to use the CLI with their development server.
   if (error.errno === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
     return 'Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.';
   }

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -6,6 +6,7 @@ import open from 'open';
 import {printAndExit} from '../testing/helpers';
 import {promptForInput} from '../testing/helpers';
 import {storeCodaApiKey} from './config_storage';
+import {tryParseSystemError} from './errors';
 
 interface RegisterArgs {
   apiToken?: string;
@@ -33,7 +34,8 @@ export async function handleRegister({apiToken, codaApiEndpoint}: Arguments<Regi
       return printAndExit(`Invalid API token provided.`);
     }
   } catch (err) {
-    return printAndExit(`Unexpected error while checking validity of API token: ${err}`);
+    const errors = [`Unexpected error while checking validity of API token: ${err}`, tryParseSystemError(err)];
+    return printAndExit(errors.join('\n'));
   }
 
   storeCodaApiKey(apiToken, process.env.PWD, codaApiEndpoint);

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -9,6 +9,7 @@ import {importManifest} from './helpers';
 import {isCodaError} from './errors';
 import * as path from 'path';
 import {printAndExit} from '../testing/helpers';
+import {tryParseSystemError} from './errors';
 
 interface ReleaseArgs {
   manifestFile: string;
@@ -63,6 +64,7 @@ async function handleResponse<T extends any>(p: Promise<T>): Promise<T> {
     }
     return p;
   } catch (err) {
-    return printAndExit(`Unexpected error while creating release: ${formatError(err)}`);
+    const errors = [`Unexpected error while creating release: ${formatError(err)}`, tryParseSystemError(err)];
+    return printAndExit(errors.join('\n'));
   }
 }

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -6,7 +6,7 @@ import {compilePackMetadata} from '../helpers/metadata';
 import {computeSha256} from '../helpers/crypto';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
-import {formatError} from './errors';
+import {formatError, tryParseSystemError} from './errors';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {importManifest} from './helpers';
@@ -92,6 +92,7 @@ export async function handleUpload({manifestFile, codaApiEndpoint, notes}: Argum
     if (isCodaError(registerResponse)) {
       return printAndExit(`Error while registering pack version: ${formatError(registerResponse)}`);
     }
+
     const {uploadUrl, headers} = registerResponse;
 
     logger.info('Uploading Pack...');
@@ -103,7 +104,8 @@ export async function handleUpload({manifestFile, codaApiEndpoint, notes}: Argum
       printAndExit(`Error while finalizing pack version: ${formatError(uploadCompleteResponse)}`);
     }
   } catch (err) {
-    printAndExit(`Unepected error during pack upload: ${formatError(err)}`);
+    const errors = [`Unexpected error during Pack upload: ${formatError(err)}`, tryParseSystemError(err)];
+    printAndExit(errors.join(`\n`));
   }
 
   logger.info('Done!');

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -30,6 +30,7 @@ const errors_2 = require("./errors");
 const path = __importStar(require("path"));
 const helpers_3 = require("../testing/helpers");
 const config_storage_4 = require("./config_storage");
+const errors_3 = require("./errors");
 async function handleCreate({ manifestFile, codaApiEndpoint, name, description }) {
     await createPack(manifestFile, codaApiEndpoint, { name, description });
 }
@@ -60,7 +61,8 @@ async function createPack(manifestFile, codaApiEndpoint, { name, description }) 
         return helpers_3.printAndExit(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
     }
     catch (err) {
-        return helpers_3.printAndExit(`Unable to create your pack, received error: ${errors_1.formatError(err)}`);
+        const errors = [`Unable to create your pack, received error: ${errors_1.formatError(err)}`, errors_3.tryParseSystemError(err)];
+        return helpers_3.printAndExit(errors.join('\n'));
     }
 }
 exports.createPack = createPack;

--- a/dist/cli/errors.d.ts
+++ b/dist/cli/errors.d.ts
@@ -4,4 +4,5 @@ export interface CodaError {
     message: string;
 }
 export declare function isCodaError(value: any): value is CodaError;
+export declare function tryParseSystemError(error: any): "" | "Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.";
 export declare function formatError(obj: any): string;

--- a/dist/cli/errors.js
+++ b/dist/cli/errors.js
@@ -3,12 +3,19 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.formatError = exports.isCodaError = void 0;
+exports.formatError = exports.tryParseSystemError = exports.isCodaError = void 0;
 const util_1 = __importDefault(require("util"));
 function isCodaError(value) {
     return value && 'statusCode' in value && typeof value.statusCode === 'number' && value.statusCode >= 400;
 }
 exports.isCodaError = isCodaError;
+function tryParseSystemError(error) {
+    if (error.errno === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+        return 'Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.';
+    }
+    return '';
+}
+exports.tryParseSystemError = tryParseSystemError;
 function formatError(obj) {
     return util_1.default.inspect(obj, false, null, true);
 }

--- a/dist/cli/errors.js
+++ b/dist/cli/errors.js
@@ -10,6 +10,7 @@ function isCodaError(value) {
 }
 exports.isCodaError = isCodaError;
 function tryParseSystemError(error) {
+    // NB(alan): this should only be hit for Coda developers trying to use the CLI with their development server.
     if (error.errno === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
         return 'Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.';
     }

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -11,6 +11,7 @@ const open_1 = __importDefault(require("open"));
 const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const config_storage_1 = require("./config_storage");
+const errors_2 = require("./errors");
 async function handleRegister({ apiToken, codaApiEndpoint }) {
     const formattedEndpoint = helpers_2.formatEndpoint(codaApiEndpoint);
     if (!apiToken) {
@@ -31,7 +32,8 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
         }
     }
     catch (err) {
-        return helpers_3.printAndExit(`Unexpected error while checking validity of API token: ${err}`);
+        const errors = [`Unexpected error while checking validity of API token: ${err}`, errors_2.tryParseSystemError(err)];
+        return helpers_3.printAndExit(errors.join('\n'));
     }
     config_storage_1.storeCodaApiKey(apiToken, process.env.PWD, codaApiEndpoint);
     helpers_3.printAndExit(`API key validated and stored successfully!`, 0);

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -30,6 +30,7 @@ const helpers_3 = require("./helpers");
 const errors_2 = require("./errors");
 const path = __importStar(require("path"));
 const helpers_4 = require("../testing/helpers");
+const errors_3 = require("./errors");
 async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }) {
     const manifestDir = path.dirname(manifestFile);
     const apiKey = config_storage_1.getApiKey(codaApiEndpoint);
@@ -66,6 +67,7 @@ async function handleResponse(p) {
         return p;
     }
     catch (err) {
-        return helpers_4.printAndExit(`Unexpected error while creating release: ${errors_1.formatError(err)}`);
+        const errors = [`Unexpected error while creating release: ${errors_1.formatError(err)}`, errors_3.tryParseSystemError(err)];
+        return helpers_4.printAndExit(errors.join('\n'));
     }
 }

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -105,7 +105,8 @@ async function handleUpload({ manifestFile, codaApiEndpoint, notes }) {
         }
     }
     catch (err) {
-        helpers_5.printAndExit(`Unepected error during pack upload: ${errors_1.formatError(err)}`);
+        const errors = [`Unexpected error during Pack upload: ${errors_1.formatError(err)}`, errors_1.tryParseSystemError(err)];
+        helpers_5.printAndExit(errors.join(`\n`));
     }
     logger.info('Done!');
 }


### PR DESCRIPTION
Prints out an extra line at the end:
```
Unexpected error during Pack upload: FetchError: request to https://dev.coda.io:8080/apis/v1/packs/2000000024/versions/2.3/register failed, reason: unable to verify the first certificate
    at ClientRequest.<anonymous> (/Users/alanfang/code/packs-sdk/node_modules/node-fetch/lib/index.js:1461:11)
    at ClientRequest.emit (events.js:315:20)
    at ClientRequest.EventEmitter.emit (domain.js:467:12)
    at TLSSocket.socketErrorListener (_http_client.js:469:9)
    at TLSSocket.emit (events.js:315:20)
    at TLSSocket.EventEmitter.emit (domain.js:467:12)
    at emitErrorNT (internal/streams/destroy.js:106:8)
    at emitErrorCloseNT (internal/streams/destroy.js:74:3)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  type: 'system',
  errno: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
  code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
}
Run `export NODE_TLS_REJECT_UNAUTHORIZED=1` and rerun your command.
```