### PR TITLE
Put all in-line examples in code blocks

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -220,10 +220,14 @@ type ParameterOptions<T extends ParameterType> = Omit<ParamDef<ParameterTypeMap[
  * Create a definition for a parameter for a formula or sync.
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
+ * ```
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
+ * ```
  */
 export function makeParameter<T extends ParameterType>(
   paramDefinition: ParameterOptions<T>,
@@ -502,29 +506,39 @@ export function makeStringFormula<ParamDefsT extends ParamDefs>(
  * created using {@link makeObjectSchema} if the elements are objects.
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, name: 'Hello', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Object,
  *   schema: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObject',
  *   ...
  * });
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Array,
  *   items: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObjectArray',
  *   ...
  * });
+ * ```
  */
 export function makeFormula<ParamDefsT extends ParamDefs>(
   fullDefinition: FormulaDefinitionV2<ParamDefsT>,

--- a/builder.ts
+++ b/builder.ts
@@ -25,10 +25,12 @@ import {wrapMetadataFunction} from './api';
  * Creates a new skeleton pack definition that can be added to.
  *
  * @example
+ * ```
  * export const pack = newPack();
  * pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});
  * pack.addSyncTable('MyTable', ...);
  * pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+ * ```
  */
 export function newPack(definition?: Partial<PackVersionDefinition>): PackDefinitionBuilder {
   return new PackDefinitionBuilder(definition);
@@ -75,6 +77,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
    *
    * @example
+   * ```
    * pack.addFormula({
    *   resultType: ValueType.String,
    *    name: 'MyFormula',
@@ -90,6 +93,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    *      return `Hello ${param}`;
    *    },
    * });
+   * ```
    */
   addFormula<ParamDefsT extends ParamDefs>(definition: FormulaDefinitionV2<ParamDefsT>): this {
     const formula = makeFormula({
@@ -106,6 +110,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
    *
    * @example
+   * ```
    * pack.addSyncTable({
    *   name: 'MySyncTable',
    *   identityName: 'EntityName',
@@ -116,6 +121,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    *     ...
    *   },
    * });
+   * ```
    */
   addSyncTable<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>>({
     name,
@@ -144,6 +150,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
    *
    * @example
+   * ```
    * pack.addDynamicSyncTable({
    *   name: 'MySyncTable',
    *   getName: async (context) => {
@@ -156,6 +163,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    *   },
    *   ...
    * });
+   * ```
    */
   addDynamicSyncTable<ParamDefsT extends ParamDefs>(definition: DynamicSyncTableOptions<ParamDefsT>): this {
     const dynamicSyncTable = makeDynamicSyncTable({
@@ -172,10 +180,12 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
    *
    * @example
+   * ```
    * pack.addColumnFormat({
    *   name: 'MyColumn',
    *   formulaName: 'MyFormula',
    * });
+   * ```
    */
   addColumnFormat(format: Format): this {
     this.formats.push(format);
@@ -197,9 +207,11 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * this method.
    *
    * @example
+   * ```
    * pack.setUserAuthentication({
    *   type: AuthenticationType.HeaderBearerToken,
    * });
+   * ```
    */
   setUserAuthentication(authDef: AuthenticationDef & {defaultConnectionRequirement?: ConnectionRequirement}): this {
     const {defaultConnectionRequirement = ConnectionRequirement.Required, ...authentication} = authDef;
@@ -234,9 +246,11 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * authentication definition.
    *
    * @example
+   * ```
    * pack.setSystemAuthentication({
    *   type: AuthenticationType.HeaderBearerToken,
    * });
+   * ```
    */
   setSystemAuthentication(systemAuthentication: SystemAuthenticationDef): this {
     const {
@@ -264,7 +278,9 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * to connect to multiple domains, contact Coda Support for approval.
    *
    * @example
+   * ```
    * pack.addNetworkDomain('example.com');
+   * ```
    */
   addNetworkDomain(...domain: string[]): this {
     this.networkDomains.push(...domain);
@@ -280,7 +296,9 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * each time you build a version.
    *
    * @example
+   * ```
    * pack.setVersion('1.2.3');
+   * ```
    */
   setVersion(version: string): this {
     this.version = version;

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -155,10 +155,14 @@ declare type ParameterOptions<T extends ParameterType> = Omit<ParamDef<Parameter
  * Create a definition for a parameter for a formula or sync.
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
+ * ```
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
+ * ```
  */
 export declare function makeParameter<T extends ParameterType>(paramDefinition: ParameterOptions<T>): ParamDef<ParameterTypeMap[T]>;
 export declare function makeStringParameter(name: string, description: string, args?: ParamArgs<Type.string>): ParamDef<Type.string>;
@@ -268,29 +272,39 @@ export declare function makeStringFormula<ParamDefsT extends ParamDefs>(definiti
  * created using {@link makeObjectSchema} if the elements are objects.
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, name: 'Hello', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Object,
  *   schema: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObject',
  *   ...
  * });
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Array,
  *   items: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObjectArray',
  *   ...
  * });
+ * ```
  */
 export declare function makeFormula<ParamDefsT extends ParamDefs>(fullDefinition: FormulaDefinitionV2<ParamDefsT>): Formula<ParamDefsT>;
 interface BaseFormulaDefV2<ParamDefsT extends ParamDefs, ResultT extends string | number | boolean | object> extends PackFormulaDef<ParamDefsT, ResultT> {

--- a/dist/api.js
+++ b/dist/api.js
@@ -79,10 +79,14 @@ exports.wrapMetadataFunction = wrapMetadataFunction;
  * Create a definition for a parameter for a formula or sync.
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
+ * ```
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
+ * ```
  */
 function makeParameter(paramDefinition) {
     const { type, autocomplete: autocompleteDefOrItems, ...rest } = paramDefinition;
@@ -210,29 +214,39 @@ exports.makeStringFormula = makeStringFormula;
  * created using {@link makeObjectSchema} if the elements are objects.
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, name: 'Hello', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Object,
  *   schema: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObject',
  *   ...
  * });
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Array,
  *   items: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObjectArray',
  *   ...
  * });
+ * ```
  */
 function makeFormula(fullDefinition) {
     let formula;

--- a/dist/builder.d.ts
+++ b/dist/builder.d.ts
@@ -17,10 +17,12 @@ import type { SystemAuthenticationDef } from './types';
  * Creates a new skeleton pack definition that can be added to.
  *
  * @example
+ * ```
  * export const pack = newPack();
  * pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});
  * pack.addSyncTable('MyTable', ...);
  * pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+ * ```
  */
 export declare function newPack(definition?: Partial<PackVersionDefinition>): PackDefinitionBuilder;
 export declare class PackDefinitionBuilder implements BasicPackDefinition {
@@ -40,6 +42,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
      *
      * @example
+     * ```
      * pack.addFormula({
      *   resultType: ValueType.String,
      *    name: 'MyFormula',
@@ -55,6 +58,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      *      return `Hello ${param}`;
      *    },
      * });
+     * ```
      */
     addFormula<ParamDefsT extends ParamDefs>(definition: FormulaDefinitionV2<ParamDefsT>): this;
     /**
@@ -63,6 +67,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
      *
      * @example
+     * ```
      * pack.addSyncTable({
      *   name: 'MySyncTable',
      *   identityName: 'EntityName',
@@ -73,6 +78,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      *     ...
      *   },
      * });
+     * ```
      */
     addSyncTable<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>>({ name, identityName, schema, formula, connectionRequirement, dynamicOptions, }: SyncTableOptions<K, L, ParamDefsT, SchemaT>): this;
     /**
@@ -81,6 +87,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
      *
      * @example
+     * ```
      * pack.addDynamicSyncTable({
      *   name: 'MySyncTable',
      *   getName: async (context) => {
@@ -93,6 +100,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      *   },
      *   ...
      * });
+     * ```
      */
     addDynamicSyncTable<ParamDefsT extends ParamDefs>(definition: DynamicSyncTableOptions<ParamDefsT>): this;
     /**
@@ -101,10 +109,12 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
      *
      * @example
+     * ```
      * pack.addColumnFormat({
      *   name: 'MyColumn',
      *   formulaName: 'MyFormula',
      * });
+     * ```
      */
     addColumnFormat(format: Format): this;
     /**
@@ -122,9 +132,11 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * this method.
      *
      * @example
+     * ```
      * pack.setUserAuthentication({
      *   type: AuthenticationType.HeaderBearerToken,
      * });
+     * ```
      */
     setUserAuthentication(authDef: AuthenticationDef & {
         defaultConnectionRequirement?: ConnectionRequirement;
@@ -140,9 +152,11 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * authentication definition.
      *
      * @example
+     * ```
      * pack.setSystemAuthentication({
      *   type: AuthenticationType.HeaderBearerToken,
      * });
+     * ```
      */
     setSystemAuthentication(systemAuthentication: SystemAuthenticationDef): this;
     /**
@@ -158,7 +172,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * to connect to multiple domains, contact Coda Support for approval.
      *
      * @example
+     * ```
      * pack.addNetworkDomain('example.com');
+     * ```
      */
     addNetworkDomain(...domain: string[]): this;
     /**
@@ -170,7 +186,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * each time you build a version.
      *
      * @example
+     * ```
      * pack.setVersion('1.2.3');
+     * ```
      */
     setVersion(version: string): this;
     private _setDefaultConnectionRequirement;

--- a/dist/builder.js
+++ b/dist/builder.js
@@ -13,10 +13,12 @@ const api_6 = require("./api");
  * Creates a new skeleton pack definition that can be added to.
  *
  * @example
+ * ```
  * export const pack = newPack();
  * pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});
  * pack.addSyncTable('MyTable', ...);
  * pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+ * ```
  */
 function newPack(definition) {
     return new PackDefinitionBuilder(definition);
@@ -40,6 +42,7 @@ class PackDefinitionBuilder {
      * In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
      *
      * @example
+     * ```
      * pack.addFormula({
      *   resultType: ValueType.String,
      *    name: 'MyFormula',
@@ -55,6 +58,7 @@ class PackDefinitionBuilder {
      *      return `Hello ${param}`;
      *    },
      * });
+     * ```
      */
     addFormula(definition) {
         const formula = (0, api_3.makeFormula)({
@@ -70,6 +74,7 @@ class PackDefinitionBuilder {
      * In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
      *
      * @example
+     * ```
      * pack.addSyncTable({
      *   name: 'MySyncTable',
      *   identityName: 'EntityName',
@@ -80,6 +85,7 @@ class PackDefinitionBuilder {
      *     ...
      *   },
      * });
+     * ```
      */
     addSyncTable({ name, identityName, schema, formula, connectionRequirement, dynamicOptions = {}, }) {
         const connectionRequirementToUse = connectionRequirement || this._defaultConnectionRequirement;
@@ -100,6 +106,7 @@ class PackDefinitionBuilder {
      * In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
      *
      * @example
+     * ```
      * pack.addDynamicSyncTable({
      *   name: 'MySyncTable',
      *   getName: async (context) => {
@@ -112,6 +119,7 @@ class PackDefinitionBuilder {
      *   },
      *   ...
      * });
+     * ```
      */
     addDynamicSyncTable(definition) {
         const dynamicSyncTable = (0, api_2.makeDynamicSyncTable)({
@@ -127,10 +135,12 @@ class PackDefinitionBuilder {
      * In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
      *
      * @example
+     * ```
      * pack.addColumnFormat({
      *   name: 'MyColumn',
      *   formulaName: 'MyFormula',
      * });
+     * ```
      */
     addColumnFormat(format) {
         this.formats.push(format);
@@ -151,9 +161,11 @@ class PackDefinitionBuilder {
      * this method.
      *
      * @example
+     * ```
      * pack.setUserAuthentication({
      *   type: AuthenticationType.HeaderBearerToken,
      * });
+     * ```
      */
     setUserAuthentication(authDef) {
         const { defaultConnectionRequirement = api_types_1.ConnectionRequirement.Required, ...authentication } = authDef;
@@ -182,9 +194,11 @@ class PackDefinitionBuilder {
      * authentication definition.
      *
      * @example
+     * ```
      * pack.setSystemAuthentication({
      *   type: AuthenticationType.HeaderBearerToken,
      * });
+     * ```
      */
     setSystemAuthentication(systemAuthentication) {
         const { getConnectionName: getConnectionNameDef, getConnectionUserId: getConnectionUserIdDef, ...rest } = systemAuthentication;
@@ -206,7 +220,9 @@ class PackDefinitionBuilder {
      * to connect to multiple domains, contact Coda Support for approval.
      *
      * @example
+     * ```
      * pack.addNetworkDomain('example.com');
+     * ```
      */
     addNetworkDomain(...domain) {
         this.networkDomains.push(...domain);
@@ -221,7 +237,9 @@ class PackDefinitionBuilder {
      * each time you build a version.
      *
      * @example
+     * ```
      * pack.setVersion('1.2.3');
+     * ```
      */
     setVersion(version) {
         this.version = version;

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -620,10 +620,14 @@ export declare type ParameterOptions<T extends ParameterType> = Omit<ParamDef<Pa
  * Create a definition for a parameter for a formula or sync.
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
+ * ```
  *
  * @example
+ * ```
  * makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
+ * ```
  */
 export declare function makeParameter<T extends ParameterType>(paramDefinition: ParameterOptions<T>): ParamDef<ParameterTypeMap[T]>;
 export interface PackFormulas {
@@ -692,29 +696,39 @@ export declare type SyncFormula<K extends string, L extends string, ParamDefsT e
  * created using {@link makeObjectSchema} if the elements are objects.
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, name: 'Hello', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Object,
  *   schema: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObject',
  *   ...
  * });
+ * ```
  *
  * @example
+ * ```
  * makeFormula({
  *   resultType: ValueType.Array,
  *   items: makeObjectSchema({type: ValueType.Object, properties: {...}}),
  *   name: 'HelloObjectArray',
  *   ...
  * });
+ * ```
  */
 export declare function makeFormula<ParamDefsT extends ParamDefs>(fullDefinition: FormulaDefinitionV2<ParamDefsT>): Formula<ParamDefsT>;
 export interface BaseFormulaDefV2<ParamDefsT extends ParamDefs, ResultT extends string | number | boolean | object> extends PackFormulaDef<ParamDefsT, ResultT> {
@@ -1584,10 +1598,12 @@ export interface PackDefinition extends PackVersionDefinition {
  * Creates a new skeleton pack definition that can be added to.
  *
  * @example
+ * ```
  * export const pack = newPack();
  * pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});
  * pack.addSyncTable('MyTable', ...);
  * pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+ * ```
  */
 export declare function newPack(definition?: Partial<PackVersionDefinition>): PackDefinitionBuilder;
 export declare class PackDefinitionBuilder implements BasicPackDefinition {
@@ -1607,6 +1623,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
 	 *
 	 * @example
+	 * ```
 	 * pack.addFormula({
 	 *   resultType: ValueType.String,
 	 *    name: 'MyFormula',
@@ -1622,6 +1639,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 *      return `Hello ${param}`;
 	 *    },
 	 * });
+	 * ```
 	 */
 	addFormula<ParamDefsT extends ParamDefs>(definition: FormulaDefinitionV2<ParamDefsT>): this;
 	/**
@@ -1630,6 +1648,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
 	 *
 	 * @example
+	 * ```
 	 * pack.addSyncTable({
 	 *   name: 'MySyncTable',
 	 *   identityName: 'EntityName',
@@ -1640,6 +1659,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 *     ...
 	 *   },
 	 * });
+	 * ```
 	 */
 	addSyncTable<K extends string, L extends string, ParamDefsT extends ParamDefs, SchemaT extends ObjectSchema<K, L>>({ name, identityName, schema, formula, connectionRequirement, dynamicOptions, }: SyncTableOptions<K, L, ParamDefsT, SchemaT>): this;
 	/**
@@ -1648,6 +1668,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
 	 *
 	 * @example
+	 * ```
 	 * pack.addDynamicSyncTable({
 	 *   name: 'MySyncTable',
 	 *   getName: async (context) => {
@@ -1660,6 +1681,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 *   },
 	 *   ...
 	 * });
+	 * ```
 	 */
 	addDynamicSyncTable<ParamDefsT extends ParamDefs>(definition: DynamicSyncTableOptions<ParamDefsT>): this;
 	/**
@@ -1668,10 +1690,12 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
 	 *
 	 * @example
+	 * ```
 	 * pack.addColumnFormat({
 	 *   name: 'MyColumn',
 	 *   formulaName: 'MyFormula',
 	 * });
+	 * ```
 	 */
 	addColumnFormat(format: Format): this;
 	/**
@@ -1689,9 +1713,11 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * this method.
 	 *
 	 * @example
+	 * ```
 	 * pack.setUserAuthentication({
 	 *   type: AuthenticationType.HeaderBearerToken,
 	 * });
+	 * ```
 	 */
 	setUserAuthentication(authDef: AuthenticationDef & {
 		defaultConnectionRequirement?: ConnectionRequirement;
@@ -1707,9 +1733,11 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * authentication definition.
 	 *
 	 * @example
+	 * ```
 	 * pack.setSystemAuthentication({
 	 *   type: AuthenticationType.HeaderBearerToken,
 	 * });
+	 * ```
 	 */
 	setSystemAuthentication(systemAuthentication: SystemAuthenticationDef): this;
 	/**
@@ -1725,7 +1753,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * to connect to multiple domains, contact Coda Support for approval.
 	 *
 	 * @example
+	 * ```
 	 * pack.addNetworkDomain('example.com');
+	 * ```
 	 */
 	addNetworkDomain(...domain: string[]): this;
 	/**
@@ -1737,7 +1767,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * each time you build a version.
 	 *
 	 * @example
+	 * ```
 	 * pack.setVersion('1.2.3');
+	 * ```
 	 */
 	setVersion(version: string): this;
 	private _setDefaultConnectionRequirement;

--- a/docs/reference/sdk/classes/PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/PackDefinitionBuilder.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[builder.ts:51](https://github.com/coda/packs-sdk/blob/main/builder.ts#L51)
+[builder.ts:53](https://github.com/coda/packs-sdk/blob/main/builder.ts#L53)
 
 ## Properties
 
@@ -32,7 +32,7 @@ BasicPackDefinition.defaultAuthentication
 
 #### Defined in
 
-[builder.ts:43](https://github.com/coda/packs-sdk/blob/main/builder.ts#L43)
+[builder.ts:45](https://github.com/coda/packs-sdk/blob/main/builder.ts#L45)
 
 ___
 
@@ -46,7 +46,7 @@ BasicPackDefinition.formats
 
 #### Defined in
 
-[builder.ts:39](https://github.com/coda/packs-sdk/blob/main/builder.ts#L39)
+[builder.ts:41](https://github.com/coda/packs-sdk/blob/main/builder.ts#L41)
 
 ___
 
@@ -60,7 +60,7 @@ BasicPackDefinition.formulaNamespace
 
 #### Defined in
 
-[builder.ts:47](https://github.com/coda/packs-sdk/blob/main/builder.ts#L47)
+[builder.ts:49](https://github.com/coda/packs-sdk/blob/main/builder.ts#L49)
 
 ___
 
@@ -74,7 +74,7 @@ BasicPackDefinition.formulas
 
 #### Defined in
 
-[builder.ts:38](https://github.com/coda/packs-sdk/blob/main/builder.ts#L38)
+[builder.ts:40](https://github.com/coda/packs-sdk/blob/main/builder.ts#L40)
 
 ___
 
@@ -88,7 +88,7 @@ BasicPackDefinition.networkDomains
 
 #### Defined in
 
-[builder.ts:41](https://github.com/coda/packs-sdk/blob/main/builder.ts#L41)
+[builder.ts:43](https://github.com/coda/packs-sdk/blob/main/builder.ts#L43)
 
 ___
 
@@ -102,7 +102,7 @@ BasicPackDefinition.syncTables
 
 #### Defined in
 
-[builder.ts:40](https://github.com/coda/packs-sdk/blob/main/builder.ts#L40)
+[builder.ts:42](https://github.com/coda/packs-sdk/blob/main/builder.ts#L42)
 
 ___
 
@@ -116,7 +116,7 @@ BasicPackDefinition.systemConnectionAuthentication
 
 #### Defined in
 
-[builder.ts:44](https://github.com/coda/packs-sdk/blob/main/builder.ts#L44)
+[builder.ts:46](https://github.com/coda/packs-sdk/blob/main/builder.ts#L46)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[builder.ts:46](https://github.com/coda/packs-sdk/blob/main/builder.ts#L46)
+[builder.ts:48](https://github.com/coda/packs-sdk/blob/main/builder.ts#L48)
 
 ## Methods
 
@@ -139,10 +139,12 @@ Adds a column format definition to this pack.
 In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
 
 **`example`**
+```
 pack.addColumnFormat({
   name: 'MyColumn',
   formulaName: 'MyFormula',
 });
+```
 
 #### Parameters
 
@@ -156,7 +158,7 @@ pack.addColumnFormat({
 
 #### Defined in
 
-[builder.ts:180](https://github.com/coda/packs-sdk/blob/main/builder.ts#L180)
+[builder.ts:190](https://github.com/coda/packs-sdk/blob/main/builder.ts#L190)
 
 ___
 
@@ -169,6 +171,7 @@ Adds a dynamic sync table definition to this pack.
 In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
 
 **`example`**
+```
 pack.addDynamicSyncTable({
   name: 'MySyncTable',
   getName: async (context) => {
@@ -181,6 +184,7 @@ pack.addDynamicSyncTable({
   },
   ...
 });
+```
 
 #### Type parameters
 
@@ -200,7 +204,7 @@ pack.addDynamicSyncTable({
 
 #### Defined in
 
-[builder.ts:160](https://github.com/coda/packs-sdk/blob/main/builder.ts#L160)
+[builder.ts:168](https://github.com/coda/packs-sdk/blob/main/builder.ts#L168)
 
 ___
 
@@ -213,6 +217,7 @@ Adds a formula definition to this pack.
 In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
 
 **`example`**
+```
 pack.addFormula({
   resultType: ValueType.String,
    name: 'MyFormula',
@@ -228,6 +233,7 @@ pack.addFormula({
      return `Hello ${param}`;
    },
 });
+```
 
 #### Type parameters
 
@@ -247,7 +253,7 @@ pack.addFormula({
 
 #### Defined in
 
-[builder.ts:94](https://github.com/coda/packs-sdk/blob/main/builder.ts#L94)
+[builder.ts:98](https://github.com/coda/packs-sdk/blob/main/builder.ts#L98)
 
 ___
 
@@ -267,7 +273,9 @@ You are allowed one network domain per pack by default. If your pack needs
 to connect to multiple domains, contact Coda Support for approval.
 
 **`example`**
+```
 pack.addNetworkDomain('example.com');
+```
 
 #### Parameters
 
@@ -281,7 +289,7 @@ pack.addNetworkDomain('example.com');
 
 #### Defined in
 
-[builder.ts:269](https://github.com/coda/packs-sdk/blob/main/builder.ts#L269)
+[builder.ts:285](https://github.com/coda/packs-sdk/blob/main/builder.ts#L285)
 
 ___
 
@@ -294,6 +302,7 @@ Adds a sync table definition to this pack.
 In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
 
 **`example`**
+```
 pack.addSyncTable({
   name: 'MySyncTable',
   identityName: 'EntityName',
@@ -304,6 +313,7 @@ pack.addSyncTable({
     ...
   },
 });
+```
 
 #### Type parameters
 
@@ -326,7 +336,7 @@ pack.addSyncTable({
 
 #### Defined in
 
-[builder.ts:120](https://github.com/coda/packs-sdk/blob/main/builder.ts#L120)
+[builder.ts:126](https://github.com/coda/packs-sdk/blob/main/builder.ts#L126)
 
 ___
 
@@ -344,9 +354,11 @@ In the web editor, the `/SystemAuthentication` shortcut will insert a snippet of
 authentication definition.
 
 **`example`**
+```
 pack.setSystemAuthentication({
   type: AuthenticationType.HeaderBearerToken,
 });
+```
 
 #### Parameters
 
@@ -360,7 +372,7 @@ pack.setSystemAuthentication({
 
 #### Defined in
 
-[builder.ts:241](https://github.com/coda/packs-sdk/blob/main/builder.ts#L241)
+[builder.ts:255](https://github.com/coda/packs-sdk/blob/main/builder.ts#L255)
 
 ___
 
@@ -382,9 +394,11 @@ formula. To change the default, you can pass a `defaultConnectionRequirement` op
 this method.
 
 **`example`**
+```
 pack.setUserAuthentication({
   type: AuthenticationType.HeaderBearerToken,
 });
+```
 
 #### Parameters
 
@@ -398,7 +412,7 @@ pack.setUserAuthentication({
 
 #### Defined in
 
-[builder.ts:204](https://github.com/coda/packs-sdk/blob/main/builder.ts#L204)
+[builder.ts:216](https://github.com/coda/packs-sdk/blob/main/builder.ts#L216)
 
 ___
 
@@ -414,7 +428,9 @@ and the web editor will automatically provide an appropriate semantic version
 each time you build a version.
 
 **`example`**
+```
 pack.setVersion('1.2.3');
+```
 
 #### Parameters
 
@@ -428,4 +444,4 @@ pack.setVersion('1.2.3');
 
 #### Defined in
 
-[builder.ts:285](https://github.com/coda/packs-sdk/blob/main/builder.ts#L285)
+[builder.ts:303](https://github.com/coda/packs-sdk/blob/main/builder.ts#L303)

--- a/docs/reference/sdk/functions/autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/autocompleteSearchObjects.md
@@ -23,4 +23,4 @@
 
 #### Defined in
 
-[api.ts:736](https://github.com/coda/packs-sdk/blob/main/api.ts#L736)
+[api.ts:750](https://github.com/coda/packs-sdk/blob/main/api.ts#L750)

--- a/docs/reference/sdk/functions/makeDynamicSyncTable.md
+++ b/docs/reference/sdk/functions/makeDynamicSyncTable.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[api.ts:1008](https://github.com/coda/packs-sdk/blob/main/api.ts#L1008)
+[api.ts:1022](https://github.com/coda/packs-sdk/blob/main/api.ts#L1022)

--- a/docs/reference/sdk/functions/makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/makeEmptyFormula.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[api.ts:1088](https://github.com/coda/packs-sdk/blob/main/api.ts#L1088)
+[api.ts:1102](https://github.com/coda/packs-sdk/blob/main/api.ts#L1102)

--- a/docs/reference/sdk/functions/makeFormula.md
+++ b/docs/reference/sdk/functions/makeFormula.md
@@ -21,29 +21,39 @@ indicating that the array elements are all just strings, or it could be an objec
 created using [makeObjectSchema](makeObjectSchema.md) if the elements are objects.
 
 **`example`**
+```
 makeFormula({resultType: ValueType.String, name: 'Hello', ...});
+```
 
 **`example`**
+```
 makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
+```
 
 **`example`**
+```
 makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
+```
 
 **`example`**
+```
 makeFormula({
   resultType: ValueType.Object,
   schema: makeObjectSchema({type: ValueType.Object, properties: {...}}),
   name: 'HelloObject',
   ...
 });
+```
 
 **`example`**
+```
 makeFormula({
   resultType: ValueType.Array,
   items: makeObjectSchema({type: ValueType.Object, properties: {...}}),
   name: 'HelloObjectArray',
   ...
 });
+```
 
 #### Type parameters
 
@@ -63,4 +73,4 @@ makeFormula({
 
 #### Defined in
 
-[api.ts:529](https://github.com/coda/packs-sdk/blob/main/api.ts#L529)
+[api.ts:543](https://github.com/coda/packs-sdk/blob/main/api.ts#L543)

--- a/docs/reference/sdk/functions/makeMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeMetadataFormula.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[api.ts:683](https://github.com/coda/packs-sdk/blob/main/api.ts#L683)
+[api.ts:697](https://github.com/coda/packs-sdk/blob/main/api.ts#L697)

--- a/docs/reference/sdk/functions/makeParameter.md
+++ b/docs/reference/sdk/functions/makeParameter.md
@@ -5,10 +5,14 @@
 Create a definition for a parameter for a formula or sync.
 
 **`example`**
+```
 makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
+```
 
 **`example`**
+```
 makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
+```
 
 #### Type parameters
 
@@ -28,4 +32,4 @@ makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', descriptio
 
 #### Defined in
 
-[api.ts:228](https://github.com/coda/packs-sdk/blob/main/api.ts#L228)
+[api.ts:232](https://github.com/coda/packs-sdk/blob/main/api.ts#L232)

--- a/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
@@ -14,4 +14,4 @@
 
 #### Defined in
 
-[api.ts:753](https://github.com/coda/packs-sdk/blob/main/api.ts#L753)
+[api.ts:767](https://github.com/coda/packs-sdk/blob/main/api.ts#L767)

--- a/docs/reference/sdk/functions/makeSyncTable.md
+++ b/docs/reference/sdk/functions/makeSyncTable.md
@@ -34,4 +34,4 @@ See [Normalization](/index.html#normalization) for more information about schema
 
 #### Defined in
 
-[api.ts:927](https://github.com/coda/packs-sdk/blob/main/api.ts#L927)
+[api.ts:941](https://github.com/coda/packs-sdk/blob/main/api.ts#L941)

--- a/docs/reference/sdk/functions/makeTranslateObjectFormula.md
+++ b/docs/reference/sdk/functions/makeTranslateObjectFormula.md
@@ -21,4 +21,4 @@
 
 #### Defined in
 
-[api.ts:1059](https://github.com/coda/packs-sdk/blob/main/api.ts#L1059)
+[api.ts:1073](https://github.com/coda/packs-sdk/blob/main/api.ts#L1073)

--- a/docs/reference/sdk/functions/newPack.md
+++ b/docs/reference/sdk/functions/newPack.md
@@ -5,10 +5,12 @@
 Creates a new skeleton pack definition that can be added to.
 
 **`example`**
+```
 export const pack = newPack();
 pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});
 pack.addSyncTable('MyTable', ...);
 pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+```
 
 #### Parameters
 
@@ -22,4 +24,4 @@ pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
 
 #### Defined in
 
-[builder.ts:33](https://github.com/coda/packs-sdk/blob/main/builder.ts#L33)
+[builder.ts:35](https://github.com/coda/packs-sdk/blob/main/builder.ts#L35)

--- a/docs/reference/sdk/functions/simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/simpleAutocomplete.md
@@ -15,4 +15,4 @@
 
 #### Defined in
 
-[api.ts:715](https://github.com/coda/packs-sdk/blob/main/api.ts#L715)
+[api.ts:729](https://github.com/coda/packs-sdk/blob/main/api.ts#L729)

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[api.ts:378](https://github.com/coda/packs-sdk/blob/main/api.ts#L378)
+[api.ts:382](https://github.com/coda/packs-sdk/blob/main/api.ts#L382)
 
 ___
 

--- a/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
@@ -11,7 +11,7 @@ than is used internally.
 
 #### Defined in
 
-[api.ts:660](https://github.com/coda/packs-sdk/blob/main/api.ts#L660)
+[api.ts:674](https://github.com/coda/packs-sdk/blob/main/api.ts#L674)
 
 ___
 
@@ -21,7 +21,7 @@ ___
 
 #### Defined in
 
-[api.ts:662](https://github.com/coda/packs-sdk/blob/main/api.ts#L662)
+[api.ts:676](https://github.com/coda/packs-sdk/blob/main/api.ts#L676)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[api.ts:661](https://github.com/coda/packs-sdk/blob/main/api.ts#L661)
+[api.ts:675](https://github.com/coda/packs-sdk/blob/main/api.ts#L675)

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -233,4 +233,4 @@ CommonPackFormulaDef.varargParameters
 
 #### Defined in
 
-[api.ts:355](https://github.com/coda/packs-sdk/blob/main/api.ts#L355)
+[api.ts:359](https://github.com/coda/packs-sdk/blob/main/api.ts#L359)

--- a/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
+++ b/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[api.ts:711](https://github.com/coda/packs-sdk/blob/main/api.ts#L711)
+[api.ts:725](https://github.com/coda/packs-sdk/blob/main/api.ts#L725)
 
 ___
 
@@ -18,4 +18,4 @@ ___
 
 #### Defined in
 
-[api.ts:712](https://github.com/coda/packs-sdk/blob/main/api.ts#L712)
+[api.ts:726](https://github.com/coda/packs-sdk/blob/main/api.ts#L726)

--- a/docs/reference/sdk/interfaces/SyncFormulaResult.md
+++ b/docs/reference/sdk/interfaces/SyncFormulaResult.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api.ts:435](https://github.com/coda/packs-sdk/blob/main/api.ts#L435)
+[api.ts:439](https://github.com/coda/packs-sdk/blob/main/api.ts#L439)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[api.ts:434](https://github.com/coda/packs-sdk/blob/main/api.ts#L434)
+[api.ts:438](https://github.com/coda/packs-sdk/blob/main/api.ts#L438)

--- a/docs/reference/sdk/types/Formula.md
+++ b/docs/reference/sdk/types/Formula.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[api.ts:410](https://github.com/coda/packs-sdk/blob/main/api.ts#L410)
+[api.ts:414](https://github.com/coda/packs-sdk/blob/main/api.ts#L414)

--- a/docs/reference/sdk/types/MetadataContext.md
+++ b/docs/reference/sdk/types/MetadataContext.md
@@ -9,4 +9,4 @@ values are provided in this context object.
 
 #### Defined in
 
-[api.ts:671](https://github.com/coda/packs-sdk/blob/main/api.ts#L671)
+[api.ts:685](https://github.com/coda/packs-sdk/blob/main/api.ts#L685)

--- a/docs/reference/sdk/types/MetadataFormula.md
+++ b/docs/reference/sdk/types/MetadataFormula.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api.ts:674](https://github.com/coda/packs-sdk/blob/main/api.ts#L674)
+[api.ts:688](https://github.com/coda/packs-sdk/blob/main/api.ts#L688)

--- a/docs/reference/sdk/types/MetadataFormulaResultType.md
+++ b/docs/reference/sdk/types/MetadataFormulaResultType.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api.ts:673](https://github.com/coda/packs-sdk/blob/main/api.ts#L673)
+[api.ts:687](https://github.com/coda/packs-sdk/blob/main/api.ts#L687)

--- a/docs/reference/sdk/types/PackFormulaMetadata.md
+++ b/docs/reference/sdk/types/PackFormulaMetadata.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api.ts:419](https://github.com/coda/packs-sdk/blob/main/api.ts#L419)
+[api.ts:423](https://github.com/coda/packs-sdk/blob/main/api.ts#L423)

--- a/docs/reference/sdk/types/TypedPackFormula.md
+++ b/docs/reference/sdk/types/TypedPackFormula.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api.ts:416](https://github.com/coda/packs-sdk/blob/main/api.ts#L416)
+[api.ts:420](https://github.com/coda/packs-sdk/blob/main/api.ts#L420)


### PR DESCRIPTION
Improves how they are displayed in the rendered docs. [Preview](https://coda-packs-sdk.readthedocs-hosted.com/en/ek-example/reference/sdk/functions/makeFormula/).

### Before
![Before](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/d5uR5WX6/90cd7793-a294-4dc9-b350-bd450711e9cf.jpg?v=8ce972885f6020d7d3940b98bddaceee)

### After
![After](https://p-zmf7dq.b0.n0.cdn.getcloudapp.com/items/geuAewKj/67615753-5417-4b10-9d69-a7e99c257159.jpg?v=f0859b47444e39d14d59d181664aa17d)