### PR TITLE
add a note for oauth providers only taking comma-separated scopes

### DIFF
--- a/docs/enums/FeatureSet.html
+++ b/docs/enums/FeatureSet.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Basic&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L255">types.ts:255</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L261">types.ts:261</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Enterprise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Enterprise&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L258">types.ts:258</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L264">types.ts:264</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pro<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Pro&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L256">types.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L262">types.ts:262</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Team<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Team&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L257">types.ts:257</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L263">types.ts:263</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/QuotaLimitType.html
+++ b/docs/enums/QuotaLimitType.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Action<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Action&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L262">types.ts:262</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L268">types.ts:268</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Getter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Getter&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L263">types.ts:263</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L269">types.ts:269</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Metadata&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L265">types.ts:265</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L271">types.ts:271</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Sync<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sync&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L264">types.ts:264</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L270">types.ts:270</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/SyncInterval.html
+++ b/docs/enums/SyncInterval.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Daily<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Daily&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L270">types.ts:270</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L276">types.ts:276</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Every<wbr>Ten<wbr>Minutes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;EveryTenMinutes&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L272">types.ts:272</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L278">types.ts:278</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hourly<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Hourly&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L271">types.ts:271</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L277">types.ts:277</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Manual<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Manual&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L269">types.ts:269</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L275">types.ts:275</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ExternalPackVersionMetadata.html
+++ b/docs/interfaces/ExternalPackVersionMetadata.html
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L323">types.ts:323</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.networkDomains</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.version</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L310">types.ts:310</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Format.html
+++ b/docs/interfaces/Format.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L246">types.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L252">types.ts:252</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L245">types.ts:245</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>NoConnection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L248">types.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L254">types.ts:254</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">instructions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L249">types.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L255">types.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L250">types.ts:250</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L256">types.ts:256</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L244">types.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L250">types.ts:250</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">placeholder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L257">types.ts:257</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/OAuth2Authentication.html
+++ b/docs/interfaces/OAuth2Authentication.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">additional<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L150">types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L156">types.ts:156</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L154">types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L160">types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">scopes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L148">types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L153">types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L149">types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L155">types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Query<wbr>Param<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L157">types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L163">types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackDefinition.html
+++ b/docs/interfaces/PackDefinition.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">category<span class="tsd-signature-symbol">:</span> <a href="../enums/PackCategory.html" class="tsd-signature-type" data-tsd-kind="Enumeration">PackCategory</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L335">types.ts:335</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L341">types.ts:341</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#defaultAuthentication">defaultAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L308">types.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L333">types.ts:333</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L339">types.ts:339</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">enabled<wbr>Config<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L337">types.ts:337</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L343">types.ts:343</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Images<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L338">types.ts:338</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L344">types.ts:344</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Video<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L339">types.ts:339</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L345">types.ts:345</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formats">formats</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L325">types.ts:325</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formulaNamespace">formulaNamespace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L323">types.ts:323</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formulas">formulas</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L318">types.ts:318</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L324">types.ts:324</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L330">types.ts:330</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L336">types.ts:336</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>System<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L346">types.ts:346</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L352">types.ts:352</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">logo<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L336">types.ts:336</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L342">types.ts:342</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimum<wbr>Feature<wbr>Set<span class="tsd-signature-symbol">:</span> <a href="../enums/FeatureSet.html" class="tsd-signature-type" data-tsd-kind="Enumeration">FeatureSet</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L340">types.ts:340</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L346">types.ts:346</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L331">types.ts:331</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L337">types.ts:337</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -284,7 +284,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#networkDomains">networkDomains</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -294,7 +294,7 @@
 					<div class="tsd-signature tsd-kind-icon">permissions<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L334">types.ts:334</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L340">types.ts:340</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">quotas<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>Basic<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Enterprise<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Pro<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Team<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L341">types.ts:341</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L347">types.ts:347</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<wbr>Limits<span class="tsd-signature-symbol">:</span> <a href="RateLimits.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimits</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L342">types.ts:342</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L348">types.ts:348</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -324,7 +324,7 @@
 					<div class="tsd-signature tsd-kind-icon">short<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L332">types.ts:332</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L338">types.ts:338</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#syncTables">syncTables</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L326">types.ts:326</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#systemConnectionAuthentication">systemConnectionAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L313">types.ts:313</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#version">version</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L310">types.ts:310</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackFormatMetadata.html
+++ b/docs/interfaces/PackFormatMetadata.html
@@ -104,7 +104,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L246">types.ts:246</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L252">types.ts:252</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L245">types.ts:245</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.hasNoConnection</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L248">types.ts:248</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L254">types.ts:254</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.instructions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L249">types.ts:249</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L255">types.ts:255</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L244">types.ts:244</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L250">types.ts:250</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.placeholder</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L251">types.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L257">types.ts:257</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackVersionDefinition.html
+++ b/docs/interfaces/PackVersionDefinition.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#Authentication" class="tsd-signature-type" data-tsd-kind="Type alias">Authentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L308">types.ts:308</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">formats<span class="tsd-signature-symbol">:</span> <a href="Format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L325">types.ts:325</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L317">types.ts:317</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L323">types.ts:323</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">formulas<span class="tsd-signature-symbol">:</span> <a href="PackFormulas.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulas</a><span class="tsd-signature-symbol"> | </span><a href="../modules.html#Formula" class="tsd-signature-type" data-tsd-kind="Type alias">Formula</a><span class="tsd-signature-symbol">&lt;</span><a href="../modules.html#ParamDefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L318">types.ts:318</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L324">types.ts:324</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<wbr>Domains<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L314">types.ts:314</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Tables<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncTable</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L320">types.ts:320</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L326">types.ts:326</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">system<wbr>Connection<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#SystemAuthentication" class="tsd-signature-type" data-tsd-kind="Type alias">SystemAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L313">types.ts:313</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L319">types.ts:319</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L304">types.ts:304</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L310">types.ts:310</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Quota.html
+++ b/docs/interfaces/Quota.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Sync<wbr>Interval<span class="tsd-signature-symbol">:</span> <a href="../enums/SyncInterval.html" class="tsd-signature-type" data-tsd-kind="Enumeration">SyncInterval</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L283">types.ts:283</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L289">types.ts:289</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">monthly<wbr>Limits<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>Action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Getter<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Metadata<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Sync<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L281">types.ts:281</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L287">types.ts:287</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<span class="tsd-signature-symbol">:</span> <a href="SyncQuota.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncQuota</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L284">types.ts:284</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L290">types.ts:290</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/RateLimit.html
+++ b/docs/interfaces/RateLimit.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">interval<wbr>Seconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L289">types.ts:289</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L295">types.ts:295</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">operations<wbr>Per<wbr>Interval<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L288">types.ts:288</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L294">types.ts:294</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/RateLimits.html
+++ b/docs/interfaces/RateLimits.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">overall<span class="tsd-signature-symbol">:</span> <a href="RateLimit.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L293">types.ts:293</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L299">types.ts:299</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">per<wbr>Connection<span class="tsd-signature-symbol">:</span> <a href="RateLimit.html" class="tsd-signature-type" data-tsd-kind="Interface">RateLimit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L294">types.ts:294</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L300">types.ts:300</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SyncQuota.html
+++ b/docs/interfaces/SyncQuota.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Interval<span class="tsd-signature-symbol">:</span> <a href="../enums/SyncInterval.html" class="tsd-signature-type" data-tsd-kind="Enumeration">SyncInterval</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L276">types.ts:276</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L282">types.ts:282</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<wbr>Row<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L277">types.ts:277</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L283">types.ts:283</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/VariousAuthentication.html
+++ b/docs/interfaces/VariousAuthentication.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/AuthenticationType.html#Various" class="tsd-signature-type" data-tsd-kind="Enumeration member">Various</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L177">types.ts:177</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L183">types.ts:183</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/WebBasicAuthentication.html
+++ b/docs/interfaces/WebBasicAuthentication.html
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/AuthenticationType.html#WebBasic" class="tsd-signature-type" data-tsd-kind="Enumeration member">WebBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L161">types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L167">types.ts:167</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">ux<wbr>Config<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>placeholderPassword<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>placeholderUsername<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>usernameOnly<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L162">types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L168">types.ts:168</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/VariousAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">VariousAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CodaApiBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/OAuth2Authentication.html" class="tsd-signature-type" data-tsd-kind="Interface">OAuth2Authentication</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L180">types.ts:180</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L186">types.ts:186</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -386,7 +386,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<wbr>Pack<wbr>Definition<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/PackVersionDefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackVersionDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;version&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L297">types.ts:297</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L303">types.ts:303</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -745,7 +745,7 @@
 					<div class="tsd-signature tsd-kind-icon">System<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L210">types.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L216">types.ts:216</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -765,7 +765,7 @@
 					<div class="tsd-signature tsd-kind-icon">Various<wbr>Supported<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L233">types.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L239">types.ts:239</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/types.ts
+++ b/types.ts
@@ -145,7 +145,13 @@ export interface OAuth2Authentication extends BaseAuthentication {
   type: AuthenticationType.OAuth2;
   authorizationUrl: string;
   tokenUrl: string;
+
+  // This field assumes that the OAuth provider accepts space delimited scopes per
+  // https://datatracker.ietf.org/doc/html/rfc6749#section-3.3. In case the OAuth provider
+  // only accepts comma-delimited scopes, simply pass the whole scopes string like
+  // scopes: ["scope1,scope2,scope3"].
   scopes?: string[];
+
   tokenPrefix?: string;
   additionalParams?: {[key: string]: any};
 


### PR DESCRIPTION
Caught today debugging the strava pack. 

This is not a fix but just adding a note before we want to decide if this is ever going to be fixed. 