### PR TITLE
Improve search results

### DIFF
--- a/docs/reference/sdk/README.md
+++ b/docs/reference/sdk/README.md
@@ -1,3 +1,5 @@
+# @codahq/packs-sdk
+
 ## Enumerations
 
 - [AttributionNodeType](enums/AttributionNodeType.md)

--- a/docs/reference/sdk/classes/PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/PackDefinitionBuilder.md
@@ -1,3 +1,5 @@
+# Class: PackDefinitionBuilder
+
 ## Implements
 
 - [`BasicPackDefinition`](../types/BasicPackDefinition.md)

--- a/docs/reference/sdk/classes/StatusCodeError.md
+++ b/docs/reference/sdk/classes/StatusCodeError.md
@@ -1,3 +1,5 @@
+# Class: StatusCodeError
+
 StatusCodeError is a simple version of StatusCodeError in request-promise to keep backwards compatibility.
 This tries to replicate its exact structure, massaging as necessary to handle the various transforms
 in our stack.

--- a/docs/reference/sdk/classes/UserVisibleError.md
+++ b/docs/reference/sdk/classes/UserVisibleError.md
@@ -1,3 +1,5 @@
+# Class: UserVisibleError
+
 An error whose message will be shown to the end user in the UI when it occurs.
 If an error is encountered in a formula and you want to describe the error
 to the end user, throw a UserVisibleError with a user-friendly message

--- a/docs/reference/sdk/enums/AttributionNodeType.md
+++ b/docs/reference/sdk/enums/AttributionNodeType.md
@@ -1,3 +1,5 @@
+# Enumeration: AttributionNodeType
+
 ## Enumeration members
 
 ### Image

--- a/docs/reference/sdk/enums/AuthenticationType.md
+++ b/docs/reference/sdk/enums/AuthenticationType.md
@@ -1,3 +1,5 @@
+# Enumeration: AuthenticationType
+
 Authentication types supported by Coda Packs.
 
 ## Enumeration members

--- a/docs/reference/sdk/enums/ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/ConnectionRequirement.md
@@ -1,3 +1,5 @@
+# Enumeration: ConnectionRequirement
+
 ## Enumeration members
 
 ### None

--- a/docs/reference/sdk/enums/CurrencyFormat.md
+++ b/docs/reference/sdk/enums/CurrencyFormat.md
@@ -1,3 +1,5 @@
+# Enumeration: CurrencyFormat
+
 ## Enumeration members
 
 ### Accounting

--- a/docs/reference/sdk/enums/DefaultConnectionType.md
+++ b/docs/reference/sdk/enums/DefaultConnectionType.md
@@ -1,3 +1,5 @@
+# Enumeration: DefaultConnectionType
+
 Ways in which a user account can be used with a doc.
 
 ## Enumeration members

--- a/docs/reference/sdk/enums/DurationUnit.md
+++ b/docs/reference/sdk/enums/DurationUnit.md
@@ -1,3 +1,5 @@
+# Enumeration: DurationUnit
+
 ## Enumeration members
 
 ### Days

--- a/docs/reference/sdk/enums/NetworkConnection.md
+++ b/docs/reference/sdk/enums/NetworkConnection.md
@@ -1,3 +1,5 @@
+# Enumeration: NetworkConnection
+
 **`deprecated`** use `ConnectionRequirement` instead
 
 ## Enumeration members

--- a/docs/reference/sdk/enums/ParameterType.md
+++ b/docs/reference/sdk/enums/ParameterType.md
@@ -1,3 +1,5 @@
+# Enumeration: ParameterType
+
 ## Enumeration members
 
 ### Boolean

--- a/docs/reference/sdk/enums/PostSetupType.md
+++ b/docs/reference/sdk/enums/PostSetupType.md
@@ -1,3 +1,5 @@
+# Enumeration: PostSetupType
+
 Enumeration of post-account-setup step types. See {@link PostSetup}.
 
 ## Enumeration members

--- a/docs/reference/sdk/enums/PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/PrecannedDateRange.md
@@ -1,3 +1,5 @@
+# Enumeration: PrecannedDateRange
+
 ## Enumeration members
 
 ### Everything

--- a/docs/reference/sdk/enums/Type.md
+++ b/docs/reference/sdk/enums/Type.md
@@ -1,3 +1,5 @@
+# Enumeration: Type
+
 ## Enumeration members
 
 ### boolean

--- a/docs/reference/sdk/enums/ValueHintType.md
+++ b/docs/reference/sdk/enums/ValueHintType.md
@@ -1,3 +1,5 @@
+# Enumeration: ValueHintType
+
 Synthetic types that instruct Coda how to coerce values from primitives at ingestion time.
 
 ## Enumeration members

--- a/docs/reference/sdk/enums/ValueType.md
+++ b/docs/reference/sdk/enums/ValueType.md
@@ -1,3 +1,5 @@
+# Enumeration: ValueType
+
 The set of primitive value types that can be used as return values for formulas
 or in object schemas.
 

--- a/docs/reference/sdk/functions/assertCondition.md
+++ b/docs/reference/sdk/functions/assertCondition.md
@@ -1,3 +1,5 @@
+# Function: assertCondition
+
 ▸ **assertCondition**(`condition`, `message?`): asserts condition
 
 #### Parameters

--- a/docs/reference/sdk/functions/autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/autocompleteSearchObjects.md
@@ -1,3 +1,5 @@
+# Function: autocompleteSearchObjects
+
 ▸ **autocompleteSearchObjects**<`T`\>(`search`, `objs`, `displayKey`, `valueKey`): `Promise`<[`MetadataFormulaObjectResultType`](../interfaces/MetadataFormulaObjectResultType.md)[]\>
 
 #### Type parameters

--- a/docs/reference/sdk/functions/ensureExists.md
+++ b/docs/reference/sdk/functions/ensureExists.md
@@ -1,3 +1,5 @@
+# Function: ensureExists
+
 ▸ **ensureExists**<`T`\>(`value`, `message?`): `T`
 
 #### Type parameters

--- a/docs/reference/sdk/functions/ensureNonEmptyString.md
+++ b/docs/reference/sdk/functions/ensureNonEmptyString.md
@@ -1,3 +1,5 @@
+# Function: ensureNonEmptyString
+
 ▸ **ensureNonEmptyString**(`value`, `message?`): `string`
 
 #### Parameters

--- a/docs/reference/sdk/functions/ensureUnreachable.md
+++ b/docs/reference/sdk/functions/ensureUnreachable.md
@@ -1,3 +1,5 @@
+# Function: ensureUnreachable
+
 ▸ **ensureUnreachable**(`value`, `message?`): `never`
 
 #### Parameters

--- a/docs/reference/sdk/functions/generateSchema.md
+++ b/docs/reference/sdk/functions/generateSchema.md
@@ -1,3 +1,5 @@
+# Function: generateSchema
+
 ▸ **generateSchema**(`obj`): [`Schema`](../types/Schema.md)
 
 #### Parameters

--- a/docs/reference/sdk/functions/getQueryParams.md
+++ b/docs/reference/sdk/functions/getQueryParams.md
@@ -1,3 +1,5 @@
+# Function: getQueryParams
+
 ▸ **getQueryParams**(`url`): `Object`
 
 #### Parameters

--- a/docs/reference/sdk/functions/joinUrl.md
+++ b/docs/reference/sdk/functions/joinUrl.md
@@ -1,3 +1,5 @@
+# Function: joinUrl
+
 ▸ **joinUrl**(...`tokens`): `string`
 
 Joins all the tokens into a single URL string separated by '/'. Zero length tokens cause errors.

--- a/docs/reference/sdk/functions/makeAttributionNode.md
+++ b/docs/reference/sdk/functions/makeAttributionNode.md
@@ -1,3 +1,5 @@
+# Function: makeAttributionNode
+
 ▸ **makeAttributionNode**<`T`\>(`node`): `T`
 
 #### Type parameters

--- a/docs/reference/sdk/functions/makeDynamicSyncTable.md
+++ b/docs/reference/sdk/functions/makeDynamicSyncTable.md
@@ -1,3 +1,5 @@
+# Function: makeDynamicSyncTable
+
 ▸ **makeDynamicSyncTable**<`K`, `L`, `ParamDefsT`\>(`__namedParameters`): [`DynamicSyncTableDef`](../interfaces/DynamicSyncTableDef.md)<`K`, `L`, `ParamDefsT`, `any`\>
 
 #### Type parameters

--- a/docs/reference/sdk/functions/makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/makeEmptyFormula.md
@@ -1,3 +1,5 @@
+# Function: makeEmptyFormula
+
 ▸ **makeEmptyFormula**<`ParamDefsT`\>(`definition`): { `cacheTtlSecs?`: `number` ; `connectionRequirement?`: [`ConnectionRequirement`](../enums/ConnectionRequirement.md) ; `description`: `string` ; `examples?`: { `params`: [`PackFormulaValue`](../types/PackFormulaValue.md)[] ; `result`: [`PackFormulaResult`](../types/PackFormulaResult.md)  }[] ; `extraOAuthScopes?`: `string`[] ; `isAction?`: `boolean` ; `isExperimental?`: `boolean` ; `isSystem?`: `boolean` ; `name`: `string` ; `network?`: [`Network`](../interfaces/Network.md) ; `parameters`: `ParamDefsT` ; `varargParameters?`: [`ParamDefs`](../types/ParamDefs.md)  } & { `execute`: (`params`: [`ParamValues`](../types/ParamValues.md)<`ParamDefsT`\>, `context`: [`ExecutionContext`](../interfaces/ExecutionContext.md)) => `Promise`<`string`\> ; `resultType`: [`string`](../enums/Type.md#string)  }
 
 #### Type parameters

--- a/docs/reference/sdk/functions/makeFormula.md
+++ b/docs/reference/sdk/functions/makeFormula.md
@@ -1,3 +1,5 @@
+# Function: makeFormula
+
 ▸ **makeFormula**<`ParamDefsT`\>(`fullDefinition`): [`Formula`](../types/Formula.md)<`ParamDefsT`\>
 
 Creates a formula definition.

--- a/docs/reference/sdk/functions/makeMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeMetadataFormula.md
@@ -1,3 +1,5 @@
+# Function: makeMetadataFormula
+
 ▸ **makeMetadataFormula**(`execute`, `options?`): [`MetadataFormula`](../types/MetadataFormula.md)
 
 #### Parameters

--- a/docs/reference/sdk/functions/makeObjectSchema.md
+++ b/docs/reference/sdk/functions/makeObjectSchema.md
@@ -1,3 +1,5 @@
+# Function: makeObjectSchema
+
 ▸ **makeObjectSchema**<`K`, `L`, `T`\>(`schemaDef`): [`ObjectSchema`](../interfaces/ObjectSchema.md)<`K`, `L`\>
 
 #### Type parameters

--- a/docs/reference/sdk/functions/makeParameter.md
+++ b/docs/reference/sdk/functions/makeParameter.md
@@ -1,3 +1,5 @@
+# Function: makeParameter
+
 ▸ **makeParameter**<`T`\>(`paramDefinition`): [`ParamDef`](../interfaces/ParamDef.md)<`ParameterTypeMap`[`T`]\>
 
 Create a definition for a parameter for a formula or sync.

--- a/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
@@ -1,3 +1,5 @@
+# Function: makeReferenceSchemaFromObjectSchema
+
 ▸ **makeReferenceSchemaFromObjectSchema**(`schema`, `identityName?`): [`GenericObjectSchema`](../types/GenericObjectSchema.md)
 
 Convenience for creating a reference object schema from an existing schema for the

--- a/docs/reference/sdk/functions/makeSchema.md
+++ b/docs/reference/sdk/functions/makeSchema.md
@@ -1,3 +1,5 @@
+# Function: makeSchema
+
 ▸ **makeSchema**<`T`\>(`schema`): `T`
 
 #### Type parameters

--- a/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
@@ -1,3 +1,5 @@
+# Function: makeSimpleAutocompleteMetadataFormula
+
 ▸ **makeSimpleAutocompleteMetadataFormula**(`options`): [`MetadataFormula`](../types/MetadataFormula.md)
 
 #### Parameters

--- a/docs/reference/sdk/functions/makeSyncTable.md
+++ b/docs/reference/sdk/functions/makeSyncTable.md
@@ -1,3 +1,5 @@
+# Function: makeSyncTable
+
 ▸ **makeSyncTable**<`K`, `L`, `ParamDefsT`, `SchemaDefT`, `SchemaT`\>(`__namedParameters`): [`SyncTableDef`](../interfaces/SyncTableDef.md)<`K`, `L`, `ParamDefsT`, `SchemaT`\>
 
 Wrapper to produce a sync table definition. All (non-dynamic) sync tables should be created

--- a/docs/reference/sdk/functions/makeTranslateObjectFormula.md
+++ b/docs/reference/sdk/functions/makeTranslateObjectFormula.md
@@ -1,3 +1,5 @@
+# Function: makeTranslateObjectFormula
+
 ▸ **makeTranslateObjectFormula**<`ParamDefsT`, `ResultT`\>(`__namedParameters`): { `cacheTtlSecs?`: `number` ; `connectionRequirement?`: [`ConnectionRequirement`](../enums/ConnectionRequirement.md) ; `description`: `string` ; `examples?`: { `params`: [`PackFormulaValue`](../types/PackFormulaValue.md)[] ; `result`: [`PackFormulaResult`](../types/PackFormulaResult.md)  }[] ; `extraOAuthScopes?`: `string`[] ; `isAction?`: `boolean` ; `isExperimental?`: `boolean` ; `isSystem?`: `boolean` ; `name`: `string` ; `network?`: [`Network`](../interfaces/Network.md) ; `parameters`: `ParamDefsT` ; `request`: `RequestHandlerTemplate` ; `varargParameters?`: [`ParamDefs`](../types/ParamDefs.md)  } & { `execute`: (`params`: [`ParamValues`](../types/ParamValues.md)<`ParamDefsT`\>, `context`: [`ExecutionContext`](../interfaces/ExecutionContext.md)) => `Promise`<[`SchemaType`](../types/SchemaType.md)<`ResultT`\>\> ; `resultType`: [`object`](../enums/Type.md#object) ; `schema`: `undefined` \| `ResultT`  }
 
 #### Type parameters

--- a/docs/reference/sdk/functions/newPack.md
+++ b/docs/reference/sdk/functions/newPack.md
@@ -1,3 +1,5 @@
+# Function: newPack
+
 ▸ **newPack**(`definition?`): [`PackDefinitionBuilder`](../classes/PackDefinitionBuilder.md)
 
 Creates a new skeleton pack definition that can be added to.

--- a/docs/reference/sdk/functions/simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/simpleAutocomplete.md
@@ -1,3 +1,5 @@
+# Function: simpleAutocomplete
+
 ▸ **simpleAutocomplete**(`search`, `options`): `Promise`<[`MetadataFormulaObjectResultType`](../interfaces/MetadataFormulaObjectResultType.md)[]\>
 
 #### Parameters

--- a/docs/reference/sdk/functions/withQueryParams.md
+++ b/docs/reference/sdk/functions/withQueryParams.md
@@ -1,3 +1,5 @@
+# Function: withQueryParams
+
 ▸ **withQueryParams**(`url`, `params?`): `string`
 
 #### Parameters

--- a/docs/reference/sdk/interfaces/ArraySchema.md
+++ b/docs/reference/sdk/interfaces/ArraySchema.md
@@ -1,3 +1,5 @@
+# Interface: ArraySchema<T\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/ArrayType.md
+++ b/docs/reference/sdk/interfaces/ArrayType.md
@@ -1,3 +1,5 @@
+# Interface: ArrayType<T\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/BooleanSchema.md
+++ b/docs/reference/sdk/interfaces/BooleanSchema.md
@@ -1,3 +1,5 @@
+# Interface: BooleanSchema
+
 ## Hierarchy
 
 - `BaseSchema`

--- a/docs/reference/sdk/interfaces/Continuation.md
+++ b/docs/reference/sdk/interfaces/Continuation.md
@@ -1,3 +1,5 @@
+# Interface: Continuation
+
 Container for arbitrary data about which page of data to retrieve in this sync invocation.
 
 Sync formulas fetch one reasonable size "page" of data per invocation such that the formula

--- a/docs/reference/sdk/interfaces/CurrencySchema.md
+++ b/docs/reference/sdk/interfaces/CurrencySchema.md
@@ -1,3 +1,5 @@
+# Interface: CurrencySchema
+
 ## Hierarchy
 
 - [`NumberSchema`](NumberSchema.md)

--- a/docs/reference/sdk/interfaces/DateSchema.md
+++ b/docs/reference/sdk/interfaces/DateSchema.md
@@ -1,3 +1,5 @@
+# Interface: DateSchema
+
 ## Hierarchy
 
 - `BaseDateSchema`

--- a/docs/reference/sdk/interfaces/DateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/DateTimeSchema.md
@@ -1,3 +1,5 @@
+# Interface: DateTimeSchema
+
 ## Hierarchy
 
 - `BaseDateSchema`

--- a/docs/reference/sdk/interfaces/DurationSchema.md
+++ b/docs/reference/sdk/interfaces/DurationSchema.md
@@ -1,3 +1,5 @@
+# Interface: DurationSchema
+
 ## Hierarchy
 
 - [`StringSchema`](StringSchema.md)<[`Duration`](../enums/ValueHintType.md#duration)\>

--- a/docs/reference/sdk/interfaces/DynamicSyncTableDef.md
+++ b/docs/reference/sdk/interfaces/DynamicSyncTableDef.md
@@ -1,3 +1,5 @@
+# Interface: DynamicSyncTableDef<K, L, ParamDefsT, SchemaT\>
+
 Type definition for a Dynamic Sync Table. Should not be necessary to use directly,
 instead, define dynamic sync tables using [makeDynamicSyncTable](../functions/makeDynamicSyncTable.md).
 

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -1,3 +1,5 @@
+# Interface: EmptyFormulaDef<ParamsT\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/ExecutionContext.md
@@ -1,3 +1,5 @@
+# Interface: ExecutionContext
+
 ## Hierarchy
 
 - **`ExecutionContext`**

--- a/docs/reference/sdk/interfaces/ExternalPackVersionMetadata.md
+++ b/docs/reference/sdk/interfaces/ExternalPackVersionMetadata.md
@@ -1,3 +1,5 @@
+# Interface: ExternalPackVersionMetadata
+
 Further stripped-down version of `PackVersionMetadata` that contains only what the browser needs.
 
 ## Hierarchy

--- a/docs/reference/sdk/interfaces/FetchRequest.md
+++ b/docs/reference/sdk/interfaces/FetchRequest.md
@@ -1,3 +1,5 @@
+# Interface: FetchRequest
+
 ## Properties
 
 ### body

--- a/docs/reference/sdk/interfaces/FetchResponse.md
+++ b/docs/reference/sdk/interfaces/FetchResponse.md
@@ -1,3 +1,5 @@
+# Interface: FetchResponse<T\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/Fetcher.md
+++ b/docs/reference/sdk/interfaces/Fetcher.md
@@ -1,3 +1,5 @@
+# Interface: Fetcher
+
 ## Methods
 
 ### fetch

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -1,3 +1,5 @@
+# Interface: Format
+
 Definition for a custom column type that users can apply to any column in any Coda table.
 A column format tells Coda to interpret the value in a cell by executing a formula
 using that value, typically looking up data related to that value from a third-party API.

--- a/docs/reference/sdk/interfaces/Identity.md
+++ b/docs/reference/sdk/interfaces/Identity.md
@@ -1,3 +1,5 @@
+# Interface: Identity
+
 ## Hierarchy
 
 - [`IdentityDefinition`](IdentityDefinition.md)

--- a/docs/reference/sdk/interfaces/IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/IdentityDefinition.md
@@ -1,3 +1,5 @@
+# Interface: IdentityDefinition
+
 ## Hierarchy
 
 - **`IdentityDefinition`**

--- a/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
@@ -1,3 +1,5 @@
+# Interface: MetadataFormulaObjectResultType
+
 The return type for a metadata formula that should return a different display to the user
 than is used internally.
 

--- a/docs/reference/sdk/interfaces/Network.md
+++ b/docs/reference/sdk/interfaces/Network.md
@@ -1,3 +1,5 @@
+# Interface: Network
+
 **`deprecated`** use `isAction` and `connectionRequirement` on the formula definition instead.
 
 ## Properties

--- a/docs/reference/sdk/interfaces/NumberSchema.md
+++ b/docs/reference/sdk/interfaces/NumberSchema.md
@@ -1,3 +1,5 @@
+# Interface: NumberSchema
+
 ## Hierarchy
 
 - `BaseSchema`

--- a/docs/reference/sdk/interfaces/NumericSchema.md
+++ b/docs/reference/sdk/interfaces/NumericSchema.md
@@ -1,3 +1,5 @@
+# Interface: NumericSchema
+
 ## Hierarchy
 
 - [`NumberSchema`](NumberSchema.md)

--- a/docs/reference/sdk/interfaces/OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/OAuth2Authentication.md
@@ -1,3 +1,5 @@
+# Interface: OAuth2Authentication
+
 Authenticate using OAuth2. You must specify the authorization URL, token exchange URL, and
 scopes here as part of the pack definition. You'll provide the application's client ID and
 client secret in the pack management UI, so that these can be stored securely.

--- a/docs/reference/sdk/interfaces/ObjectSchema.md
+++ b/docs/reference/sdk/interfaces/ObjectSchema.md
@@ -1,3 +1,5 @@
+# Interface: ObjectSchema<K, L\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
@@ -1,3 +1,5 @@
+# Interface: ObjectSchemaProperty
+
 ## Properties
 
 ### fromKey

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -1,3 +1,5 @@
+# Interface: PackDefinition
+
 **`deprecated`** use `#PackVersionDefinition`
 
 The legacy complete definition of a Pack including un-versioned metadata.

--- a/docs/reference/sdk/interfaces/PackFormatMetadata.md
+++ b/docs/reference/sdk/interfaces/PackFormatMetadata.md
@@ -1,3 +1,5 @@
+# Interface: PackFormatMetadata
+
 ## Hierarchy
 
 - `Omit`<[`Format`](Format.md), ``"matchers"``\>

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -1,3 +1,5 @@
+# Interface: PackFormulaDef<ParamsT, ResultT\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/PackFormulas.md
+++ b/docs/reference/sdk/interfaces/PackFormulas.md
@@ -1,3 +1,5 @@
+# Interface: PackFormulas
+
 ## Indexable
 
 ▪ [namespace: `string`]: [`Formula`](../types/Formula.md)[]

--- a/docs/reference/sdk/interfaces/PackFormulasMetadata.md
+++ b/docs/reference/sdk/interfaces/PackFormulasMetadata.md
@@ -1,3 +1,5 @@
+# Interface: PackFormulasMetadata
+
 ## Indexable
 
 ▪ [namespace: `string`]: [`PackFormulaMetadata`](../types/PackFormulaMetadata.md)[]

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -1,3 +1,5 @@
+# Interface: PackVersionDefinition
+
 The definition of the contents of a Pack at a specific version. This is the
 heart of the implementation of a Pack.
 

--- a/docs/reference/sdk/interfaces/ParamDef.md
+++ b/docs/reference/sdk/interfaces/ParamDef.md
@@ -1,3 +1,5 @@
+# Interface: ParamDef<T\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/ScaleSchema.md
+++ b/docs/reference/sdk/interfaces/ScaleSchema.md
@@ -1,3 +1,5 @@
+# Interface: ScaleSchema
+
 ## Hierarchy
 
 - [`NumberSchema`](NumberSchema.md)

--- a/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
+++ b/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
@@ -1,3 +1,5 @@
+# Interface: SimpleAutocompleteOption
+
 ## Properties
 
 ### display

--- a/docs/reference/sdk/interfaces/SliderSchema.md
+++ b/docs/reference/sdk/interfaces/SliderSchema.md
@@ -1,3 +1,5 @@
+# Interface: SliderSchema
+
 ## Hierarchy
 
 - [`NumberSchema`](NumberSchema.md)

--- a/docs/reference/sdk/interfaces/StringSchema.md
+++ b/docs/reference/sdk/interfaces/StringSchema.md
@@ -1,3 +1,5 @@
+# Interface: StringSchema<T\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/SyncExecutionContext.md
@@ -1,3 +1,5 @@
+# Interface: SyncExecutionContext
+
 ## Hierarchy
 
 - [`ExecutionContext`](ExecutionContext.md)

--- a/docs/reference/sdk/interfaces/SyncFormulaResult.md
+++ b/docs/reference/sdk/interfaces/SyncFormulaResult.md
@@ -1,3 +1,5 @@
+# Interface: SyncFormulaResult<ResultT\>
+
 ## Type parameters
 
 | Name | Type |

--- a/docs/reference/sdk/interfaces/SyncTableDef.md
+++ b/docs/reference/sdk/interfaces/SyncTableDef.md
@@ -1,3 +1,5 @@
+# Interface: SyncTableDef<K, L, ParamDefsT, SchemaT\>
+
 Type definition for a Sync Table. Should not be necessary to use directly,
 instead, define sync tables using [makeSyncTable](../functions/makeSyncTable.md).
 

--- a/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
@@ -1,3 +1,5 @@
+# Interface: TemporaryBlobStorage
+
 ## Methods
 
 ### storeBlob

--- a/docs/reference/sdk/interfaces/TimeSchema.md
+++ b/docs/reference/sdk/interfaces/TimeSchema.md
@@ -1,3 +1,5 @@
+# Interface: TimeSchema
+
 ## Hierarchy
 
 - `BaseDateSchema`

--- a/docs/reference/sdk/interfaces/WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/WebBasicAuthentication.md
@@ -1,3 +1,5 @@
+# Interface: WebBasicAuthentication
+
 Authenticate using HTTP Basic authorization. The user provides a username and password
 (sometimes optional) which are included as an HTTP header according to the Basic auth standard.
 

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -1,3 +1,5 @@
+# Type alias: Authentication
+
 Ƭ **Authentication**: `NoAuthentication` \| `VariousAuthentication` \| `HeaderBearerTokenAuthentication` \| `CodaApiBearerTokenAuthentication` \| `CustomHeaderTokenAuthentication` \| `QueryParamTokenAuthentication` \| `MultiQueryParamTokenAuthentication` \| [`OAuth2Authentication`](../interfaces/OAuth2Authentication.md) \| [`WebBasicAuthentication`](../interfaces/WebBasicAuthentication.md) \| `AWSSignature4Authentication`
 
 The union of supported authentication methods.

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -1,3 +1,5 @@
+# Type alias: BasicPackDefinition
+
 Ƭ **BasicPackDefinition**: `Omit`<[`PackVersionDefinition`](../interfaces/PackVersionDefinition.md), ``"version"``\>
 
 A pack definition without an author-defined semantic version, for use in the web

--- a/docs/reference/sdk/types/DefaultValueType.md
+++ b/docs/reference/sdk/types/DefaultValueType.md
@@ -1,3 +1,5 @@
+# Type alias: DefaultValueType<T\>
+
 Ƭ **DefaultValueType**<`T`\>: `T` extends [`ArrayType`](../interfaces/ArrayType.md)<[`date`](../enums/Type.md#date)\> ? `TypeOfMap`<`T`\> \| [`PrecannedDateRange`](../enums/PrecannedDateRange.md) : `TypeOfMap`<`T`\>
 
 #### Type parameters

--- a/docs/reference/sdk/types/ExternalObjectPackFormula.md
+++ b/docs/reference/sdk/types/ExternalObjectPackFormula.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalObjectPackFormula
+
 Ƭ **ExternalObjectPackFormula**: `ObjectPackFormulaMetadata`
 
 #### Defined in

--- a/docs/reference/sdk/types/ExternalPackFormat.md
+++ b/docs/reference/sdk/types/ExternalPackFormat.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalPackFormat
+
 Ƭ **ExternalPackFormat**: [`Format`](../interfaces/Format.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/ExternalPackFormatMetadata.md
+++ b/docs/reference/sdk/types/ExternalPackFormatMetadata.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalPackFormatMetadata
+
 Ƭ **ExternalPackFormatMetadata**: [`PackFormatMetadata`](../interfaces/PackFormatMetadata.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/ExternalPackFormula.md
+++ b/docs/reference/sdk/types/ExternalPackFormula.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalPackFormula
+
 Ƭ **ExternalPackFormula**: [`PackFormulaMetadata`](PackFormulaMetadata.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/ExternalPackFormulas.md
+++ b/docs/reference/sdk/types/ExternalPackFormulas.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalPackFormulas
+
 Ƭ **ExternalPackFormulas**: [`PackFormulasMetadata`](../interfaces/PackFormulasMetadata.md) \| [`PackFormulaMetadata`](PackFormulaMetadata.md)[]
 
 #### Defined in

--- a/docs/reference/sdk/types/ExternalPackMetadata.md
+++ b/docs/reference/sdk/types/ExternalPackMetadata.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalPackMetadata
+
 Ƭ **ExternalPackMetadata**: [`ExternalPackVersionMetadata`](../interfaces/ExternalPackVersionMetadata.md) & `Pick`<[`PackMetadata`](PackMetadata.md), ``"id"`` \| ``"name"`` \| ``"shortDescription"`` \| ``"description"`` \| ``"permissionsDescription"`` \| ``"category"`` \| ``"logoPath"`` \| ``"exampleImages"`` \| ``"exampleVideoIds"`` \| ``"minimumFeatureSet"`` \| ``"quotas"`` \| ``"rateLimits"`` \| ``"isSystem"``\>
 
 Further stripped-down version of `PackMetadata` that contains only what the browser needs.

--- a/docs/reference/sdk/types/ExternalSyncTable.md
+++ b/docs/reference/sdk/types/ExternalSyncTable.md
@@ -1,3 +1,5 @@
+# Type alias: ExternalSyncTable
+
 Ƭ **ExternalSyncTable**: [`PackSyncTable`](PackSyncTable.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/FetchMethodType.md
+++ b/docs/reference/sdk/types/FetchMethodType.md
@@ -1,3 +1,5 @@
+# Type alias: FetchMethodType
+
 Ƭ **FetchMethodType**: typeof `ValidFetchMethods`[`number`]
 
 #### Defined in

--- a/docs/reference/sdk/types/Formula.md
+++ b/docs/reference/sdk/types/Formula.md
@@ -1,3 +1,5 @@
+# Type alias: Formula<ParamDefsT\>
+
 Ƭ **Formula**<`ParamDefsT`\>: `NumericPackFormula`<`ParamDefsT`\> \| `StringPackFormula`<`ParamDefsT`, `any`\> \| `BooleanPackFormula`<`ParamDefsT`\> \| `ObjectPackFormula`<`ParamDefsT`, [`Schema`](Schema.md)\>
 
 #### Type parameters

--- a/docs/reference/sdk/types/GenericDynamicSyncTable.md
+++ b/docs/reference/sdk/types/GenericDynamicSyncTable.md
@@ -1,3 +1,5 @@
+# Type alias: GenericDynamicSyncTable
+
 Ƭ **GenericDynamicSyncTable**: [`DynamicSyncTableDef`](../interfaces/DynamicSyncTableDef.md)<`any`, `any`, [`ParamDefs`](ParamDefs.md), `any`\>
 
 Type definition for a dynamic sync table.

--- a/docs/reference/sdk/types/GenericObjectSchema.md
+++ b/docs/reference/sdk/types/GenericObjectSchema.md
@@ -1,3 +1,5 @@
+# Type alias: GenericObjectSchema
+
 Ƭ **GenericObjectSchema**: [`ObjectSchema`](../interfaces/ObjectSchema.md)<`string`, `string`\>
 
 #### Defined in

--- a/docs/reference/sdk/types/GenericSyncFormula.md
+++ b/docs/reference/sdk/types/GenericSyncFormula.md
@@ -1,3 +1,5 @@
+# Type alias: GenericSyncFormula
+
 Ƭ **GenericSyncFormula**: `SyncFormula`<`any`, `any`, [`ParamDefs`](ParamDefs.md), `any`\>
 
 Type definition for the formula that implements a sync table.

--- a/docs/reference/sdk/types/GenericSyncFormulaResult.md
+++ b/docs/reference/sdk/types/GenericSyncFormulaResult.md
@@ -1,3 +1,5 @@
+# Type alias: GenericSyncFormulaResult
+
 Ƭ **GenericSyncFormulaResult**: [`SyncFormulaResult`](../interfaces/SyncFormulaResult.md)<`any`\>
 
 Type definition for the return value of a sync table.

--- a/docs/reference/sdk/types/GenericSyncTable.md
+++ b/docs/reference/sdk/types/GenericSyncTable.md
@@ -1,3 +1,5 @@
+# Type alias: GenericSyncTable
+
 Ƭ **GenericSyncTable**: [`SyncTableDef`](../interfaces/SyncTableDef.md)<`any`, `any`, [`ParamDefs`](ParamDefs.md), `any`\>
 
 Type definition for a static (non-dynamic) sync table.

--- a/docs/reference/sdk/types/MetadataContext.md
+++ b/docs/reference/sdk/types/MetadataContext.md
@@ -1,3 +1,5 @@
+# Type alias: MetadataContext
+
 Ƭ **MetadataContext**: `Record`<`string`, `any`\>
 
 A context object that is provided to a metadata formula at execution time.

--- a/docs/reference/sdk/types/MetadataFormula.md
+++ b/docs/reference/sdk/types/MetadataFormula.md
@@ -1,3 +1,5 @@
+# Type alias: MetadataFormula
+
 Ƭ **MetadataFormula**: `ObjectPackFormula`<[[`ParamDef`](../interfaces/ParamDef.md)<[`string`](../enums/Type.md#string)\>, [`ParamDef`](../interfaces/ParamDef.md)<[`string`](../enums/Type.md#string)\>], `any`\>
 
 #### Defined in

--- a/docs/reference/sdk/types/MetadataFormulaResultType.md
+++ b/docs/reference/sdk/types/MetadataFormulaResultType.md
@@ -1,3 +1,5 @@
+# Type alias: MetadataFormulaResultType
+
 Ƭ **MetadataFormulaResultType**: `string` \| `number` \| [`MetadataFormulaObjectResultType`](../interfaces/MetadataFormulaObjectResultType.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/ObjectSchemaProperties.md
@@ -1,3 +1,5 @@
+# Type alias: ObjectSchemaProperties<K\>
+
 Ƭ **ObjectSchemaProperties**<`K`\>: { [K2 in K \| string]: Schema & ObjectSchemaProperty}
 
 #### Type parameters

--- a/docs/reference/sdk/types/PackFormulaMetadata.md
+++ b/docs/reference/sdk/types/PackFormulaMetadata.md
@@ -1,3 +1,5 @@
+# Type alias: PackFormulaMetadata
+
 Ƭ **PackFormulaMetadata**: `Omit`<[`TypedPackFormula`](TypedPackFormula.md), ``"execute"``\>
 
 #### Defined in

--- a/docs/reference/sdk/types/PackFormulaResult.md
+++ b/docs/reference/sdk/types/PackFormulaResult.md
@@ -1,3 +1,5 @@
+# Type alias: PackFormulaResult
+
 Ƭ **PackFormulaResult**: `$Values`<`TypeMap`\> \| [`PackFormulaResult`](PackFormulaResult.md)[]
 
 #### Defined in

--- a/docs/reference/sdk/types/PackFormulaValue.md
+++ b/docs/reference/sdk/types/PackFormulaValue.md
@@ -1,3 +1,5 @@
+# Type alias: PackFormulaValue
+
 Ƭ **PackFormulaValue**: `$Values`<`Omit`<`TypeMap`, [`object`](../enums/Type.md#object)\>\> \| [`PackFormulaValue`](PackFormulaValue.md)[]
 
 #### Defined in

--- a/docs/reference/sdk/types/PackId.md
+++ b/docs/reference/sdk/types/PackId.md
@@ -1,3 +1,5 @@
+# Type alias: PackId
+
 Ƭ **PackId**: `number`
 
 **`deprecated`** Use `number` in new code.

--- a/docs/reference/sdk/types/PackMetadata.md
+++ b/docs/reference/sdk/types/PackMetadata.md
@@ -1,3 +1,5 @@
+# Type alias: PackMetadata
+
 Ƭ **PackMetadata**: [`PackVersionMetadata`](PackVersionMetadata.md) & `Pick`<[`PackDefinition`](../interfaces/PackDefinition.md), ``"id"`` \| ``"name"`` \| ``"shortDescription"`` \| ``"description"`` \| ``"permissionsDescription"`` \| ``"category"`` \| ``"logoPath"`` \| ``"exampleImages"`` \| ``"exampleVideoIds"`` \| ``"minimumFeatureSet"`` \| ``"quotas"`` \| ``"rateLimits"`` \| ``"enabledConfigName"`` \| ``"isSystem"``\>
 
 Stripped-down version of `PackDefinition` that doesn't contain formula definitions.

--- a/docs/reference/sdk/types/PackSyncTable.md
+++ b/docs/reference/sdk/types/PackSyncTable.md
@@ -1,3 +1,5 @@
+# Type alias: PackSyncTable
+
 Ƭ **PackSyncTable**: `Omit`<`SyncTable`, ``"getter"`` \| ``"getName"`` \| ``"getSchema"`` \| ``"listDynamicUrls"`` \| ``"getDisplayUrl"``\> & { `getDisplayUrl?`: `MetadataFormulaMetadata` ; `getName?`: `MetadataFormulaMetadata` ; `getSchema?`: `MetadataFormulaMetadata` ; `getter`: [`PackFormulaMetadata`](PackFormulaMetadata.md) ; `hasDynamicSchema?`: `boolean` ; `isDynamic?`: `boolean` ; `listDynamicUrls?`: `MetadataFormulaMetadata`  }
 
 #### Defined in

--- a/docs/reference/sdk/types/PackVersionMetadata.md
+++ b/docs/reference/sdk/types/PackVersionMetadata.md
@@ -1,3 +1,5 @@
+# Type alias: PackVersionMetadata
+
 Ƭ **PackVersionMetadata**: `Omit`<[`PackVersionDefinition`](../interfaces/PackVersionDefinition.md), ``"formulas"`` \| ``"formats"`` \| ``"defaultAuthentication"`` \| ``"syncTables"``\> & { `defaultAuthentication?`: `AuthenticationMetadata` ; `formats`: [`PackFormatMetadata`](../interfaces/PackFormatMetadata.md)[] ; `formulas`: [`PackFormulasMetadata`](../interfaces/PackFormulasMetadata.md) \| [`PackFormulaMetadata`](PackFormulaMetadata.md)[] ; `syncTables`: [`PackSyncTable`](PackSyncTable.md)[]  }
 
 Stripped-down version of `PackVersionDefinition` that doesn't contain formula definitions.

--- a/docs/reference/sdk/types/ParamDefs.md
+++ b/docs/reference/sdk/types/ParamDefs.md
@@ -1,3 +1,5 @@
+# Type alias: ParamDefs
+
 Ƭ **ParamDefs**: [[`ParamDef`](../interfaces/ParamDef.md)<`UnionType`\>, ...ParamDef<UnionType\>[]] \| []
 
 #### Defined in

--- a/docs/reference/sdk/types/ParamValues.md
+++ b/docs/reference/sdk/types/ParamValues.md
@@ -1,3 +1,5 @@
+# Type alias: ParamValues<ParamDefsT\>
+
 Ƭ **ParamValues**<`ParamDefsT`\>: { [K in keyof ParamDefsT]: ParamDefsT[K] extends ParamDef<infer T\> ? TypeOfMap<T\> : never} & `any`[]
 
 #### Type parameters

--- a/docs/reference/sdk/types/ParamsList.md
+++ b/docs/reference/sdk/types/ParamsList.md
@@ -1,3 +1,5 @@
+# Type alias: ParamsList
+
 Ƭ **ParamsList**: [`ParamDef`](../interfaces/ParamDef.md)<`UnionType`\>[]
 
 #### Defined in

--- a/docs/reference/sdk/types/Schema.md
+++ b/docs/reference/sdk/types/Schema.md
@@ -1,3 +1,5 @@
+# Type alias: Schema
+
 Ƭ **Schema**: [`BooleanSchema`](../interfaces/BooleanSchema.md) \| [`NumberSchema`](../interfaces/NumberSchema.md) \| [`StringSchema`](../interfaces/StringSchema.md) \| [`ArraySchema`](../interfaces/ArraySchema.md) \| [`GenericObjectSchema`](GenericObjectSchema.md)
 
 #### Defined in

--- a/docs/reference/sdk/types/SchemaType.md
+++ b/docs/reference/sdk/types/SchemaType.md
@@ -1,3 +1,5 @@
+# Type alias: SchemaType<T\>
+
 Ƭ **SchemaType**<`T`\>: `T` extends [`BooleanSchema`](../interfaces/BooleanSchema.md) ? `boolean` : `T` extends [`NumberSchema`](../interfaces/NumberSchema.md) ? `number` : `T` extends [`StringSchema`](../interfaces/StringSchema.md) ? `StringHintTypeToSchemaType`<`T`[``"codaType"``]\> : `T` extends [`ArraySchema`](../interfaces/ArraySchema.md) ? [`SchemaType`](SchemaType.md)<`T`[``"items"``]\>[] : `T` extends [`GenericObjectSchema`](GenericObjectSchema.md) ? `PickOptional`<{ [K in keyof T["properties"]]: SchemaType<T["properties"][K]\>}, `$Values`<{ [K in keyof T["properties"]]: T["properties"][K] extends object ? K : never}\>\> : `never`
 
 #### Type parameters

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -1,3 +1,5 @@
+# Type alias: SystemAuthentication
+
 Ƭ **SystemAuthentication**: `HeaderBearerTokenAuthentication` \| `CustomHeaderTokenAuthentication` \| `QueryParamTokenAuthentication` \| `MultiQueryParamTokenAuthentication` \| [`WebBasicAuthentication`](../interfaces/WebBasicAuthentication.md) \| `AWSSignature4Authentication`
 
 The union of authentication methods that are supported for system authentication,

--- a/docs/reference/sdk/types/TypedPackFormula.md
+++ b/docs/reference/sdk/types/TypedPackFormula.md
@@ -1,3 +1,5 @@
+# Type alias: TypedPackFormula
+
 Ƭ **TypedPackFormula**: [`Formula`](Formula.md) \| [`GenericSyncFormula`](GenericSyncFormula.md)
 
 #### Defined in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ markdown_extensions:
   - toc:
       permalink: true
       # Don't show TOC entries for h4 and below, as it clutters the TOC in the reference docs.
-      toc_depth: 2-3
+      toc_depth: 1-3
 plugins:
     - search
     # Navigation enhancements.

--- a/typedoc.js
+++ b/typedoc.js
@@ -13,5 +13,4 @@ module.exports = {
   hideBreadcrumbs: true,
   hideInPageTOC: true,
   allReflectionsHaveOwnDocument: true,
-  hidePageTitle: true,
 };


### PR DESCRIPTION
Some recent changes I made to page titles and headings turned out to have a negative impact on the search results UX. I reverted some of these changes (include H1s in the TOC, don't hide page titles in generated reference) to fix the search results. The one downside is that the left nav for the reference docs once again include a lot of extraneous prefixes ("Interface: ...", "Class: ...") but it's a tolerable tradeoff for now.

[Preview](https://coda-packs-sdk.readthedocs-hosted.com/en/ek-search/)

## "Get started"
### Before
!["Get started" before](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/lluolmKk/205c0e36-129b-4882-8ee1-0881f2e880f6.jpg?v=30037bd588034d89d09bb00d4e34037e)
### After
!["Get started" after](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/12uv89Wp/89fd8e67-85a9-4ebb-83e3-bbb353f18416.jpg?v=753146acbd0f16acbd4be615a12f23a5)

## "OAuth2"
### Before
!["OAuth2" before](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/nOuvOEx6/254e568c-2d95-4e7e-9e44-28b431b37ed6.jpg?v=3ae252551969ec7f0342b164eaf2293d)
### After
!["OAuth2" after](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/2NulD1NE/2d8b5028-8c6c-4152-9725-b7026b43b087.jpg?v=62a4cb6c82e1b2b1901a5fec90931e13)