### PR TITLE
Enforce that formula parameters have unique names

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -486,7 +486,19 @@ const formulaMetadataSchema = z.union([
     stringPackFormulaSchema,
     booleanPackFormulaSchema,
     objectPackFormulaSchema,
-]);
+]).superRefine((data, context) => {
+    const parameters = data.parameters;
+    const varargParameters = data.varargParameters || [];
+    const paramNames = new Set();
+    for (const param of [...parameters, ...varargParameters]) {
+        if (paramNames.has(param.name)) {
+            context.addIssue({ code: z.ZodIssueCode.custom,
+                path: ['parameters'],
+                message: `Parameter names must be unique. Found duplicate name "${param.name}".` });
+        }
+        paramNames.add(param.name);
+    }
+});
 const formatMetadataSchema = zodCompleteObject({
     name: z.string(),
     formulaNamespace: z.string(),

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -455,6 +455,20 @@ describe('Pack metadata Validation', () => {
           },
         ]);
       });
+
+      it('invalid formula with duplicate params', async () => {
+        const metadata = makeMetadataFromParams([
+          makeParameter({type: ParameterType.String, name: 'p1', description: ''}),
+          makeParameter({type: ParameterType.String, name: 'p1', description: ''}),
+        ]);
+        const err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: 'Parameter names must be unique. Found duplicate name "p1".',
+            path: 'formulas[0].parameters',
+          },
+        ]);
+      });
     });
 
     describe('sync tables', () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -581,7 +581,19 @@ const formulaMetadataSchema = z.union([
   stringPackFormulaSchema,
   booleanPackFormulaSchema,
   objectPackFormulaSchema,
-]);
+]).superRefine((data, context) => {
+  const parameters = data.parameters as ParamDefs;
+  const varargParameters = data.varargParameters || [] as ParamDefs;
+  const paramNames = new Set();
+  for (const param of [...parameters, ...varargParameters]) {
+    if (paramNames.has(param.name)) {
+      context.addIssue({code: z.ZodIssueCode.custom,
+      path: ['parameters'],
+      message: `Parameter names must be unique. Found duplicate name "${param.name}".`})
+    }
+    paramNames.add(param.name);
+  }
+});
 
 const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
   name: z.string(),


### PR DESCRIPTION
Bug here: https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/Bugs-Feature-requests_suyN0#Open-Bugs_tu6FU/r132&modal=true

This PR enforces that all formula parameters (standard and vararg) have unique names. Although Tarunjeet's error came from parameters with autocomplete, duplicate parameter names are probably likely to break for a bunch of different types of parameters generally.