### PR TITLE
When registering an API token, deep link to the token modal and pre-select the Packs scope.

### DIFF
--- a/cli/register.ts
+++ b/cli/register.ts
@@ -21,8 +21,7 @@ export async function handleRegister({apiToken, codaApiEndpoint}: Arguments<Regi
     if (!shouldOpenBrowser.toLocaleLowerCase().startsWith('y')) {
       return process.exit(1);
     }
-    // TODO: figure out how to deep-link to the API tokens section of account settings
-    await open(`${formattedEndpoint}/account`);
+    await open(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack`);
     apiToken = promptForInput('Please paste the token here: ', {mask: true});
   }
 

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -20,8 +20,7 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
         if (!shouldOpenBrowser.toLocaleLowerCase().startsWith('y')) {
             return process.exit(1);
         }
-        // TODO: figure out how to deep-link to the API tokens section of account settings
-        await open_1.default(`${formattedEndpoint}/account`);
+        await open_1.default(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack`);
         apiToken = helpers_4.promptForInput('Please paste the token here: ', { mask: true });
     }
     const client = helpers_1.createCodaClient(apiToken, formattedEndpoint);


### PR DESCRIPTION
Totally forgot that the deep-linking was already implemented.

PTAL @huayang-codaio @patrick-codaio @coda/packs 