### PR TITLE
better handling or git remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ generated-documentation:
 
 .PHONY: typedoc
 typedoc:
-	if [ "${shell git config --get remote.origin.url}" != "git@github.com:coda/packs-sdk.git" ]; then \
+	if [ -z "${shell git config --get remote.origin.url | grep coda/packs-sdk}" ]; then \
 		echo "Please config your git origin to git@github.com:coda/packs-sdk.git"; \
 		exit 1; \
 	fi


### PR DESCRIPTION
realized that `git@github.com:coda/packs-sdk.git` is too restrict. 

ppl might be using `https://github.com/coda/packs-sdk.git` or `https://github.com/coda/packs-sdk`. let just check coda/packs-sdk exists.

testing:

```
➜  packs-sdk git:(hg-add-remote-to-build-docs) ✗ git remote -v 
origin  git@github.com:kr-project/packs-sdk.git (fetch)
origin  git@github.com:kr-project/packs-sdk.git (push)
➜  packs-sdk git:(hg-add-remote-to-build-docs) ✗ make typedoc  
Please config your git origin to git@github.com:coda/packs-sdk.git
make: *** [typedoc] Error 1
```