### PR TITLE
Fix Circle CI for gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,3 @@ workflows:
       - build:
           context:
             - dockerhub
-          filters:
-            branches:
-              ignore: gh-pages

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,10 @@ publish-docs:
 		echo "The documentation can only be published from main at head."; \
 		exit 1; \
 	fi
-	# Build the docs and push them to the gh-pages brance.
+	# Build the docs and push them to the gh-pages branch.
 	# See: https://www.mkdocs.org/user-guide/deploying-your-docs/#github-pages
-	${PIPENV} run mkdocs gh-deploy
+	# Including the tag "[ci skip]" in the commit message to prevent CircleCI from building the branch.
+	${PIPENV} run mkdocs gh-deploy --message "Deployed {sha} with MkDocs version: {version} [ci skip]"
 
 .PHONY: test
 test:


### PR DESCRIPTION
In PR #1363 I attempted to disable CircleCI on the gh-pages branch. That approach failed because that branch doesn't contain the `.circleci/config.yml` file, and so the build fails with "No configuration was found in your project". 

As per [this forum thread](https://discuss.circleci.com/t/no-config-found-builds-marked-as-failed/24912/2), the suggest approach is to append `[ci skip]` to the commit message, which can be done using the `--message` argument to `mkdocs deploy`.