### PR TITLE
Fix thunk for sync tables like Jira Issues, which are not strictly dynamic but have dynamic schema.

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -4784,23 +4784,27 @@ function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionCo
         case MetadataFormulaType.SyncGetSchema:
           if (syncTables) {
             const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
-            if (syncTable && isDynamicSyncTable(syncTable)) {
+            if (syncTable) {
               let formula;
-              switch (formulaSpec.metadataFormulaType) {
-                case MetadataFormulaType.SyncListDynamicUrls:
-                  formula = syncTable.listDynamicUrls;
-                  break;
-                case MetadataFormulaType.SyncGetDisplayUrl:
-                  formula = syncTable.getDisplayUrl;
-                  break;
-                case MetadataFormulaType.SyncGetTableName:
-                  formula = syncTable.getName;
-                  break;
-                case MetadataFormulaType.SyncGetSchema:
-                  formula = syncTable.getSchema;
-                  break;
-                default:
-                  return ensureSwitchUnreachable(formulaSpec);
+              if (isDynamicSyncTable(syncTable)) {
+                switch (formulaSpec.metadataFormulaType) {
+                  case MetadataFormulaType.SyncListDynamicUrls:
+                    formula = syncTable.listDynamicUrls;
+                    break;
+                  case MetadataFormulaType.SyncGetDisplayUrl:
+                    formula = syncTable.getDisplayUrl;
+                    break;
+                  case MetadataFormulaType.SyncGetTableName:
+                    formula = syncTable.getName;
+                    break;
+                  case MetadataFormulaType.SyncGetSchema:
+                    formula = syncTable.getSchema;
+                    break;
+                  default:
+                    return ensureSwitchUnreachable(formulaSpec);
+                }
+              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
+                formula = syncTable.getSchema;
               }
               if (formula) {
                 return formula.execute(params, executionContext);

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -4784,23 +4784,27 @@ function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionCo
         case MetadataFormulaType.SyncGetSchema:
           if (syncTables) {
             const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
-            if (syncTable && isDynamicSyncTable(syncTable)) {
+            if (syncTable) {
               let formula;
-              switch (formulaSpec.metadataFormulaType) {
-                case MetadataFormulaType.SyncListDynamicUrls:
-                  formula = syncTable.listDynamicUrls;
-                  break;
-                case MetadataFormulaType.SyncGetDisplayUrl:
-                  formula = syncTable.getDisplayUrl;
-                  break;
-                case MetadataFormulaType.SyncGetTableName:
-                  formula = syncTable.getName;
-                  break;
-                case MetadataFormulaType.SyncGetSchema:
-                  formula = syncTable.getSchema;
-                  break;
-                default:
-                  return ensureSwitchUnreachable(formulaSpec);
+              if (isDynamicSyncTable(syncTable)) {
+                switch (formulaSpec.metadataFormulaType) {
+                  case MetadataFormulaType.SyncListDynamicUrls:
+                    formula = syncTable.listDynamicUrls;
+                    break;
+                  case MetadataFormulaType.SyncGetDisplayUrl:
+                    formula = syncTable.getDisplayUrl;
+                    break;
+                  case MetadataFormulaType.SyncGetTableName:
+                    formula = syncTable.getName;
+                    break;
+                  case MetadataFormulaType.SyncGetSchema:
+                    formula = syncTable.getSchema;
+                    break;
+                  default:
+                    return ensureSwitchUnreachable(formulaSpec);
+                }
+              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
+                formula = syncTable.getSchema;
               }
               if (formula) {
                 return formula.execute(params, executionContext);

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -77,23 +77,30 @@ function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionCo
                 case types_3.MetadataFormulaType.SyncGetSchema:
                     if (syncTables) {
                         const syncTable = syncTables.find(table => table.name === formulaSpec.syncTableName);
-                        if (syncTable && api_2.isDynamicSyncTable(syncTable)) {
+                        if (syncTable) {
                             let formula;
-                            switch (formulaSpec.metadataFormulaType) {
-                                case types_3.MetadataFormulaType.SyncListDynamicUrls:
-                                    formula = syncTable.listDynamicUrls;
-                                    break;
-                                case types_3.MetadataFormulaType.SyncGetDisplayUrl:
-                                    formula = syncTable.getDisplayUrl;
-                                    break;
-                                case types_3.MetadataFormulaType.SyncGetTableName:
-                                    formula = syncTable.getName;
-                                    break;
-                                case types_3.MetadataFormulaType.SyncGetSchema:
-                                    formula = syncTable.getSchema;
-                                    break;
-                                default:
-                                    return ensureSwitchUnreachable(formulaSpec);
+                            if (api_2.isDynamicSyncTable(syncTable)) {
+                                switch (formulaSpec.metadataFormulaType) {
+                                    case types_3.MetadataFormulaType.SyncListDynamicUrls:
+                                        formula = syncTable.listDynamicUrls;
+                                        break;
+                                    case types_3.MetadataFormulaType.SyncGetDisplayUrl:
+                                        formula = syncTable.getDisplayUrl;
+                                        break;
+                                    case types_3.MetadataFormulaType.SyncGetTableName:
+                                        formula = syncTable.getName;
+                                        break;
+                                    case types_3.MetadataFormulaType.SyncGetSchema:
+                                        formula = syncTable.getSchema;
+                                        break;
+                                    default:
+                                        return ensureSwitchUnreachable(formulaSpec);
+                                }
+                            }
+                            else if (formulaSpec.metadataFormulaType === types_3.MetadataFormulaType.SyncGetSchema) {
+                                // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
+                                // in order to augment a static base schema with dynamic properties.
+                                formula = syncTable.getSchema;
                             }
                             if (formula) {
                                 return formula.execute(params, executionContext);

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -111,23 +111,29 @@ function doFindAndExecutePackFunction<T extends FormulaSpecification>(
         case MetadataFormulaType.SyncGetSchema:
           if (syncTables) {
             const syncTable = syncTables.find(table => table.name === formulaSpec.syncTableName);
-            if (syncTable && isDynamicSyncTable(syncTable)) {
+            if (syncTable) {
               let formula: MetadataFormula | undefined;
-              switch (formulaSpec.metadataFormulaType) {
-                case MetadataFormulaType.SyncListDynamicUrls:
-                  formula = syncTable.listDynamicUrls;
-                  break;
-                case MetadataFormulaType.SyncGetDisplayUrl:
-                  formula = syncTable.getDisplayUrl;
-                  break;
-                case MetadataFormulaType.SyncGetTableName:
-                  formula = syncTable.getName;
-                  break;
-                case MetadataFormulaType.SyncGetSchema:
-                  formula = syncTable.getSchema;
-                  break;
-                default:
-                  return ensureSwitchUnreachable(formulaSpec);
+              if (isDynamicSyncTable(syncTable)) {
+                switch (formulaSpec.metadataFormulaType) {
+                  case MetadataFormulaType.SyncListDynamicUrls:
+                    formula = syncTable.listDynamicUrls;
+                    break;
+                  case MetadataFormulaType.SyncGetDisplayUrl:
+                    formula = syncTable.getDisplayUrl;
+                    break;
+                  case MetadataFormulaType.SyncGetTableName:
+                    formula = syncTable.getName;
+                    break;
+                  case MetadataFormulaType.SyncGetSchema:
+                    formula = syncTable.getSchema;
+                    break;
+                  default:
+                    return ensureSwitchUnreachable(formulaSpec);
+                }
+              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
+                // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
+                // in order to augment a static base schema with dynamic properties.
+                formula = syncTable.getSchema;
               }
               if (formula) {
                 return formula.execute(params as any, executionContext);


### PR DESCRIPTION
This is the cause of the error `Could not find a formula matching formula spec {"type":"Metadata","metadataFormulaType":"SyncGetSchema","syncTableName":"Issues"}` for Jira.

It's this weird kind of sync table that has a getSchema method, but doesn't have `isDynamic: true`. So it was returning false on the `isDynamicSyncTable()` check (which is just a TypeScript guard) and we weren't resolving a formula for it.

PTAL @huayang-codaio @alan-codaio @coda/packs 