### PR TITLE
add pre-commit hook to avoid adding https://github.com/kr-project/ to docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,10 @@ validate-no-changes: compile
 .PHONY: npm-publish
 npm-publish:
 	npm publish --tag alpha --tag latest --access public
+
+.PHONY: pre-commit-hook
+pre-commit-hook:
+	if [[ ! -z "${shell git diff HEAD -- docs | grep -E '^\+' | grep 'https://github.com/kr-project/'}" ]]; then \
+		echo "Please avoid the legacy https://github.com/kr-project/ in generated docs. This is usually because you have an old entry in git remote -v"; \
+		exit 1; \
+	fi

--- a/package.json
+++ b/package.json
@@ -74,11 +74,20 @@
     "eslint-plugin-ban": "^1.5.2",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-local": "^1.0.0",
+    "husky": "^7.0.1",
     "mocha": "^9.0.3",
     "mock-fs": "^5.0.0",
     "ts-loader": "^9.2.4",
     "ts-node": "^10.1.0",
     "typedoc": "^0.21.5"
+  },
+  "scripts": {
+    "postinstall": "husky install"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pre-commit-hook"
+    }
   },
   "resolutions": {
     "marked": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,6 +1986,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+husky@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.1.tgz#579f4180b5da4520263e8713cc832942b48e1f1c"
+  integrity sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
testing:

```
➜  packs-sdk git:(hg-avoid-kr-project) ✗ git diff HEAD -- docs | grep -E '^\+' 
+++ b/docs/enums/DefaultConnectionType.html
+                                                       <li>Defined in <a href="https://github.com/kr-project/packs-sdk/blob/main/types.ts#L46">types.ts:46</a></li>


➜  packs-sdk git:(hg-avoid-kr-project) ✗ git commit -am "test"
Please avoid the legacy https://github.com/kr-project/ in generated docs. This is usually because you have an old entry in git remote -v
make: *** [pre-commit-hook] Error 1

```