### PR TITLE
use a dedicated git remote to generate type docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ generated-documentation:
 
 .PHONY: typedoc
 typedoc:
-	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main
+	# add a typedoc remote in case some folks have a legacy origin pointing to kr-project.
+	if [[ -z "${shell git remote -v | grep typedoc}" ]]; then \
+		git remote add typedoc git@github.com:coda/packs-sdk.git; \
+	fi
+	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main --gitRemote typedoc
 
 .PHONY: docs
 docs: generated-documentation typedoc

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ generated-documentation:
 
 .PHONY: typedoc
 typedoc:
-	# add a typedoc remote in case some folks have a legacy origin pointing to kr-project.
-	if [[ -z "${shell git remote -v | grep typedoc}" ]]; then \
-		git remote add typedoc git@github.com:coda/packs-sdk.git; \
+	if [ "${shell git config --get remote.origin.url}" != "git@github.com:coda/packs-sdk.git" ]; then \
+		echo "Please config your git origin to git@github.com:coda/packs-sdk.git"; \
+		exit 1; \
 	fi
-	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main --gitRemote typedoc
+	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main
 
 .PHONY: docs
 docs: generated-documentation typedoc


### PR DESCRIPTION
leverage typedoc `gitRemote` option.


unfortunately it doesn't support passing a url so we have to create a special remote if one doesn't exist. 