### PR TITLE
Always set the file mode first before writing credentials.

### DIFF
--- a/cli/config_storage.ts
+++ b/cli/config_storage.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import * as path from 'path';
 import {readJSONFile} from '../testing/helpers';
 import urlParse from 'url-parse';
@@ -60,12 +59,7 @@ function readApiKeyFile(filename: string): ApiKeyFile | undefined {
 }
 
 function writeApiKeyFile(filename: string, fileContents: ApiKeyFile): void {
-  const fileExisted = fs.existsSync(filename);
-  writeJSONFile(filename, fileContents);
-  if (!fileExisted) {
-    // When we create the file, make sure only the owner can read it, because it contains sensitive credentials.
-    fs.chmodSync(filename, 0o600);
-  }
+  writeJSONFile(filename, fileContents, 0o600);
 }
 
 export function storePackId(manifestDir: string, packId: number, codaApiEndpoint: string): void {

--- a/dist/cli/config_storage.js
+++ b/dist/cli/config_storage.js
@@ -23,7 +23,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getPackId = exports.storePackId = exports.storeCodaApiKey = exports.getApiKey = exports.PACK_ID_FILE_NAME = exports.DEFAULT_API_ENDPOINT = void 0;
-const fs_1 = __importDefault(require("fs"));
 const path = __importStar(require("path"));
 const helpers_1 = require("../testing/helpers");
 const url_parse_1 = __importDefault(require("url-parse"));
@@ -72,12 +71,7 @@ function readApiKeyFile(filename) {
     return helpers_1.readJSONFile(filename);
 }
 function writeApiKeyFile(filename, fileContents) {
-    const fileExisted = fs_1.default.existsSync(filename);
-    helpers_2.writeJSONFile(filename, fileContents);
-    if (!fileExisted) {
-        // When we create the file, make sure only the owner can read it, because it contains sensitive credentials.
-        fs_1.default.chmodSync(filename, 0o600);
-    }
+    helpers_2.writeJSONFile(filename, fileContents, 0o600);
 }
 function storePackId(manifestDir, packId, codaApiEndpoint) {
     const fileContents = readPackIdFile(manifestDir) || { packId: -1 };

--- a/dist/testing/auth.js
+++ b/dist/testing/auth.js
@@ -18,9 +18,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.readCredentialsFile = exports.storeCredential = exports.setupAuth = exports.setupAuthFromModule = exports.DEFAULT_OAUTH_SERVER_PORT = void 0;
 const types_1 = require("../types");
@@ -28,7 +25,6 @@ const ensure_1 = require("../helpers/ensure");
 const ensure_2 = require("../helpers/ensure");
 const ensure_3 = require("../helpers/ensure");
 const ensure_4 = require("../helpers/ensure");
-const fs_1 = __importDefault(require("fs"));
 const helpers_1 = require("../cli/helpers");
 const oauth_server_1 = require("./oauth_server");
 const oauth_server_2 = require("./oauth_server");
@@ -218,11 +214,6 @@ function readCredentialsFile(manifestDir) {
 }
 exports.readCredentialsFile = readCredentialsFile;
 function writeCredentialsFile(credentialsFile, credentials) {
-    const fileExisted = fs_1.default.existsSync(credentialsFile);
     const fileContents = { credentials };
-    helpers_6.writeJSONFile(credentialsFile, fileContents);
-    if (!fileExisted) {
-        // When we create the file, make sure only the owner can read it, because it contains sensitive credentials.
-        fs_1.default.chmodSync(credentialsFile, 0o600);
-    }
+    helpers_6.writeJSONFile(credentialsFile, fileContents, 0o600);
 }

--- a/dist/testing/helpers.d.ts
+++ b/dist/testing/helpers.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import type { PackVersionDefinition } from '../types';
+import fs from 'fs';
 export declare function getManifestFromModule(module: any): PackVersionDefinition;
 export declare const print: {
     (...data: any[]): void;
@@ -11,5 +12,5 @@ export declare function promptForInput(prompt: string, { mask }?: {
 }): string;
 export declare function readFile(fileName: string): Buffer | undefined;
 export declare function readJSONFile(fileName: string): any | undefined;
-export declare function writeJSONFile(fileName: string, payload: any): void;
+export declare function writeJSONFile(fileName: string, payload: any, mode?: fs.Mode): void;
 export declare function getExpirationDate(expiresInSeconds: number): Date;

--- a/dist/testing/helpers.js
+++ b/dist/testing/helpers.js
@@ -65,13 +65,18 @@ function readJSONFile(fileName) {
     return file ? JSON.parse(file.toString()) : undefined;
 }
 exports.readJSONFile = readJSONFile;
-function writeJSONFile(fileName, payload) {
+function writeJSONFile(fileName, payload, mode) {
     ensure_1.ensureNonEmptyString(fileName);
     const dirname = path_1.default.dirname(fileName);
     if (!fs_1.default.existsSync(dirname)) {
         fs_1.default.mkdirSync(dirname, { recursive: true });
     }
-    fs_1.default.writeFileSync(fileName, JSON.stringify(payload, undefined, 2));
+    if (mode && fs_1.default.existsSync(fileName)) {
+        // If the file already existed, make sure we update the mode before writing anything
+        // sensitive to it.
+        fs_1.default.chmodSync(fileName, mode);
+    }
+    fs_1.default.writeFileSync(fileName, JSON.stringify(payload, undefined, 2), { mode });
 }
 exports.writeJSONFile = writeJSONFile;
 function getExpirationDate(expiresInSeconds) {

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -9,7 +9,6 @@ import {assertCondition} from '../helpers/ensure';
 import {ensureExists} from '../helpers/ensure';
 import {ensureNonEmptyString} from '../helpers/ensure';
 import {ensureUnreachable} from '../helpers/ensure';
-import fs from 'fs';
 import {getPackAuth} from '../cli/helpers';
 import {launchOAuthServerFlow} from './oauth_server';
 import {makeRedirectUrl} from './oauth_server';
@@ -256,11 +255,6 @@ export function readCredentialsFile(manifestDir: string): Credentials | undefine
 }
 
 function writeCredentialsFile(credentialsFile: string, credentials: Credentials): void {
-  const fileExisted = fs.existsSync(credentialsFile);
   const fileContents: CredentialsFile = {credentials};
-  writeJSONFile(credentialsFile, fileContents);
-  if (!fileExisted) {
-    // When we create the file, make sure only the owner can read it, because it contains sensitive credentials.
-    fs.chmodSync(credentialsFile, 0o600);
-  }
+  writeJSONFile(credentialsFile, fileContents, 0o600);
 }

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -42,13 +42,18 @@ export function readJSONFile(fileName: string): any | undefined {
   return file ? JSON.parse(file.toString()) : undefined;
 }
 
-export function writeJSONFile(fileName: string, payload: any): void {
+export function writeJSONFile(fileName: string, payload: any, mode?: fs.Mode): void {
   ensureNonEmptyString(fileName);
   const dirname = path.dirname(fileName);
   if (!fs.existsSync(dirname)) {
     fs.mkdirSync(dirname, {recursive: true});
   }
-  fs.writeFileSync(fileName, JSON.stringify(payload, undefined, 2));
+  if (mode && fs.existsSync(fileName)) {
+    // If the file already existed, make sure we update the mode before writing anything
+    // sensitive to it.
+    fs.chmodSync(fileName, mode);
+  }
+  fs.writeFileSync(fileName, JSON.stringify(payload, undefined, 2), {mode});
 }
 
 export function getExpirationDate(expiresInSeconds: number): Date {


### PR DESCRIPTION
This came up in NCC's review as a minor race condition, where the credentials are written to a world-readable file ever briefly before chmod happens to restrict the file to the current user only.

The social engineering attack that they alluded to briefly was actually a bit more interesting to me, if somebody shares pack boilerplate with you that already has a .coda.json file, that's already world-readable, the existing code wouldn't update the permissions, so you could be engineered into storing credentials into a world-readable file. This changes things to always reset the mode before writing anything.

PTAL @huayang-codaio @patrick-codaio CC @chris-codaio @coda/packs 