### PR TITLE
build isolated binary that runs on amazon linux 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,6 @@ YARN_CACHE_DIR=~/.yarncache
 ISOLATED_VM_VERSION_COMMAND="require('./node_modules/isolated-vm/package.json').version"
 ISOLATED_VM_VERSION=$(shell node -p -e $(ISOLATED_VM_VERSION_COMMAND))
 
-iv:
-	if [ `node -p -e "require('./runtime/isolated-vm/package.json').version"` == $(ISOLATED_VM_VERSION) ]; \
-		then echo 'here'; \
-		else echo 'there'; \
-	fi
-
 # Aliases
 bs: bootstrap
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ ROOTDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 # CircleCI yarn cache directory may also need to be updated in sync with this
 YARN_CACHE_DIR=~/.yarncache
 
+ISOLATED_VM_VERSION_COMMAND="require('./node_modules/isolated-vm/package.json').version"
+ISOLATED_VM_VERSION=$(shell node -p -e $(ISOLATED_VM_VERSION_COMMAND))
+
+iv:
+	if [ `node -p -e "require('./runtime/isolated-vm/package.json').version"` == $(ISOLATED_VM_VERSION) ]; \
+		then echo 'here'; \
+		else echo 'there'; \
+	fi
+
 # Aliases
 bs: bootstrap
 
@@ -36,6 +45,27 @@ lint:
 lint-fix:
 	find . -name "*.ts" | grep -v /dist/ | grep -v /node_modules/ | grep -v .d.ts | xargs ${ROOTDIR}/node_modules/.bin/eslint --fix
 
+.PHONY: do-compile-isolated-vm
+do-compile-isolated-vm:
+	rm -rf build-isolated-vm
+
+	mkdir build-isolated-vm && \
+		cd build-isolated-vm && \
+		npm init -y && \
+		docker run --rm -v `pwd`:/var/task amazon/aws-sam-cli-build-image-nodejs14.x:latest npm install isolated-vm@${ISOLATED_VM_VERSION}
+	cp build-isolated-vm/node_modules/isolated-vm/package.json runtime/isolated-vm/
+	cp build-isolated-vm/node_modules/isolated-vm/isolated-vm.js runtime/isolated-vm/
+	cp build-isolated-vm/node_modules/isolated-vm/out/isolated_vm.node runtime/isolated-vm/out/
+
+	rm -rf build-isolated-vm
+
+.PHONY: compile-isolated-vm
+compile-isolated-vm:
+	if [ `node -p -e "require('./runtime/isolated-vm/package.json').version"` != $(ISOLATED_VM_VERSION) ]; \
+		then $(MAKE) do-compile-isolated-vm; \
+		else echo "isolated-vm version matches, skipping."; \
+	fi
+
 .PHONY: compile
 compile:
 	${ROOTDIR}/node_modules/.bin/tsc
@@ -55,6 +85,8 @@ compile:
 	${ROOTDIR}/node_modules/.bin/dts-bundle-generator ${ROOTDIR}/index.ts \
   	-o ${ROOTDIR}/dist/bundle.d.ts \
 		--no-banner
+	# Generate isolated-vm binaries that's compatible to Amazon Linux 2.
+	$(MAKE) compile-isolated-vm
 
 .PHONY: generated-documentation
 generated-documentation:

--- a/runtime/isolated-vm/isolated-vm.js
+++ b/runtime/isolated-vm/isolated-vm.js
@@ -1,0 +1,1 @@
+module.exports = require('./out/isolated_vm').ivm;

--- a/runtime/isolated-vm/package.json
+++ b/runtime/isolated-vm/package.json
@@ -1,0 +1,58 @@
+{
+  "_from": "isolated-vm@4.3.2",
+  "_id": "isolated-vm@4.3.2",
+  "_inBundle": false,
+  "_integrity": "sha512-ENBKkW+ViWq3Dor7rXA/6/sl7Pp/bn8vw6zAPsriXQqd9+uagrV3triiv0AO8HyerSqa3kymGteNq+zOvung6Q==",
+  "_location": "/isolated-vm",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "isolated-vm@4.3.2",
+    "name": "isolated-vm",
+    "escapedName": "isolated-vm",
+    "rawSpec": "4.3.2",
+    "saveSpec": null,
+    "fetchSpec": "4.3.2"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.3.2.tgz",
+  "_shasum": "8ddbe8a024b3b6c01901534aa256018d34b49bdd",
+  "_spec": "isolated-vm@4.3.2",
+  "_where": "/var/task",
+  "author": {
+    "name": "https://github.com/laverdet/"
+  },
+  "bugs": {
+    "url": "https://github.com/laverdet/isolated-vm/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "description": "Access to multiple isolates",
+  "devDependencies": {
+    "isolated-vm": "."
+  },
+  "engines": {
+    "node": ">=10.4.0"
+  },
+  "gypfile": true,
+  "homepage": "https://github.com/laverdet/isolated-vm#readme",
+  "license": "ISC",
+  "main": "isolated-vm.js",
+  "name": "isolated-vm",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/laverdet/isolated-vm.git"
+  },
+  "scripts": {
+    "install": "node-gyp rebuild --release -j 4",
+    "lint": "find src -name '*.cc' | xargs -n1 clang-tidy",
+    "postinstall": "node-gyp clean",
+    "test": "node test.js || nodejs test.js"
+  },
+  "types": "isolated-vm.d.ts",
+  "version": "4.3.2"
+}


### PR DESCRIPTION
per slack discussion, we want to build an isolated-vm binary that's compatible with lambda instance type (i.e. amazon linux 2). 

the 3 files in `runtime/isolated-vm/` are basically all we need for lambda functions to use isolated vm. 

@chris-codaio after thinking about this again, it seems better to build this binary file in the primary coda repo with `make build-packs-runtime`. what do you think?