### PR TITLE
Teach our marshaling the difference between null and undefined

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -4664,6 +4664,7 @@ function unmarshalNumber(val) {
 }
 
 // runtime/common/marshaling/index.ts
+var HACK_UNDEFINED_JSON_VALUE = "__UNDEFINED__";
 var MaxTraverseDepth = 100;
 var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
 var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
@@ -4678,6 +4679,9 @@ function serialize(val) {
 }
 function deserialize(_, val) {
   if (val) {
+    if (val === HACK_UNDEFINED_JSON_VALUE) {
+      return void 0;
+    }
     for (const unmarshaler of customUnmarshalers) {
       const result = unmarshaler(val);
       if (result !== void 0) {
@@ -4691,7 +4695,10 @@ function processValue(val, depth = 0) {
   if (depth >= MaxTraverseDepth) {
     throw new Error("marshaling value is too deep or containing circular strcture");
   }
-  if (val === void 0 || val === null) {
+  if (val === void 0) {
+    return HACK_UNDEFINED_JSON_VALUE;
+  }
+  if (val === null) {
     return val;
   }
   if (Array.isArray(val)) {

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -4664,6 +4664,7 @@ function unmarshalNumber(val) {
 }
 
 // runtime/common/marshaling/index.ts
+var HACK_UNDEFINED_JSON_VALUE = "__UNDEFINED__";
 var MaxTraverseDepth = 100;
 var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
 var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
@@ -4678,6 +4679,9 @@ function serialize(val) {
 }
 function deserialize(_, val) {
   if (val) {
+    if (val === HACK_UNDEFINED_JSON_VALUE) {
+      return void 0;
+    }
     for (const unmarshaler of customUnmarshalers) {
       const result = unmarshaler(val);
       if (result !== void 0) {
@@ -4691,7 +4695,10 @@ function processValue(val, depth = 0) {
   if (depth >= MaxTraverseDepth) {
     throw new Error("marshaling value is too deep or containing circular strcture");
   }
-  if (val === void 0 || val === null) {
+  if (val === void 0) {
+    return HACK_UNDEFINED_JSON_VALUE;
+  }
+  if (val === null) {
     return val;
   }
   if (Array.isArray(val)) {

--- a/dist/runtime/common/marshaling/index.js
+++ b/dist/runtime/common/marshaling/index.js
@@ -9,6 +9,8 @@ const marshal_buffer_2 = require("./marshal_buffer");
 const marshal_dates_2 = require("./marshal_dates");
 const marshal_errors_2 = require("./marshal_errors");
 const marshal_numbers_2 = require("./marshal_numbers");
+// JSON has no native way to represent `undefined`.
+const HACK_UNDEFINED_JSON_VALUE = '__UNDEFINED__';
 const MaxTraverseDepth = 100;
 const customMarshalers = [marshal_errors_1.marshalError, marshal_buffer_1.marshalBuffer, marshal_numbers_1.marshalNumber, marshal_dates_1.marshalDate];
 const customUnmarshalers = [marshal_errors_2.unmarshalError, marshal_buffer_2.unmarshalBuffer, marshal_numbers_2.unmarshalNumber, marshal_dates_2.unmarshalDate];
@@ -23,6 +25,9 @@ function serialize(val) {
 }
 function deserialize(_, val) {
     if (val) {
+        if (val === HACK_UNDEFINED_JSON_VALUE) {
+            return undefined;
+        }
         for (const unmarshaler of customUnmarshalers) {
             const result = unmarshaler(val);
             if (result !== undefined) {
@@ -36,7 +41,10 @@ function processValue(val, depth = 0) {
     if (depth >= MaxTraverseDepth) {
         throw new Error('marshaling value is too deep or containing circular strcture');
     }
-    if (val === undefined || val === null) {
+    if (val === undefined) {
+        return HACK_UNDEFINED_JSON_VALUE;
+    }
+    if (val === null) {
         return val;
     }
     if (Array.isArray(val)) {

--- a/test/marshaling_test.ts
+++ b/test/marshaling_test.ts
@@ -20,6 +20,7 @@ describe('Marshaling', () => {
     assert.deepEqual(transform([undefined]), [undefined]);
     assert.deepEqual(transform({a: undefined}), {a: undefined});
     assert.deepEqual(transform(null), null);
+    assert.deepEqual(transform([null]), [null]);
     assert.deepEqual(transform(true), true);
     assert.deepEqual(transform(Number(123)), Number(123));
     assert.deepEqual(transform(NaN), NaN);
@@ -36,7 +37,7 @@ describe('Marshaling', () => {
   it('works for a variety of compound objects', () => {
     const testObjects: any = [
       [null, undefined, 0, false, NaN, Infinity, {undefined: 1, null: undefined}],
-      {Array: [], Boolean: false, new: {}, function: undefined, NaN: 1},
+      {Array: [], Boolean: false, new: {_: null}, function: undefined, NaN: 1},
       [{undefined: [{false: [{true: [{null: 0}]}]}]}],
     ];
     testObjects.forEach((x: any) => assert.deepEqual(transform(x), x));

--- a/test/marshaling_test.ts
+++ b/test/marshaling_test.ts
@@ -17,6 +17,7 @@ describe('Marshaling', () => {
     assert.deepEqual([1], transform([1]));
     assert.deepEqual({a: 1}, transform({a: 1}));
     assert.deepEqual(undefined, transform(undefined));
+    assert.deepEqual([undefined], transform([undefined]));
     assert.deepEqual(null, transform(null));
     assert.deepEqual(true, transform(true));
     assert.deepEqual(Number(123), transform(Number(123)));

--- a/test/marshaling_test.ts
+++ b/test/marshaling_test.ts
@@ -11,25 +11,35 @@ describe('Marshaling', () => {
   it('works for regular objects', () => {
     // this test covers most of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
 
-    assert.deepEqual(1, transform(1));
-    assert.deepEqual(1.1, transform(1.1));
-    assert.deepEqual('1', transform('1'));
-    assert.deepEqual([1], transform([1]));
-    assert.deepEqual({a: 1}, transform({a: 1}));
-    assert.deepEqual(undefined, transform(undefined));
-    assert.deepEqual([undefined], transform([undefined]));
-    assert.deepEqual(null, transform(null));
-    assert.deepEqual(true, transform(true));
-    assert.deepEqual(Number(123), transform(Number(123)));
-    assert.deepEqual(NaN, transform(NaN));
-    assert.deepEqual(Infinity, transform(Infinity));
-    assert.deepEqual(new Date(123), transform(new Date(123)));
+    assert.deepEqual(transform(1), 1);
+    assert.deepEqual(transform(1.1), 1.1);
+    assert.deepEqual(transform('1'), '1');
+    assert.deepEqual(transform([1]), [1]);
+    assert.deepEqual(transform({a: 1}), {a: 1});
+    assert.deepEqual(transform(undefined), undefined);
+    assert.deepEqual(transform([undefined]), [undefined]);
+    assert.deepEqual(transform({a: undefined}), {a: undefined});
+    assert.deepEqual(transform(null), null);
+    assert.deepEqual(transform(true), true);
+    assert.deepEqual(transform(Number(123)), Number(123));
+    assert.deepEqual(transform(NaN), NaN);
+    assert.deepEqual(transform(Infinity), Infinity);
+    assert.deepEqual(transform(new Date(123)), new Date(123));
 
     // the following doesn't work yet.
-    // assert.deepEqual(/123/, transform(/123/));
-    // assert.deepEqual(Uint8Array.from([1, 2, 3]), transform(Uint8Array.from([1, 2, 3])));
-    // assert.deepEqual(new Set([1, 2]), transform(new Set([1, 2])));
-    // assert.deepEqual(new Map([['a', 2]]), transform(new Map([['a', 2]])));
+    // assert.deepEqual(transform(/123/), /123/);
+    // assert.deepEqual(transform(Uint8Array.from([1, 2, 3])), Uint8Array.from([1, 2, 3]));
+    // assert.deepEqual(transform(new Set([1, 2])), new Set([1, 2]));
+    // assert.deepEqual(transform(new Map([['a', 2]])), new Map([['a', 2]]));
+  });
+
+  it('works for a variety of compound objects', () => {
+    const testObjects: any = [
+      [null, undefined, 0, false, NaN, Infinity, {undefined: 1, null: undefined}],
+      {Array: [], Boolean: false, new: {}, function: undefined, NaN: 1},
+      [{undefined: [{false: [{true: [{null: 0}]}]}]}],
+    ];
+    testObjects.forEach((x: any) => assert.deepEqual(transform(x), x));
   });
 
   it('does not throw error for unhandled objects', () => {
@@ -59,7 +69,7 @@ describe('Marshaling', () => {
 
     it('works for regular error', () => {
       const error = new Error('test');
-      assertErrorsEqual(error, transform(error));
+      assertErrorsEqual(transform(error), error);
     });
 
     it('works for common system errors', () => {
@@ -72,7 +82,7 @@ describe('Marshaling', () => {
     it('works for whitelisted coda errors', () => {
       const error = new StatusCodeError(404, '', {url: 'https://coda.io', method: 'GET'}, {headers: {}, body: ''});
       const transformedError = transform(error);
-      assertErrorsEqual(error, transformedError);
+      assertErrorsEqual(transformedError, error);
       assert.isTrue(transformedError instanceof StatusCodeError);
     });
   });


### PR DESCRIPTION
Fixes https://go/bug/19250. Specifically, the issue was caused by pack code that assumed that an un-set boolean param would be `undefined` when it came through as `null`. This happened because JSON has no native way to represent `undefined`, and so we hack.