### PR TITLE
a few changes for debugging v1 packs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ compile:
 		--no-banner
 	# Generate isolated-vm binaries that's compatible to Amazon Linux 2.
 	$(MAKE) compile-isolated-vm
+	# copy these esm format js files to dist directly.
+	cp -r ${ROOTDIR}/testing/injections ${ROOTDIR}/dist/testing/
 
 .PHONY: generated-documentation
 generated-documentation:

--- a/cli/build.ts
+++ b/cli/build.ts
@@ -1,19 +1,25 @@
 import type {Arguments} from 'yargs';
-import { compilePackBundle } from '../testing/compile';
+import {compilePackBundle} from '../testing/compile';
 import {print} from '../testing/helpers';
 
 interface BuildArgs {
   manifestFile: string;
   outputDir?: string;
+  minify: boolean;
+  timers: boolean;
 }
 
-export async function handleBuild({outputDir, manifestFile}: Arguments<BuildArgs>) {
+export async function handleBuild({outputDir, manifestFile, minify, timers}: Arguments<BuildArgs>) {
   const {bundlePath, intermediateOutputDirectory} = await compilePackBundle({
     manifestPath: manifestFile,
+    minify,
     outputDirectory: outputDir,
+    enableTimers: timers,
   });
   if (outputDir) {
-    print(`Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${intermediateOutputDirectory}`);
+    print(
+      `Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${intermediateOutputDirectory}`,
+    );
   } else {
     print(`Pack built successfully. Compiled output is in ${bundlePath}.`);
   }
@@ -21,7 +27,7 @@ export async function handleBuild({outputDir, manifestFile}: Arguments<BuildArgs
 
 export async function build(manifestFile: string): Promise<string> {
   const {bundlePath} = await compilePackBundle({
-    manifestPath: manifestFile,  
+    manifestPath: manifestFile,
   });
 
   return bundlePath;

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -34,6 +34,11 @@ if (require.main === module) {
           string: true,
           desc: 'For a dynamic sync table with a variable source location, specify the URL to test here.',
         },
+        timers: {
+          boolean: true,
+          default: false,
+          desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
+        },
       },
     })
     .command({
@@ -82,6 +87,15 @@ if (require.main === module) {
           string: true,
           alias: 'o',
           default: undefined,
+        },
+        minify: {
+          boolean: true,
+          default: true,
+        },
+        timers: {
+          boolean: true,
+          default: false,
+          desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
         },
       },
       handler: handleBuild,

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -39,6 +39,11 @@ if (require.main === module) {
           default: false,
           desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
         },
+        browserifyWithEsbuild: {
+          boolean: true,
+          default: false,
+          desc: 'Set to true to let esbuild do browserify',
+        },
       },
     })
     .command({

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -39,11 +39,6 @@ if (require.main === module) {
           default: false,
           desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
         },
-        browserifyWithEsbuild: {
-          boolean: true,
-          default: false,
-          desc: 'Set to true to let esbuild do browserify',
-        },
       },
     })
     .command({

--- a/cli/execute.ts
+++ b/cli/execute.ts
@@ -12,6 +12,7 @@ export interface ExecuteArgs {
   vm?: boolean;
   dynamicUrl?: string;
   timers: boolean;
+  browserifyWithEsbuild: boolean;
 }
 
 export async function handleExecute({
@@ -22,12 +23,14 @@ export async function handleExecute({
   vm,
   dynamicUrl,
   timers,
+  browserifyWithEsbuild,
 }: Arguments<ExecuteArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestPath);
   const {bundlePath, bundleSourceMapPath} = await compilePackBundle({
     manifestPath: fullManifestPath,
     minify: false,
     enableTimers: timers,
+    browserifyWithEsbuild,
   });
   const manifest = await importManifest(bundlePath);
   await executeFormulaOrSyncFromCLI({

--- a/cli/execute.ts
+++ b/cli/execute.ts
@@ -1,5 +1,5 @@
 import type {Arguments} from 'yargs';
-import {build} from './build';
+import {compilePackBundle} from '../testing/compile';
 import {executeFormulaOrSyncFromCLI} from '../testing/execution';
 import {importManifest} from './helpers';
 import {makeManifestFullPath} from './helpers';
@@ -11,6 +11,7 @@ export interface ExecuteArgs {
   fetch?: boolean;
   vm?: boolean;
   dynamicUrl?: string;
+  timers: boolean;
 }
 
 export async function handleExecute({
@@ -20,10 +21,15 @@ export async function handleExecute({
   fetch,
   vm,
   dynamicUrl,
+  timers,
 }: Arguments<ExecuteArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestPath);
-  const bundleFilename = await build(fullManifestPath);
-  const manifest = await importManifest(bundleFilename);
+  const {bundlePath, bundleSourceMapPath} = await compilePackBundle({
+    manifestPath: fullManifestPath,
+    minify: false,
+    enableTimers: timers,
+  });
+  const manifest = await importManifest(bundlePath);
   await executeFormulaOrSyncFromCLI({
     formulaName,
     params,
@@ -31,6 +37,8 @@ export async function handleExecute({
     manifestPath,
     vm,
     dynamicUrl,
+    bundleSourceMapPath,
+    bundlePath,
     contextOptions: {useRealFetcher: fetch},
   });
 }

--- a/cli/execute.ts
+++ b/cli/execute.ts
@@ -12,7 +12,6 @@ export interface ExecuteArgs {
   vm?: boolean;
   dynamicUrl?: string;
   timers: boolean;
-  browserifyWithEsbuild: boolean;
 }
 
 export async function handleExecute({
@@ -23,14 +22,12 @@ export async function handleExecute({
   vm,
   dynamicUrl,
   timers,
-  browserifyWithEsbuild,
 }: Arguments<ExecuteArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestPath);
   const {bundlePath, bundleSourceMapPath} = await compilePackBundle({
     manifestPath: fullManifestPath,
     minify: false,
     enableTimers: timers,
-    browserifyWithEsbuild,
   });
   const manifest = await importManifest(bundlePath);
   await executeFormulaOrSyncFromCLI({

--- a/dist/cli/build.d.ts
+++ b/dist/cli/build.d.ts
@@ -2,7 +2,9 @@ import type { Arguments } from 'yargs';
 interface BuildArgs {
     manifestFile: string;
     outputDir?: string;
+    minify: boolean;
+    timers: boolean;
 }
-export declare function handleBuild({ outputDir, manifestFile }: Arguments<BuildArgs>): Promise<void>;
+export declare function handleBuild({ outputDir, manifestFile, minify, timers }: Arguments<BuildArgs>): Promise<void>;
 export declare function build(manifestFile: string): Promise<string>;
 export {};

--- a/dist/cli/build.js
+++ b/dist/cli/build.js
@@ -3,10 +3,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.build = exports.handleBuild = void 0;
 const compile_1 = require("../testing/compile");
 const helpers_1 = require("../testing/helpers");
-async function handleBuild({ outputDir, manifestFile }) {
+async function handleBuild({ outputDir, manifestFile, minify, timers }) {
     const { bundlePath, intermediateOutputDirectory } = await compile_1.compilePackBundle({
         manifestPath: manifestFile,
+        minify,
         outputDirectory: outputDir,
+        enableTimers: timers,
     });
     if (outputDir) {
         helpers_1.print(`Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${intermediateOutputDirectory}`);

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -42,6 +42,11 @@ if (require.main === module) {
                 default: false,
                 desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
             },
+            browserifyWithEsbuild: {
+                boolean: true,
+                default: false,
+                desc: 'Set to true to let esbuild do browserify',
+            },
         },
     })
         .command({

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -37,6 +37,11 @@ if (require.main === module) {
                 string: true,
                 desc: 'For a dynamic sync table with a variable source location, specify the URL to test here.',
             },
+            timers: {
+                boolean: true,
+                default: false,
+                desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
+            },
         },
     })
         .command({
@@ -84,6 +89,15 @@ if (require.main === module) {
                 string: true,
                 alias: 'o',
                 default: undefined,
+            },
+            minify: {
+                boolean: true,
+                default: true,
+            },
+            timers: {
+                boolean: true,
+                default: false,
+                desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
             },
         },
         handler: build_1.handleBuild,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -42,11 +42,6 @@ if (require.main === module) {
                 default: false,
                 desc: 'Set to true to enable timer methods in the build. i.e. setTimeout',
             },
-            browserifyWithEsbuild: {
-                boolean: true,
-                default: false,
-                desc: 'Set to true to let esbuild do browserify',
-            },
         },
     })
         .command({

--- a/dist/cli/execute.d.ts
+++ b/dist/cli/execute.d.ts
@@ -7,6 +7,5 @@ export interface ExecuteArgs {
     vm?: boolean;
     dynamicUrl?: string;
     timers: boolean;
-    browserifyWithEsbuild: boolean;
 }
-export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, browserifyWithEsbuild, }: Arguments<ExecuteArgs>): Promise<void>;
+export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }: Arguments<ExecuteArgs>): Promise<void>;

--- a/dist/cli/execute.d.ts
+++ b/dist/cli/execute.d.ts
@@ -6,5 +6,6 @@ export interface ExecuteArgs {
     fetch?: boolean;
     vm?: boolean;
     dynamicUrl?: string;
+    timers: boolean;
 }
-export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, }: Arguments<ExecuteArgs>): Promise<void>;
+export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }: Arguments<ExecuteArgs>): Promise<void>;

--- a/dist/cli/execute.d.ts
+++ b/dist/cli/execute.d.ts
@@ -7,5 +7,6 @@ export interface ExecuteArgs {
     vm?: boolean;
     dynamicUrl?: string;
     timers: boolean;
+    browserifyWithEsbuild: boolean;
 }
-export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }: Arguments<ExecuteArgs>): Promise<void>;
+export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, browserifyWithEsbuild, }: Arguments<ExecuteArgs>): Promise<void>;

--- a/dist/cli/execute.js
+++ b/dist/cli/execute.js
@@ -5,12 +5,13 @@ const compile_1 = require("../testing/compile");
 const execution_1 = require("../testing/execution");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
-async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }) {
+async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, browserifyWithEsbuild, }) {
     const fullManifestPath = helpers_2.makeManifestFullPath(manifestPath);
     const { bundlePath, bundleSourceMapPath } = await compile_1.compilePackBundle({
         manifestPath: fullManifestPath,
         minify: false,
         enableTimers: timers,
+        browserifyWithEsbuild,
     });
     const manifest = await helpers_1.importManifest(bundlePath);
     await execution_1.executeFormulaOrSyncFromCLI({

--- a/dist/cli/execute.js
+++ b/dist/cli/execute.js
@@ -1,14 +1,18 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleExecute = void 0;
-const build_1 = require("./build");
+const compile_1 = require("../testing/compile");
 const execution_1 = require("../testing/execution");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
-async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, }) {
+async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }) {
     const fullManifestPath = helpers_2.makeManifestFullPath(manifestPath);
-    const bundleFilename = await build_1.build(fullManifestPath);
-    const manifest = await helpers_1.importManifest(bundleFilename);
+    const { bundlePath, bundleSourceMapPath } = await compile_1.compilePackBundle({
+        manifestPath: fullManifestPath,
+        minify: false,
+        enableTimers: timers,
+    });
+    const manifest = await helpers_1.importManifest(bundlePath);
     await execution_1.executeFormulaOrSyncFromCLI({
         formulaName,
         params,
@@ -16,6 +20,8 @@ async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dyn
         manifestPath,
         vm,
         dynamicUrl,
+        bundleSourceMapPath,
+        bundlePath,
         contextOptions: { useRealFetcher: fetch },
     });
 }

--- a/dist/cli/execute.js
+++ b/dist/cli/execute.js
@@ -5,13 +5,12 @@ const compile_1 = require("../testing/compile");
 const execution_1 = require("../testing/execution");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
-async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, browserifyWithEsbuild, }) {
+async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timers, }) {
     const fullManifestPath = helpers_2.makeManifestFullPath(manifestPath);
     const { bundlePath, bundleSourceMapPath } = await compile_1.compilePackBundle({
         manifestPath: fullManifestPath,
         minify: false,
         enableTimers: timers,
-        browserifyWithEsbuild,
     });
     const manifest = await helpers_1.importManifest(bundlePath);
     await execution_1.executeFormulaOrSyncFromCLI({

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -110,8 +110,10 @@ async function executeThunk(context, { params, formulaSpec }, packBundlePath, pa
         const err = marshaling_3.unwrapError(wrappedError);
         const translatedStacktrace = await source_map_1.translateErrorStackFromVM({
             stacktrace: err.stack,
-            bundleSourceMapPath: packBundleSourceMapPath,
-            vmFilename: packBundlePath,
+            // the sourcemap needs packBundleSourceMapPath to be either absolute or relative, but not something like
+            // 'bundle.js' or 'bundle.js.map'.
+            bundleSourceMapPath: path_1.default.resolve(packBundleSourceMapPath),
+            vmFilename: path_1.default.resolve(packBundlePath),
         });
         const messageSuffix = err.message ? `: ${err.message}` : '';
         err.stack = `${err.constructor.name}${messageSuffix}\n${translatedStacktrace}`;

--- a/dist/runtime/common/source_map.js
+++ b/dist/runtime/common/source_map.js
@@ -35,7 +35,8 @@ async function translateErrorStackFromVM({ stacktrace, bundleSourceMapPath, vmFi
         const consumer = await new source_map_1.SourceMapConsumer(fs_1.default.readFileSync(bundleSourceMapPath, 'utf8'));
         const stack = stackTraceParser.parse(stacktrace);
         const translatedStack = stack.map(frame => {
-            if (frame.file !== vmFilename || frame.lineNumber === null || frame.column === null) {
+            var _a;
+            if (!((_a = frame.file) === null || _a === void 0 ? void 0 : _a.endsWith(vmFilename)) || frame.lineNumber === null || frame.column === null) {
                 return frame;
             }
             const originalFrame = consumer.originalPositionFor({ line: frame.lineNumber, column: frame.column - 1 });

--- a/dist/testing/compile.d.ts
+++ b/dist/testing/compile.d.ts
@@ -6,7 +6,6 @@ export interface CompilePackBundleOptions {
     sourceMap?: boolean;
     minify?: boolean;
     enableTimers?: boolean;
-    browserifyWithEsbuild?: boolean;
 }
 export interface CompilePackBundleResult {
     bundlePath: string;
@@ -14,4 +13,4 @@ export interface CompilePackBundleResult {
     intermediateOutputDirectory: string;
 }
 export declare function compilePackBundle({ bundleFilename, // the output bundle filename
-outputDirectory, manifestPath, minify, intermediateOutputDirectory, enableTimers, browserifyWithEsbuild, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;
+outputDirectory, manifestPath, minify, intermediateOutputDirectory, enableTimers, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;

--- a/dist/testing/compile.d.ts
+++ b/dist/testing/compile.d.ts
@@ -5,6 +5,7 @@ export interface CompilePackBundleOptions {
     intermediateOutputDirectory?: string;
     sourceMap?: boolean;
     minify?: boolean;
+    enableTimers?: boolean;
 }
 export interface CompilePackBundleResult {
     bundlePath: string;
@@ -12,4 +13,4 @@ export interface CompilePackBundleResult {
     intermediateOutputDirectory: string;
 }
 export declare function compilePackBundle({ bundleFilename, // the output bundle filename
-outputDirectory, manifestPath, minify, intermediateOutputDirectory, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;
+outputDirectory, manifestPath, minify, intermediateOutputDirectory, enableTimers, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;

--- a/dist/testing/compile.d.ts
+++ b/dist/testing/compile.d.ts
@@ -6,6 +6,7 @@ export interface CompilePackBundleOptions {
     sourceMap?: boolean;
     minify?: boolean;
     enableTimers?: boolean;
+    browserifyWithEsbuild?: boolean;
 }
 export interface CompilePackBundleResult {
     bundlePath: string;
@@ -13,4 +14,4 @@ export interface CompilePackBundleResult {
     intermediateOutputDirectory: string;
 }
 export declare function compilePackBundle({ bundleFilename, // the output bundle filename
-outputDirectory, manifestPath, minify, intermediateOutputDirectory, enableTimers, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;
+outputDirectory, manifestPath, minify, intermediateOutputDirectory, enableTimers, browserifyWithEsbuild, }: CompilePackBundleOptions): Promise<CompilePackBundleResult>;

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -80,14 +80,14 @@ async function uglifyBundle({ lastBundleFilename, outputBundleFilename, }) {
     fs_1.default.writeFileSync(outputBundleFilename, uglifyOutput.code);
     fs_1.default.writeFileSync(`${outputBundleFilename}.map`, uglifyOutput.map);
 }
-async function buildWithES({ lastBundleFilename, outputBundleFilename, options: { enableTimers, browserifyWithEsbuild }, }) {
+async function buildWithES({ lastBundleFilename, outputBundleFilename, options: { enableTimers }, }) {
     const options = {
         banner: { js: "'use strict';" },
         bundle: true,
         entryPoints: [lastBundleFilename],
         outfile: outputBundleFilename,
         format: 'cjs',
-        platform: browserifyWithEsbuild ? 'browser' : 'node',
+        platform: 'node',
         // TODO(huayang): still add another timers shim to throw useful error messages if timers is not enabled.
         inject: enableTimers ? [`${__dirname}/injections/timers_shim.js`] : undefined,
         minify: false,
@@ -96,7 +96,7 @@ async function buildWithES({ lastBundleFilename, outputBundleFilename, options: 
     await esbuild.build(options);
 }
 async function compilePackBundle({ bundleFilename = 'bundle.js', // the output bundle filename
-outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enableTimers = false, browserifyWithEsbuild = false, }) {
+outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enableTimers = false, }) {
     const esbuildBundleFilename = 'esbuild-bundle.js';
     const browserifyBundleFilename = 'browserify-bundle.js';
     const browserifyWithShimBundleFilename = 'browserify-with-shim-bundle.js';
@@ -111,14 +111,11 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enabl
         minify,
         intermediateOutputDirectory,
         enableTimers,
-        browserifyWithEsbuild,
     };
     const buildChain = [
         { builder: buildWithES, outputFilename: esbuildBundleFilename },
+        { builder: browserifyBundle, outputFilename: browserifyBundleFilename },
     ];
-    if (!browserifyWithEsbuild) {
-        buildChain.push({ builder: browserifyBundle, outputFilename: browserifyBundleFilename });
-    }
     if (enableTimers) {
         // if timers are enabled, we'll need to shim it again after browserifying because it will
         // introduce extra code that needs shim.

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -144,7 +144,7 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enabl
         await loadIntoVM(tempBundlePath);
     }
     catch (err) {
-        throw helpers_1.processVmError(err, tempBundlePath);
+        throw await helpers_1.processVmError(err, tempBundlePath);
     }
     if (!outputDirectory || outputDirectory === intermediateOutputDirectory) {
         return {

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -80,14 +80,14 @@ async function uglifyBundle({ lastBundleFilename, outputBundleFilename, }) {
     fs_1.default.writeFileSync(outputBundleFilename, uglifyOutput.code);
     fs_1.default.writeFileSync(`${outputBundleFilename}.map`, uglifyOutput.map);
 }
-async function buildWithES({ lastBundleFilename, outputBundleFilename, options: { enableTimers }, }) {
+async function buildWithES({ lastBundleFilename, outputBundleFilename, options: { enableTimers, browserifyWithEsbuild }, }) {
     const options = {
         banner: { js: "'use strict';" },
         bundle: true,
         entryPoints: [lastBundleFilename],
         outfile: outputBundleFilename,
         format: 'cjs',
-        platform: 'node',
+        platform: browserifyWithEsbuild ? 'browser' : 'node',
         // TODO(huayang): still add another timers shim to throw useful error messages if timers is not enabled.
         inject: enableTimers ? [`${__dirname}/injections/timers_shim.js`] : undefined,
         minify: false,
@@ -96,7 +96,7 @@ async function buildWithES({ lastBundleFilename, outputBundleFilename, options: 
     await esbuild.build(options);
 }
 async function compilePackBundle({ bundleFilename = 'bundle.js', // the output bundle filename
-outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enableTimers = false, }) {
+outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enableTimers = false, browserifyWithEsbuild = false, }) {
     const esbuildBundleFilename = 'esbuild-bundle.js';
     const browserifyBundleFilename = 'browserify-bundle.js';
     const browserifyWithShimBundleFilename = 'browserify-with-shim-bundle.js';
@@ -111,11 +111,14 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, enabl
         minify,
         intermediateOutputDirectory,
         enableTimers,
+        browserifyWithEsbuild,
     };
     const buildChain = [
         { builder: buildWithES, outputFilename: esbuildBundleFilename },
-        { builder: browserifyBundle, outputFilename: browserifyBundleFilename },
     ];
+    if (!browserifyWithEsbuild) {
+        buildChain.push({ builder: browserifyBundle, outputFilename: browserifyBundleFilename });
+    }
     if (enableTimers) {
         // if timers are enabled, we'll need to shim it again after browserifying because it will
         // introduce extra code that needs shim.

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -20,13 +20,15 @@ export interface ContextOptions {
     manifestPath?: string;
 }
 export declare function executeFormulaFromPackDef<T extends PackFormulaResult | SyncFormulaResult<object> = any>(packDef: PackVersionDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<T>;
-export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, manifestPath, vm, dynamicUrl, contextOptions, }: {
+export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, manifestPath, vm, dynamicUrl, bundleSourceMapPath, bundlePath, contextOptions, }: {
     formulaName: string;
     params: string[];
     manifest: PackVersionDefinition;
     manifestPath: string;
     vm?: boolean;
     dynamicUrl?: string;
+    bundleSourceMapPath: string;
+    bundlePath: string;
     contextOptions?: ContextOptions;
 }): Promise<void>;
 export declare function executeFormulaOrSyncWithVM<T extends PackFormulaResult | SyncFormulaResult<object> = any>({ formulaName, params, bundlePath, executionContext, }: {
@@ -42,12 +44,6 @@ export declare class VMError {
     constructor(name: string, message: string, stack: string);
     [util.inspect.custom](): string;
 }
-export declare function executeFormulaOrSyncWithRawParamsInVM<T extends SyncFormulaSpecification | StandardFormulaSpecification>({ formulaSpecification, params: rawParams, manifestPath, executionContext, }: {
-    formulaSpecification: T;
-    params: string[];
-    manifestPath: string;
-    executionContext?: SyncExecutionContext;
-}): Promise<T extends SyncFormulaSpecification ? SyncFormulaResult<object> : PackFormulaResult>;
 export declare function executeFormulaOrSyncWithRawParams<T extends StandardFormulaSpecification | SyncFormulaSpecification>({ formulaSpecification, params: rawParams, manifest, executionContext, }: {
     formulaSpecification: T;
     params: string[];

--- a/dist/testing/helpers.d.ts
+++ b/dist/testing/helpers.d.ts
@@ -14,3 +14,4 @@ export declare function readFile(fileName: string): Buffer | undefined;
 export declare function readJSONFile(fileName: string): any | undefined;
 export declare function writeJSONFile(fileName: string, payload: any, mode?: fs.Mode): void;
 export declare function getExpirationDate(expiresInSeconds: number): Date;
+export declare function processVmError(vmError: Error, bundlePath: string): Promise<Error>;

--- a/dist/testing/injections/timers_disabled_shim.js
+++ b/dist/testing/injections/timers_disabled_shim.js
@@ -1,0 +1,13 @@
+// ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
+// so for now we just have this file in js.
+
+const ErrorMessage = 'Please use --timers option to enable timers. Be aware that timing methods ' + 
+  "like setTimeout or setInternal aren't reliable in the pack execution environments. You should" + 
+  " avoid using them if possible.";
+
+export function setTimeout() { throw new Error(ErrorMessage); }
+
+export function setInterval() { throw new Error(ErrorMessage); }
+
+export function clearTimeout() { throw new Error(ErrorMessage); }
+export function clearInterval() { throw new Error(ErrorMessage); }

--- a/dist/testing/injections/timers_disabled_shim.js
+++ b/dist/testing/injections/timers_disabled_shim.js
@@ -1,9 +1,12 @@
 // ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
 // so for now we just have this file in js.
 
-const ErrorMessage = 'Please use --timers option to enable timers. Be aware that timing methods ' + 
-  "like setTimeout or setInternal aren't reliable in the pack execution environments. You should" + 
-  " avoid using them if possible.";
+const ErrorMessage = 
+  `Please use the --timers flag to enable shimmed timing primitives. Native node timing ` + 
+  `primitives like setTimeout or setInternal aren't supported in the pack execution sandbox ` + 
+  `environment. However, if you are using a library that relies upon them, you can use the ` + 
+  `--timers flag to build your pack with shimmed implementations that approximate the native ` + 
+  `behavior. Because of this, be aware that packs that use timing primitives may not work reliably.`
 
 export function setTimeout() { throw new Error(ErrorMessage); }
 

--- a/dist/testing/injections/timers_shim.js
+++ b/dist/testing/injections/timers_shim.js
@@ -6,7 +6,7 @@
 // of the current thread. 
 export function setTimeout(callback, _) { new Promise(_ => callback()) }
 
-// can't actually set internal in ivm. this would only be executed once. maybe we should 
+// can't actually set interval in ivm. this would only be executed once. maybe we should 
 // just throw an error if setInterval is called. 
 export function setInterval(callback, _) { new Promise(_ => callback()) }
 

--- a/dist/testing/injections/timers_shim.js
+++ b/dist/testing/injections/timers_shim.js
@@ -1,0 +1,14 @@
+// ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
+// so for now we just have this file in js.
+
+// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to 
+// an ivm context isn't safe. so we create a workaround to use a Promise to yield execution
+// of the current thread. 
+export function setTimeout(callback, _) { new Promise(_ => callback()) }
+
+// can't actually set internal in ivm. this would only be executed once. maybe we should 
+// just throw an error if setInterval is called. 
+export function setInterval(callback, _) { new Promise(_ => callback()) }
+
+export function clearTimeout() {}
+export function clearInterval() {}

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -160,8 +160,10 @@ export async function executeThunk<T extends FormulaSpecification>(
     const err = unwrapError(wrappedError);
     const translatedStacktrace = await translateErrorStackFromVM({
       stacktrace: err.stack,
-      bundleSourceMapPath: packBundleSourceMapPath,
-      vmFilename: packBundlePath,
+      // the sourcemap needs packBundleSourceMapPath to be either absolute or relative, but not something like
+      // 'bundle.js' or 'bundle.js.map'.
+      bundleSourceMapPath: path.resolve(packBundleSourceMapPath),
+      vmFilename: path.resolve(packBundlePath),
     });
     const messageSuffix = err.message ? `: ${err.message}` : '';
     err.stack = `${err.constructor.name}${messageSuffix}\n${translatedStacktrace}`;

--- a/runtime/common/source_map.ts
+++ b/runtime/common/source_map.ts
@@ -21,7 +21,7 @@ export async function translateErrorStackFromVM({
     const stack = stackTraceParser.parse(stacktrace);
 
     const translatedStack = stack.map(frame => {
-      if (frame.file !== vmFilename || frame.lineNumber === null || frame.column === null) {
+      if (!frame.file?.endsWith(vmFilename) || frame.lineNumber === null || frame.column === null) {
         return frame;
       }
 

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -27,6 +27,16 @@ export const manifest: PackDefinition = createFakePack({
   formulaNamespace: 'Fake',
   formulas: [
     makeNumericFormula({
+      name: 'Timer',
+      description: 'Timer',
+      examples: [],
+      parameters: [makeNumericParameter('value', 'The time to wait.')],
+      execute: ([value]) => {
+        setTimeout(() => {}, value);
+        return value;
+      },
+    }),
+    makeNumericFormula({
       name: 'Square',
       description: 'Square a number',
       examples: [],

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -193,7 +193,7 @@ export async function compilePackBundle({
   try {
     await loadIntoVM(tempBundlePath);
   } catch (err) {
-    throw processVmError(err, tempBundlePath);
+    throw await processVmError(err, tempBundlePath);
   }
 
   if (!outputDirectory || outputDirectory === intermediateOutputDirectory) {

--- a/testing/injections/timers_disabled_shim.js
+++ b/testing/injections/timers_disabled_shim.js
@@ -1,0 +1,13 @@
+// ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
+// so for now we just have this file in js.
+
+const ErrorMessage = 'Please use --timers option to enable timers. Be aware that timing methods ' + 
+  "like setTimeout or setInternal aren't reliable in the pack execution environments. You should" + 
+  " avoid using them if possible.";
+
+export function setTimeout() { throw new Error(ErrorMessage); }
+
+export function setInterval() { throw new Error(ErrorMessage); }
+
+export function clearTimeout() { throw new Error(ErrorMessage); }
+export function clearInterval() { throw new Error(ErrorMessage); }

--- a/testing/injections/timers_disabled_shim.js
+++ b/testing/injections/timers_disabled_shim.js
@@ -1,9 +1,12 @@
 // ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
 // so for now we just have this file in js.
 
-const ErrorMessage = 'Please use --timers option to enable timers. Be aware that timing methods ' + 
-  "like setTimeout or setInternal aren't reliable in the pack execution environments. You should" + 
-  " avoid using them if possible.";
+const ErrorMessage = 
+  `Please use the --timers flag to enable shimmed timing primitives. Native node timing ` + 
+  `primitives like setTimeout or setInternal aren't supported in the pack execution sandbox ` + 
+  `environment. However, if you are using a library that relies upon them, you can use the ` + 
+  `--timers flag to build your pack with shimmed implementations that approximate the native ` + 
+  `behavior. Because of this, be aware that packs that use timing primitives may not work reliably.`
 
 export function setTimeout() { throw new Error(ErrorMessage); }
 

--- a/testing/injections/timers_shim.js
+++ b/testing/injections/timers_shim.js
@@ -6,7 +6,7 @@
 // of the current thread. 
 export function setTimeout(callback, _) { new Promise(_ => callback()) }
 
-// can't actually set internal in ivm. this would only be executed once. maybe we should 
+// can't actually set interval in ivm. this would only be executed once. maybe we should 
 // just throw an error if setInterval is called. 
 export function setInterval(callback, _) { new Promise(_ => callback()) }
 

--- a/testing/injections/timers_shim.js
+++ b/testing/injections/timers_shim.js
@@ -1,0 +1,14 @@
+// ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
+// so for now we just have this file in js.
+
+// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to 
+// an ivm context isn't safe. so we create a workaround to use a Promise to yield execution
+// of the current thread. 
+export function setTimeout(callback, _) { new Promise(_ => callback()) }
+
+// can't actually set internal in ivm. this would only be executed once. maybe we should 
+// just throw an error if setInterval is called. 
+export function setInterval(callback, _) { new Promise(_ => callback()) }
+
+export function clearTimeout() {}
+export function clearInterval() {}


### PR DESCRIPTION
sending this out since it's getting bigger than I expected. basically a few necessary changes to help debugging v1 packs. 

- support a minify flag for CLI buid for debugging purpose. (easier to identify issues).
- add a timer method in the fake pack for debugging. (to debug setTimeout)
- add an extra level of esbuild for shim injection. (for setTimeout)
- translate error stack from loadIntoIVM (this happens)
- add shim for timing methods (i.e. setTimeout)
- don't build another bundle for exec-in-vm

I am adding `timers` as an option instead of the default because I still need to test esbuild for browserifying capability. 