### PR TITLE
Move typedoc config to a file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,8 @@ generated-documentation:
 
 .PHONY: typedoc
 typedoc:
-	if [ -z "${shell git config --get remote.origin.url | grep coda/packs-sdk}" ]; then \
-		echo "Please config your git origin to git@github.com:coda/packs-sdk.git"; \
-		exit 1; \
-	fi
-	${ROOTDIR}/node_modules/.bin/typedoc index.ts --out ${ROOTDIR}/docs --excludeExternals --excludePrivate --excludeProtected --gitRevision main
+	# Most options loaded from typedoc.js.
+	${ROOTDIR}/node_modules/.bin/typedoc index.ts --options typedoc.js --out ${ROOTDIR}/docs
 
 .PHONY: docs
 docs: typedoc generated-documentation

--- a/docs/classes/PackDefinitionBuilder.html
+++ b/docs/classes/PackDefinitionBuilder.html
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L51">builder.ts:51</a></li>
+									<li>Defined in builder.ts:51</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.defaultAuthentication</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L43">builder.ts:43</a></li>
+							<li>Defined in builder.ts:43</li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formats</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L39">builder.ts:39</a></li>
+							<li>Defined in builder.ts:39</li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L47">builder.ts:47</a></li>
+							<li>Defined in builder.ts:47</li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.formulas</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L38">builder.ts:38</a></li>
+							<li>Defined in builder.ts:38</li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.networkDomains</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L41">builder.ts:41</a></li>
+							<li>Defined in builder.ts:41</li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.syncTables</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L40">builder.ts:40</a></li>
+							<li>Defined in builder.ts:40</li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of BasicPackDefinition.systemConnectionAuthentication</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L44">builder.ts:44</a></li>
+							<li>Defined in builder.ts:44</li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L46">builder.ts:46</a></li>
+							<li>Defined in builder.ts:46</li>
 						</ul>
 					</aside>
 				</section>
@@ -244,7 +244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L180">builder.ts:180</a></li>
+									<li>Defined in builder.ts:180</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -281,7 +281,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L160">builder.ts:160</a></li>
+									<li>Defined in builder.ts:160</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -332,7 +332,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L94">builder.ts:94</a></li>
+									<li>Defined in builder.ts:94</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L269">builder.ts:269</a></li>
+									<li>Defined in builder.ts:269</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -426,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L120">builder.ts:120</a></li>
+									<li>Defined in builder.ts:120</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L241">builder.ts:241</a></li>
+									<li>Defined in builder.ts:241</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -524,7 +524,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L204">builder.ts:204</a></li>
+									<li>Defined in builder.ts:204</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -567,7 +567,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L285">builder.ts:285</a></li>
+									<li>Defined in builder.ts:285</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/StatusCodeError.html
+++ b/docs/classes/StatusCodeError.html
@@ -123,7 +123,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Error.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L85">api.ts:85</a></li>
+									<li>Defined in api.ts:85</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L80">api.ts:80</a></li>
+							<li>Defined in api.ts:80</li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L81">api.ts:81</a></li>
+							<li>Defined in api.ts:81</li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides Error.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L78">api.ts:78</a></li>
+							<li>Defined in api.ts:78</li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/FetchRequest.html" class="tsd-signature-type" data-tsd-kind="Interface">FetchRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L82">api.ts:82</a></li>
+							<li>Defined in api.ts:82</li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">StatusCodeErrorResponse</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L83">api.ts:83</a></li>
+							<li>Defined in api.ts:83</li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L79">api.ts:79</a></li>
+							<li>Defined in api.ts:79</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/UserVisibleError.html
+++ b/docs/classes/UserVisibleError.html
@@ -119,7 +119,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides Error.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L59">api.ts:59</a></li>
+									<li>Defined in api.ts:59</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">internal<wbr>Error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Error</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L57">api.ts:57</a></li>
+							<li>Defined in api.ts:57</li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>User<wbr>Visible<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> = true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L56">api.ts:56</a></li>
+							<li>Defined in api.ts:56</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/AttributionNodeType.html
+++ b/docs/enums/AttributionNodeType.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L205">schema.ts:205</a></li>
+							<li>Defined in schema.ts:205</li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Link<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L204">schema.ts:204</a></li>
+							<li>Defined in schema.ts:204</li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L203">schema.ts:203</a></li>
+							<li>Defined in schema.ts:203</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/AuthenticationType.html
+++ b/docs/enums/AuthenticationType.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">Coda<wbr>Api<wbr>Header<wbr>Bearer<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CodaApiHeaderBearerToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L98">types.ts:98</a></li>
+							<li>Defined in types.ts:98</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">Custom<wbr>Header<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;CustomHeaderToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L49">types.ts:49</a></li>
+							<li>Defined in types.ts:49</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">Header<wbr>Bearer<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;HeaderBearerToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L44">types.ts:44</a></li>
+							<li>Defined in types.ts:44</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">Multi<wbr>Query<wbr>Param<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;MultiQueryParamToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L63">types.ts:63</a></li>
+							<li>Defined in types.ts:63</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;None&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L40">types.ts:40</a></li>
+							<li>Defined in types.ts:40</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">OAuth2<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;OAuth2&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L71">types.ts:71</a></li>
+							<li>Defined in types.ts:71</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">Query<wbr>Param<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;QueryParamToken&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L56">types.ts:56</a></li>
+							<li>Defined in types.ts:56</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">Web<wbr>Basic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;WebBasic&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L78">types.ts:78</a></li>
+							<li>Defined in types.ts:78</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/ConnectionRequirement.html
+++ b/docs/enums/ConnectionRequirement.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;none&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L261">api_types.ts:261</a></li>
+							<li>Defined in api_types.ts:261</li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;optional&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L262">api_types.ts:262</a></li>
+							<li>Defined in api_types.ts:262</li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;required&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L263">api_types.ts:263</a></li>
+							<li>Defined in api_types.ts:263</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/CurrencyFormat.html
+++ b/docs/enums/CurrencyFormat.html
@@ -86,7 +86,7 @@
 					<div class="tsd-signature tsd-kind-icon">Accounting<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;accounting&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L95">schema.ts:95</a></li>
+							<li>Defined in schema.ts:95</li>
 						</ul>
 					</aside>
 				</section>
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Currency<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;currency&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L94">schema.ts:94</a></li>
+							<li>Defined in schema.ts:94</li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Financial<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;financial&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L96">schema.ts:96</a></li>
+							<li>Defined in schema.ts:96</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/DefaultConnectionType.html
+++ b/docs/enums/DefaultConnectionType.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">Proxy<wbr>Actions<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L126">types.ts:126</a></li>
+							<li>Defined in types.ts:126</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">Shared<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L119">types.ts:119</a></li>
+							<li>Defined in types.ts:119</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">Shared<wbr>Data<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L115">types.ts:115</a></li>
+							<li>Defined in types.ts:115</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/enums/DurationUnit.html
+++ b/docs/enums/DurationUnit.html
@@ -87,7 +87,7 @@
 					<div class="tsd-signature tsd-kind-icon">Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L144">schema.ts:144</a></li>
+							<li>Defined in schema.ts:144</li>
 						</ul>
 					</aside>
 				</section>
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">Hours<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;hours&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L145">schema.ts:145</a></li>
+							<li>Defined in schema.ts:145</li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Minutes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;minutes&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L146">schema.ts:146</a></li>
+							<li>Defined in schema.ts:146</li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Seconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;seconds&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L147">schema.ts:147</a></li>
+							<li>Defined in schema.ts:147</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/NetworkConnection.html
+++ b/docs/enums/NetworkConnection.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">None<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;none&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L268">api_types.ts:268</a></li>
+							<li>Defined in api_types.ts:268</li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;optional&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269">api_types.ts:269</a></li>
+							<li>Defined in api_types.ts:269</li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;required&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L270">api_types.ts:270</a></li>
+							<li>Defined in api_types.ts:270</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/ParameterType.html
+++ b/docs/enums/ParameterType.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;boolean&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L88">api_types.ts:88</a></li>
+							<li>Defined in api_types.ts:88</li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;booleanArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L95">api_types.ts:95</a></li>
+							<li>Defined in api_types.ts:95</li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L89">api_types.ts:89</a></li>
+							<li>Defined in api_types.ts:89</li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;dateArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L96">api_types.ts:96</a></li>
+							<li>Defined in api_types.ts:96</li>
 						</ul>
 					</aside>
 				</section>
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;html&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L90">api_types.ts:90</a></li>
+							<li>Defined in api_types.ts:90</li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;htmlArray&#x60;&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L97">api_types.ts:97</a></li>
+							<li>Defined in api_types.ts:97</li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;image&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L91">api_types.ts:91</a></li>
+							<li>Defined in api_types.ts:91</li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;imageArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L98">api_types.ts:98</a></li>
+							<li>Defined in api_types.ts:98</li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L87">api_types.ts:87</a></li>
+							<li>Defined in api_types.ts:87</li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;numberArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L94">api_types.ts:94</a></li>
+							<li>Defined in api_types.ts:94</li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;string&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L86">api_types.ts:86</a></li>
+							<li>Defined in api_types.ts:86</li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;stringArray&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L93">api_types.ts:93</a></li>
+							<li>Defined in api_types.ts:93</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/PostSetupType.html
+++ b/docs/enums/PostSetupType.html
@@ -84,7 +84,7 @@
 					<div class="tsd-signature tsd-kind-icon">Set<wbr>Endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;SetEndPoint&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L144">types.ts:144</a></li>
+							<li>Defined in types.ts:144</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/PrecannedDateRange.html
+++ b/docs/enums/PrecannedDateRange.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Everything<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;everything&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L387">api_types.ts:387</a></li>
+							<li>Defined in api_types.ts:387</li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last30<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_30_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L360">api_types.ts:360</a></li>
+							<li>Defined in api_types.ts:360</li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last3<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_3_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L363">api_types.ts:363</a></li>
+							<li>Defined in api_types.ts:363</li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last6<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_6_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L364">api_types.ts:364</a></li>
+							<li>Defined in api_types.ts:364</li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last7<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_7_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359">api_types.ts:359</a></li>
+							<li>Defined in api_types.ts:359</li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L362">api_types.ts:362</a></li>
+							<li>Defined in api_types.ts:362</li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L361">api_types.ts:361</a></li>
+							<li>Defined in api_types.ts:361</li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">Last<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;last_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L365">api_types.ts:365</a></li>
+							<li>Defined in api_types.ts:365</li>
 						</ul>
 					</aside>
 				</section>
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next30<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_30_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L380">api_types.ts:380</a></li>
+							<li>Defined in api_types.ts:380</li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next3<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_3_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383">api_types.ts:383</a></li>
+							<li>Defined in api_types.ts:383</li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next6<wbr>Months<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_6_months&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L384">api_types.ts:384</a></li>
+							<li>Defined in api_types.ts:384</li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next7<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_7_days&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379">api_types.ts:379</a></li>
+							<li>Defined in api_types.ts:379</li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L382">api_types.ts:382</a></li>
+							<li>Defined in api_types.ts:382</li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L381">api_types.ts:381</a></li>
+							<li>Defined in api_types.ts:381</li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">Next<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;next_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L385">api_types.ts:385</a></li>
+							<li>Defined in api_types.ts:385</li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Month<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_month&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L371">api_types.ts:371</a></li>
+							<li>Defined in api_types.ts:371</li>
 						</ul>
 					</aside>
 				</section>
@@ -268,7 +268,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Month<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_month_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L372">api_types.ts:372</a></li>
+							<li>Defined in api_types.ts:372</li>
 						</ul>
 					</aside>
 				</section>
@@ -278,7 +278,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Week<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_week&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L369">api_types.ts:369</a></li>
+							<li>Defined in api_types.ts:369</li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Week<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_week_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L370">api_types.ts:370</a></li>
+							<li>Defined in api_types.ts:370</li>
 						</ul>
 					</aside>
 				</section>
@@ -298,7 +298,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Year<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_year&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L375">api_types.ts:375</a></li>
+							<li>Defined in api_types.ts:375</li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<div class="tsd-signature tsd-kind-icon">This<wbr>Year<wbr>Start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;this_year_start&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L373">api_types.ts:373</a></li>
+							<li>Defined in api_types.ts:373</li>
 						</ul>
 					</aside>
 				</section>
@@ -318,7 +318,7 @@
 					<div class="tsd-signature tsd-kind-icon">Today<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;today&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368">api_types.ts:368</a></li>
+							<li>Defined in api_types.ts:368</li>
 						</ul>
 					</aside>
 				</section>
@@ -328,7 +328,7 @@
 					<div class="tsd-signature tsd-kind-icon">Tomorrow<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;tomorrow&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L378">api_types.ts:378</a></li>
+							<li>Defined in api_types.ts:378</li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<div class="tsd-signature tsd-kind-icon">Year<wbr>ToDate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;year_to_date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L374">api_types.ts:374</a></li>
+							<li>Defined in api_types.ts:374</li>
 						</ul>
 					</aside>
 				</section>
@@ -348,7 +348,7 @@
 					<div class="tsd-signature tsd-kind-icon">Yesterday<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;yesterday&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358">api_types.ts:358</a></li>
+							<li>Defined in api_types.ts:358</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/Type.html
+++ b/docs/enums/Type.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L10">api_types.ts:10</a></li>
+							<li>Defined in api_types.ts:10</li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 4</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L11">api_types.ts:11</a></li>
+							<li>Defined in api_types.ts:11</li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 5</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L12">api_types.ts:12</a></li>
+							<li>Defined in api_types.ts:12</li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">image<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 6</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L13">api_types.ts:13</a></li>
+							<li>Defined in api_types.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L8">api_types.ts:8</a></li>
+							<li>Defined in api_types.ts:8</li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">object<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L9">api_types.ts:9</a></li>
+							<li>Defined in api_types.ts:9</li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">string<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = 0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L7">api_types.ts:7</a></li>
+							<li>Defined in api_types.ts:7</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/ValueHintType.html
+++ b/docs/enums/ValueHintType.html
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">Attachment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;attachment&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L41">schema.ts:41</a></li>
+							<li>Defined in schema.ts:41</li>
 						</ul>
 					</aside>
 				</section>
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">Currency<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;currency&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L33">schema.ts:33</a></li>
+							<li>Defined in schema.ts:33</li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;date&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L27">schema.ts:27</a></li>
+							<li>Defined in schema.ts:27</li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">Date<wbr>Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;datetime&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L29">schema.ts:29</a></li>
+							<li>Defined in schema.ts:29</li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;duration&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L30">schema.ts:30</a></li>
+							<li>Defined in schema.ts:30</li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">Embed<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;embed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L39">schema.ts:39</a></li>
+							<li>Defined in schema.ts:39</li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">Html<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;html&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L38">schema.ts:38</a></li>
+							<li>Defined in schema.ts:38</li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<wbr>Attachment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;imageAttachment&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L35">schema.ts:35</a></li>
+							<li>Defined in schema.ts:35</li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">Image<wbr>Reference<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;image&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L34">schema.ts:34</a></li>
+							<li>Defined in schema.ts:34</li>
 						</ul>
 					</aside>
 				</section>
@@ -197,7 +197,7 @@
 					<div class="tsd-signature tsd-kind-icon">Markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;markdown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L37">schema.ts:37</a></li>
+							<li>Defined in schema.ts:37</li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<div class="tsd-signature tsd-kind-icon">Percent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;percent&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L32">schema.ts:32</a></li>
+							<li>Defined in schema.ts:32</li>
 						</ul>
 					</aside>
 				</section>
@@ -217,7 +217,7 @@
 					<div class="tsd-signature tsd-kind-icon">Person<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;person&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L31">schema.ts:31</a></li>
+							<li>Defined in schema.ts:31</li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<div class="tsd-signature tsd-kind-icon">Reference<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;reference&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L40">schema.ts:40</a></li>
+							<li>Defined in schema.ts:40</li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<div class="tsd-signature tsd-kind-icon">Scale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;scale&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L43">schema.ts:43</a></li>
+							<li>Defined in schema.ts:43</li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">Slider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;slider&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L42">schema.ts:42</a></li>
+							<li>Defined in schema.ts:42</li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">Time<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;time&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L28">schema.ts:28</a></li>
+							<li>Defined in schema.ts:28</li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;url&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L36">schema.ts:36</a></li>
+							<li>Defined in schema.ts:36</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/ValueType.html
+++ b/docs/enums/ValueType.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;array&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L19">schema.ts:19</a></li>
+							<li>Defined in schema.ts:19</li>
 						</ul>
 					</aside>
 				</section>
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">Boolean<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;boolean&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L16">schema.ts:16</a></li>
+							<li>Defined in schema.ts:16</li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">Number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;number&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L17">schema.ts:17</a></li>
+							<li>Defined in schema.ts:17</li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;object&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L20">schema.ts:20</a></li>
+							<li>Defined in schema.ts:20</li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">String<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;string&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L18">schema.ts:18</a></li>
+							<li>Defined in schema.ts:18</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ArraySchema.html
+++ b/docs/interfaces/ArraySchema.html
@@ -108,7 +108,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L162">schema.ts:162</a></li>
+							<li>Defined in schema.ts:162</li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueType.html#Array" class="tsd-signature-type" data-tsd-kind="Enumeration member">Array</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L161">schema.ts:161</a></li>
+							<li>Defined in schema.ts:161</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ArrayType.html
+++ b/docs/interfaces/ArrayType.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">items<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L20">api_types.ts:20</a></li>
+							<li>Defined in api_types.ts:20</li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;array&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L19">api_types.ts:19</a></li>
+							<li>Defined in api_types.ts:19</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/BooleanSchema.html
+++ b/docs/interfaces/BooleanSchema.html
@@ -99,7 +99,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueType.html#Boolean" class="tsd-signature-type" data-tsd-kind="Enumeration member">Boolean</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L79">schema.ts:79</a></li>
+							<li>Defined in schema.ts:79</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/CurrencySchema.html
+++ b/docs/interfaces/CurrencySchema.html
@@ -103,7 +103,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#codaType">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L100">schema.ts:100</a></li>
+							<li>Defined in schema.ts:100</li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">currency<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L102">schema.ts:102</a></li>
+							<li>Defined in schema.ts:102</li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <a href="../enums/CurrencyFormat.html" class="tsd-signature-type" data-tsd-kind="Enumeration">CurrencyFormat</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L103">schema.ts:103</a></li>
+							<li>Defined in schema.ts:103</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L101">schema.ts:101</a></li>
+							<li>Defined in schema.ts:101</li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in schema.ts:83</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/DateSchema.html
+++ b/docs/interfaces/DateSchema.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueHintType.html#Date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L124">schema.ts:124</a></li>
+							<li>Defined in schema.ts:124</li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L126">schema.ts:126</a></li>
+							<li>Defined in schema.ts:126</li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in schema.ts:120</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/DateTimeSchema.html
+++ b/docs/interfaces/DateTimeSchema.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueHintType.html#DateTime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L136">schema.ts:136</a></li>
+							<li>Defined in schema.ts:136</li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">date<wbr>Format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L138">schema.ts:138</a></li>
+							<li>Defined in schema.ts:138</li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">time<wbr>Format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L140">schema.ts:140</a></li>
+							<li>Defined in schema.ts:140</li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in schema.ts:120</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/DurationSchema.html
+++ b/docs/interfaces/DurationSchema.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="StringSchema.html">StringSchema</a>.<a href="StringSchema.html#codaType">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L157">schema.ts:157</a></li>
+							<li>Defined in schema.ts:157</li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="StringSchema.html">StringSchema</a>.<a href="StringSchema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">max<wbr>Unit<span class="tsd-signature-symbol">:</span> <a href="../enums/DurationUnit.html" class="tsd-signature-type" data-tsd-kind="Enumeration">DurationUnit</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L152">schema.ts:152</a></li>
+							<li>Defined in schema.ts:152</li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L151">schema.ts:151</a></li>
+							<li>Defined in schema.ts:151</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="StringSchema.html">StringSchema</a>.<a href="StringSchema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L156">schema.ts:156</a></li>
+							<li>Defined in schema.ts:156</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/DynamicSyncTableDef.html
+++ b/docs/interfaces/DynamicSyncTableDef.html
@@ -131,7 +131,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="SyncTableDef.html">SyncTableDef</a>.<a href="SyncTableDef.html#entityName">entityName</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L118">api.ts:118</a></li>
+							<li>Defined in api.ts:118</li>
 						</ul>
 					</aside>
 				</section>
@@ -141,7 +141,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Display<wbr>Url<span class="tsd-signature-symbol">:</span> <a href="../modules.html#MetadataFormula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L134">api.ts:134</a></li>
+							<li>Defined in api.ts:134</li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Name<span class="tsd-signature-symbol">:</span> <a href="../modules.html#MetadataFormula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L133">api.ts:133</a></li>
+							<li>Defined in api.ts:133</li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="SyncTableDef.html">SyncTableDef</a>.<a href="SyncTableDef.html#getSchema">getSchema</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L132">api.ts:132</a></li>
+							<li>Defined in api.ts:132</li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="SyncTableDef.html">SyncTableDef</a>.<a href="SyncTableDef.html#getter">getter</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L116">api.ts:116</a></li>
+							<li>Defined in api.ts:116</li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Dynamic<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L131">api.ts:131</a></li>
+							<li>Defined in api.ts:131</li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">list<wbr>Dynamic<wbr>Urls<span class="tsd-signature-symbol">:</span> <a href="../modules.html#MetadataFormula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L135">api.ts:135</a></li>
+							<li>Defined in api.ts:135</li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="SyncTableDef.html">SyncTableDef</a>.<a href="SyncTableDef.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L114">api.ts:114</a></li>
+							<li>Defined in api.ts:114</li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="SyncTableDef.html">SyncTableDef</a>.<a href="SyncTableDef.html#schema">schema</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L115">api.ts:115</a></li>
+							<li>Defined in api.ts:115</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/EmptyFormulaDef.html
+++ b/docs/interfaces/EmptyFormulaDef.html
@@ -118,7 +118,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.cacheTtlSecs</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235">api_types.ts:235</a></li>
+							<li>Defined in api_types.ts:235</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.connectionRequirement</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227">api_types.ts:227</a></li>
+							<li>Defined in api_types.ts:227</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L201">api_types.ts:201</a></li>
+							<li>Defined in api_types.ts:201</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -166,7 +166,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.examples</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L216">api_types.ts:216</a></li>
+							<li>Defined in api_types.ts:216</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.extraOAuthScopes</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257">api_types.ts:257</a></li>
+							<li>Defined in api_types.ts:257</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isAction</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222">api_types.ts:222</a></li>
+							<li>Defined in api_types.ts:222</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isExperimental</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241">api_types.ts:241</a></li>
+							<li>Defined in api_types.ts:241</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -237,7 +237,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.isSystem</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247">api_types.ts:247</a></li>
+							<li>Defined in api_types.ts:247</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L196">api_types.ts:196</a></li>
+							<li>Defined in api_types.ts:196</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -270,7 +270,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.network</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L230">api_types.ts:230</a></li>
+							<li>Defined in api_types.ts:230</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -288,7 +288,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.parameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L206">api_types.ts:206</a></li>
+							<li>Defined in api_types.ts:206</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 					<div class="tsd-signature tsd-kind-icon">request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RequestHandlerTemplate</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L379">api.ts:379</a></li>
+							<li>Defined in api.ts:379</li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.varargParameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L211">api_types.ts:211</a></li>
+							<li>Defined in api_types.ts:211</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/ExecutionContext.html
+++ b/docs/interfaces/ExecutionContext.html
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340">api_types.ts:340</a></li>
+							<li>Defined in api_types.ts:340</li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">fetcher<span class="tsd-signature-symbol">:</span> <a href="Fetcher.html" class="tsd-signature-type" data-tsd-kind="Interface">Fetcher</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L337">api_types.ts:337</a></li>
+							<li>Defined in api_types.ts:337</li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">invocation<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">InvocationLocation</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L341">api_types.ts:341</a></li>
+							<li>Defined in api_types.ts:341</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">invocation<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L346">api_types.ts:346</a></li>
+							<li>Defined in api_types.ts:346</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">logger<span class="tsd-signature-symbol">:</span> <a href="Logger.html" class="tsd-signature-type" data-tsd-kind="Interface">Logger</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L339">api_types.ts:339</a></li>
+							<li>Defined in api_types.ts:339</li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Sync</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L347">api_types.ts:347</a></li>
+							<li>Defined in api_types.ts:347</li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">temporary<wbr>Blob<wbr>Storage<span class="tsd-signature-symbol">:</span> <a href="TemporaryBlobStorage.html" class="tsd-signature-type" data-tsd-kind="Interface">TemporaryBlobStorage</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338">api_types.ts:338</a></li>
+							<li>Defined in api_types.ts:338</li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">timezone<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L342">api_types.ts:342</a></li>
+							<li>Defined in api_types.ts:342</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ExternalPackVersionMetadata.html
+++ b/docs/interfaces/ExternalPackVersionMetadata.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>deferConnectionSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>endpointDomain<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>params<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-symbol">{ </span>description<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>postSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">PostSetupMetadata</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>requiresEndpointUrl<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>shouldAutoAuthSetup<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>type<span class="tsd-signature-symbol">: </span><a href="../enums/AuthenticationType.html" class="tsd-signature-type" data-tsd-kind="Enumeration">AuthenticationType</a><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L96">compiled_types.ts:96</a></li>
+							<li>Defined in compiled_types.ts:96</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">formats<span class="tsd-signature-symbol">:</span> <a href="Format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L109">compiled_types.ts:109</a></li>
+							<li>Defined in compiled_types.ts:109</li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L432">types.ts:432</a></li>
+							<li>Defined in types.ts:432</li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">formulas<span class="tsd-signature-symbol">:</span> <a href="../modules.html#ExternalPackFormulas" class="tsd-signature-type" data-tsd-kind="Type alias">ExternalPackFormulas</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L108">compiled_types.ts:108</a></li>
+							<li>Defined in compiled_types.ts:108</li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 					<div class="tsd-signature tsd-kind-icon">instructions<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L105">compiled_types.ts:105</a></li>
+							<li>Defined in compiled_types.ts:105</li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.networkDomains</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L429">types.ts:429</a></li>
+							<li>Defined in types.ts:429</li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Tables<span class="tsd-signature-symbol">:</span> <a href="../modules.html#PackSyncTable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L110">compiled_types.ts:110</a></li>
+							<li>Defined in compiled_types.ts:110</li>
 						</ul>
 					</aside>
 				</section>
@@ -210,7 +210,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BasePackVersionMetadata.version</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L419">types.ts:419</a></li>
+							<li>Defined in types.ts:419</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/FetchRequest.html
+++ b/docs/interfaces/FetchRequest.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288">api_types.ts:288</a></li>
+							<li>Defined in api_types.ts:288</li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">cache<wbr>Ttl<wbr>Secs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292">api_types.ts:292</a></li>
+							<li>Defined in api_types.ts:292</li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">disable<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L296">api_types.ts:296</a></li>
+							<li>Defined in api_types.ts:296</li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">form<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289">api_types.ts:289</a></li>
+							<li>Defined in api_types.ts:289</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L290">api_types.ts:290</a></li>
+							<li>Defined in api_types.ts:290</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>Binary<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294">api_types.ts:294</a></li>
+							<li>Defined in api_types.ts:294</li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;GET&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PATCH&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;POST&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PUT&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;DELETE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L286">api_types.ts:286</a></li>
+							<li>Defined in api_types.ts:286</li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287">api_types.ts:287</a></li>
+							<li>Defined in api_types.ts:287</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/FetchResponse.html
+++ b/docs/interfaces/FetchResponse.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L302">api_types.ts:302</a></li>
+							<li>Defined in api_types.ts:302</li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303">api_types.ts:303</a></li>
+							<li>Defined in api_types.ts:303</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L301">api_types.ts:301</a></li>
+							<li>Defined in api_types.ts:301</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Fetcher.html
+++ b/docs/interfaces/Fetcher.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L307">api_types.ts:307</a></li>
+									<li>Defined in api_types.ts:307</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/Format.html
+++ b/docs/interfaces/Format.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L357">types.ts:357</a></li>
+							<li>Defined in types.ts:357</li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L356">types.ts:356</a></li>
+							<li>Defined in types.ts:356</li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>NoConnection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L359">types.ts:359</a></li>
+							<li>Defined in types.ts:359</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -135,7 +135,7 @@
 					<div class="tsd-signature tsd-kind-icon">instructions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L360">types.ts:360</a></li>
+							<li>Defined in types.ts:360</li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L361">types.ts:361</a></li>
+							<li>Defined in types.ts:361</li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L355">types.ts:355</a></li>
+							<li>Defined in types.ts:355</li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">placeholder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L362">types.ts:362</a></li>
+							<li>Defined in types.ts:362</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Identity.html
+++ b/docs/interfaces/Identity.html
@@ -101,7 +101,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="IdentityDefinition.html">IdentityDefinition</a>.<a href="IdentityDefinition.html#attribution">attribution</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L179">schema.ts:179</a></li>
+							<li>Defined in schema.ts:179</li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="IdentityDefinition.html">IdentityDefinition</a>.<a href="IdentityDefinition.html#dynamicUrl">dynamicUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L178">schema.ts:178</a></li>
+							<li>Defined in schema.ts:178</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="IdentityDefinition.html">IdentityDefinition</a>.<a href="IdentityDefinition.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L177">schema.ts:177</a></li>
+							<li>Defined in schema.ts:177</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="IdentityDefinition.html">IdentityDefinition</a>.<a href="IdentityDefinition.html#packId">packId</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L185">schema.ts:185</a></li>
+							<li>Defined in schema.ts:185</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/IdentityDefinition.html
+++ b/docs/interfaces/IdentityDefinition.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">attribution<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AttributionNode</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L179">schema.ts:179</a></li>
+							<li>Defined in schema.ts:179</li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">dynamic<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L178">schema.ts:178</a></li>
+							<li>Defined in schema.ts:178</li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L177">schema.ts:177</a></li>
+							<li>Defined in schema.ts:177</li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">pack<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L181">schema.ts:181</a></li>
+							<li>Defined in schema.ts:181</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Logger.html
+++ b/docs/interfaces/Logger.html
@@ -100,7 +100,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L325">api_types.ts:325</a></li>
+									<li>Defined in api_types.ts:325</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -126,7 +126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328">api_types.ts:328</a></li>
+									<li>Defined in api_types.ts:328</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L326">api_types.ts:326</a></li>
+									<li>Defined in api_types.ts:326</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -178,7 +178,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324">api_types.ts:324</a></li>
+									<li>Defined in api_types.ts:324</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L327">api_types.ts:327</a></li>
+									<li>Defined in api_types.ts:327</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/MetadataFormulaObjectResultType.html
+++ b/docs/interfaces/MetadataFormulaObjectResultType.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">display<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L661">api.ts:661</a></li>
+							<li>Defined in api.ts:661</li>
 						</ul>
 					</aside>
 				</section>
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Children<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L663">api.ts:663</a></li>
+							<li>Defined in api.ts:663</li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L662">api.ts:662</a></li>
+							<li>Defined in api.ts:662</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/Network.html
+++ b/docs/interfaces/Network.html
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">connection<span class="tsd-signature-symbol">:</span> <a href="../enums/NetworkConnection.html" class="tsd-signature-type" data-tsd-kind="Enumeration">NetworkConnection</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277">api_types.ts:277</a></li>
+							<li>Defined in api_types.ts:277</li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Side<wbr>Effect<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275">api_types.ts:275</a></li>
+							<li>Defined in api_types.ts:275</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">requires<wbr>Connection<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L276">api_types.ts:276</a></li>
+							<li>Defined in api_types.ts:276</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/NumberSchema.html
+++ b/docs/interfaces/NumberSchema.html
@@ -113,7 +113,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueHintType.html#Date" class="tsd-signature-type" data-tsd-kind="Enumeration member">Date</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#Time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#DateTime" class="tsd-signature-type" data-tsd-kind="Enumeration member">DateTime</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#Percent" class="tsd-signature-type" data-tsd-kind="Enumeration member">Percent</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#Currency" class="tsd-signature-type" data-tsd-kind="Enumeration member">Currency</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#Slider" class="tsd-signature-type" data-tsd-kind="Enumeration member">Slider</a><span class="tsd-signature-symbol"> | </span><a href="../enums/ValueHintType.html#Scale" class="tsd-signature-type" data-tsd-kind="Enumeration member">Scale</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L84">schema.ts:84</a></li>
+							<li>Defined in schema.ts:84</li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueType.html#Number" class="tsd-signature-type" data-tsd-kind="Enumeration member">Number</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in schema.ts:83</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/NumericSchema.html
+++ b/docs/interfaces/NumericSchema.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#codaType">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L88">schema.ts:88</a></li>
+							<li>Defined in schema.ts:88</li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">precision<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L89">schema.ts:89</a></li>
+							<li>Defined in schema.ts:89</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in schema.ts:83</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">use<wbr>Thousands<wbr>Separator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L90">schema.ts:90</a></li>
+							<li>Defined in schema.ts:90</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/OAuth2Authentication.html
+++ b/docs/interfaces/OAuth2Authentication.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">additional<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L249">types.ts:249</a></li>
+							<li>Defined in types.ts:249</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">authorization<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L245">types.ts:245</a></li>
+							<li>Defined in types.ts:245</li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.defaultConnectionType</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L158">types.ts:158</a></li>
+							<li>Defined in types.ts:158</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.endpointDomain</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L180">types.ts:180</a></li>
+							<li>Defined in types.ts:180</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -176,7 +176,7 @@
 					<div class="tsd-signature tsd-kind-icon">endpoint<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L253">types.ts:253</a></li>
+							<li>Defined in types.ts:253</li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L150">types.ts:150</a></li>
+							<li>Defined in types.ts:150</li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionUserId</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L151">types.ts:151</a></li>
+							<li>Defined in types.ts:151</li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.instructionsUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L163">types.ts:163</a></li>
+							<li>Defined in types.ts:163</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -225,7 +225,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.postSetup</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L186">types.ts:186</a></li>
+							<li>Defined in types.ts:186</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.requiresEndpointUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L171">types.ts:171</a></li>
+							<li>Defined in types.ts:171</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">scopes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L247">types.ts:247</a></li>
+							<li>Defined in types.ts:247</li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L248">types.ts:248</a></li>
+							<li>Defined in types.ts:248</li>
 						</ul>
 					</aside>
 				</section>
@@ -280,7 +280,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Query<wbr>Param<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L256">types.ts:256</a></li>
+							<li>Defined in types.ts:256</li>
 						</ul>
 					</aside>
 				</section>
@@ -290,7 +290,7 @@
 					<div class="tsd-signature tsd-kind-icon">token<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L246">types.ts:246</a></li>
+							<li>Defined in types.ts:246</li>
 						</ul>
 					</aside>
 				</section>
@@ -300,7 +300,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/AuthenticationType.html#OAuth2" class="tsd-signature-type" data-tsd-kind="Enumeration member">OAuth2</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L244">types.ts:244</a></li>
+							<li>Defined in types.ts:244</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ObjectSchema.html
+++ b/docs/interfaces/ObjectSchema.html
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.codaType</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L193">schema.ts:193</a></li>
+							<li>Defined in schema.ts:193</li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.featured</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L194">schema.ts:194</a></li>
+							<li>Defined in schema.ts:194</li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.id</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L191">schema.ts:191</a></li>
+							<li>Defined in schema.ts:191</li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides ObjectSchemaDefinition.identity</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L199">schema.ts:199</a></li>
+							<li>Defined in schema.ts:199</li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.primary</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L192">schema.ts:192</a></li>
+							<li>Defined in schema.ts:192</li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.properties</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L190">schema.ts:190</a></li>
+							<li>Defined in schema.ts:190</li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ObjectSchemaDefinition.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L189">schema.ts:189</a></li>
+							<li>Defined in schema.ts:189</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ObjectSchemaProperty.html
+++ b/docs/interfaces/ObjectSchemaProperty.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">from<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L166">schema.ts:166</a></li>
+							<li>Defined in schema.ts:166</li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L167">schema.ts:167</a></li>
+							<li>Defined in schema.ts:167</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackDefinition.html
+++ b/docs/interfaces/PackDefinition.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">category<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">PackCategory</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L450">types.ts:450</a></li>
+							<li>Defined in types.ts:450</li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#defaultAuthentication">defaultAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L423">types.ts:423</a></li>
+							<li>Defined in types.ts:423</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L448">types.ts:448</a></li>
+							<li>Defined in types.ts:448</li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">enabled<wbr>Config<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L452">types.ts:452</a></li>
+							<li>Defined in types.ts:452</li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Images<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L453">types.ts:453</a></li>
+							<li>Defined in types.ts:453</li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">example<wbr>Video<wbr>Ids<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L454">types.ts:454</a></li>
+							<li>Defined in types.ts:454</li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formats">formats</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L434">types.ts:434</a></li>
+							<li>Defined in types.ts:434</li>
 						</ul>
 					</aside>
 				</section>
@@ -207,7 +207,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formulaNamespace">formulaNamespace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L432">types.ts:432</a></li>
+							<li>Defined in types.ts:432</li>
 						</ul>
 					</aside>
 				</section>
@@ -218,7 +218,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#formulas">formulas</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L433">types.ts:433</a></li>
+							<li>Defined in types.ts:433</li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L445">types.ts:445</a></li>
+							<li>Defined in types.ts:445</li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<div class="tsd-signature tsd-kind-icon">is<wbr>System<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L461">types.ts:461</a></li>
+							<li>Defined in types.ts:461</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -253,7 +253,7 @@
 					<div class="tsd-signature tsd-kind-icon">logo<wbr>Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L451">types.ts:451</a></li>
+							<li>Defined in types.ts:451</li>
 						</ul>
 					</aside>
 				</section>
@@ -263,7 +263,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimum<wbr>Feature<wbr>Set<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">FeatureSet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L455">types.ts:455</a></li>
+							<li>Defined in types.ts:455</li>
 						</ul>
 					</aside>
 				</section>
@@ -273,7 +273,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L446">types.ts:446</a></li>
+							<li>Defined in types.ts:446</li>
 						</ul>
 					</aside>
 				</section>
@@ -284,7 +284,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#networkDomains">networkDomains</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L429">types.ts:429</a></li>
+							<li>Defined in types.ts:429</li>
 						</ul>
 					</aside>
 				</section>
@@ -294,7 +294,7 @@
 					<div class="tsd-signature tsd-kind-icon">permissions<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L449">types.ts:449</a></li>
+							<li>Defined in types.ts:449</li>
 						</ul>
 					</aside>
 				</section>
@@ -304,7 +304,7 @@
 					<div class="tsd-signature tsd-kind-icon">quotas<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{ </span>Basic<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Enterprise<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Pro<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span>Team<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L456">types.ts:456</a></li>
+							<li>Defined in types.ts:456</li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<div class="tsd-signature tsd-kind-icon">rate<wbr>Limits<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RateLimits</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L457">types.ts:457</a></li>
+							<li>Defined in types.ts:457</li>
 						</ul>
 					</aside>
 				</section>
@@ -324,7 +324,7 @@
 					<div class="tsd-signature tsd-kind-icon">short<wbr>Description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L447">types.ts:447</a></li>
+							<li>Defined in types.ts:447</li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#syncTables">syncTables</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L435">types.ts:435</a></li>
+							<li>Defined in types.ts:435</li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#systemConnectionAuthentication">systemConnectionAuthentication</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L428">types.ts:428</a></li>
+							<li>Defined in types.ts:428</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="PackVersionDefinition.html">PackVersionDefinition</a>.<a href="PackVersionDefinition.html#version">version</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L419">types.ts:419</a></li>
+							<li>Defined in types.ts:419</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackFormatMetadata.html
+++ b/docs/interfaces/PackFormatMetadata.html
@@ -104,7 +104,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L357">types.ts:357</a></li>
+							<li>Defined in types.ts:357</li>
 						</ul>
 					</aside>
 				</section>
@@ -115,7 +115,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.formulaNamespace</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L356">types.ts:356</a></li>
+							<li>Defined in types.ts:356</li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.hasNoConnection</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L359">types.ts:359</a></li>
+							<li>Defined in types.ts:359</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.instructions</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L360">types.ts:360</a></li>
+							<li>Defined in types.ts:360</li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">matchers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L27">compiled_types.ts:27</a></li>
+							<li>Defined in compiled_types.ts:27</li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L355">types.ts:355</a></li>
+							<li>Defined in types.ts:355</li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Omit.placeholder</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L362">types.ts:362</a></li>
+							<li>Defined in types.ts:362</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/PackFormulaDef.html
+++ b/docs/interfaces/PackFormulaDef.html
@@ -126,7 +126,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.cacheTtlSecs</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235">api_types.ts:235</a></li>
+							<li>Defined in api_types.ts:235</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.connectionRequirement</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227">api_types.ts:227</a></li>
+							<li>Defined in api_types.ts:227</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L201">api_types.ts:201</a></li>
+							<li>Defined in api_types.ts:201</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.examples</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L216">api_types.ts:216</a></li>
+							<li>Defined in api_types.ts:216</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.extraOAuthScopes</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257">api_types.ts:257</a></li>
+							<li>Defined in api_types.ts:257</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isAction</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222">api_types.ts:222</a></li>
+							<li>Defined in api_types.ts:222</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isExperimental</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241">api_types.ts:241</a></li>
+							<li>Defined in api_types.ts:241</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.isSystem</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247">api_types.ts:247</a></li>
+							<li>Defined in api_types.ts:247</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -262,7 +262,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L196">api_types.ts:196</a></li>
+							<li>Defined in api_types.ts:196</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -278,7 +278,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.network</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L230">api_types.ts:230</a></li>
+							<li>Defined in api_types.ts:230</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.parameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L206">api_types.ts:206</a></li>
+							<li>Defined in api_types.ts:206</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -312,7 +312,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CommonPackFormulaDef.varargParameters</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L211">api_types.ts:211</a></li>
+							<li>Defined in api_types.ts:211</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L356">api.ts:356</a></li>
+									<li>Defined in api.ts:356</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/PackVersionDefinition.html
+++ b/docs/interfaces/PackVersionDefinition.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#Authentication" class="tsd-signature-type" data-tsd-kind="Type alias">Authentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L423">types.ts:423</a></li>
+							<li>Defined in types.ts:423</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -127,7 +127,7 @@
 					<div class="tsd-signature tsd-kind-icon">formats<span class="tsd-signature-symbol">:</span> <a href="Format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L434">types.ts:434</a></li>
+							<li>Defined in types.ts:434</li>
 						</ul>
 					</aside>
 				</section>
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">formula<wbr>Namespace<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L432">types.ts:432</a></li>
+							<li>Defined in types.ts:432</li>
 						</ul>
 					</aside>
 				</section>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">formulas<span class="tsd-signature-symbol">:</span> <a href="PackFormulas.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulas</a><span class="tsd-signature-symbol"> | </span><a href="../modules.html#Formula" class="tsd-signature-type" data-tsd-kind="Type alias">Formula</a><span class="tsd-signature-symbol">&lt;</span><a href="../modules.html#ParamDefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L433">types.ts:433</a></li>
+							<li>Defined in types.ts:433</li>
 						</ul>
 					</aside>
 				</section>
@@ -157,7 +157,7 @@
 					<div class="tsd-signature tsd-kind-icon">network<wbr>Domains<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L429">types.ts:429</a></li>
+							<li>Defined in types.ts:429</li>
 						</ul>
 					</aside>
 				</section>
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">sync<wbr>Tables<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncTable</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L435">types.ts:435</a></li>
+							<li>Defined in types.ts:435</li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">system<wbr>Connection<wbr>Authentication<span class="tsd-signature-symbol">:</span> <a href="../modules.html#SystemAuthentication" class="tsd-signature-type" data-tsd-kind="Type alias">SystemAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L428">types.ts:428</a></li>
+							<li>Defined in types.ts:428</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L419">types.ts:419</a></li>
+							<li>Defined in types.ts:419</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/ParamDef.html
+++ b/docs/interfaces/ParamDef.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">autocomplete<span class="tsd-signature-symbol">:</span> <a href="../modules.html#MetadataFormula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L164">api_types.ts:164</a></li>
+							<li>Defined in api_types.ts:164</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Value<span class="tsd-signature-symbol">:</span> <a href="../modules.html#DefaultValueType" class="tsd-signature-type" data-tsd-kind="Type alias">DefaultValueType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L168">api_types.ts:168</a></li>
+							<li>Defined in api_types.ts:168</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 					<div class="tsd-signature tsd-kind-icon">description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L145">api_types.ts:145</a></li>
+							<li>Defined in api_types.ts:145</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">hidden<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L151">api_types.ts:151</a></li>
+							<li>Defined in api_types.ts:151</li>
 						</ul>
 					</aside>
 				</section>
@@ -168,7 +168,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L137">api_types.ts:137</a></li>
+							<li>Defined in api_types.ts:137</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">optional<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L150">api_types.ts:150</a></li>
+							<li>Defined in api_types.ts:150</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L141">api_types.ts:141</a></li>
+							<li>Defined in api_types.ts:141</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/ScaleSchema.html
+++ b/docs/interfaces/ScaleSchema.html
@@ -102,7 +102,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#codaType">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L114">schema.ts:114</a></li>
+							<li>Defined in schema.ts:114</li>
 						</ul>
 					</aside>
 				</section>
@@ -113,7 +113,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L116">schema.ts:116</a></li>
+							<li>Defined in schema.ts:116</li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L115">schema.ts:115</a></li>
+							<li>Defined in schema.ts:115</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in schema.ts:83</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SimpleAutocompleteOption.html
+++ b/docs/interfaces/SimpleAutocompleteOption.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">display<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L712">api.ts:712</a></li>
+							<li>Defined in api.ts:712</li>
 						</ul>
 					</aside>
 				</section>
@@ -103,7 +103,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L713">api.ts:713</a></li>
+							<li>Defined in api.ts:713</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SliderSchema.html
+++ b/docs/interfaces/SliderSchema.html
@@ -103,7 +103,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#codaType">codaType</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L107">schema.ts:107</a></li>
+							<li>Defined in schema.ts:107</li>
 						</ul>
 					</aside>
 				</section>
@@ -114,7 +114,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#description">description</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -124,7 +124,7 @@
 					<div class="tsd-signature tsd-kind-icon">maximum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L109">schema.ts:109</a></li>
+							<li>Defined in schema.ts:109</li>
 						</ul>
 					</aside>
 				</section>
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">minimum<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L108">schema.ts:108</a></li>
+							<li>Defined in schema.ts:108</li>
 						</ul>
 					</aside>
 				</section>
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">step<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L110">schema.ts:110</a></li>
+							<li>Defined in schema.ts:110</li>
 						</ul>
 					</aside>
 				</section>
@@ -155,7 +155,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="NumberSchema.html">NumberSchema</a>.<a href="NumberSchema.html#type">type</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L83">schema.ts:83</a></li>
+							<li>Defined in schema.ts:83</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/StringSchema.html
+++ b/docs/interfaces/StringSchema.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L157">schema.ts:157</a></li>
+							<li>Defined in schema.ts:157</li>
 						</ul>
 					</aside>
 				</section>
@@ -123,7 +123,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueType.html#String" class="tsd-signature-type" data-tsd-kind="Enumeration member">String</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L156">schema.ts:156</a></li>
+							<li>Defined in schema.ts:156</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SyncExecutionContext.html
+++ b/docs/interfaces/SyncExecutionContext.html
@@ -105,7 +105,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#endpoint">endpoint</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340">api_types.ts:340</a></li>
+							<li>Defined in api_types.ts:340</li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#fetcher">fetcher</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L337">api_types.ts:337</a></li>
+							<li>Defined in api_types.ts:337</li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#invocationLocation">invocationLocation</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L341">api_types.ts:341</a></li>
+							<li>Defined in api_types.ts:341</li>
 						</ul>
 					</aside>
 				</section>
@@ -138,7 +138,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#invocationToken">invocationToken</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L346">api_types.ts:346</a></li>
+							<li>Defined in api_types.ts:346</li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#logger">logger</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L339">api_types.ts:339</a></li>
+							<li>Defined in api_types.ts:339</li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#sync">sync</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L351">api_types.ts:351</a></li>
+							<li>Defined in api_types.ts:351</li>
 						</ul>
 					</aside>
 				</section>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#temporaryBlobStorage">temporaryBlobStorage</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338">api_types.ts:338</a></li>
+							<li>Defined in api_types.ts:338</li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="ExecutionContext.html">ExecutionContext</a>.<a href="ExecutionContext.html#timezone">timezone</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L342">api_types.ts:342</a></li>
+							<li>Defined in api_types.ts:342</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SyncFormulaResult.html
+++ b/docs/interfaces/SyncFormulaResult.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">continuation<span class="tsd-signature-symbol">:</span> <a href="Continuation.html" class="tsd-signature-type" data-tsd-kind="Interface">Continuation</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L436">api.ts:436</a></li>
+							<li>Defined in api.ts:436</li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ResultT</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L435">api.ts:435</a></li>
+							<li>Defined in api.ts:435</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/SyncTableDef.html
+++ b/docs/interfaces/SyncTableDef.html
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">entity<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L118">api.ts:118</a></li>
+							<li>Defined in api.ts:118</li>
 						</ul>
 					</aside>
 				</section>
@@ -136,7 +136,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<wbr>Schema<span class="tsd-signature-symbol">:</span> <a href="../modules.html#MetadataFormula" class="tsd-signature-type" data-tsd-kind="Type alias">MetadataFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L117">api.ts:117</a></li>
+							<li>Defined in api.ts:117</li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">getter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">L</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">SchemaT</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L116">api.ts:116</a></li>
+							<li>Defined in api.ts:116</li>
 						</ul>
 					</aside>
 				</section>
@@ -156,7 +156,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L114">api.ts:114</a></li>
+							<li>Defined in api.ts:114</li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 					<div class="tsd-signature tsd-kind-icon">schema<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SchemaT</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L115">api.ts:115</a></li>
+							<li>Defined in api.ts:115</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/TemporaryBlobStorage.html
+++ b/docs/interfaces/TemporaryBlobStorage.html
@@ -97,7 +97,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L312">api_types.ts:312</a></li>
+									<li>Defined in api_types.ts:312</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311">api_types.ts:311</a></li>
+									<li>Defined in api_types.ts:311</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/TimeSchema.html
+++ b/docs/interfaces/TimeSchema.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">coda<wbr>Type<span class="tsd-signature-symbol">:</span> <a href="../enums/ValueHintType.html#Time" class="tsd-signature-type" data-tsd-kind="Enumeration member">Time</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L130">schema.ts:130</a></li>
+							<li>Defined in schema.ts:130</li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.description</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L75">schema.ts:75</a></li>
+							<li>Defined in schema.ts:75</li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">format<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L132">schema.ts:132</a></li>
+							<li>Defined in schema.ts:132</li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseDateSchema.type</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L120">schema.ts:120</a></li>
+							<li>Defined in schema.ts:120</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/VariousAuthentication.html
+++ b/docs/interfaces/VariousAuthentication.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Various</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L276">types.ts:276</a></li>
+							<li>Defined in types.ts:276</li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/WebBasicAuthentication.html
+++ b/docs/interfaces/WebBasicAuthentication.html
@@ -106,7 +106,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.defaultConnectionType</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L158">types.ts:158</a></li>
+							<li>Defined in types.ts:158</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -124,7 +124,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.endpointDomain</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L180">types.ts:180</a></li>
+							<li>Defined in types.ts:180</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionName</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L150">types.ts:150</a></li>
+							<li>Defined in types.ts:150</li>
 						</ul>
 					</aside>
 				</section>
@@ -154,7 +154,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.getConnectionUserId</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L151">types.ts:151</a></li>
+							<li>Defined in types.ts:151</li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.instructionsUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L163">types.ts:163</a></li>
+							<li>Defined in types.ts:163</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.postSetup</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L186">types.ts:186</a></li>
+							<li>Defined in types.ts:186</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -198,7 +198,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from BaseAuthentication.requiresEndpointUrl</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L171">types.ts:171</a></li>
+							<li>Defined in types.ts:171</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <a href="../enums/AuthenticationType.html#WebBasic" class="tsd-signature-type" data-tsd-kind="Enumeration member">WebBasic</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L260">types.ts:260</a></li>
+							<li>Defined in types.ts:260</li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">ux<wbr>Config<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>placeholderPassword<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>placeholderUsername<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>usernameOnly<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L261">types.ts:261</a></li>
+							<li>Defined in types.ts:261</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/VariousAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">VariousAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CodaApiBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/OAuth2Authentication.html" class="tsd-signature-type" data-tsd-kind="Interface">OAuth2Authentication</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L279">types.ts:279</a></li>
+							<li>Defined in types.ts:279</li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">Basic<wbr>Pack<wbr>Definition<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/PackVersionDefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackVersionDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;version&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L412">types.ts:412</a></li>
+							<li>Defined in types.ts:412</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">Default<wbr>Value<wbr>Type&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/ArrayType.html" class="tsd-signature-type" data-tsd-kind="Interface">ArrayType</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/Type.html#date" class="tsd-signature-type" data-tsd-kind="Enumeration member">date</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="enums/PrecannedDateRange.html" class="tsd-signature-type" data-tsd-kind="Enumeration">PrecannedDateRange</a><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L188">api_types.ts:188</a></li>
+							<li>Defined in api_types.ts:188</li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Object<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ObjectPackFormulaMetadata</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L83">compiled_types.ts:83</a></li>
+							<li>Defined in compiled_types.ts:83</li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Format<span class="tsd-signature-symbol">:</span> <a href="interfaces/Format.html" class="tsd-signature-type" data-tsd-kind="Interface">Format</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L85">compiled_types.ts:85</a></li>
+							<li>Defined in compiled_types.ts:85</li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Format<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="interfaces/PackFormatMetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormatMetadata</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L86">compiled_types.ts:86</a></li>
+							<li>Defined in compiled_types.ts:86</li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <a href="modules.html#PackFormulaMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L84">compiled_types.ts:84</a></li>
+							<li>Defined in compiled_types.ts:84</li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Formulas<span class="tsd-signature-symbol">:</span> <a href="interfaces/PackFormulasMetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulasMetadata</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#PackFormulaMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L82">compiled_types.ts:82</a></li>
+							<li>Defined in compiled_types.ts:82</li>
 						</ul>
 					</aside>
 				</section>
@@ -307,7 +307,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Pack<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="interfaces/ExternalPackVersionMetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">ExternalPackVersionMetadata</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="modules.html#PackMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackMetadata</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;id&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;name&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;shortDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;description&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;permissionsDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;category&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;logoPath&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleImages&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleVideoIds&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;minimumFeatureSet&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;quotas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;rateLimits&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;isSystem&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L114">compiled_types.ts:114</a></li>
+							<li>Defined in compiled_types.ts:114</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -322,7 +322,7 @@
 					<div class="tsd-signature tsd-kind-icon">External<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="modules.html#PackSyncTable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L87">compiled_types.ts:87</a></li>
+							<li>Defined in compiled_types.ts:87</li>
 						</ul>
 					</aside>
 				</section>
@@ -332,7 +332,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fetch<wbr>Method<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">typeof </span><span class="tsd-signature-type">ValidFetchMethods</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282">api_types.ts:282</a></li>
+							<li>Defined in api_types.ts:282</li>
 						</ul>
 					</aside>
 				</section>
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">Formula&lt;ParamDefsT&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NumericPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">StringPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">BooleanPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">ObjectPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">, </span><a href="modules.html#Schema" class="tsd-signature-type" data-tsd-kind="Type alias">Schema</a><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L411">api.ts:411</a></li>
+							<li>Defined in api.ts:411</li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -358,7 +358,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Dynamic<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="interfaces/DynamicSyncTableDef.html" class="tsd-signature-type" data-tsd-kind="Interface">DynamicSyncTableDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#ParamDefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L188">api.ts:188</a></li>
+							<li>Defined in api.ts:188</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -375,7 +375,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Object<wbr>Schema<span class="tsd-signature-symbol">:</span> <a href="interfaces/ObjectSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">ObjectSchema</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L174">schema.ts:174</a></li>
+							<li>Defined in schema.ts:174</li>
 						</ul>
 					</aside>
 				</section>
@@ -385,7 +385,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SyncFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#ParamDefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L170">api.ts:170</a></li>
+							<li>Defined in api.ts:170</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -402,7 +402,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Formula<wbr>Result<span class="tsd-signature-symbol">:</span> <a href="interfaces/SyncFormulaResult.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncFormulaResult</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L176">api.ts:176</a></li>
+							<li>Defined in api.ts:176</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -419,7 +419,7 @@
 					<div class="tsd-signature tsd-kind-icon">Generic<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <a href="interfaces/SyncTableDef.html" class="tsd-signature-type" data-tsd-kind="Interface">SyncTableDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><a href="modules.html#ParamDefs" class="tsd-signature-type" data-tsd-kind="Type alias">ParamDefs</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L182">api.ts:182</a></li>
+							<li>Defined in api.ts:182</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -436,7 +436,7 @@
 					<div class="tsd-signature tsd-kind-icon">Logger<wbr>Param<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L321">api_types.ts:321</a></li>
+							<li>Defined in api_types.ts:321</li>
 						</ul>
 					</aside>
 				</section>
@@ -446,7 +446,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Context<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L672">api.ts:672</a></li>
+							<li>Defined in api.ts:672</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -464,7 +464,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Formula<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ObjectPackFormula</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">[</span><a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/Type.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">string</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><a href="enums/Type.html#string" class="tsd-signature-type" data-tsd-kind="Enumeration member">string</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L675">api.ts:675</a></li>
+							<li>Defined in api.ts:675</li>
 						</ul>
 					</aside>
 				</section>
@@ -474,7 +474,7 @@
 					<div class="tsd-signature tsd-kind-icon">Metadata<wbr>Formula<wbr>Result<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/MetadataFormulaObjectResultType.html" class="tsd-signature-type" data-tsd-kind="Interface">MetadataFormulaObjectResultType</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L674">api.ts:674</a></li>
+							<li>Defined in api.ts:674</li>
 						</ul>
 					</aside>
 				</section>
@@ -484,7 +484,7 @@
 					<div class="tsd-signature tsd-kind-icon">Object<wbr>Schema<wbr>Properties&lt;K&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K2</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="modules.html#Schema" class="tsd-signature-type" data-tsd-kind="Type alias">Schema</a><span class="tsd-signature-symbol"> &amp; </span><a href="interfaces/ObjectSchemaProperty.html" class="tsd-signature-type" data-tsd-kind="Interface">ObjectSchemaProperty</a><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L170">schema.ts:170</a></li>
+							<li>Defined in schema.ts:170</li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -500,7 +500,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="modules.html#TypedPackFormula" class="tsd-signature-type" data-tsd-kind="Type alias">TypedPackFormula</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;execute&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L420">api.ts:420</a></li>
+							<li>Defined in api.ts:420</li>
 						</ul>
 					</aside>
 				</section>
@@ -510,7 +510,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Result<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TypeMap</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="modules.html#PackFormulaResult" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaResult</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L71">api_types.ts:71</a></li>
+							<li>Defined in api_types.ts:71</li>
 						</ul>
 					</aside>
 				</section>
@@ -520,7 +520,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Formula<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TypeMap</span><span class="tsd-signature-symbol">, </span><a href="enums/Type.html#object" class="tsd-signature-type" data-tsd-kind="Enumeration member">object</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="modules.html#PackFormulaValue" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaValue</a><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L70">api_types.ts:70</a></li>
+							<li>Defined in api_types.ts:70</li>
 						</ul>
 					</aside>
 				</section>
@@ -530,7 +530,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L8">types.ts:8</a></li>
+							<li>Defined in types.ts:8</li>
 						</ul>
 					</aside>
 				</section>
@@ -540,7 +540,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Metadata<span class="tsd-signature-symbol">:</span> <a href="modules.html#PackVersionMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackVersionMetadata</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/PackDefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;id&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;name&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;shortDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;description&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;permissionsDescription&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;category&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;logoPath&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleImages&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;exampleVideoIds&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;minimumFeatureSet&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;quotas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;rateLimits&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;enabledConfigName&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;isSystem&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L60">compiled_types.ts:60</a></li>
+							<li>Defined in compiled_types.ts:60</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -555,7 +555,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Sync<wbr>Table<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">SyncTable</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;getter&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getName&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getSchema&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;listDynamicUrls&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;getDisplayUrl&quot;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>getDisplayUrl<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getName<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getSchema<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol">; </span>getter<span class="tsd-signature-symbol">: </span><a href="modules.html#PackFormulaMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">; </span>hasDynamicSchema<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>isDynamic<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span>listDynamicUrls<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">MetadataFormulaMetadata</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L13">compiled_types.ts:13</a></li>
+							<li>Defined in compiled_types.ts:13</li>
 						</ul>
 					</aside>
 				</section>
@@ -565,7 +565,7 @@
 					<div class="tsd-signature tsd-kind-icon">Pack<wbr>Version<wbr>Metadata<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="interfaces/PackVersionDefinition.html" class="tsd-signature-type" data-tsd-kind="Interface">PackVersionDefinition</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;formulas&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;formats&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;defaultAuthentication&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;syncTables&quot;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>defaultAuthentication<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">AuthenticationMetadata</span><span class="tsd-signature-symbol">; </span>formats<span class="tsd-signature-symbol">: </span><a href="interfaces/PackFormatMetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormatMetadata</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>formulas<span class="tsd-signature-symbol">: </span><a href="interfaces/PackFormulasMetadata.html" class="tsd-signature-type" data-tsd-kind="Interface">PackFormulasMetadata</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#PackFormulaMetadata" class="tsd-signature-type" data-tsd-kind="Type alias">PackFormulaMetadata</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">; </span>syncTables<span class="tsd-signature-symbol">: </span><a href="modules.html#PackSyncTable" class="tsd-signature-type" data-tsd-kind="Type alias">PackSyncTable</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/compiled_types.ts#L48">compiled_types.ts:48</a></li>
+							<li>Defined in compiled_types.ts:48</li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -580,7 +580,7 @@
 					<div class="tsd-signature tsd-kind-icon">Param<wbr>Defs<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">[</span><a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">...</span><a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L173">api_types.ts:173</a></li>
+							<li>Defined in api_types.ts:173</li>
 						</ul>
 					</aside>
 				</section>
@@ -590,7 +590,7 @@
 					<div class="tsd-signature tsd-kind-icon">Param<wbr>Values&lt;ParamDefsT&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ParamDefsT</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">infer </span> T<span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">TypeOfMap</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L183">api_types.ts:183</a></li>
+							<li>Defined in api_types.ts:183</li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -606,7 +606,7 @@
 					<div class="tsd-signature tsd-kind-icon">Params<wbr>List<span class="tsd-signature-symbol">:</span> <a href="interfaces/ParamDef.html" class="tsd-signature-type" data-tsd-kind="Interface">ParamDef</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnionType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api_types.ts#L175">api_types.ts:175</a></li>
+							<li>Defined in api_types.ts:175</li>
 						</ul>
 					</aside>
 				</section>
@@ -616,7 +616,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schema<span class="tsd-signature-symbol">:</span> <a href="interfaces/BooleanSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">BooleanSchema</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/NumberSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">NumberSchema</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/StringSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">StringSchema</a><span class="tsd-signature-symbol"> | </span><a href="interfaces/ArraySchema.html" class="tsd-signature-type" data-tsd-kind="Interface">ArraySchema</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#GenericObjectSchema" class="tsd-signature-type" data-tsd-kind="Type alias">GenericObjectSchema</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L230">schema.ts:230</a></li>
+							<li>Defined in schema.ts:230</li>
 						</ul>
 					</aside>
 				</section>
@@ -626,7 +626,7 @@
 					<div class="tsd-signature tsd-kind-icon">Schema<wbr>Type&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/BooleanSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">BooleanSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/NumberSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">NumberSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/StringSchema.html" class="tsd-signature-type" data-tsd-kind="Interface">StringSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">StringHintTypeToSchemaType</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;codaType&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="interfaces/ArraySchema.html" class="tsd-signature-type" data-tsd-kind="Interface">ArraySchema</a><span class="tsd-signature-symbol"> ? </span><a href="modules.html#SchemaType" class="tsd-signature-type" data-tsd-kind="Type alias">SchemaType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;items&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol"> extends </span><a href="modules.html#GenericObjectSchema" class="tsd-signature-type" data-tsd-kind="Type alias">GenericObjectSchema</a><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">PickOptional</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="modules.html#SchemaType" class="tsd-signature-type" data-tsd-kind="Type alias">SchemaType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">$Values</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">&quot;properties&quot;</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> extends </span><span class="tsd-signature-symbol">{ </span>required<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">never</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L249">schema.ts:249</a></li>
+							<li>Defined in schema.ts:249</li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -642,7 +642,7 @@
 					<div class="tsd-signature tsd-kind-icon">System<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">AWSSignature4Authentication</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L326">types.ts:326</a></li>
+							<li>Defined in types.ts:326</li>
 						</ul>
 					</aside>
 				</section>
@@ -652,7 +652,7 @@
 					<div class="tsd-signature tsd-kind-icon">Typed<wbr>Pack<wbr>Formula<span class="tsd-signature-symbol">:</span> <a href="modules.html#Formula" class="tsd-signature-type" data-tsd-kind="Type alias">Formula</a><span class="tsd-signature-symbol"> | </span><a href="modules.html#GenericSyncFormula" class="tsd-signature-type" data-tsd-kind="Type alias">GenericSyncFormula</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L417">api.ts:417</a></li>
+							<li>Defined in api.ts:417</li>
 						</ul>
 					</aside>
 				</section>
@@ -662,7 +662,7 @@
 					<div class="tsd-signature tsd-kind-icon">Various<wbr>Supported<wbr>Authentication<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">NoAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HeaderBearerTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">CustomHeaderTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">QueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">MultiQueryParamTokenAuthentication</span><span class="tsd-signature-symbol"> | </span><a href="interfaces/WebBasicAuthentication.html" class="tsd-signature-type" data-tsd-kind="Interface">WebBasicAuthentication</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/types.ts#L344">types.ts:344</a></li>
+							<li>Defined in types.ts:344</li>
 						</ul>
 					</aside>
 				</section>
@@ -679,7 +679,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L25">helpers/ensure.ts:25</a></li>
+									<li>Defined in helpers/ensure.ts:25</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -705,7 +705,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L737">api.ts:737</a></li>
+									<li>Defined in api.ts:737</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -743,7 +743,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L14">helpers/ensure.ts:14</a></li>
+									<li>Defined in helpers/ensure.ts:14</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -775,7 +775,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L7">helpers/ensure.ts:7</a></li>
+									<li>Defined in helpers/ensure.ts:7</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -801,7 +801,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/ensure.ts#L3">helpers/ensure.ts:3</a></li>
+									<li>Defined in helpers/ensure.ts:3</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -827,7 +827,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L266">schema.ts:266</a></li>
+									<li>Defined in schema.ts:266</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -850,7 +850,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L17">helpers/url.ts:17</a></li>
+									<li>Defined in helpers/url.ts:17</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -878,7 +878,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L27">helpers/url.ts:27</a></li>
+									<li>Defined in helpers/url.ts:27</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -909,7 +909,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L226">schema.ts:226</a></li>
+									<li>Defined in schema.ts:226</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -938,7 +938,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L1009">api.ts:1009</a></li>
+									<li>Defined in api.ts:1009</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -999,7 +999,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L1089">api.ts:1089</a></li>
+									<li>Defined in api.ts:1089</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1028,7 +1028,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L530">api.ts:530</a></li>
+									<li>Defined in api.ts:530</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1101,7 +1101,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L684">api.ts:684</a></li>
+									<li>Defined in api.ts:684</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1132,7 +1132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L302">schema.ts:302</a></li>
+									<li>Defined in schema.ts:302</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1167,7 +1167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L229">api.ts:229</a></li>
+									<li>Defined in api.ts:229</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1209,7 +1209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L401">schema.ts:401</a></li>
+									<li>Defined in schema.ts:401</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1244,7 +1244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/schema.ts#L296">schema.ts:296</a></li>
+									<li>Defined in schema.ts:296</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1273,7 +1273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L754">api.ts:754</a></li>
+									<li>Defined in api.ts:754</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1296,7 +1296,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L928">api.ts:928</a></li>
+									<li>Defined in api.ts:928</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1350,7 +1350,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L1060">api.ts:1060</a></li>
+									<li>Defined in api.ts:1060</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -1382,7 +1382,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/builder.ts#L33">builder.ts:33</a></li>
+									<li>Defined in builder.ts:33</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1418,7 +1418,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/api.ts#L716">api.ts:716</a></li>
+									<li>Defined in api.ts:716</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1444,7 +1444,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/coda/packs-sdk/blob/main/helpers/url.ts#L5">helpers/url.ts:5</a></li>
+									<li>Defined in helpers/url.ts:5</li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,9 @@
+// Typedoc settings.
+// See: https://typedoc.org/guides/options/
+module.exports = {
+  excludeExternals: true,
+  excludePrivate: true,
+  excludeProtected: true,
+  gitRemote: 'git@github.com:coda/packs-sdk.git',
+  gitRevision: 'main',
+};


### PR DESCRIPTION
Will be adding more options as we move to MkDocs, and this makes them easier to manage. Also set the git remote via config, so you don't need to manually modify it when working off of a fork.