### PR TITLE
Auto scroll to API settings when opening account settings via `coda register`

### DIFF
--- a/cli/register.ts
+++ b/cli/register.ts
@@ -21,7 +21,7 @@ export async function handleRegister({apiToken, codaApiEndpoint}: Arguments<Regi
     if (!shouldOpenBrowser.toLocaleLowerCase().startsWith('y')) {
       return process.exit(1);
     }
-    await open(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack`);
+    await open(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`);
     apiToken = promptForInput('Please paste the token here: ', {mask: true});
   }
 

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -20,7 +20,7 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
         if (!shouldOpenBrowser.toLocaleLowerCase().startsWith('y')) {
             return process.exit(1);
         }
-        await (0, open_1.default)(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack`);
+        await (0, open_1.default)(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`);
         apiToken = (0, helpers_4.promptForInput)('Please paste the token here: ', { mask: true });
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);

--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -100,7 +100,7 @@ The `coda` CLI uses the Coda API under the hood to upload your code, and likewis
 
 1. In the **Name** field enter "Hello World Pack" and then click **Generate API token**.
 
-1. Scroll down the page to the **Coda API tokens** section, find the token you just created, and click the **Copy token** link.
+1. In the **Coda API tokens** section, find the token you just created, and click the **Copy token** link.
 
 1. Switch back to your terminal, paste your token into the prompt, and hit enter.
 


### PR DESCRIPTION
Bug here: https://staging.coda.io/d/Packs-IA-go-packs_d36WK4zgrYx/My-Tasks_suDJO#View-of-My-Bugs_tu8_z/r196&modal=true

Our accounts page already has an abstraction that handles this! Tested by opening https://dev.coda.io:8080/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings. 

https://user-images.githubusercontent.com/79662144/134059447-9c451e45-10ca-40f6-a1b9-aefcb1588433.mov

