### PR TITLE
Fix the edit link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ artifacts
 dist/test
 yarn-error.log
 local-docs
+site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@
 site_name: Coda Packs SDK
 site_url: https://coda.github.io/packs-sdk/
 repo_url: https://github.com/coda/packs-sdk
+edit_uri: https://github.com/coda/packs-sdk/blob/main/docs
 docs_dir: docs
 extra_css:
   - assets/custom.css


### PR DESCRIPTION
The edit link was defaulting to the `master` branch instead of `main`. Also as per [notes in their guide](https://www.mkdocs.org/user-guide/configuration/#edit_uri), switched the edit link to `/blob` instead of `/edit` so that the user isn't forced into a GitHub login screen.