### PR TITLE
Augment the setTimeout() shim to block synchronously before yielding with a Promise.

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -26,9 +26,13 @@ export async function handleBuild({outputDir, manifestFile, minify, timerStrateg
   }
 }
 
-export async function build(manifestFile: string): Promise<string> {
+export async function build(
+  manifestFile: string,
+  {timerStrategy}: {timerStrategy?: TimerShimStrategy} = {},
+): Promise<string> {
   const {bundlePath} = await compilePackBundle({
     manifestPath: manifestFile,
+    timerStrategy,
   });
 
   return bundlePath;

--- a/dist/cli/build.d.ts
+++ b/dist/cli/build.d.ts
@@ -7,5 +7,7 @@ interface BuildArgs {
     timerStrategy: TimerShimStrategy;
 }
 export declare function handleBuild({ outputDir, manifestFile, minify, timerStrategy }: Arguments<BuildArgs>): Promise<void>;
-export declare function build(manifestFile: string): Promise<string>;
+export declare function build(manifestFile: string, { timerStrategy }?: {
+    timerStrategy?: TimerShimStrategy;
+}): Promise<string>;
 export {};

--- a/dist/cli/build.js
+++ b/dist/cli/build.js
@@ -18,9 +18,10 @@ async function handleBuild({ outputDir, manifestFile, minify, timerStrategy }) {
     }
 }
 exports.handleBuild = handleBuild;
-async function build(manifestFile) {
+async function build(manifestFile, { timerStrategy } = {}) {
     const { bundlePath } = await compile_1.compilePackBundle({
         manifestPath: manifestFile,
+        timerStrategy,
     });
     return bundlePath;
 }

--- a/dist/testing/injections/timers_shim.js
+++ b/dist/testing/injections/timers_shim.js
@@ -1,13 +1,16 @@
 // ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
 // so for now we just have this file in js.
 
-// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to 
-// an ivm context isn't safe. so we create a workaround to use a Promise to yield execution
-// of the current thread. 
-export function setTimeout(callback, _) { new Promise(_ => callback()) }
+// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to
+// an ivm context isn't safe. so we create a workaround to (1) block syncronously and then
+// (2) use a Promise to yield execution of the current thread.
+export function setTimeout(callback, timeout) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, timeout);
+  new Promise(_ => callback());
+}
 
-// can't actually set interval in ivm. this would only be executed once. maybe we should 
-// just throw an error if setInterval is called. 
+// can't actually set interval in ivm. this would only be executed once. maybe we should
+// just throw an error if setInterval is called.
 export function setInterval(callback, _) { new Promise(_ => callback()) }
 
 export function clearTimeout() {}

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -3,6 +3,7 @@ import {AuthenticationType} from '../types';
 import type {Formula} from '../api';
 import type {ResponseHandlerTemplate} from '../handler_templates';
 import type {Schema} from '../schema';
+import {TimerShimStrategy} from '../testing/compile';
 import {ValueType} from '../schema';
 import {assertCondition} from '../helpers/ensure';
 import {build as buildBundle} from '../cli/build';
@@ -28,7 +29,7 @@ describe('Execution', () => {
   let bundlePath: string;
 
   before(async () => {
-    bundlePath = await buildBundle(`${__dirname}/packs/fake`);
+    bundlePath = await buildBundle(`${__dirname}/packs/fake`, {timerStrategy: TimerShimStrategy.Fake});
   });
 
   it('executes a formula by name', async () => {
@@ -62,6 +63,15 @@ describe('Execution', () => {
       bundlePath,
     });
     assert.deepEqual(result, {result: [{Name: 'Alice'}, {Name: 'Bob'}], continuation: {page: 2}});
+  });
+
+  it('exercises timer shim in VM', async () => {
+    const result = await executeFormulaOrSyncWithVM({
+      formulaName: 'Timer',
+      params: [1],
+      bundlePath,
+    });
+    assert.equal(result, 1);
   });
 
   describe('execution errors', () => {

--- a/testing/injections/timers_shim.js
+++ b/testing/injections/timers_shim.js
@@ -1,13 +1,16 @@
 // ts file compiled js file somehow end up with cjs format but esbuild needs esm format for shims.
 // so for now we just have this file in js.
 
-// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to 
-// an ivm context isn't safe. so we create a workaround to use a Promise to yield execution
-// of the current thread. 
-export function setTimeout(callback, _) { new Promise(_ => callback()) }
+// per https://github.com/laverdet/isolated-vm/issues/136, passing the real setTimeout to
+// an ivm context isn't safe. so we create a workaround to (1) block syncronously and then
+// (2) use a Promise to yield execution of the current thread.
+export function setTimeout(callback, timeout) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, timeout);
+  new Promise(_ => callback());
+}
 
-// can't actually set interval in ivm. this would only be executed once. maybe we should 
-// just throw an error if setInterval is called. 
+// can't actually set interval in ivm. this would only be executed once. maybe we should
+// just throw an error if setInterval is called.
 export function setInterval(callback, _) { new Promise(_ => callback()) }
 
 export function clearTimeout() {}


### PR DESCRIPTION
Context for those not already in the discussion, our own Coda Internal pack makes a Coda API mutation request, and then needs to poll the getMutationStatus endpoint until the mutation is applied. It's using setTimeout() to do this today, to sleep in between hitting that endpoint. Future packs that do Coda API mutations may need this too, as well as user packs with similar constraints.

Alex found the suggestion of using `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, timeout);` as a way to synchronously block in `node`. By adding this to our shim, we seem to get the best of both worlds, where the timeout is still respected, however because it's not actually scheduled at the system level at the system level, when the isolate times out and gets torn down, this blocking call should get torn down immediately too.

Because other tasks can't happen in between as one would generally expect with setTimeout(), we'll still leave this shim disabled by default, so developers will have to see and acknowledge our caveat first.

PTAL @chris-codaio @alexd-codaio @huayang-codaio @coda/packs 