### PR TITLE
Don't error out if falsy values are returned in the result object schema

### DIFF
--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -295,7 +295,7 @@ function validateObject(result, schema, context) {
             errors.push(...propertyLevelErrors);
         }
     }
-    if (schema.id && schema.id in result && (result[schema.id] === null || result[schema.id] === undefined)) {
+    if (schema.id && schema.id in result && !objectUtils.isDefined(result[schema.id])) {
         errors.push({
             message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
         });

--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -281,6 +281,7 @@ function validateObjectResult(formula, result) {
         throw types_3.ResultValidationException.fromErrors(formula.name, errors);
     }
 }
+const ACCEPTED_FALSY_VALUES = [0];
 function validateObject(result, schema, context) {
     const errors = [];
     for (const [propertyKey, propertySchema] of Object.entries(schema.properties)) {
@@ -295,7 +296,10 @@ function validateObject(result, schema, context) {
             errors.push(...propertyLevelErrors);
         }
     }
-    if (schema.id && schema.id in result && !objectUtils.isDefined(result[schema.id])) {
+    const idValue = schema.id && schema.id in result ? result[schema.id] : undefined;
+    // Some objects will return an id field of 0, but other falsy values (i.e. '') are more likely to be actual errors
+    if (schema.id && schema.id in result &&
+        (!objectUtils.isDefined(idValue) || (!idValue && !ACCEPTED_FALSY_VALUES.includes(idValue)))) {
         errors.push({
             message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
         });

--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -295,7 +295,7 @@ function validateObject(result, schema, context) {
             errors.push(...propertyLevelErrors);
         }
     }
-    if (schema.id && schema.id in result && !result[schema.id]) {
+    if (schema.id && schema.id in result && (result[schema.id] === null || result[schema.id] === undefined)) {
         errors.push({
             message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
         });

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -338,7 +338,7 @@ function validateObject<ResultT extends Record<string, unknown>>(
     }
   }
 
-  if (schema.id && schema.id in result && !result[schema.id]) {
+  if (schema.id && schema.id in result && (result[schema.id] === null || result[schema.id] === undefined)) {
     errors.push({
       message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
     });

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -338,7 +338,7 @@ function validateObject<ResultT extends Record<string, unknown>>(
     }
   }
 
-  if (schema.id && schema.id in result && (result[schema.id] === null || result[schema.id] === undefined)) {
+  if (schema.id && schema.id in result && !objectUtils.isDefined(result[schema.id])) {
     errors.push({
       message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
     });

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -314,6 +314,8 @@ function validateObjectResult<ResultT extends Record<string, unknown>>(
   }
 }
 
+const ACCEPTED_FALSY_VALUES: any[] = [0];
+
 function validateObject<ResultT extends Record<string, unknown>>(
   result: ResultT,
   schema: GenericObjectSchema,
@@ -338,7 +340,10 @@ function validateObject<ResultT extends Record<string, unknown>>(
     }
   }
 
-  if (schema.id && schema.id in result && !objectUtils.isDefined(result[schema.id])) {
+  const idValue = schema.id && schema.id in result ? result[schema.id] : undefined;
+  // Some objects will return an id field of 0, but other falsy values (i.e. '') are more likely to be actual errors
+  if (schema.id && schema.id in result && 
+    (!objectUtils.isDefined(idValue) || (!idValue && !ACCEPTED_FALSY_VALUES.includes(idValue)))) {
     errors.push({
       message: `Schema declares "${schema.id}" as an id property but an empty value was found in result.`,
     });


### PR DESCRIPTION
Part of https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/Bugs-Feature-requests_suyN0#Open-Bugs_tu6FU/r61&modal=true, where if the id field returned by a formula was falsy (i.e. 0, ''), then the result validation would fail.

Now we only error out if the ID field is specifically empty (null or undefined).