### PR TITLE
Switch to new API client that throws errors.

### DIFF
--- a/cli/create.ts
+++ b/cli/create.ts
@@ -3,6 +3,7 @@ import {PACK_ID_FILE_NAME} from './config_storage';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
+import {formatResponseError} from './errors';
 import fs from 'fs';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
@@ -65,7 +66,7 @@ export async function createPack(
     return printAndExit(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
   } catch (err: any) {
     if (isResponseError(err)) {
-      return printAndExit(`Unable to create your pack, received error: ${formatError(err.response)}`);
+      return printAndExit(`Unable to create your pack, received error: ${await formatResponseError(err)}`);
     }
     const errors = [`Unable to create your pack, received error: ${formatError(err)}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -6,7 +6,7 @@ import {formatError} from './errors';
 import fs from 'fs';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
-import {isCodaError} from './errors';
+import {isResponseError} from '../helpers/external-api/coda';
 import * as path from 'path';
 import {printAndExit} from '../testing/helpers';
 import {storePackId} from './config_storage';
@@ -20,15 +20,20 @@ interface CreateArgs {
   workspace?: string;
 }
 
-export async function handleCreate(
-  {manifestFile, codaApiEndpoint, name, description, workspace}: Arguments<CreateArgs>) {
+export async function handleCreate({
+  manifestFile,
+  codaApiEndpoint,
+  name,
+  description,
+  workspace,
+}: Arguments<CreateArgs>) {
   await createPack(manifestFile, codaApiEndpoint, {name, description, workspace});
 }
 
 export async function createPack(
   manifestFile: string,
   codaApiEndpoint: string,
-  {name, description, workspace}: {name?: string; description?: string, workspace?: string},
+  {name, description, workspace}: {name?: string; description?: string; workspace?: string},
 ) {
   const manifestDir = path.dirname(manifestFile);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
@@ -54,15 +59,14 @@ export async function createPack(
 
   const codaClient = createCodaClient(apiKey, formattedEndpoint);
   try {
-    const response = await codaClient.createPack({}, 
-      {name, description, workspaceId: parseWorkspace(workspace)});
-    if (isCodaError(response)) {
-      return printAndExit(`Unable to create your pack, received error: ${formatError(response)}`);
-    }
+    const response = await codaClient.createPack({}, {name, description, workspaceId: parseWorkspace(workspace)});
     const packId = response.packId;
     storePackId(manifestDir, packId, codaApiEndpoint);
     return printAndExit(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
   } catch (err: any) {
+    if (isResponseError(err)) {
+      return printAndExit(`Unable to create your pack, received error: ${formatError(err.response)}`);
+    }
     const errors = [`Unable to create your pack, received error: ${formatError(err)}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));
   }

--- a/cli/errors.ts
+++ b/cli/errors.ts
@@ -1,13 +1,4 @@
 import util from 'util';
-export interface CodaError {
-  statusCode: number;
-  statusMessage: string;
-  message: string;
-}
-
-export function isCodaError(value: any): value is CodaError {
-  return value && 'statusCode' in value && typeof value.statusCode === 'number' && value.statusCode >= 400;
-}
 
 export function tryParseSystemError(error: any) {
   // NB(alan): this should only be hit for Coda developers trying to use the CLI with their development server.

--- a/cli/errors.ts
+++ b/cli/errors.ts
@@ -1,3 +1,4 @@
+import type {ResponseError} from '../helpers/external-api/coda';
 import util from 'util';
 
 export function tryParseSystemError(error: any) {
@@ -6,6 +7,11 @@ export function tryParseSystemError(error: any) {
     return 'Run `export NODE_TLS_REJECT_UNAUTHORIZED=0` and rerun your command.';
   }
   return '';
+}
+
+export async function formatResponseError(err: ResponseError): Promise<string> {
+  const json = await err.response.json();
+  return formatError(json);
 }
 
 export function formatError(obj: any): string {

--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -12,8 +12,8 @@ export function spawnProcess(command: string) {
   });
 }
 
-export function createCodaClient(apiKey: string, protocolAndHost?: string) {
-  return new Client(protocolAndHost ?? 'https://coda.io', apiKey);
+export function createCodaClient(apiToken: string, protocolAndHost?: string) {
+  return new Client({protocolAndHost, apiToken});
 }
 
 export function formatEndpoint(endpoint: string) {

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -1,7 +1,7 @@
 import type {Arguments} from 'yargs';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
-import {isCodaError} from './errors';
+import {isResponseError} from '../helpers/external-api/coda';
 import open from 'open';
 import {printAndExit} from '../testing/helpers';
 import {promptForInput} from '../testing/helpers';
@@ -28,11 +28,12 @@ export async function handleRegister({apiToken, codaApiEndpoint}: Arguments<Regi
   const client = createCodaClient(apiToken, formattedEndpoint);
 
   try {
-    const response = await client.whoami();
-    if (isCodaError(response)) {
+    await client.whoami();
+  } catch (err: any) {
+    if (isResponseError(err)) {
       return printAndExit(`Invalid API token provided.`);
     }
-  } catch (err: any) {
+
     const errors = [`Unexpected error while checking validity of API token: ${err}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));
   }

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -6,7 +6,7 @@ import {formatError} from './errors';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {importManifest} from './helpers';
-import {isCodaError} from './errors';
+import {isResponseError} from '../helpers/external-api/coda';
 import * as path from 'path';
 import {printAndExit} from '../testing/helpers';
 import {tryParseSystemError} from './errors';
@@ -58,12 +58,11 @@ export async function handleRelease({
 
 async function handleResponse<T extends any>(p: Promise<T>): Promise<T> {
   try {
-    const response = await p;
-    if (isCodaError(response)) {
-      return printAndExit(`Error while creating pack release: ${formatError(response)}`);
-    }
-    return p;
+    return await p;
   } catch (err: any) {
+    if (isResponseError(err)) {
+      return printAndExit(`Error while creating pack release: ${formatError(err.response)}`);
+    }
     const errors = [`Unexpected error while creating release: ${formatError(err)}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));
   }

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -3,6 +3,7 @@ import {build} from './build';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
+import {formatResponseError} from './errors';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {importManifest} from './helpers';
@@ -61,7 +62,7 @@ async function handleResponse<T extends any>(p: Promise<T>): Promise<T> {
     return await p;
   } catch (err: any) {
     if (isResponseError(err)) {
-      return printAndExit(`Error while creating pack release: ${formatError(err.response)}`);
+      return printAndExit(`Error while creating pack release: ${await formatResponseError(err)}`);
     }
     const errors = [`Unexpected error while creating release: ${formatError(err)}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -1,6 +1,7 @@
 import type {Arguments} from 'yargs';
 import type {Logger} from '../api_types';
 import type {PackUpload} from '../compiled_types';
+import type {PublicApiPackVersionUploadInfo} from '../helpers/external-api/v1';
 import type {TimerShimStrategy} from '../testing/compile';
 import {compilePackBundle} from '../testing/compile';
 import {compilePackMetadata} from '../helpers/metadata';
@@ -12,7 +13,7 @@ import fs from 'fs-extra';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {importManifest} from './helpers';
-import {isCodaError} from './errors';
+import {isResponseError} from '../helpers/external-api/coda';
 import {isTestCommand} from './helpers';
 import os from 'os';
 import * as path from 'path';
@@ -125,9 +126,14 @@ export async function handleUpload({
     await validateMetadata(metadata);
 
     logger.info('Registering new Pack version...');
-    const registerResponse = await client.registerPackVersion(packId, packVersion, {}, {bundleHash});
-    if (isCodaError(registerResponse)) {
-      return printAndExit(`Error while registering pack version: ${formatError(registerResponse)}`);
+    let registerResponse: PublicApiPackVersionUploadInfo;
+    try {
+      registerResponse = await client.registerPackVersion(packId, packVersion, {}, {bundleHash});
+    } catch (err: any) {
+      if (isResponseError(err)) {
+        return printAndExit(`Error while registering pack version: ${formatError(err.response)}`);
+      }
+      throw err;
     }
 
     const {uploadUrl, headers} = registerResponse;
@@ -136,9 +142,13 @@ export async function handleUpload({
     await uploadPack(uploadUrl, uploadPayload, headers);
 
     logger.info('Validating upload...');
-    const uploadCompleteResponse = await client.packVersionUploadComplete(packId, packVersion, {}, {notes});
-    if (isCodaError(uploadCompleteResponse)) {
-      printAndExit(`Error while finalizing pack version: ${formatError(uploadCompleteResponse)}`);
+    try {
+      await client.packVersionUploadComplete(packId, packVersion, {}, {notes});
+    } catch (err: any) {
+      if (isResponseError(err)) {
+        printAndExit(`Error while finalizing pack version: ${formatError(err.response)}`);
+      }
+      throw err;
     }
   } catch (err: any) {
     const errors = [`Unexpected error during Pack upload: ${formatError(err)}`, tryParseSystemError(err)];

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -9,6 +9,7 @@ import {computeSha256} from '../helpers/crypto';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
+import {formatResponseError} from './errors';
 import fs from 'fs-extra';
 import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
@@ -131,7 +132,7 @@ export async function handleUpload({
       registerResponse = await client.registerPackVersion(packId, packVersion, {}, {bundleHash});
     } catch (err: any) {
       if (isResponseError(err)) {
-        return printAndExit(`Error while registering pack version: ${formatError(err.response)}`);
+        return printAndExit(`Error while registering pack version: ${await formatResponseError(err)}`);
       }
       throw err;
     }
@@ -146,7 +147,7 @@ export async function handleUpload({
       await client.packVersionUploadComplete(packId, packVersion, {}, {notes});
     } catch (err: any) {
       if (isResponseError(err)) {
-        printAndExit(`Error while finalizing pack version: ${formatError(err.response)}`);
+        printAndExit(`Error while finalizing pack version: ${await formatResponseError(err)}`);
       }
       throw err;
     }

--- a/dist/cli/create.d.ts
+++ b/dist/cli/create.d.ts
@@ -6,7 +6,7 @@ interface CreateArgs {
     description?: string;
     workspace?: string;
 }
-export declare function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace }: Arguments<CreateArgs>): Promise<void>;
+export declare function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, }: Arguments<CreateArgs>): Promise<void>;
 export declare function createPack(manifestFile: string, codaApiEndpoint: string, { name, description, workspace }: {
     name?: string;
     description?: string;

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -27,6 +27,7 @@ const config_storage_1 = require("./config_storage");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
+const errors_2 = require("./errors");
 const fs_1 = __importDefault(require("fs"));
 const config_storage_2 = require("./config_storage");
 const config_storage_3 = require("./config_storage");
@@ -34,7 +35,7 @@ const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
 const helpers_3 = require("../testing/helpers");
 const config_storage_4 = require("./config_storage");
-const errors_2 = require("./errors");
+const errors_3 = require("./errors");
 async function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, }) {
     await createPack(manifestFile, codaApiEndpoint, { name, description, workspace });
 }
@@ -66,9 +67,9 @@ async function createPack(manifestFile, codaApiEndpoint, { name, description, wo
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {
-            return (0, helpers_3.printAndExit)(`Unable to create your pack, received error: ${(0, errors_1.formatError)(err.response)}`);
+            return (0, helpers_3.printAndExit)(`Unable to create your pack, received error: ${await (0, errors_2.formatResponseError)(err)}`);
         }
-        const errors = [`Unable to create your pack, received error: ${(0, errors_1.formatError)(err)}`, (0, errors_2.tryParseSystemError)(err)];
+        const errors = [`Unable to create your pack, received error: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
         return (0, helpers_3.printAndExit)(errors.join('\n'));
     }
 }

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -30,12 +30,12 @@ const errors_1 = require("./errors");
 const fs_1 = __importDefault(require("fs"));
 const config_storage_2 = require("./config_storage");
 const config_storage_3 = require("./config_storage");
-const errors_2 = require("./errors");
+const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
 const helpers_3 = require("../testing/helpers");
 const config_storage_4 = require("./config_storage");
-const errors_3 = require("./errors");
-async function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace }) {
+const errors_2 = require("./errors");
+async function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, }) {
     await createPack(manifestFile, codaApiEndpoint, { name, description, workspace });
 }
 exports.handleCreate = handleCreate;
@@ -60,15 +60,15 @@ async function createPack(manifestFile, codaApiEndpoint, { name, description, wo
     const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     try {
         const response = await codaClient.createPack({}, { name, description, workspaceId: parseWorkspace(workspace) });
-        if ((0, errors_2.isCodaError)(response)) {
-            return (0, helpers_3.printAndExit)(`Unable to create your pack, received error: ${(0, errors_1.formatError)(response)}`);
-        }
         const packId = response.packId;
         (0, config_storage_4.storePackId)(manifestDir, packId, codaApiEndpoint);
         return (0, helpers_3.printAndExit)(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
     }
     catch (err) {
-        const errors = [`Unable to create your pack, received error: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
+        if ((0, coda_1.isResponseError)(err)) {
+            return (0, helpers_3.printAndExit)(`Unable to create your pack, received error: ${(0, errors_1.formatError)(err.response)}`);
+        }
+        const errors = [`Unable to create your pack, received error: ${(0, errors_1.formatError)(err)}`, (0, errors_2.tryParseSystemError)(err)];
         return (0, helpers_3.printAndExit)(errors.join('\n'));
     }
 }

--- a/dist/cli/errors.d.ts
+++ b/dist/cli/errors.d.ts
@@ -1,8 +1,2 @@
-export interface CodaError {
-    statusCode: number;
-    statusMessage: string;
-    message: string;
-}
-export declare function isCodaError(value: any): value is CodaError;
 export declare function tryParseSystemError(error: any): "" | "Run `export NODE_TLS_REJECT_UNAUTHORIZED=0` and rerun your command.";
 export declare function formatError(obj: any): string;

--- a/dist/cli/errors.d.ts
+++ b/dist/cli/errors.d.ts
@@ -1,2 +1,4 @@
+import type { ResponseError } from '../helpers/external-api/coda';
 export declare function tryParseSystemError(error: any): "" | "Run `export NODE_TLS_REJECT_UNAUTHORIZED=0` and rerun your command.";
+export declare function formatResponseError(err: ResponseError): Promise<string>;
 export declare function formatError(obj: any): string;

--- a/dist/cli/errors.js
+++ b/dist/cli/errors.js
@@ -3,12 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.formatError = exports.tryParseSystemError = exports.isCodaError = void 0;
+exports.formatError = exports.tryParseSystemError = void 0;
 const util_1 = __importDefault(require("util"));
-function isCodaError(value) {
-    return value && 'statusCode' in value && typeof value.statusCode === 'number' && value.statusCode >= 400;
-}
-exports.isCodaError = isCodaError;
 function tryParseSystemError(error) {
     // NB(alan): this should only be hit for Coda developers trying to use the CLI with their development server.
     if (error.errno === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {

--- a/dist/cli/errors.js
+++ b/dist/cli/errors.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.formatError = exports.tryParseSystemError = void 0;
+exports.formatError = exports.formatResponseError = exports.tryParseSystemError = void 0;
 const util_1 = __importDefault(require("util"));
 function tryParseSystemError(error) {
     // NB(alan): this should only be hit for Coda developers trying to use the CLI with their development server.
@@ -13,6 +13,11 @@ function tryParseSystemError(error) {
     return '';
 }
 exports.tryParseSystemError = tryParseSystemError;
+async function formatResponseError(err) {
+    const json = await err.response.json();
+    return formatError(json);
+}
+exports.formatResponseError = formatResponseError;
 function formatError(obj) {
     return util_1.default.inspect(obj, false, null, true);
 }

--- a/dist/cli/helpers.d.ts
+++ b/dist/cli/helpers.d.ts
@@ -3,7 +3,7 @@ import type { Authentication } from '../types';
 import { Client } from '../helpers/external-api/coda';
 import type { PackVersionDefinition } from '../types';
 export declare function spawnProcess(command: string): import("child_process").SpawnSyncReturns<Buffer>;
-export declare function createCodaClient(apiKey: string, protocolAndHost?: string): Client;
+export declare function createCodaClient(apiToken: string, protocolAndHost?: string): Client;
 export declare function formatEndpoint(endpoint: string): string;
 export declare function isTestCommand(): boolean;
 export declare function makeManifestFullPath(manifestPath: string): string;

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -34,8 +34,8 @@ function spawnProcess(command) {
     });
 }
 exports.spawnProcess = spawnProcess;
-function createCodaClient(apiKey, protocolAndHost) {
-    return new coda_1.Client(protocolAndHost !== null && protocolAndHost !== void 0 ? protocolAndHost : 'https://coda.io', apiKey);
+function createCodaClient(apiToken, protocolAndHost) {
+    return new coda_1.Client({ protocolAndHost, apiToken });
 }
 exports.createCodaClient = createCodaClient;
 function formatEndpoint(endpoint) {

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -6,12 +6,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleRegister = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
-const errors_1 = require("./errors");
+const coda_1 = require("../helpers/external-api/coda");
 const open_1 = __importDefault(require("open"));
 const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const config_storage_1 = require("./config_storage");
-const errors_2 = require("./errors");
+const errors_1 = require("./errors");
 async function handleRegister({ apiToken, codaApiEndpoint }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     if (!apiToken) {
@@ -25,13 +25,13 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     try {
-        const response = await client.whoami();
-        if ((0, errors_1.isCodaError)(response)) {
-            return (0, helpers_3.printAndExit)(`Invalid API token provided.`);
-        }
+        await client.whoami();
     }
     catch (err) {
-        const errors = [`Unexpected error while checking validity of API token: ${err}`, (0, errors_2.tryParseSystemError)(err)];
+        if ((0, coda_1.isResponseError)(err)) {
+            return (0, helpers_3.printAndExit)(`Invalid API token provided.`);
+        }
+        const errors = [`Unexpected error while checking validity of API token: ${err}`, (0, errors_1.tryParseSystemError)(err)];
         return (0, helpers_3.printAndExit)(errors.join('\n'));
     }
     (0, config_storage_1.storeCodaApiKey)(apiToken, process.env.PWD, codaApiEndpoint);

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -27,10 +27,10 @@ const errors_1 = require("./errors");
 const config_storage_1 = require("./config_storage");
 const config_storage_2 = require("./config_storage");
 const helpers_3 = require("./helpers");
-const errors_2 = require("./errors");
+const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
 const helpers_4 = require("../testing/helpers");
-const errors_3 = require("./errors");
+const errors_2 = require("./errors");
 async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }) {
     const manifestDir = path.dirname(manifestFile);
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
@@ -60,14 +60,13 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
 exports.handleRelease = handleRelease;
 async function handleResponse(p) {
     try {
-        const response = await p;
-        if ((0, errors_2.isCodaError)(response)) {
-            return (0, helpers_4.printAndExit)(`Error while creating pack release: ${(0, errors_1.formatError)(response)}`);
-        }
-        return p;
+        return await p;
     }
     catch (err) {
-        const errors = [`Unexpected error while creating release: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
+        if ((0, coda_1.isResponseError)(err)) {
+            return (0, helpers_4.printAndExit)(`Error while creating pack release: ${(0, errors_1.formatError)(err.response)}`);
+        }
+        const errors = [`Unexpected error while creating release: ${(0, errors_1.formatError)(err)}`, (0, errors_2.tryParseSystemError)(err)];
         return (0, helpers_4.printAndExit)(errors.join('\n'));
     }
 }

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -24,13 +24,14 @@ const build_1 = require("./build");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
+const errors_2 = require("./errors");
 const config_storage_1 = require("./config_storage");
 const config_storage_2 = require("./config_storage");
 const helpers_3 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
 const helpers_4 = require("../testing/helpers");
-const errors_2 = require("./errors");
+const errors_3 = require("./errors");
 async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }) {
     const manifestDir = path.dirname(manifestFile);
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
@@ -64,9 +65,9 @@ async function handleResponse(p) {
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {
-            return (0, helpers_4.printAndExit)(`Error while creating pack release: ${(0, errors_1.formatError)(err.response)}`);
+            return (0, helpers_4.printAndExit)(`Error while creating pack release: ${await (0, errors_2.formatResponseError)(err)}`);
         }
-        const errors = [`Unexpected error while creating release: ${(0, errors_1.formatError)(err)}`, (0, errors_2.tryParseSystemError)(err)];
+        const errors = [`Unexpected error while creating release: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
         return (0, helpers_4.printAndExit)(errors.join('\n'));
     }
 }

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -29,6 +29,7 @@ const crypto_1 = require("../helpers/crypto");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const errors_1 = require("./errors");
+const errors_2 = require("./errors");
 const fs_extra_1 = __importDefault(require("fs-extra"));
 const config_storage_1 = require("./config_storage");
 const config_storage_2 = require("./config_storage");
@@ -40,7 +41,7 @@ const path = __importStar(require("path"));
 const helpers_5 = require("../testing/helpers");
 const helpers_6 = require("../testing/helpers");
 const request_promise_native_1 = __importDefault(require("request-promise-native"));
-const errors_2 = require("./errors");
+const errors_3 = require("./errors");
 const uuid_1 = require("uuid");
 const validate_1 = require("./validate");
 function cleanup(intermediateOutputDirectory, logger) {
@@ -117,7 +118,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         }
         catch (err) {
             if ((0, coda_1.isResponseError)(err)) {
-                return printAndExit(`Error while registering pack version: ${(0, errors_1.formatError)(err.response)}`);
+                return printAndExit(`Error while registering pack version: ${await (0, errors_2.formatResponseError)(err)}`);
             }
             throw err;
         }
@@ -130,13 +131,13 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         }
         catch (err) {
             if ((0, coda_1.isResponseError)(err)) {
-                printAndExit(`Error while finalizing pack version: ${(0, errors_1.formatError)(err.response)}`);
+                printAndExit(`Error while finalizing pack version: ${await (0, errors_2.formatResponseError)(err)}`);
             }
             throw err;
         }
     }
     catch (err) {
-        const errors = [`Unexpected error during Pack upload: ${(0, errors_1.formatError)(err)}`, (0, errors_2.tryParseSystemError)(err)];
+        const errors = [`Unexpected error during Pack upload: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
         printAndExit(errors.join(`\n`));
     }
     cleanup(intermediateOutputDirectory, logger);

--- a/dist/helpers/external-api/coda.d.ts
+++ b/dist/helpers/external-api/coda.d.ts
@@ -3,16 +3,26 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: c17f33bab1c1496bf73356d09380fa0a04e074f97741adc801db545ea8db0026
+ * Hash: 3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d
  */
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
 import * as types from './v1';
+export declare class ResponseError extends Error {
+    response: Response;
+    constructor(response: Response);
+}
+export declare function isResponseError(err: any): err is ResponseError;
 export declare class Client {
     private readonly protocolAndHost;
-    private readonly apiKey;
+    private readonly apiToken;
     private readonly userAgent;
-    constructor(protocolAndHost: string, apiKey: string, userAgent?: string);
+    constructor({ apiToken, protocolAndHost, userAgent, }: {
+        apiToken: string;
+        protocolAndHost?: string;
+        userAgent?: string;
+    });
+    private _makeRequest;
     listCategories(params?: {}): Promise<types.PublicApiDocCategoryList>;
     listDocs(params?: {
         isOwner?: boolean;
@@ -115,6 +125,7 @@ export declare class Client {
     listPacks(params?: {
         accessType?: types.PublicApiPackAccessType;
         sortBy?: types.PublicApiPacksSortBy;
+        workspaceId?: string;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackSummaryList>;
@@ -125,6 +136,8 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackVersionList>;
+    getNextPackVersion(packId: number, params: {} | undefined, payload: types.PublicApiGetNextPackVersionRequest): Promise<types.PublicApiNextPackVersionInfo>;
+    getPackVersionDiffs(packId: number, basePackVersion: string, targetPackVersion: string, params?: {}): Promise<types.PublicApiPackVersionDiffs>;
     registerPackVersion(packId: number, packVersion: string, params: {} | undefined, payload: types.PublicApiRegisterPackVersionRequest): Promise<types.PublicApiPackVersionUploadInfo>;
     packVersionUploadComplete(packId: number, packVersion: string, params: {} | undefined, payload: types.PublicApiCreatePackVersionRequest): Promise<types.PublicApiCreatePackVersionResponse>;
     createPackRelease(packId: number, params: {} | undefined, payload: types.PublicApiCreatePackReleaseRequest): Promise<types.PublicApiPackRelease>;
@@ -132,20 +145,46 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackReleaseList>;
-    setPackLiveVersion(packId: number, params: {} | undefined, payload: types.PublicApiSetPackLiveVersionRequest): Promise<types.PublicApiSetPackLiveVersionResponse>;
-    setPackSystemConnection(packId: number, params: {} | undefined, payload: types.PublicApiSetPackSystemConnectionRequest): Promise<types.PublicApiPackSystemConnection>;
-    deletePackSystemConnection(packId: number, params?: {}): Promise<types.PublicApiDeletePackSystemConnectionResponse>;
-    getPackSystemConnection(packId: number, params?: {}): Promise<types.PublicApiPackSystemConnection>;
+    setPackOauthConfig(packId: number, params: {} | undefined, payload: types.PublicApiSetPackOauthConfigRequest): Promise<types.PublicApiPackOauthConfigMetadata>;
+    getPackOauthConfig(packId: number, params?: {}): Promise<types.PublicApiPackOauthConfigMetadata>;
+    setPackSystemConnection(packId: number, params: {} | undefined, payload: types.PublicApiSetPackSystemConnectionRequest): Promise<types.PublicApiPackSystemConnectionMetadata>;
+    patchPackSystemConnection(packId: number, params: {} | undefined, payload: types.PublicApiPatchPackSystemConnectionRequest): Promise<types.PublicApiPackSystemConnectionMetadata>;
+    getPackSystemConnection(packId: number, params?: {}): Promise<types.PublicApiPackSystemConnectionMetadata>;
     getPackPermissions(packId: number, params?: {}): Promise<types.PublicApiPackPermissionList>;
     addPackPermission(packId: number, params: {} | undefined, payload: types.PublicApiAddPackPermissionRequest): Promise<types.PublicApiAddPackPermissionResponse>;
     deletePackPermission(packId: number, permissionId: string, params?: {}): Promise<types.PublicApiDeletePackPermissionResponse>;
+    listPackMakers(packId: number, params?: {
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiListPackMakersResponse>;
+    addPackMaker(packId: number, params: {} | undefined, payload: types.PublicApiAddPackMakerRequest): Promise<types.PublicApiAddPackMakerResponse>;
+    deletePackMaker(packId: number, loginId: string, params?: {}): Promise<types.PublicApiAddPackMakerResponse>;
+    listPackCategories(packId: number, params?: {
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiListPackCategoriesResponse>;
+    addPackCategory(packId: number, params: {} | undefined, payload: types.PublicApiAddPackCategoryRequest): Promise<types.PublicApiAddPackCategoryResponse>;
+    deletePackCategory(packId: number, categoryName: string, params?: {}): Promise<types.PublicApiDeletePackCategoryResponse>;
     uploadPackAsset(packId: number, params: {} | undefined, payload: types.PublicApiUploadPackAssetRequest): Promise<types.PublicApiPackAssetUploadInfo>;
     uploadPackSourceCode(packId: number, params: {} | undefined, payload: types.PublicApiUploadPackSourceCodeRequest): Promise<types.PublicApiPackSourceCodeUploadInfo>;
     packAssetUploadComplete(packId: number, packAssetId: string, packAssetType: types.PublicApiPackAssetType, params?: {}): Promise<types.PublicApiPackAssetUploadCompleteResponse>;
     packSourceCodeUploadComplete(packId: number, packVersion: string, params: {} | undefined, payload: types.PublicApiPackSourceCodeUploadCompleteRequest): Promise<types.PublicApiPackSourceCodeUploadCompleteResponse>;
     getPackSourceCode(packId: number, packVersion: string, params?: {}): Promise<types.PublicApiPackSourceCodeInfo>;
     listPackListings(params?: {
+        packAccessTypes?: types.PublicApiPackAccessTypes;
+        packIds?: string;
+        excludePublicPacks?: boolean;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackListingList>;
+    getPackListing(packId: number, params?: {}): Promise<types.PublicApiPackListingDetail>;
+    listPackLogs(packId: number, docId: string, params?: {
+        logTypes?: string;
+        beforeTimestamp?: string;
+        afterTimestamp?: string;
+        order?: string;
+        q?: string;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiPackLogsList>;
 }

--- a/dist/helpers/external-api/coda.js
+++ b/dist/helpers/external-api/coda.js
@@ -5,33 +5,51 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: c17f33bab1c1496bf73356d09380fa0a04e074f97741adc801db545ea8db0026
+ * Hash: 3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Client = void 0;
+exports.Client = exports.isResponseError = exports.ResponseError = void 0;
 require("es6-promise/auto");
 require("isomorphic-fetch");
 const url_1 = require("../url");
+class ResponseError extends Error {
+    constructor(response) {
+        super(response.statusText);
+        this.response = response;
+    }
+}
+exports.ResponseError = ResponseError;
+function isResponseError(err) {
+    return err instanceof ResponseError;
+}
+exports.isResponseError = isResponseError;
 class Client {
-    constructor(protocolAndHost, apiKey, userAgent = 'Coda-Typescript-API-Client') {
+    constructor({ apiToken, protocolAndHost = 'https://coda.io', userAgent = 'Coda-Typescript-API-Client', }) {
         this.protocolAndHost = protocolAndHost;
-        this.apiKey = apiKey;
+        this.apiToken = apiToken;
         this.userAgent = userAgent;
+    }
+    async _makeRequest(method, url, body) {
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${this.apiToken}`,
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent,
+            },
+            method,
+            body,
+        });
+        if (response.status >= 400) {
+            throw new ResponseError(response);
+        }
+        return response.json();
     }
     async listCategories(params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/categories`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listDocs(params = {}) {
         const allParams = {
@@ -39,153 +57,70 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async createDoc(params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async getDoc(docId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async deleteDoc(docId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl);
     }
     async getSharingMetadata(docId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/acl/metadata`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getPermissions(docId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/acl/permissions`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async addPermission(docId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/acl/permissions`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async deletePermission(docId, permissionId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/acl/permissions/${permissionId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl);
     }
     async publishDoc(docId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/publish`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('PUT', codaUrl, JSON.stringify(payload));
     }
     async unpublishDoc(docId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/publish`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl);
     }
     async listPages(docId, params = {}) {
         const allParams = {
@@ -193,46 +128,21 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/pages`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getPage(docId, pageIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/pages/${pageIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async updatePage(docId, pageIdOrName, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/pages/${pageIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('PUT', codaUrl, JSON.stringify(payload));
     }
     async listTables(docId, params = {}) {
         const allParams = {
@@ -240,30 +150,14 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getTable(docId, tableIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listColumns(docId, tableIdOrName, params = {}) {
         const allParams = {
@@ -271,15 +165,7 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/columns`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listRows(docId, tableIdOrName, params = {}) {
         const allParams = {
@@ -287,123 +173,56 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async upsertRows(docId, tableIdOrName, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async deleteRows(docId, tableIdOrName, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl, JSON.stringify(payload));
     }
     async getRow(docId, tableIdOrName, rowIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows/${rowIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async updateRow(docId, tableIdOrName, rowIdOrName, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows/${rowIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('PUT', codaUrl, JSON.stringify(payload));
     }
     async deleteRow(docId, tableIdOrName, rowIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows/${rowIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl);
     }
     async pushButton(docId, tableIdOrName, rowIdOrName, columnIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows/${rowIdOrName}/buttons/${columnIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl);
     }
     async getColumn(docId, tableIdOrName, columnIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/tables/${tableIdOrName}/columns/${columnIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listFormulas(docId, params = {}) {
         const allParams = {
@@ -411,30 +230,14 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/formulas`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getFormula(docId, formulaIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/formulas/${formulaIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listControls(docId, params = {}) {
         const allParams = {
@@ -442,45 +245,21 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/controls`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getControl(docId, controlIdOrName, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/controls/${controlIdOrName}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async whoami(params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/whoami`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async resolveBrowserLink(url, params = {}) {
         const allParams = {
@@ -488,30 +267,14 @@ class Client {
             url,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/resolveBrowserLink`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getMutationStatus(requestId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/mutationStatus/${requestId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listDocAnalytics(params = {}) {
         const allParams = {
@@ -519,15 +282,7 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/docs`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listWorkspaceMembers(workspaceId, params = {}) {
         const allParams = {
@@ -535,31 +290,14 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/workspaces/${workspaceId}/users`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async changeUserRole(workspaceId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/workspaces/${workspaceId}/users/role`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async listWorkspaceRoleActivity(workspaceId, params = {}) {
         const allParams = {
@@ -567,15 +305,7 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/workspaces/${workspaceId}/roles`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listPacks(params = {}) {
         const allParams = {
@@ -583,62 +313,28 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async createPack(params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async getPack(packId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async updatePack(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PATCH',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('PATCH', codaUrl, JSON.stringify(payload));
     }
     async listPackVersions(packId, params = {}) {
         const allParams = {
@@ -646,63 +342,42 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
+    }
+    async getNextPackVersion(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/nextVersion`, allParams);
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+    }
+    async getPackVersionDiffs(packId, basePackVersion, targetPackVersion, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions/${basePackVersion}/diff/${targetPackVersion}`, allParams);
+        return this._makeRequest('GET', codaUrl);
     }
     async registerPackVersion(packId, packVersion, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions/${packVersion}/register`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async packVersionUploadComplete(packId, packVersion, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions/${packVersion}/uploadComplete`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async createPackRelease(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/releases`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async listPackReleases(packId, params = {}) {
         const allParams = {
@@ -710,201 +385,142 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/releases`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
-    async setPackLiveVersion(packId, params = {}, payload) {
+    async setPackOauthConfig(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
-        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/liveVersion`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/oauthConfig`, allParams);
+        return this._makeRequest('PUT', codaUrl, JSON.stringify(payload));
+    }
+    async getPackOauthConfig(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/oauthConfig`, allParams);
+        return this._makeRequest('GET', codaUrl);
     }
     async setPackSystemConnection(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/systemConnection`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'PUT',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('PUT', codaUrl, JSON.stringify(payload));
     }
-    async deletePackSystemConnection(packId, params = {}) {
+    async patchPackSystemConnection(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/systemConnection`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('PATCH', codaUrl, JSON.stringify(payload));
     }
     async getPackSystemConnection(packId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/systemConnection`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async getPackPermissions(packId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async addPackPermission(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async deletePackPermission(packId, permissionId, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/permissions/${permissionId}`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'DELETE',
-        });
-        return response.json();
+        return this._makeRequest('DELETE', codaUrl);
+    }
+    async listPackMakers(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/makers`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async addPackMaker(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/maker`, allParams);
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+    }
+    async deletePackMaker(packId, loginId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/maker/${loginId}`, allParams);
+        return this._makeRequest('DELETE', codaUrl);
+    }
+    async listPackCategories(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/categories`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async addPackCategory(packId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/category`, allParams);
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+    }
+    async deletePackCategory(packId, categoryName, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/category/${categoryName}`, allParams);
+        return this._makeRequest('DELETE', codaUrl);
     }
     async uploadPackAsset(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/uploadAsset`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async uploadPackSourceCode(packId, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/uploadSourceCode`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async packAssetUploadComplete(packId, packAssetId, packAssetType, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/assets/${packAssetId}/assetType/${packAssetType}/uploadComplete`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl);
     }
     async packSourceCodeUploadComplete(packId, packVersion, params = {}, payload) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions/${packVersion}/sourceCode/uploadComplete`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'POST',
-            body: JSON.stringify(payload),
-        });
-        return response.json();
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
     }
     async getPackSourceCode(packId, packVersion, params = {}) {
         const allParams = {
             ...params,
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/versions/${packVersion}/sourceCode`, allParams);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
     }
     async listPackListings(params = {}) {
         const allParams = {
@@ -912,15 +528,22 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/listings`, pageToken ? { pageToken } : rest);
-        const response = await fetch(codaUrl, {
-            headers: {
-                Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json',
-                'User-Agent': this.userAgent,
-            },
-            method: 'GET',
-        });
-        return response.json();
+        return this._makeRequest('GET', codaUrl);
+    }
+    async getPackListing(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/listing`, allParams);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listPackLogs(packId, docId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/logs`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
     }
 }
 exports.Client = Client;

--- a/dist/helpers/external-api/v1.d.ts
+++ b/dist/helpers/external-api/v1.d.ts
@@ -1,32 +1,38 @@
 /**
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
-export declare const OpenApiSpecHash = "c17f33bab1c1496bf73356d09380fa0a04e074f97741adc801db545ea8db0026";
-export declare const OpenApiSpecVersion = "1.2.0";
+export declare const OpenApiSpecHash = "3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d";
+export declare const OpenApiSpecVersion = "1.2.1";
 /**
  * A constant identifying the type of the resource.
  */
 export declare enum PublicApiType {
-    Doc = "doc",
-    AclPermissions = "aclPermissions",
     AclMetadata = "aclMetadata",
-    User = "user",
+    AclPermissions = "aclPermissions",
     ApiLink = "apiLink",
-    Page = "page",
-    Table = "table",
-    Row = "row",
     Column = "column",
-    Formula = "formula",
     Control = "control",
+    Doc = "doc",
     DocAnalytics = "docAnalytics",
+    Folder = "folder",
+    Formula = "formula",
     MutationStatus = "mutationStatus",
-    Workspace = "workspace",
     Pack = "pack",
-    PackVersion = "packVersion",
     PackAclPermissions = "packAclPermissions",
     PackAsset = "packAsset",
+    PackCategory = "packCategory",
+    PackLog = "packLog",
+    PackMaker = "packMaker",
+    PackOauthConfig = "packOauthConfig",
     PackRelease = "packRelease",
-    PackSourceCode = "packSourceCode"
+    PackSourceCode = "packSourceCode",
+    PackSystemConnection = "packSystemConnection",
+    PackVersion = "packVersion",
+    Page = "page",
+    Row = "row",
+    Table = "table",
+    User = "user",
+    Workspace = "workspace"
 }
 /**
  * Type of principal.
@@ -138,7 +144,7 @@ export interface PublicApiDocReference {
     /**
      * The type of this resource.
      */
-    type: 'doc';
+    type: PublicApiType.Doc;
     /**
      * API link to the Coda doc.
      */
@@ -159,7 +165,7 @@ export interface PublicApiDoc {
     /**
      * The type of this resource.
      */
-    type: 'doc';
+    type: PublicApiType.Doc;
     /**
      * API link to the Coda doc.
      */
@@ -192,6 +198,8 @@ export interface PublicApiDoc {
      */
     updatedAt: string;
     published?: PublicApiDocPublished;
+    folder: PublicApiFolderReference;
+    workspace: PublicApiWorkspaceReference;
     /**
      * ID of the Coda workspace containing this doc.
      */
@@ -248,7 +256,7 @@ export interface PublicApiDocCreate {
      */
     timezone?: string;
     /**
-     * The ID of the folder within which to create this doc. Defaults to your "My Docs" folder in the oldest workspace you joined; this is subject to change. You can get this ID by opening the folder in the docs list on your computer and grabbing the `folderId` query parameter.
+     * The ID of the folder within which to create this doc. Defaults to your "My docs" folder in the oldest workspace you joined; this is subject to change. You can get this ID by opening the folder in the docs list on your computer and grabbing the `folderId` query parameter.
      *
      */
     folderId?: string;
@@ -288,10 +296,6 @@ export interface PublicApiDocPublish {
      */
     slug?: string;
     /**
-     * If true, the doc will display a copy button in the header.
-     */
-    copyable?: boolean;
-    /**
      * If true, indicates that the doc is discoverable.
      */
     discoverable?: boolean;
@@ -322,10 +326,6 @@ export interface PublicApiDocPublished {
      * URL to the cover image for the published doc.
      */
     imageLink?: string;
-    /**
-     * If true, the doc will display a copy button in the header.
-     */
-    copyable: boolean;
     /**
      * If true, indicates that the doc is discoverable.
      */
@@ -369,7 +369,7 @@ export interface PublicApiDocumentCreationResult {
     /**
      * The type of this resource.
      */
-    type: 'doc';
+    type: PublicApiType.Doc;
     /**
      * API link to the Coda doc.
      */
@@ -402,6 +402,8 @@ export interface PublicApiDocumentCreationResult {
      */
     updatedAt: string;
     published?: PublicApiDocPublished;
+    folder: PublicApiFolderReference;
+    workspace: PublicApiWorkspaceReference;
     /**
      * ID of the Coda workspace containing this doc.
      */
@@ -426,7 +428,7 @@ export interface PublicApiPageReference {
     /**
      * The type of this resource.
      */
-    type: 'page';
+    type: PublicApiType.Page;
     /**
      * API link to the page.
      */
@@ -451,7 +453,7 @@ export interface PublicApiPage {
     /**
      * The type of this resource.
      */
-    type: 'page';
+    type: PublicApiType.Page;
     /**
      * API link to the page.
      */
@@ -580,7 +582,7 @@ export interface PublicApiTableReference {
     /**
      * The type of this resource.
      */
-    type: 'table';
+    type: PublicApiType.Table;
     tableType: PublicApiTableType;
     /**
      * API link to the table.
@@ -607,7 +609,7 @@ export interface PublicApiTable {
     /**
      * The type of this resource.
      */
-    type: 'table';
+    type: PublicApiType.Table;
     tableType: PublicApiTableType;
     /**
      * API link to the table.
@@ -666,7 +668,7 @@ export interface PublicApiColumnReference {
     /**
      * The type of this resource.
      */
-    type: 'column';
+    type: PublicApiType.Column;
     /**
      * API link to the column.
      */
@@ -683,7 +685,7 @@ export interface PublicApiColumn {
     /**
      * The type of this resource.
      */
-    type: 'column';
+    type: PublicApiType.Column;
     /**
      * API link to the column.
      */
@@ -700,6 +702,14 @@ export interface PublicApiColumn {
      * Whether the column has a formula set on it.
      */
     calculated?: boolean;
+    /**
+     * Formula on the column.
+     */
+    formula?: string;
+    /**
+     * Default value formula for the column.
+     */
+    defaultValue?: string;
     format: PublicApiColumnFormat;
 }
 /**
@@ -713,7 +723,7 @@ export interface PublicApiColumnDetail {
     /**
      * The type of this resource.
      */
-    type: 'column';
+    type: PublicApiType.Column;
     /**
      * API link to the column.
      */
@@ -730,6 +740,14 @@ export interface PublicApiColumnDetail {
      * Whether the column has a formula set on it.
      */
     calculated?: boolean;
+    /**
+     * Formula on the column.
+     */
+    formula?: string;
+    /**
+     * Default value formula for the column.
+     */
+    defaultValue?: string;
     format: PublicApiColumnFormat;
     parent: PublicApiTableReference;
 }
@@ -859,6 +877,23 @@ export declare type PublicApiSliderColumnFormat = PublicApiSimpleColumnFormat & 
     step?: {} & PublicApiNumberOrNumberFormula;
 };
 /**
+ * Format of a button column.
+ */
+export declare type PublicApiButtonColumnFormat = PublicApiSimpleColumnFormat & {
+    /**
+     * Label formula for the button.
+     */
+    label?: string;
+    /**
+     * DisableIf formula for the button.
+     */
+    disableIf?: string;
+    /**
+     * Action formula for the button.
+     */
+    action?: string;
+};
+/**
  * List of available icon sets.
  */
 export declare enum PublicApiIconSet {
@@ -896,7 +931,7 @@ export declare type PublicApiScaleColumnFormat = PublicApiSimpleColumnFormat & {
 /**
  * Format of a column.
  */
-export declare type PublicApiColumnFormat = PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiEmailColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
+export declare type PublicApiColumnFormat = PublicApiButtonColumnFormat | PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiEmailColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
 /**
  * Format type of the column
  */
@@ -946,7 +981,7 @@ export interface PublicApiRow {
     /**
      * The type of this resource.
      */
-    type: 'row';
+    type: PublicApiType.Row;
     /**
      * API link to the row.
      */
@@ -990,7 +1025,7 @@ export interface PublicApiRowDetail {
     /**
      * The type of this resource.
      */
-    type: 'row';
+    type: PublicApiType.Row;
     /**
      * API link to the row.
      */
@@ -1301,7 +1336,7 @@ export interface PublicApiFormulaReference {
     /**
      * The type of this resource.
      */
-    type: 'formula';
+    type: PublicApiType.Formula;
     /**
      * API link to the formula.
      */
@@ -1323,7 +1358,7 @@ export interface PublicApiFormula {
     /**
      * The type of this resource.
      */
-    type: 'formula';
+    type: PublicApiType.Formula;
     /**
      * API link to the formula.
      */
@@ -1358,7 +1393,7 @@ export interface PublicApiControlReference {
     /**
      * The type of this resource.
      */
-    type: 'control';
+    type: PublicApiType.Control;
     /**
      * API link to the control.
      */
@@ -1380,7 +1415,7 @@ export interface PublicApiControl {
     /**
      * The type of this resource.
      */
-    type: 'control';
+    type: PublicApiType.Control;
     /**
      * API link to the control.
      */
@@ -1435,7 +1470,7 @@ export interface PublicApiUser {
     /**
      * The type of this resource.
      */
-    type: 'user';
+    type: PublicApiType.User;
     /**
      * Browser-friendly link to the user's avatar image.
      */
@@ -1469,7 +1504,7 @@ export interface PublicApiUserSummary {
     /**
      * The type of this resource.
      */
-    type: 'user';
+    type: PublicApiType.User;
     /**
      * Browser-friendly link to the user's avatar image.
      */
@@ -1489,13 +1524,88 @@ export declare type PublicApiNextPageLink = string;
  */
 export declare type PublicApiNextSyncToken = string;
 /**
+ * Info about a publishing category
+ */
+export interface PublicApiPublishingCategory {
+    /**
+     * The ID for this category.
+     */
+    categoryId: string;
+    /**
+     * The name of the category.
+     */
+    categoryName: string;
+}
+/**
+ * Info about the maker
+ */
+export interface PublicApiMaker {
+    /**
+     * Name of the maker.
+     */
+    name: string;
+    /**
+     * Browser-friendly link to the maker's avatar image.
+     */
+    pictureLink?: string;
+    /**
+     * Maker profile identifier for the maker.
+     */
+    slug?: string;
+    /**
+     * Job title for maker.
+     */
+    jobTitle?: string;
+    /**
+     * Employer for maker.
+     */
+    employer?: string;
+    /**
+     * Description for the maker.
+     */
+    description?: string;
+    /**
+     * Email address of the user.
+     */
+    loginId: string;
+}
+/**
+ * Summary about a maker
+ */
+export interface PublicApiMakerSummary {
+    /**
+     * Name of the maker.
+     */
+    name: string;
+    /**
+     * Browser-friendly link to the maker's avatar image.
+     */
+    pictureLink?: string;
+    /**
+     * Maker profile identifier for the maker.
+     */
+    slug?: string;
+    /**
+     * Job title for maker.
+     */
+    jobTitle?: string;
+    /**
+     * Employer for maker.
+     */
+    employer?: string;
+    /**
+     * Description for the maker.
+     */
+    description?: string;
+}
+/**
  * Info about a resolved link to an API resource.
  */
 export interface PublicApiApiLink {
     /**
      * The type of this resource.
      */
-    type: 'apiLink';
+    type: PublicApiType.ApiLink;
     /**
      * Self link to this query.
      */
@@ -1608,6 +1718,23 @@ export interface PublicApiMutationStatus {
     completed: boolean;
 }
 /**
+ * Reference to a Coda folder.
+ */
+export interface PublicApiFolderReference {
+    /**
+     * ID of the Coda folder.
+     */
+    id: string;
+    /**
+     * The type of this resource.
+     */
+    type: PublicApiType.Folder;
+    /**
+     * Browser-friendly link to the folder.
+     */
+    browserLink: string;
+}
+/**
  * Reference to a Coda workspace.
  */
 export interface PublicApiWorkspaceReference {
@@ -1618,7 +1745,11 @@ export interface PublicApiWorkspaceReference {
     /**
      * The type of this resource.
      */
-    type: 'workspace';
+    type: PublicApiType.Workspace;
+    /**
+     * ID of the organization bound to this workspace, if any.
+     */
+    organizationId?: string;
     /**
      * Browser-friendly link to the Coda workspace.
      */
@@ -1635,7 +1766,11 @@ export interface PublicApiWorkspace {
     /**
      * The type of this resource.
      */
-    type: 'workspace';
+    type: PublicApiType.Workspace;
+    /**
+     * ID of the organization bound to this workspace, if any.
+     */
+    organizationId?: string;
     /**
      * Browser-friendly link to the Coda workspace.
      */
@@ -1829,9 +1964,17 @@ export interface PublicApiPack {
      */
     logoUrl?: string;
     /**
+     * The link to the cover photo of the Pack.
+     */
+    coverUrl?: string;
+    /**
      * The parent workspace for the Pack.
      */
     workspaceId: string;
+    /**
+     * Publishing categories associated with this Pack.
+     */
+    categories: PublicApiPublishingCategory[];
     /**
      * The name of the Pack.
      */
@@ -1844,6 +1987,10 @@ export interface PublicApiPack {
      * A short version of the description of the Pack.
      */
     shortDescription: string;
+    /**
+     * A contact email for the Pack.
+     */
+    supportEmail?: string;
     overallRateLimit?: PublicApiPackRateLimit;
     perConnectionRateLimit?: PublicApiPackRateLimit;
 }
@@ -1860,9 +2007,17 @@ export interface PublicApiPackSummary {
      */
     logoUrl?: string;
     /**
+     * The link to the cover photo of the Pack.
+     */
+    coverUrl?: string;
+    /**
      * The parent workspace for the Pack.
      */
     workspaceId: string;
+    /**
+     * Publishing categories associated with this Pack.
+     */
+    categories: PublicApiPublishingCategory[];
     /**
      * The name of the Pack.
      */
@@ -1875,6 +2030,10 @@ export interface PublicApiPackSummary {
      * A short version of the description of the Pack.
      */
     shortDescription: string;
+    /**
+     * A contact email for the Pack.
+     */
+    supportEmail?: string;
 }
 /**
  * List of Pack summaries.
@@ -1932,14 +2091,15 @@ export declare enum PublicApiPackPrincipalType {
     Workspace = "workspace",
     Worldwide = "worldwide"
 }
-/**
- * Access type for a Pack.
- */
 export declare enum PublicApiPackAccessType {
     View = "view",
     Test = "test",
     Edit = "edit"
 }
+/**
+ * Access types for a Pack.
+ */
+export declare type PublicApiPackAccessTypes = PublicApiPackAccessType[];
 export interface PublicApiPackUserPrincipal {
     type: PublicApiPackPrincipalType.User;
     email: string;
@@ -1971,6 +2131,7 @@ export interface PublicApiPackPermission {
 }
 export declare enum PublicApiPackAssetType {
     Logo = "logo",
+    Cover = "cover",
     ExampleImage = "exampleImage"
 }
 /**
@@ -2114,6 +2275,14 @@ export interface PublicApiPackSourceCode {
     url: string;
 }
 /**
+ * Widest principal a Pack is available to.
+ */
+export declare enum PublicApiPackDiscoverability {
+    Public = "public",
+    Workspace = "workspace",
+    Private = "private"
+}
+/**
  * A Pack listing.
  */
 export interface PublicApiPackListing {
@@ -2130,6 +2299,10 @@ export interface PublicApiPackListing {
      */
     logoUrl: string;
     /**
+     * The link to the cover photo of the Pack.
+     */
+    coverUrl?: string;
+    /**
      * The name of the Pack.
      */
     name: string;
@@ -2141,6 +2314,85 @@ export interface PublicApiPackListing {
      * A short version of the description of the Pack.
      */
     shortDescription: string;
+    /**
+     * A contact email for the Pack.
+     */
+    supportEmail?: string;
+    /**
+     * Publishing Categories associated with this Pack.
+     */
+    categories: PublicApiPublishingCategory[];
+    minimumFeatureSet?: PublicApiFeatureSet;
+    unrestrictedFeatureSet?: PublicApiFeatureSet;
+    /**
+     * The url where complete metadata about the contents of the Pack version can be downloaded.
+     */
+    externalMetadataUrl: string;
+}
+/**
+ * A detailed Pack listing.
+ */
+export interface PublicApiPackListingDetail {
+    /**
+     * ID of the Pack.
+     */
+    packId: number;
+    /**
+     * The version of the Pack.
+     */
+    packVersion: string;
+    /**
+     * The link to the logo of the Pack.
+     */
+    logoUrl: string;
+    /**
+     * The link to the cover photo of the Pack.
+     */
+    coverUrl?: string;
+    /**
+     * The name of the Pack.
+     */
+    name: string;
+    /**
+     * The full description of the Pack.
+     */
+    description: string;
+    /**
+     * A short version of the description of the Pack.
+     */
+    shortDescription: string;
+    /**
+     * A contact email for the Pack.
+     */
+    supportEmail?: string;
+    /**
+     * Publishing Categories associated with this Pack.
+     */
+    categories: PublicApiPublishingCategory[];
+    minimumFeatureSet?: PublicApiFeatureSet;
+    unrestrictedFeatureSet?: PublicApiFeatureSet;
+    /**
+     * The url where complete metadata about the contents of the Pack version can be downloaded.
+     */
+    externalMetadataUrl: string;
+    /**
+     * The release number of the Pack version if it has one.
+     */
+    releaseId?: number;
+    discoverability: PublicApiPackDiscoverability;
+    /**
+     * Makers associated with this Pack.
+     */
+    makers: PublicApiMakerSummary[];
+    /**
+     * The access capabilities the current user has for this Pack.
+     */
+    userAccess: {
+        canEdit: boolean;
+        canTest: boolean;
+        canView: boolean;
+        canInstall: boolean;
+    };
 }
 /**
  * A list of Pack listings.
@@ -2151,14 +2403,37 @@ export interface PublicApiPackListingList {
     nextPageLink?: PublicApiNextPageLink & string;
 }
 /**
- * The Pack system connection.
+ * Metadata of a Pack system connection.
  */
-export interface PublicApiPackSystemConnection {
+export declare type PublicApiPackSystemConnectionMetadata = PublicApiPackConnectionHeaderMetadata | PublicApiPackConnectionUrlParamMetadata | PublicApiPackConnectionHttpBasicMetadata;
+/**
+ * The Pack OAuth configuration metadata.
+ */
+export interface PublicApiPackOauthConfigMetadata {
     /**
-     * Name of the system connection.
+     * Masked OAuth client id. If not set, empty string will be returned.
      */
-    name: string;
-    credentials: PublicApiPackSystemConnectionCredentials;
+    maskedClientId: string;
+    /**
+     * Masked OAuth client secret. If not set, empty string will be returned.
+     */
+    maskedClientSecret: string;
+    /**
+     * Authorization url of the OAuth provider.
+     */
+    authorizationUrl: string;
+    /**
+     * Token url of the OAuth provider.
+     */
+    tokenUrl: string;
+    /**
+     * Optional token prefix that's used to make the API request.
+     */
+    tokenPrefix?: string;
+    /**
+     * Optional scopes of the OAuth client.
+     */
+    scopes?: string;
 }
 /**
  * Payload for creating a Pack.
@@ -2187,6 +2462,15 @@ export interface PublicApiCreatePackResponse {
     packId: number;
 }
 /**
+ * Payload for getting the next version of a Pack.
+ */
+export interface PublicApiGetNextPackVersionRequest {
+    /**
+     * The metadata for the next version of the Pack.
+     */
+    proposedMetadata: string;
+}
+/**
  * Type of Pack connections.
  */
 export declare enum PublicApiPackConnectionType {
@@ -2198,6 +2482,26 @@ export declare enum PublicApiPackConnectionType {
  * Credentials of a Pack connection.
  */
 export declare type PublicApiPackSystemConnectionCredentials = PublicApiPackConnectionHeaderCredentials | PublicApiPackConnectionUrlParamCredentials | PublicApiPackConnectionHttpBasicCredentials;
+export interface PublicApiPackConnectionHeaderMetadata {
+    type: PublicApiPackConnectionType.Header;
+    maskedToken?: string;
+    headerName: string;
+    tokenPrefix: string;
+}
+export interface PublicApiPackConnectionUrlParamMetadata {
+    type: PublicApiPackConnectionType.UrlParam;
+    params: {
+        key: string;
+        maskedValue: string;
+    }[];
+    domain: string;
+    presetKeys: string[];
+}
+export interface PublicApiPackConnectionHttpBasicMetadata {
+    type: PublicApiPackConnectionType.HttpBasic;
+    maskedUsername?: string;
+    maskedPassword?: string;
+}
 export interface PublicApiPackConnectionHeaderCredentials {
     type: PublicApiPackConnectionType.Header;
     token: string;
@@ -2210,9 +2514,198 @@ export interface PublicApiPackConnectionUrlParamCredentials {
     }[];
 }
 export interface PublicApiPackConnectionHttpBasicCredentials {
-    type: PublicApiPackConnectionType.UrlParam;
+    type: PublicApiPackConnectionType.HttpBasic;
     username: string;
-    password: string;
+    password?: string;
+}
+export interface PublicApiPackConnectionHeaderPatch {
+    type: PublicApiPackConnectionType.Header;
+    token?: string;
+}
+export interface PublicApiPackConnectionUrlParamPatch {
+    type: PublicApiPackConnectionType.UrlParam;
+    paramsToPatch?: {
+        key: string;
+        value: string;
+    }[];
+}
+export interface PublicApiPackConnectionHttpBasicPatch {
+    type: PublicApiPackConnectionType.HttpBasic;
+    username?: string;
+    password?: string;
+}
+/**
+ * List of Pack logs.
+ */
+export interface PublicApiPackLogsList {
+    items: PublicApiPackLog[];
+    nextPageToken?: PublicApiNextPageToken;
+    nextPageLink?: PublicApiNextPageLink & string;
+}
+/**
+ * A record of Pack log.
+ */
+export declare type PublicApiPackLog = PublicApiPackCustomLog | PublicApiPackInvocationLog | PublicApiPackFetcherLog | PublicApiPackInternalLog | PublicApiPackAuthLog;
+/**
+ * Logging context that comes with a Pack log.
+ */
+export interface PublicApiPackLogContext {
+    docId: string;
+    packId: string;
+    packVersion: string;
+    formulaName: string;
+    userId: string;
+    connectionId: string;
+    /**
+     * A unique identifier of the Pack invocation that can be used to associate all log types generated in one call of a Pack formula.
+     *
+     */
+    requestId: string;
+    requestType: PublicApiPackLogRequestType;
+    /**
+     * Creation time of the log.
+     */
+    createdAt: string;
+    /**
+     * Unique identifier of this log record.
+     */
+    logId: string;
+}
+/**
+ * Pack log generated by developer's custom logging with context.logger.
+ */
+export interface PublicApiPackCustomLog {
+    type: PublicApiPackLogType.Custom;
+    context: PublicApiPackLogContext;
+    /**
+     * The message that's passed into context.logger.
+     */
+    message: string;
+    level: PublicApiLogLevel;
+}
+/**
+ * System logs of the invocations of the Pack.
+ */
+export interface PublicApiPackInvocationLog {
+    type: PublicApiPackLogType.Invocation;
+    context: PublicApiPackLogContext;
+    /**
+     * Error info if this invocation resulted in an error.
+     */
+    error?: {
+        message: string;
+    };
+}
+/**
+ * System logs of Pack calls to context.fetcher.
+ */
+export interface PublicApiPackFetcherLog {
+    type: PublicApiPackLogType.Fetcher;
+    context: PublicApiPackLogContext;
+    responseCode?: number;
+    method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+    /**
+     * base url of the fetcher request, with all query parameters stripped off.
+     */
+    baseUrl?: string;
+    /**
+     * true if the fetcher request hits catche instead of actually requesting the remote service.
+     */
+    cacheHit?: boolean;
+    /**
+     * Duration of the fetcher request in miliseconds.
+     */
+    duration?: number;
+}
+/**
+ * Coda internal logs from the packs infrastructure. Only visible to Codans.
+ */
+export interface PublicApiPackInternalLog {
+    type: PublicApiPackLogType.Internal;
+    context: PublicApiPackLogContext;
+    /**
+     * The log message.
+     */
+    message: string;
+    level: PublicApiLogLevel;
+}
+/**
+ * System logs of Pack authentication requests.
+ */
+export interface PublicApiPackAuthLog {
+    type: PublicApiPackLogType.Auth;
+    context: PublicApiPackLogContext;
+    /**
+     * The request path.
+     */
+    path: string;
+    /**
+     * The error message.
+     */
+    errorMessage?: string;
+    /**
+     * The error stacktrace (internal only).
+     */
+    errorStack?: string;
+}
+/**
+ * The context request type where a Pack log is generated.
+ */
+export declare enum PublicApiPackLogRequestType {
+    Unknown = "unknown",
+    ConnectionNameMetadataRequest = "connectionNameMetadataRequest",
+    ParameterAutocompleteMetadataRequest = "parameterAutocompleteMetadataRequest",
+    PostAuthSetupMetadataRequest = "postAuthSetupMetadataRequest",
+    GetSyncTableSchemaMetadataRequest = "getSyncTableSchemaMetadataRequest",
+    GetDynamicSyncTableNameMetadataRequest = "getDynamicSyncTableNameMetadataRequest",
+    ListSyncTableDynamicUrlsMetadataRequest = "listSyncTableDynamicUrlsMetadataRequest",
+    GetDynamicSyncTableDisplayUrlMetadataRequest = "getDynamicSyncTableDisplayUrlMetadataRequest",
+    GetIdentifiersForConnectionRequest = "getIdentifiersForConnectionRequest",
+    InvokeFormulaRequest = "invokeFormulaRequest",
+    InvokeSyncFormulaRequest = "invokeSyncFormulaRequest",
+    ImpersonateInvokeFormulaRequest = "impersonateInvokeFormulaRequest",
+    ImpersonateInvokeMetadataFormulaRequest = "impersonateInvokeMetadataFormulaRequest"
+}
+export declare enum PublicApiPackLogType {
+    Custom = "custom",
+    Fetcher = "fetcher",
+    Invocation = "invocation",
+    Internal = "internal",
+    Auth = "auth"
+}
+export declare enum PublicApiLogLevel {
+    Error = "error",
+    Warn = "warn",
+    Info = "info",
+    Debug = "debug",
+    Trace = "trace",
+    Unknown = "unknown"
+}
+/**
+ * Only relevant for original Coda packs.
+ */
+export declare enum PublicApiFeatureSet {
+    Basic = "Basic",
+    Pro = "Pro",
+    Team = "Team",
+    Enterprise = "Enterprise"
+}
+/**
+ * The request to patch pack system connection credentials.
+ */
+export declare type PublicApiPatchPackSystemConnectionRequest = PublicApiPackConnectionHeaderPatch | PublicApiPackConnectionUrlParamPatch | PublicApiPackConnectionHttpBasicPatch;
+/**
+ * Request to set the Pack OAuth configuration.
+ */
+export interface PublicApiSetPackOauthConfigRequest {
+    clientId: string;
+    clientSecret: string;
+}
+/**
+ * The request to set pack system connection credentials.
+ */
+export interface PublicApiSetPackSystemConnectionRequest {
+    credentials: PublicApiPackSystemConnectionCredentials;
 }
 /**
  * Payload for registering a Pack version.
@@ -2222,6 +2715,7 @@ export interface PublicApiRegisterPackVersionRequest {
      * The SHA-256 hash of the file to be uploaded.
      */
     bundleHash: string;
+    [k: string]: unknown;
 }
 /**
  * Payload for updating a Pack.
@@ -2258,6 +2752,10 @@ export interface PublicApiUpdatePackRequest {
      */
     logoAssetId?: string | null;
     /**
+     * The asset id of the Pack's cover image, returned by [`#PackAssetUploadComplete`](#operation/packAssetUploadComplete) endpoint.
+     */
+    coverAssetId?: string | null;
+    /**
      * The asset ids of the Pack's example images, returned by [`#PackAssetUploadComplete`](#operation/packAssetUploadComplete) endpoint, sorted by their display order.
      */
     exampleImageAssetIds?: string[] | null;
@@ -2273,15 +2771,10 @@ export interface PublicApiUpdatePackRequest {
      * A short version of the description of the Pack.
      */
     shortDescription?: string;
-}
-/**
- * Payload for setting a Pack version live.
- */
-export interface PublicApiSetPackLiveVersionRequest {
     /**
-     * The version of the Pack.
+     * A contact email for the Pack.
      */
-    packVersion: string;
+    supportEmail?: string;
 }
 /**
  * Confirmation of successful Pack version creation.
@@ -2289,9 +2782,57 @@ export interface PublicApiSetPackLiveVersionRequest {
 export interface PublicApiCreatePackVersionResponse {
 }
 /**
- * Confirmation of successfully setting a Pack version live.
+ * Confirmation of successfully retrieving Pack makers.
  */
-export interface PublicApiSetPackLiveVersionResponse {
+export interface PublicApiListPackMakersResponse {
+    makers: PublicApiMaker[];
+}
+/**
+ * Payload for adding a Pack maker.
+ */
+export interface PublicApiAddPackMakerRequest {
+    /**
+     * The email of the Pack maker.
+     */
+    loginId: string;
+}
+/**
+ * Confirmation of successfully adding a Pack maker.
+ */
+export interface PublicApiAddPackMakerResponse {
+}
+/**
+ * Confirmation of successfully deleting a Pack maker.
+ */
+export interface PublicApiDeletePackMakerResponse {
+}
+/**
+ * Confirmation of successfully retrieving Pack categories.
+ */
+export interface PublicApiListPackCategoriesResponse {
+    /**
+     * The names of categories associated with a Pack.
+     */
+    categories: PublicApiPublishingCategory[];
+}
+/**
+ * Payload for adding a Pack Category.
+ */
+export interface PublicApiAddPackCategoryRequest {
+    /**
+     * Name of the publishing category.
+     */
+    categoryName: string;
+}
+/**
+ * Confirmation of successfully adding a Pack category.
+ */
+export interface PublicApiAddPackCategoryResponse {
+}
+/**
+ * Confirmation of successfully deleting a Pack category.
+ */
+export interface PublicApiDeletePackCategoryResponse {
 }
 /**
  * Payload for upserting a Pack permission.
@@ -2371,6 +2912,7 @@ export interface PublicApiCreatePackVersionRequest {
      * Developer notes of the new Pack version.
      */
     notes?: string;
+    [k: string]: unknown;
 }
 /**
  * Payload for creating a new Pack release.
@@ -2384,6 +2926,7 @@ export interface PublicApiCreatePackReleaseRequest {
      * Developers notes.
      */
     releaseNotes?: string;
+    [k: string]: unknown;
 }
 /**
  * Payload for a Pack asset upload.
@@ -2397,17 +2940,24 @@ export interface PublicApiUploadPackSourceCodeRequest {
     packVersion?: string;
 }
 /**
- * The request to set Pack system connection.
+ * Information indicating the next Pack version definition.
  */
-export interface PublicApiSetPackSystemConnectionRequest {
+export interface PublicApiNextPackVersionInfo {
     /**
-     * Name of the system connection.
+     * The next valid version for the Pack.
      */
-    name: string;
-    credentials: PublicApiPackSystemConnectionCredentials;
+    nextVersion: string;
+    /**
+     * List of changes from the previous version.
+     */
+    findings: string[];
 }
 /**
- * Empty response of deleting pack system connection.
+ * Info about the diff between two Pack versions.
  */
-export interface PublicApiDeletePackSystemConnectionResponse {
+export interface PublicApiPackVersionDiffs {
+    /**
+     * List of changes from the previous version to the next version.
+     */
+    findings: string[];
 }

--- a/dist/helpers/external-api/v1.js
+++ b/dist/helpers/external-api/v1.js
@@ -3,35 +3,41 @@
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PublicApiPackConnectionType = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPacksSortBy = exports.PublicApiDocAnalyticsScale = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
+exports.PublicApiFeatureSet = exports.PublicApiLogLevel = exports.PublicApiPackLogType = exports.PublicApiPackLogRequestType = exports.PublicApiPackConnectionType = exports.PublicApiPackDiscoverability = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPacksSortBy = exports.PublicApiDocAnalyticsScale = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
 /* eslint-disable */
-exports.OpenApiSpecHash = 'c17f33bab1c1496bf73356d09380fa0a04e074f97741adc801db545ea8db0026';
-exports.OpenApiSpecVersion = '1.2.0';
+exports.OpenApiSpecHash = '3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d';
+exports.OpenApiSpecVersion = '1.2.1';
 /**
  * A constant identifying the type of the resource.
  */
 var PublicApiType;
 (function (PublicApiType) {
-    PublicApiType["Doc"] = "doc";
-    PublicApiType["AclPermissions"] = "aclPermissions";
     PublicApiType["AclMetadata"] = "aclMetadata";
-    PublicApiType["User"] = "user";
+    PublicApiType["AclPermissions"] = "aclPermissions";
     PublicApiType["ApiLink"] = "apiLink";
-    PublicApiType["Page"] = "page";
-    PublicApiType["Table"] = "table";
-    PublicApiType["Row"] = "row";
     PublicApiType["Column"] = "column";
-    PublicApiType["Formula"] = "formula";
     PublicApiType["Control"] = "control";
+    PublicApiType["Doc"] = "doc";
     PublicApiType["DocAnalytics"] = "docAnalytics";
+    PublicApiType["Folder"] = "folder";
+    PublicApiType["Formula"] = "formula";
     PublicApiType["MutationStatus"] = "mutationStatus";
-    PublicApiType["Workspace"] = "workspace";
     PublicApiType["Pack"] = "pack";
-    PublicApiType["PackVersion"] = "packVersion";
     PublicApiType["PackAclPermissions"] = "packAclPermissions";
     PublicApiType["PackAsset"] = "packAsset";
+    PublicApiType["PackCategory"] = "packCategory";
+    PublicApiType["PackLog"] = "packLog";
+    PublicApiType["PackMaker"] = "packMaker";
+    PublicApiType["PackOauthConfig"] = "packOauthConfig";
     PublicApiType["PackRelease"] = "packRelease";
     PublicApiType["PackSourceCode"] = "packSourceCode";
+    PublicApiType["PackSystemConnection"] = "packSystemConnection";
+    PublicApiType["PackVersion"] = "packVersion";
+    PublicApiType["Page"] = "page";
+    PublicApiType["Row"] = "row";
+    PublicApiType["Table"] = "table";
+    PublicApiType["User"] = "user";
+    PublicApiType["Workspace"] = "workspace";
 })(PublicApiType = exports.PublicApiType || (exports.PublicApiType = {}));
 /**
  * Type of principal.
@@ -267,9 +273,6 @@ var PublicApiPackPrincipalType;
     PublicApiPackPrincipalType["Workspace"] = "workspace";
     PublicApiPackPrincipalType["Worldwide"] = "worldwide";
 })(PublicApiPackPrincipalType = exports.PublicApiPackPrincipalType || (exports.PublicApiPackPrincipalType = {}));
-/**
- * Access type for a Pack.
- */
 var PublicApiPackAccessType;
 (function (PublicApiPackAccessType) {
     PublicApiPackAccessType["View"] = "view";
@@ -279,8 +282,18 @@ var PublicApiPackAccessType;
 var PublicApiPackAssetType;
 (function (PublicApiPackAssetType) {
     PublicApiPackAssetType["Logo"] = "logo";
+    PublicApiPackAssetType["Cover"] = "cover";
     PublicApiPackAssetType["ExampleImage"] = "exampleImage";
 })(PublicApiPackAssetType = exports.PublicApiPackAssetType || (exports.PublicApiPackAssetType = {}));
+/**
+ * Widest principal a Pack is available to.
+ */
+var PublicApiPackDiscoverability;
+(function (PublicApiPackDiscoverability) {
+    PublicApiPackDiscoverability["Public"] = "public";
+    PublicApiPackDiscoverability["Workspace"] = "workspace";
+    PublicApiPackDiscoverability["Private"] = "private";
+})(PublicApiPackDiscoverability = exports.PublicApiPackDiscoverability || (exports.PublicApiPackDiscoverability = {}));
 /**
  * Type of Pack connections.
  */
@@ -290,3 +303,49 @@ var PublicApiPackConnectionType;
     PublicApiPackConnectionType["UrlParam"] = "urlParam";
     PublicApiPackConnectionType["HttpBasic"] = "httpBasic";
 })(PublicApiPackConnectionType = exports.PublicApiPackConnectionType || (exports.PublicApiPackConnectionType = {}));
+/**
+ * The context request type where a Pack log is generated.
+ */
+var PublicApiPackLogRequestType;
+(function (PublicApiPackLogRequestType) {
+    PublicApiPackLogRequestType["Unknown"] = "unknown";
+    PublicApiPackLogRequestType["ConnectionNameMetadataRequest"] = "connectionNameMetadataRequest";
+    PublicApiPackLogRequestType["ParameterAutocompleteMetadataRequest"] = "parameterAutocompleteMetadataRequest";
+    PublicApiPackLogRequestType["PostAuthSetupMetadataRequest"] = "postAuthSetupMetadataRequest";
+    PublicApiPackLogRequestType["GetSyncTableSchemaMetadataRequest"] = "getSyncTableSchemaMetadataRequest";
+    PublicApiPackLogRequestType["GetDynamicSyncTableNameMetadataRequest"] = "getDynamicSyncTableNameMetadataRequest";
+    PublicApiPackLogRequestType["ListSyncTableDynamicUrlsMetadataRequest"] = "listSyncTableDynamicUrlsMetadataRequest";
+    PublicApiPackLogRequestType["GetDynamicSyncTableDisplayUrlMetadataRequest"] = "getDynamicSyncTableDisplayUrlMetadataRequest";
+    PublicApiPackLogRequestType["GetIdentifiersForConnectionRequest"] = "getIdentifiersForConnectionRequest";
+    PublicApiPackLogRequestType["InvokeFormulaRequest"] = "invokeFormulaRequest";
+    PublicApiPackLogRequestType["InvokeSyncFormulaRequest"] = "invokeSyncFormulaRequest";
+    PublicApiPackLogRequestType["ImpersonateInvokeFormulaRequest"] = "impersonateInvokeFormulaRequest";
+    PublicApiPackLogRequestType["ImpersonateInvokeMetadataFormulaRequest"] = "impersonateInvokeMetadataFormulaRequest";
+})(PublicApiPackLogRequestType = exports.PublicApiPackLogRequestType || (exports.PublicApiPackLogRequestType = {}));
+var PublicApiPackLogType;
+(function (PublicApiPackLogType) {
+    PublicApiPackLogType["Custom"] = "custom";
+    PublicApiPackLogType["Fetcher"] = "fetcher";
+    PublicApiPackLogType["Invocation"] = "invocation";
+    PublicApiPackLogType["Internal"] = "internal";
+    PublicApiPackLogType["Auth"] = "auth";
+})(PublicApiPackLogType = exports.PublicApiPackLogType || (exports.PublicApiPackLogType = {}));
+var PublicApiLogLevel;
+(function (PublicApiLogLevel) {
+    PublicApiLogLevel["Error"] = "error";
+    PublicApiLogLevel["Warn"] = "warn";
+    PublicApiLogLevel["Info"] = "info";
+    PublicApiLogLevel["Debug"] = "debug";
+    PublicApiLogLevel["Trace"] = "trace";
+    PublicApiLogLevel["Unknown"] = "unknown";
+})(PublicApiLogLevel = exports.PublicApiLogLevel || (exports.PublicApiLogLevel = {}));
+/**
+ * Only relevant for original Coda packs.
+ */
+var PublicApiFeatureSet;
+(function (PublicApiFeatureSet) {
+    PublicApiFeatureSet["Basic"] = "Basic";
+    PublicApiFeatureSet["Pro"] = "Pro";
+    PublicApiFeatureSet["Team"] = "Team";
+    PublicApiFeatureSet["Enterprise"] = "Enterprise";
+})(PublicApiFeatureSet = exports.PublicApiFeatureSet || (exports.PublicApiFeatureSet = {}));

--- a/docs/reference/sdk/enums/AttributionNodeType.md
+++ b/docs/reference/sdk/enums/AttributionNodeType.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[schema.ts:205](https://github.com/coda/packs-sdk/blob/main/schema.ts#L205)
+[schema.ts:232](https://github.com/coda/packs-sdk/blob/main/schema.ts#L232)
 
 ___
 
@@ -18,7 +18,7 @@ ___
 
 #### Defined in
 
-[schema.ts:204](https://github.com/coda/packs-sdk/blob/main/schema.ts#L204)
+[schema.ts:231](https://github.com/coda/packs-sdk/blob/main/schema.ts#L231)
 
 ___
 
@@ -28,4 +28,4 @@ ___
 
 #### Defined in
 
-[schema.ts:203](https://github.com/coda/packs-sdk/blob/main/schema.ts#L203)
+[schema.ts:230](https://github.com/coda/packs-sdk/blob/main/schema.ts#L230)

--- a/docs/reference/sdk/enums/DurationUnit.md
+++ b/docs/reference/sdk/enums/DurationUnit.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[schema.ts:144](https://github.com/coda/packs-sdk/blob/main/schema.ts#L144)
+[schema.ts:171](https://github.com/coda/packs-sdk/blob/main/schema.ts#L171)
 
 ___
 
@@ -18,7 +18,7 @@ ___
 
 #### Defined in
 
-[schema.ts:145](https://github.com/coda/packs-sdk/blob/main/schema.ts#L145)
+[schema.ts:172](https://github.com/coda/packs-sdk/blob/main/schema.ts#L172)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[schema.ts:146](https://github.com/coda/packs-sdk/blob/main/schema.ts#L146)
+[schema.ts:173](https://github.com/coda/packs-sdk/blob/main/schema.ts#L173)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[schema.ts:147](https://github.com/coda/packs-sdk/blob/main/schema.ts#L147)
+[schema.ts:174](https://github.com/coda/packs-sdk/blob/main/schema.ts#L174)

--- a/docs/reference/sdk/functions/generateSchema.md
+++ b/docs/reference/sdk/functions/generateSchema.md
@@ -14,4 +14,4 @@
 
 #### Defined in
 
-[schema.ts:266](https://github.com/coda/packs-sdk/blob/main/schema.ts#L266)
+[schema.ts:293](https://github.com/coda/packs-sdk/blob/main/schema.ts#L293)

--- a/docs/reference/sdk/functions/makeAttributionNode.md
+++ b/docs/reference/sdk/functions/makeAttributionNode.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[schema.ts:226](https://github.com/coda/packs-sdk/blob/main/schema.ts#L226)
+[schema.ts:253](https://github.com/coda/packs-sdk/blob/main/schema.ts#L253)

--- a/docs/reference/sdk/functions/makeObjectSchema.md
+++ b/docs/reference/sdk/functions/makeObjectSchema.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[schema.ts:302](https://github.com/coda/packs-sdk/blob/main/schema.ts#L302)
+[schema.ts:329](https://github.com/coda/packs-sdk/blob/main/schema.ts#L329)

--- a/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
@@ -21,4 +21,4 @@ schema it provides better code reuse to derive a reference schema instead.
 
 #### Defined in
 
-[schema.ts:401](https://github.com/coda/packs-sdk/blob/main/schema.ts#L401)
+[schema.ts:428](https://github.com/coda/packs-sdk/blob/main/schema.ts#L428)

--- a/docs/reference/sdk/functions/makeSchema.md
+++ b/docs/reference/sdk/functions/makeSchema.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[schema.ts:296](https://github.com/coda/packs-sdk/blob/main/schema.ts#L296)
+[schema.ts:323](https://github.com/coda/packs-sdk/blob/main/schema.ts#L323)

--- a/docs/reference/sdk/interfaces/ArraySchema.md
+++ b/docs/reference/sdk/interfaces/ArraySchema.md
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[schema.ts:162](https://github.com/coda/packs-sdk/blob/main/schema.ts#L162)
+[schema.ts:189](https://github.com/coda/packs-sdk/blob/main/schema.ts#L189)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[schema.ts:161](https://github.com/coda/packs-sdk/blob/main/schema.ts#L161)
+[schema.ts:188](https://github.com/coda/packs-sdk/blob/main/schema.ts#L188)

--- a/docs/reference/sdk/interfaces/CurrencySchema.md
+++ b/docs/reference/sdk/interfaces/CurrencySchema.md
@@ -26,9 +26,12 @@ ___
 
 • `Optional` **currencyCode**: `string`
 
+A three-letter ISO 4217 currency code, e.g. USD or EUR.
+If the currency code is not supported by Coda, the value will be rendered using USD.
+
 #### Defined in
 
-[schema.ts:102](https://github.com/coda/packs-sdk/blob/main/schema.ts#L102)
+[schema.ts:106](https://github.com/coda/packs-sdk/blob/main/schema.ts#L106)
 
 ___
 
@@ -52,7 +55,7 @@ ___
 
 #### Defined in
 
-[schema.ts:103](https://github.com/coda/packs-sdk/blob/main/schema.ts#L103)
+[schema.ts:107](https://github.com/coda/packs-sdk/blob/main/schema.ts#L107)
 
 ___
 

--- a/docs/reference/sdk/interfaces/DateSchema.md
+++ b/docs/reference/sdk/interfaces/DateSchema.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[schema.ts:124](https://github.com/coda/packs-sdk/blob/main/schema.ts#L124)
+[schema.ts:151](https://github.com/coda/packs-sdk/blob/main/schema.ts#L151)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[schema.ts:126](https://github.com/coda/packs-sdk/blob/main/schema.ts#L126)
+[schema.ts:153](https://github.com/coda/packs-sdk/blob/main/schema.ts#L153)
 
 ___
 
@@ -52,4 +52,4 @@ BaseDateSchema.type
 
 #### Defined in
 
-[schema.ts:120](https://github.com/coda/packs-sdk/blob/main/schema.ts#L120)
+[schema.ts:147](https://github.com/coda/packs-sdk/blob/main/schema.ts#L147)

--- a/docs/reference/sdk/interfaces/DateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/DateTimeSchema.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[schema.ts:136](https://github.com/coda/packs-sdk/blob/main/schema.ts#L136)
+[schema.ts:163](https://github.com/coda/packs-sdk/blob/main/schema.ts#L163)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[schema.ts:138](https://github.com/coda/packs-sdk/blob/main/schema.ts#L138)
+[schema.ts:165](https://github.com/coda/packs-sdk/blob/main/schema.ts#L165)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[schema.ts:140](https://github.com/coda/packs-sdk/blob/main/schema.ts#L140)
+[schema.ts:167](https://github.com/coda/packs-sdk/blob/main/schema.ts#L167)
 
 ___
 
@@ -62,4 +62,4 @@ BaseDateSchema.type
 
 #### Defined in
 
-[schema.ts:120](https://github.com/coda/packs-sdk/blob/main/schema.ts#L120)
+[schema.ts:147](https://github.com/coda/packs-sdk/blob/main/schema.ts#L147)

--- a/docs/reference/sdk/interfaces/DurationSchema.md
+++ b/docs/reference/sdk/interfaces/DurationSchema.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[schema.ts:157](https://github.com/coda/packs-sdk/blob/main/schema.ts#L157)
+[schema.ts:184](https://github.com/coda/packs-sdk/blob/main/schema.ts#L184)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:152](https://github.com/coda/packs-sdk/blob/main/schema.ts#L152)
+[schema.ts:179](https://github.com/coda/packs-sdk/blob/main/schema.ts#L179)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:151](https://github.com/coda/packs-sdk/blob/main/schema.ts#L151)
+[schema.ts:178](https://github.com/coda/packs-sdk/blob/main/schema.ts#L178)
 
 ___
 
@@ -66,4 +66,4 @@ ___
 
 #### Defined in
 
-[schema.ts:156](https://github.com/coda/packs-sdk/blob/main/schema.ts#L156)
+[schema.ts:183](https://github.com/coda/packs-sdk/blob/main/schema.ts#L183)

--- a/docs/reference/sdk/interfaces/Identity.md
+++ b/docs/reference/sdk/interfaces/Identity.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[schema.ts:179](https://github.com/coda/packs-sdk/blob/main/schema.ts#L179)
+[schema.ts:206](https://github.com/coda/packs-sdk/blob/main/schema.ts#L206)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[schema.ts:178](https://github.com/coda/packs-sdk/blob/main/schema.ts#L178)
+[schema.ts:205](https://github.com/coda/packs-sdk/blob/main/schema.ts#L205)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[schema.ts:177](https://github.com/coda/packs-sdk/blob/main/schema.ts#L177)
+[schema.ts:204](https://github.com/coda/packs-sdk/blob/main/schema.ts#L204)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[schema.ts:185](https://github.com/coda/packs-sdk/blob/main/schema.ts#L185)
+[schema.ts:212](https://github.com/coda/packs-sdk/blob/main/schema.ts#L212)

--- a/docs/reference/sdk/interfaces/IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/IdentityDefinition.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[schema.ts:179](https://github.com/coda/packs-sdk/blob/main/schema.ts#L179)
+[schema.ts:206](https://github.com/coda/packs-sdk/blob/main/schema.ts#L206)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[schema.ts:178](https://github.com/coda/packs-sdk/blob/main/schema.ts#L178)
+[schema.ts:205](https://github.com/coda/packs-sdk/blob/main/schema.ts#L205)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[schema.ts:177](https://github.com/coda/packs-sdk/blob/main/schema.ts#L177)
+[schema.ts:204](https://github.com/coda/packs-sdk/blob/main/schema.ts#L204)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[schema.ts:181](https://github.com/coda/packs-sdk/blob/main/schema.ts#L181)
+[schema.ts:208](https://github.com/coda/packs-sdk/blob/main/schema.ts#L208)

--- a/docs/reference/sdk/interfaces/ObjectSchema.md
+++ b/docs/reference/sdk/interfaces/ObjectSchema.md
@@ -25,7 +25,7 @@ ObjectSchemaDefinition.codaType
 
 #### Defined in
 
-[schema.ts:193](https://github.com/coda/packs-sdk/blob/main/schema.ts#L193)
+[schema.ts:220](https://github.com/coda/packs-sdk/blob/main/schema.ts#L220)
 
 ___
 
@@ -53,7 +53,7 @@ ObjectSchemaDefinition.featured
 
 #### Defined in
 
-[schema.ts:194](https://github.com/coda/packs-sdk/blob/main/schema.ts#L194)
+[schema.ts:221](https://github.com/coda/packs-sdk/blob/main/schema.ts#L221)
 
 ___
 
@@ -67,7 +67,7 @@ ObjectSchemaDefinition.id
 
 #### Defined in
 
-[schema.ts:191](https://github.com/coda/packs-sdk/blob/main/schema.ts#L191)
+[schema.ts:218](https://github.com/coda/packs-sdk/blob/main/schema.ts#L218)
 
 ___
 
@@ -81,7 +81,7 @@ ObjectSchemaDefinition.identity
 
 #### Defined in
 
-[schema.ts:199](https://github.com/coda/packs-sdk/blob/main/schema.ts#L199)
+[schema.ts:226](https://github.com/coda/packs-sdk/blob/main/schema.ts#L226)
 
 ___
 
@@ -95,7 +95,7 @@ ObjectSchemaDefinition.primary
 
 #### Defined in
 
-[schema.ts:192](https://github.com/coda/packs-sdk/blob/main/schema.ts#L192)
+[schema.ts:219](https://github.com/coda/packs-sdk/blob/main/schema.ts#L219)
 
 ___
 
@@ -109,7 +109,7 @@ ObjectSchemaDefinition.properties
 
 #### Defined in
 
-[schema.ts:190](https://github.com/coda/packs-sdk/blob/main/schema.ts#L190)
+[schema.ts:217](https://github.com/coda/packs-sdk/blob/main/schema.ts#L217)
 
 ___
 
@@ -123,4 +123,4 @@ ObjectSchemaDefinition.type
 
 #### Defined in
 
-[schema.ts:189](https://github.com/coda/packs-sdk/blob/main/schema.ts#L189)
+[schema.ts:216](https://github.com/coda/packs-sdk/blob/main/schema.ts#L216)

--- a/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[schema.ts:166](https://github.com/coda/packs-sdk/blob/main/schema.ts#L166)
+[schema.ts:193](https://github.com/coda/packs-sdk/blob/main/schema.ts#L193)
 
 ___
 
@@ -18,4 +18,4 @@ ___
 
 #### Defined in
 
-[schema.ts:167](https://github.com/coda/packs-sdk/blob/main/schema.ts#L167)
+[schema.ts:194](https://github.com/coda/packs-sdk/blob/main/schema.ts#L194)

--- a/docs/reference/sdk/interfaces/ScaleSchema.md
+++ b/docs/reference/sdk/interfaces/ScaleSchema.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[schema.ts:114](https://github.com/coda/packs-sdk/blob/main/schema.ts#L114)
+[schema.ts:141](https://github.com/coda/packs-sdk/blob/main/schema.ts#L141)
 
 ___
 
@@ -38,11 +38,11 @@ ___
 
 ### icon
 
-• **icon**: `string`
+• **icon**: `ScaleIconSet`
 
 #### Defined in
 
-[schema.ts:116](https://github.com/coda/packs-sdk/blob/main/schema.ts#L116)
+[schema.ts:143](https://github.com/coda/packs-sdk/blob/main/schema.ts#L143)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:115](https://github.com/coda/packs-sdk/blob/main/schema.ts#L115)
+[schema.ts:142](https://github.com/coda/packs-sdk/blob/main/schema.ts#L142)
 
 ___
 

--- a/docs/reference/sdk/interfaces/SliderSchema.md
+++ b/docs/reference/sdk/interfaces/SliderSchema.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[schema.ts:107](https://github.com/coda/packs-sdk/blob/main/schema.ts#L107)
+[schema.ts:111](https://github.com/coda/packs-sdk/blob/main/schema.ts#L111)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:109](https://github.com/coda/packs-sdk/blob/main/schema.ts#L109)
+[schema.ts:113](https://github.com/coda/packs-sdk/blob/main/schema.ts#L113)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:108](https://github.com/coda/packs-sdk/blob/main/schema.ts#L108)
+[schema.ts:112](https://github.com/coda/packs-sdk/blob/main/schema.ts#L112)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[schema.ts:110](https://github.com/coda/packs-sdk/blob/main/schema.ts#L110)
+[schema.ts:114](https://github.com/coda/packs-sdk/blob/main/schema.ts#L114)
 
 ___
 

--- a/docs/reference/sdk/interfaces/StringSchema.md
+++ b/docs/reference/sdk/interfaces/StringSchema.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[schema.ts:157](https://github.com/coda/packs-sdk/blob/main/schema.ts#L157)
+[schema.ts:184](https://github.com/coda/packs-sdk/blob/main/schema.ts#L184)
 
 ___
 
@@ -46,4 +46,4 @@ ___
 
 #### Defined in
 
-[schema.ts:156](https://github.com/coda/packs-sdk/blob/main/schema.ts#L156)
+[schema.ts:183](https://github.com/coda/packs-sdk/blob/main/schema.ts#L183)

--- a/docs/reference/sdk/interfaces/TimeSchema.md
+++ b/docs/reference/sdk/interfaces/TimeSchema.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[schema.ts:130](https://github.com/coda/packs-sdk/blob/main/schema.ts#L130)
+[schema.ts:157](https://github.com/coda/packs-sdk/blob/main/schema.ts#L157)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[schema.ts:132](https://github.com/coda/packs-sdk/blob/main/schema.ts#L132)
+[schema.ts:159](https://github.com/coda/packs-sdk/blob/main/schema.ts#L159)
 
 ___
 
@@ -52,4 +52,4 @@ BaseDateSchema.type
 
 #### Defined in
 
-[schema.ts:120](https://github.com/coda/packs-sdk/blob/main/schema.ts#L120)
+[schema.ts:147](https://github.com/coda/packs-sdk/blob/main/schema.ts#L147)

--- a/docs/reference/sdk/types/GenericObjectSchema.md
+++ b/docs/reference/sdk/types/GenericObjectSchema.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[schema.ts:174](https://github.com/coda/packs-sdk/blob/main/schema.ts#L174)
+[schema.ts:201](https://github.com/coda/packs-sdk/blob/main/schema.ts#L201)

--- a/docs/reference/sdk/types/ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/ObjectSchemaProperties.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[schema.ts:170](https://github.com/coda/packs-sdk/blob/main/schema.ts#L170)
+[schema.ts:197](https://github.com/coda/packs-sdk/blob/main/schema.ts#L197)

--- a/docs/reference/sdk/types/Schema.md
+++ b/docs/reference/sdk/types/Schema.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[schema.ts:230](https://github.com/coda/packs-sdk/blob/main/schema.ts#L230)
+[schema.ts:257](https://github.com/coda/packs-sdk/blob/main/schema.ts#L257)

--- a/docs/reference/sdk/types/SchemaType.md
+++ b/docs/reference/sdk/types/SchemaType.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[schema.ts:249](https://github.com/coda/packs-sdk/blob/main/schema.ts#L249)
+[schema.ts:276](https://github.com/coda/packs-sdk/blob/main/schema.ts#L276)

--- a/helpers/external-api/v1.ts
+++ b/helpers/external-api/v1.ts
@@ -4,34 +4,40 @@
 
 /* eslint-disable */
 
-export const OpenApiSpecHash = 'c17f33bab1c1496bf73356d09380fa0a04e074f97741adc801db545ea8db0026';
+export const OpenApiSpecHash = '3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d';
 
-export const OpenApiSpecVersion = '1.2.0';
+export const OpenApiSpecVersion = '1.2.1';
 
 /**
  * A constant identifying the type of the resource.
  */
 export enum PublicApiType {
-  Doc = 'doc',
-  AclPermissions = 'aclPermissions',
   AclMetadata = 'aclMetadata',
-  User = 'user',
+  AclPermissions = 'aclPermissions',
   ApiLink = 'apiLink',
-  Page = 'page',
-  Table = 'table',
-  Row = 'row',
   Column = 'column',
-  Formula = 'formula',
   Control = 'control',
+  Doc = 'doc',
   DocAnalytics = 'docAnalytics',
+  Folder = 'folder',
+  Formula = 'formula',
   MutationStatus = 'mutationStatus',
-  Workspace = 'workspace',
   Pack = 'pack',
-  PackVersion = 'packVersion',
   PackAclPermissions = 'packAclPermissions',
   PackAsset = 'packAsset',
+  PackCategory = 'packCategory',
+  PackLog = 'packLog',
+  PackMaker = 'packMaker',
+  PackOauthConfig = 'packOauthConfig',
   PackRelease = 'packRelease',
   PackSourceCode = 'packSourceCode',
+  PackSystemConnection = 'packSystemConnection',
+  PackVersion = 'packVersion',
+  Page = 'page',
+  Row = 'row',
+  Table = 'table',
+  User = 'user',
+  Workspace = 'workspace',
 }
 
 /**
@@ -154,7 +160,7 @@ export interface PublicApiDocReference {
   /**
    * The type of this resource.
    */
-  type: 'doc';
+  type: PublicApiType.Doc;
   /**
    * API link to the Coda doc.
    */
@@ -176,7 +182,7 @@ export interface PublicApiDoc {
   /**
    * The type of this resource.
    */
-  type: 'doc';
+  type: PublicApiType.Doc;
   /**
    * API link to the Coda doc.
    */
@@ -209,6 +215,8 @@ export interface PublicApiDoc {
    */
   updatedAt: string;
   published?: PublicApiDocPublished;
+  folder: PublicApiFolderReference;
+  workspace: PublicApiWorkspaceReference;
   /**
    * ID of the Coda workspace containing this doc.
    */
@@ -269,7 +277,7 @@ export interface PublicApiDocCreate {
    */
   timezone?: string;
   /**
-   * The ID of the folder within which to create this doc. Defaults to your "My Docs" folder in the oldest workspace you joined; this is subject to change. You can get this ID by opening the folder in the docs list on your computer and grabbing the `folderId` query parameter.
+   * The ID of the folder within which to create this doc. Defaults to your "My docs" folder in the oldest workspace you joined; this is subject to change. You can get this ID by opening the folder in the docs list on your computer and grabbing the `folderId` query parameter.
    *
    */
   folderId?: string;
@@ -311,10 +319,6 @@ export interface PublicApiDocPublish {
    */
   slug?: string;
   /**
-   * If true, the doc will display a copy button in the header.
-   */
-  copyable?: boolean;
-  /**
    * If true, indicates that the doc is discoverable.
    */
   discoverable?: boolean;
@@ -346,10 +350,6 @@ export interface PublicApiDocPublished {
    * URL to the cover image for the published doc.
    */
   imageLink?: string;
-  /**
-   * If true, the doc will display a copy button in the header.
-   */
-  copyable: boolean;
   /**
    * If true, indicates that the doc is discoverable.
    */
@@ -396,7 +396,7 @@ export interface PublicApiDocumentCreationResult {
   /**
    * The type of this resource.
    */
-  type: 'doc';
+  type: PublicApiType.Doc;
   /**
    * API link to the Coda doc.
    */
@@ -429,6 +429,8 @@ export interface PublicApiDocumentCreationResult {
    */
   updatedAt: string;
   published?: PublicApiDocPublished;
+  folder: PublicApiFolderReference;
+  workspace: PublicApiWorkspaceReference;
   /**
    * ID of the Coda workspace containing this doc.
    */
@@ -454,7 +456,7 @@ export interface PublicApiPageReference {
   /**
    * The type of this resource.
    */
-  type: 'page';
+  type: PublicApiType.Page;
   /**
    * API link to the page.
    */
@@ -480,7 +482,7 @@ export interface PublicApiPage {
   /**
    * The type of this resource.
    */
-  type: 'page';
+  type: PublicApiType.Page;
   /**
    * API link to the page.
    */
@@ -618,7 +620,7 @@ export interface PublicApiTableReference {
   /**
    * The type of this resource.
    */
-  type: 'table';
+  type: PublicApiType.Table;
   tableType: PublicApiTableType;
   /**
    * API link to the table.
@@ -646,7 +648,7 @@ export interface PublicApiTable {
   /**
    * The type of this resource.
    */
-  type: 'table';
+  type: PublicApiType.Table;
   tableType: PublicApiTableType;
   /**
    * API link to the table.
@@ -707,7 +709,7 @@ export interface PublicApiColumnReference {
   /**
    * The type of this resource.
    */
-  type: 'column';
+  type: PublicApiType.Column;
   /**
    * API link to the column.
    */
@@ -725,7 +727,7 @@ export interface PublicApiColumn {
   /**
    * The type of this resource.
    */
-  type: 'column';
+  type: PublicApiType.Column;
   /**
    * API link to the column.
    */
@@ -742,6 +744,14 @@ export interface PublicApiColumn {
    * Whether the column has a formula set on it.
    */
   calculated?: boolean;
+  /**
+   * Formula on the column.
+   */
+  formula?: string;
+  /**
+   * Default value formula for the column.
+   */
+  defaultValue?: string;
   format: PublicApiColumnFormat;
 }
 
@@ -756,7 +766,7 @@ export interface PublicApiColumnDetail {
   /**
    * The type of this resource.
    */
-  type: 'column';
+  type: PublicApiType.Column;
   /**
    * API link to the column.
    */
@@ -773,6 +783,14 @@ export interface PublicApiColumnDetail {
    * Whether the column has a formula set on it.
    */
   calculated?: boolean;
+  /**
+   * Formula on the column.
+   */
+  formula?: string;
+  /**
+   * Default value formula for the column.
+   */
+  defaultValue?: string;
   format: PublicApiColumnFormat;
   parent: PublicApiTableReference;
 }
@@ -917,6 +935,24 @@ export type PublicApiSliderColumnFormat = PublicApiSimpleColumnFormat & {
 };
 
 /**
+ * Format of a button column.
+ */
+export type PublicApiButtonColumnFormat = PublicApiSimpleColumnFormat & {
+  /**
+   * Label formula for the button.
+   */
+  label?: string;
+  /**
+   * DisableIf formula for the button.
+   */
+  disableIf?: string;
+  /**
+   * Action formula for the button.
+   */
+  action?: string;
+};
+
+/**
  * List of available icon sets.
  */
 export enum PublicApiIconSet {
@@ -957,6 +993,7 @@ export type PublicApiScaleColumnFormat = PublicApiSimpleColumnFormat & {
  * Format of a column.
  */
 export type PublicApiColumnFormat =
+  | PublicApiButtonColumnFormat
   | PublicApiDateColumnFormat
   | PublicApiDateTimeColumnFormat
   | PublicApiDurationColumnFormat
@@ -1020,7 +1057,7 @@ export interface PublicApiRow {
   /**
    * The type of this resource.
    */
-  type: 'row';
+  type: PublicApiType.Row;
   /**
    * API link to the row.
    */
@@ -1065,7 +1102,7 @@ export interface PublicApiRowDetail {
   /**
    * The type of this resource.
    */
-  type: 'row';
+  type: PublicApiType.Row;
   /**
    * API link to the row.
    */
@@ -1410,7 +1447,7 @@ export interface PublicApiFormulaReference {
   /**
    * The type of this resource.
    */
-  type: 'formula';
+  type: PublicApiType.Formula;
   /**
    * API link to the formula.
    */
@@ -1433,7 +1470,7 @@ export interface PublicApiFormula {
   /**
    * The type of this resource.
    */
-  type: 'formula';
+  type: PublicApiType.Formula;
   /**
    * API link to the formula.
    */
@@ -1470,7 +1507,7 @@ export interface PublicApiControlReference {
   /**
    * The type of this resource.
    */
-  type: 'control';
+  type: PublicApiType.Control;
   /**
    * API link to the control.
    */
@@ -1493,7 +1530,7 @@ export interface PublicApiControl {
   /**
    * The type of this resource.
    */
-  type: 'control';
+  type: PublicApiType.Control;
   /**
    * API link to the control.
    */
@@ -1551,7 +1588,7 @@ export interface PublicApiUser {
   /**
    * The type of this resource.
    */
-  type: 'user';
+  type: PublicApiType.User;
   /**
    * Browser-friendly link to the user's avatar image.
    */
@@ -1586,7 +1623,7 @@ export interface PublicApiUserSummary {
   /**
    * The type of this resource.
    */
-  type: 'user';
+  type: PublicApiType.User;
   /**
    * Browser-friendly link to the user's avatar image.
    */
@@ -1610,13 +1647,91 @@ export type PublicApiNextPageLink = string;
 export type PublicApiNextSyncToken = string;
 
 /**
+ * Info about a publishing category
+ */
+export interface PublicApiPublishingCategory {
+  /**
+   * The ID for this category.
+   */
+  categoryId: string;
+  /**
+   * The name of the category.
+   */
+  categoryName: string;
+}
+
+/**
+ * Info about the maker
+ */
+export interface PublicApiMaker {
+  /**
+   * Name of the maker.
+   */
+  name: string;
+  /**
+   * Browser-friendly link to the maker's avatar image.
+   */
+  pictureLink?: string;
+  /**
+   * Maker profile identifier for the maker.
+   */
+  slug?: string;
+  /**
+   * Job title for maker.
+   */
+  jobTitle?: string;
+  /**
+   * Employer for maker.
+   */
+  employer?: string;
+  /**
+   * Description for the maker.
+   */
+  description?: string;
+  /**
+   * Email address of the user.
+   */
+  loginId: string;
+}
+
+/**
+ * Summary about a maker
+ */
+export interface PublicApiMakerSummary {
+  /**
+   * Name of the maker.
+   */
+  name: string;
+  /**
+   * Browser-friendly link to the maker's avatar image.
+   */
+  pictureLink?: string;
+  /**
+   * Maker profile identifier for the maker.
+   */
+  slug?: string;
+  /**
+   * Job title for maker.
+   */
+  jobTitle?: string;
+  /**
+   * Employer for maker.
+   */
+  employer?: string;
+  /**
+   * Description for the maker.
+   */
+  description?: string;
+}
+
+/**
  * Info about a resolved link to an API resource.
  */
 export interface PublicApiApiLink {
   /**
    * The type of this resource.
    */
-  type: 'apiLink';
+  type: PublicApiType.ApiLink;
   /**
    * Self link to this query.
    */
@@ -1737,6 +1852,24 @@ export interface PublicApiMutationStatus {
 }
 
 /**
+ * Reference to a Coda folder.
+ */
+export interface PublicApiFolderReference {
+  /**
+   * ID of the Coda folder.
+   */
+  id: string;
+  /**
+   * The type of this resource.
+   */
+  type: PublicApiType.Folder;
+  /**
+   * Browser-friendly link to the folder.
+   */
+  browserLink: string;
+}
+
+/**
  * Reference to a Coda workspace.
  */
 export interface PublicApiWorkspaceReference {
@@ -1747,7 +1880,11 @@ export interface PublicApiWorkspaceReference {
   /**
    * The type of this resource.
    */
-  type: 'workspace';
+  type: PublicApiType.Workspace;
+  /**
+   * ID of the organization bound to this workspace, if any.
+   */
+  organizationId?: string;
   /**
    * Browser-friendly link to the Coda workspace.
    */
@@ -1765,7 +1902,11 @@ export interface PublicApiWorkspace {
   /**
    * The type of this resource.
    */
-  type: 'workspace';
+  type: PublicApiType.Workspace;
+  /**
+   * ID of the organization bound to this workspace, if any.
+   */
+  organizationId?: string;
   /**
    * Browser-friendly link to the Coda workspace.
    */
@@ -1970,9 +2111,17 @@ export interface PublicApiPack {
    */
   logoUrl?: string;
   /**
+   * The link to the cover photo of the Pack.
+   */
+  coverUrl?: string;
+  /**
    * The parent workspace for the Pack.
    */
   workspaceId: string;
+  /**
+   * Publishing categories associated with this Pack.
+   */
+  categories: PublicApiPublishingCategory[];
   /**
    * The name of the Pack.
    */
@@ -1985,6 +2134,10 @@ export interface PublicApiPack {
    * A short version of the description of the Pack.
    */
   shortDescription: string;
+  /**
+   * A contact email for the Pack.
+   */
+  supportEmail?: string;
   overallRateLimit?: PublicApiPackRateLimit;
   perConnectionRateLimit?: PublicApiPackRateLimit;
 }
@@ -2002,9 +2155,17 @@ export interface PublicApiPackSummary {
    */
   logoUrl?: string;
   /**
+   * The link to the cover photo of the Pack.
+   */
+  coverUrl?: string;
+  /**
    * The parent workspace for the Pack.
    */
   workspaceId: string;
+  /**
+   * Publishing categories associated with this Pack.
+   */
+  categories: PublicApiPublishingCategory[];
   /**
    * The name of the Pack.
    */
@@ -2017,6 +2178,10 @@ export interface PublicApiPackSummary {
    * A short version of the description of the Pack.
    */
   shortDescription: string;
+  /**
+   * A contact email for the Pack.
+   */
+  supportEmail?: string;
 }
 
 /**
@@ -2084,14 +2249,16 @@ export enum PublicApiPackPrincipalType {
   Worldwide = 'worldwide',
 }
 
-/**
- * Access type for a Pack.
- */
 export enum PublicApiPackAccessType {
   View = 'view',
   Test = 'test',
   Edit = 'edit',
 }
+
+/**
+ * Access types for a Pack.
+ */
+export type PublicApiPackAccessTypes = PublicApiPackAccessType[];
 
 export interface PublicApiPackUserPrincipal {
   type: PublicApiPackPrincipalType.User;
@@ -2129,6 +2296,7 @@ export interface PublicApiPackPermission {
 
 export enum PublicApiPackAssetType {
   Logo = 'logo',
+  Cover = 'cover',
   ExampleImage = 'exampleImage',
 }
 
@@ -2281,6 +2449,15 @@ export interface PublicApiPackSourceCode {
 }
 
 /**
+ * Widest principal a Pack is available to.
+ */
+export enum PublicApiPackDiscoverability {
+  Public = 'public',
+  Workspace = 'workspace',
+  Private = 'private',
+}
+
+/**
  * A Pack listing.
  */
 export interface PublicApiPackListing {
@@ -2297,6 +2474,10 @@ export interface PublicApiPackListing {
    */
   logoUrl: string;
   /**
+   * The link to the cover photo of the Pack.
+   */
+  coverUrl?: string;
+  /**
    * The name of the Pack.
    */
   name: string;
@@ -2308,6 +2489,86 @@ export interface PublicApiPackListing {
    * A short version of the description of the Pack.
    */
   shortDescription: string;
+  /**
+   * A contact email for the Pack.
+   */
+  supportEmail?: string;
+  /**
+   * Publishing Categories associated with this Pack.
+   */
+  categories: PublicApiPublishingCategory[];
+  minimumFeatureSet?: PublicApiFeatureSet;
+  unrestrictedFeatureSet?: PublicApiFeatureSet;
+  /**
+   * The url where complete metadata about the contents of the Pack version can be downloaded.
+   */
+  externalMetadataUrl: string;
+}
+
+/**
+ * A detailed Pack listing.
+ */
+export interface PublicApiPackListingDetail {
+  /**
+   * ID of the Pack.
+   */
+  packId: number;
+  /**
+   * The version of the Pack.
+   */
+  packVersion: string;
+  /**
+   * The link to the logo of the Pack.
+   */
+  logoUrl: string;
+  /**
+   * The link to the cover photo of the Pack.
+   */
+  coverUrl?: string;
+  /**
+   * The name of the Pack.
+   */
+  name: string;
+  /**
+   * The full description of the Pack.
+   */
+  description: string;
+  /**
+   * A short version of the description of the Pack.
+   */
+  shortDescription: string;
+  /**
+   * A contact email for the Pack.
+   */
+  supportEmail?: string;
+  /**
+   * Publishing Categories associated with this Pack.
+   */
+  categories: PublicApiPublishingCategory[];
+  minimumFeatureSet?: PublicApiFeatureSet;
+  unrestrictedFeatureSet?: PublicApiFeatureSet;
+  /**
+   * The url where complete metadata about the contents of the Pack version can be downloaded.
+   */
+  externalMetadataUrl: string;
+  /**
+   * The release number of the Pack version if it has one.
+   */
+  releaseId?: number;
+  discoverability: PublicApiPackDiscoverability;
+  /**
+   * Makers associated with this Pack.
+   */
+  makers: PublicApiMakerSummary[];
+  /**
+   * The access capabilities the current user has for this Pack.
+   */
+  userAccess: {
+    canEdit: boolean;
+    canTest: boolean;
+    canView: boolean;
+    canInstall: boolean;
+  };
 }
 
 /**
@@ -2320,14 +2581,41 @@ export interface PublicApiPackListingList {
 }
 
 /**
- * The Pack system connection.
+ * Metadata of a Pack system connection.
  */
-export interface PublicApiPackSystemConnection {
+export type PublicApiPackSystemConnectionMetadata =
+  | PublicApiPackConnectionHeaderMetadata
+  | PublicApiPackConnectionUrlParamMetadata
+  | PublicApiPackConnectionHttpBasicMetadata;
+
+/**
+ * The Pack OAuth configuration metadata.
+ */
+export interface PublicApiPackOauthConfigMetadata {
   /**
-   * Name of the system connection.
+   * Masked OAuth client id. If not set, empty string will be returned.
    */
-  name: string;
-  credentials: PublicApiPackSystemConnectionCredentials;
+  maskedClientId: string;
+  /**
+   * Masked OAuth client secret. If not set, empty string will be returned.
+   */
+  maskedClientSecret: string;
+  /**
+   * Authorization url of the OAuth provider.
+   */
+  authorizationUrl: string;
+  /**
+   * Token url of the OAuth provider.
+   */
+  tokenUrl: string;
+  /**
+   * Optional token prefix that's used to make the API request.
+   */
+  tokenPrefix?: string;
+  /**
+   * Optional scopes of the OAuth client.
+   */
+  scopes?: string;
 }
 
 /**
@@ -2359,6 +2647,16 @@ export interface PublicApiCreatePackResponse {
 }
 
 /**
+ * Payload for getting the next version of a Pack.
+ */
+export interface PublicApiGetNextPackVersionRequest {
+  /**
+   * The metadata for the next version of the Pack.
+   */
+  proposedMetadata: string;
+}
+
+/**
  * Type of Pack connections.
  */
 export enum PublicApiPackConnectionType {
@@ -2375,6 +2673,29 @@ export type PublicApiPackSystemConnectionCredentials =
   | PublicApiPackConnectionUrlParamCredentials
   | PublicApiPackConnectionHttpBasicCredentials;
 
+export interface PublicApiPackConnectionHeaderMetadata {
+  type: PublicApiPackConnectionType.Header;
+  maskedToken?: string;
+  headerName: string;
+  tokenPrefix: string;
+}
+
+export interface PublicApiPackConnectionUrlParamMetadata {
+  type: PublicApiPackConnectionType.UrlParam;
+  params: {
+    key: string;
+    maskedValue: string;
+  }[];
+  domain: string;
+  presetKeys: string[];
+}
+
+export interface PublicApiPackConnectionHttpBasicMetadata {
+  type: PublicApiPackConnectionType.HttpBasic;
+  maskedUsername?: string;
+  maskedPassword?: string;
+}
+
 export interface PublicApiPackConnectionHeaderCredentials {
   type: PublicApiPackConnectionType.Header;
   token: string;
@@ -2389,9 +2710,224 @@ export interface PublicApiPackConnectionUrlParamCredentials {
 }
 
 export interface PublicApiPackConnectionHttpBasicCredentials {
-  type: PublicApiPackConnectionType.UrlParam;
+  type: PublicApiPackConnectionType.HttpBasic;
   username: string;
-  password: string;
+  password?: string;
+}
+
+export interface PublicApiPackConnectionHeaderPatch {
+  type: PublicApiPackConnectionType.Header;
+  token?: string;
+}
+
+export interface PublicApiPackConnectionUrlParamPatch {
+  type: PublicApiPackConnectionType.UrlParam;
+  paramsToPatch?: {
+    key: string;
+    value: string;
+  }[];
+}
+
+export interface PublicApiPackConnectionHttpBasicPatch {
+  type: PublicApiPackConnectionType.HttpBasic;
+  username?: string;
+  password?: string;
+}
+
+/**
+ * List of Pack logs.
+ */
+export interface PublicApiPackLogsList {
+  items: PublicApiPackLog[];
+  nextPageToken?: PublicApiNextPageToken;
+  nextPageLink?: PublicApiNextPageLink & string;
+}
+
+/**
+ * A record of Pack log.
+ */
+export type PublicApiPackLog =
+  | PublicApiPackCustomLog
+  | PublicApiPackInvocationLog
+  | PublicApiPackFetcherLog
+  | PublicApiPackInternalLog
+  | PublicApiPackAuthLog;
+
+/**
+ * Logging context that comes with a Pack log.
+ */
+export interface PublicApiPackLogContext {
+  docId: string;
+  packId: string;
+  packVersion: string;
+  formulaName: string;
+  userId: string;
+  connectionId: string;
+  /**
+   * A unique identifier of the Pack invocation that can be used to associate all log types generated in one call of a Pack formula.
+   *
+   */
+  requestId: string;
+  requestType: PublicApiPackLogRequestType;
+  /**
+   * Creation time of the log.
+   */
+  createdAt: string;
+  /**
+   * Unique identifier of this log record.
+   */
+  logId: string;
+}
+
+/**
+ * Pack log generated by developer's custom logging with context.logger.
+ */
+export interface PublicApiPackCustomLog {
+  type: PublicApiPackLogType.Custom;
+  context: PublicApiPackLogContext;
+  /**
+   * The message that's passed into context.logger.
+   */
+  message: string;
+  level: PublicApiLogLevel;
+}
+
+/**
+ * System logs of the invocations of the Pack.
+ */
+export interface PublicApiPackInvocationLog {
+  type: PublicApiPackLogType.Invocation;
+  context: PublicApiPackLogContext;
+  /**
+   * Error info if this invocation resulted in an error.
+   */
+  error?: {
+    message: string;
+  };
+}
+
+/**
+ * System logs of Pack calls to context.fetcher.
+ */
+export interface PublicApiPackFetcherLog {
+  type: PublicApiPackLogType.Fetcher;
+  context: PublicApiPackLogContext;
+  responseCode?: number;
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  /**
+   * base url of the fetcher request, with all query parameters stripped off.
+   */
+  baseUrl?: string;
+  /**
+   * true if the fetcher request hits catche instead of actually requesting the remote service.
+   */
+  cacheHit?: boolean;
+  /**
+   * Duration of the fetcher request in miliseconds.
+   */
+  duration?: number;
+}
+
+/**
+ * Coda internal logs from the packs infrastructure. Only visible to Codans.
+ */
+export interface PublicApiPackInternalLog {
+  type: PublicApiPackLogType.Internal;
+  context: PublicApiPackLogContext;
+  /**
+   * The log message.
+   */
+  message: string;
+  level: PublicApiLogLevel;
+}
+
+/**
+ * System logs of Pack authentication requests.
+ */
+export interface PublicApiPackAuthLog {
+  type: PublicApiPackLogType.Auth;
+  context: PublicApiPackLogContext;
+  /**
+   * The request path.
+   */
+  path: string;
+  /**
+   * The error message.
+   */
+  errorMessage?: string;
+  /**
+   * The error stacktrace (internal only).
+   */
+  errorStack?: string;
+}
+
+/**
+ * The context request type where a Pack log is generated.
+ */
+export enum PublicApiPackLogRequestType {
+  Unknown = 'unknown',
+  ConnectionNameMetadataRequest = 'connectionNameMetadataRequest',
+  ParameterAutocompleteMetadataRequest = 'parameterAutocompleteMetadataRequest',
+  PostAuthSetupMetadataRequest = 'postAuthSetupMetadataRequest',
+  GetSyncTableSchemaMetadataRequest = 'getSyncTableSchemaMetadataRequest',
+  GetDynamicSyncTableNameMetadataRequest = 'getDynamicSyncTableNameMetadataRequest',
+  ListSyncTableDynamicUrlsMetadataRequest = 'listSyncTableDynamicUrlsMetadataRequest',
+  GetDynamicSyncTableDisplayUrlMetadataRequest = 'getDynamicSyncTableDisplayUrlMetadataRequest',
+  GetIdentifiersForConnectionRequest = 'getIdentifiersForConnectionRequest',
+  InvokeFormulaRequest = 'invokeFormulaRequest',
+  InvokeSyncFormulaRequest = 'invokeSyncFormulaRequest',
+  ImpersonateInvokeFormulaRequest = 'impersonateInvokeFormulaRequest',
+  ImpersonateInvokeMetadataFormulaRequest = 'impersonateInvokeMetadataFormulaRequest',
+}
+
+export enum PublicApiPackLogType {
+  Custom = 'custom',
+  Fetcher = 'fetcher',
+  Invocation = 'invocation',
+  Internal = 'internal',
+  Auth = 'auth',
+}
+
+export enum PublicApiLogLevel {
+  Error = 'error',
+  Warn = 'warn',
+  Info = 'info',
+  Debug = 'debug',
+  Trace = 'trace',
+  Unknown = 'unknown',
+}
+
+/**
+ * Only relevant for original Coda packs.
+ */
+export enum PublicApiFeatureSet {
+  Basic = 'Basic',
+  Pro = 'Pro',
+  Team = 'Team',
+  Enterprise = 'Enterprise',
+}
+
+/**
+ * The request to patch pack system connection credentials.
+ */
+export type PublicApiPatchPackSystemConnectionRequest =
+  | PublicApiPackConnectionHeaderPatch
+  | PublicApiPackConnectionUrlParamPatch
+  | PublicApiPackConnectionHttpBasicPatch;
+
+/**
+ * Request to set the Pack OAuth configuration.
+ */
+export interface PublicApiSetPackOauthConfigRequest {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * The request to set pack system connection credentials.
+ */
+export interface PublicApiSetPackSystemConnectionRequest {
+  credentials: PublicApiPackSystemConnectionCredentials;
 }
 
 /**
@@ -2402,6 +2938,7 @@ export interface PublicApiRegisterPackVersionRequest {
    * The SHA-256 hash of the file to be uploaded.
    */
   bundleHash: string;
+  [k: string]: unknown;
 }
 
 /**
@@ -2439,6 +2976,10 @@ export interface PublicApiUpdatePackRequest {
    */
   logoAssetId?: string | null;
   /**
+   * The asset id of the Pack's cover image, returned by [`#PackAssetUploadComplete`](#operation/packAssetUploadComplete) endpoint.
+   */
+  coverAssetId?: string | null;
+  /**
    * The asset ids of the Pack's example images, returned by [`#PackAssetUploadComplete`](#operation/packAssetUploadComplete) endpoint, sorted by their display order.
    */
   exampleImageAssetIds?: string[] | null;
@@ -2454,16 +2995,10 @@ export interface PublicApiUpdatePackRequest {
    * A short version of the description of the Pack.
    */
   shortDescription?: string;
-}
-
-/**
- * Payload for setting a Pack version live.
- */
-export interface PublicApiSetPackLiveVersionRequest {
   /**
-   * The version of the Pack.
+   * A contact email for the Pack.
    */
-  packVersion: string;
+  supportEmail?: string;
 }
 
 /**
@@ -2472,9 +3007,61 @@ export interface PublicApiSetPackLiveVersionRequest {
 export interface PublicApiCreatePackVersionResponse {}
 
 /**
- * Confirmation of successfully setting a Pack version live.
+ * Confirmation of successfully retrieving Pack makers.
  */
-export interface PublicApiSetPackLiveVersionResponse {}
+export interface PublicApiListPackMakersResponse {
+  makers: PublicApiMaker[];
+}
+
+/**
+ * Payload for adding a Pack maker.
+ */
+export interface PublicApiAddPackMakerRequest {
+  /**
+   * The email of the Pack maker.
+   */
+  loginId: string;
+}
+
+/**
+ * Confirmation of successfully adding a Pack maker.
+ */
+export interface PublicApiAddPackMakerResponse {}
+
+/**
+ * Confirmation of successfully deleting a Pack maker.
+ */
+export interface PublicApiDeletePackMakerResponse {}
+
+/**
+ * Confirmation of successfully retrieving Pack categories.
+ */
+export interface PublicApiListPackCategoriesResponse {
+  /**
+   * The names of categories associated with a Pack.
+   */
+  categories: PublicApiPublishingCategory[];
+}
+
+/**
+ * Payload for adding a Pack Category.
+ */
+export interface PublicApiAddPackCategoryRequest {
+  /**
+   * Name of the publishing category.
+   */
+  categoryName: string;
+}
+
+/**
+ * Confirmation of successfully adding a Pack category.
+ */
+export interface PublicApiAddPackCategoryResponse {}
+
+/**
+ * Confirmation of successfully deleting a Pack category.
+ */
+export interface PublicApiDeletePackCategoryResponse {}
 
 /**
  * Payload for upserting a Pack permission.
@@ -2561,6 +3148,7 @@ export interface PublicApiCreatePackVersionRequest {
    * Developer notes of the new Pack version.
    */
   notes?: string;
+  [k: string]: unknown;
 }
 
 /**
@@ -2575,6 +3163,7 @@ export interface PublicApiCreatePackReleaseRequest {
    * Developers notes.
    */
   releaseNotes?: string;
+  [k: string]: unknown;
 }
 
 /**
@@ -2590,17 +3179,25 @@ export interface PublicApiUploadPackSourceCodeRequest {
 }
 
 /**
- * The request to set Pack system connection.
+ * Information indicating the next Pack version definition.
  */
-export interface PublicApiSetPackSystemConnectionRequest {
+export interface PublicApiNextPackVersionInfo {
   /**
-   * Name of the system connection.
+   * The next valid version for the Pack.
    */
-  name: string;
-  credentials: PublicApiPackSystemConnectionCredentials;
+  nextVersion: string;
+  /**
+   * List of changes from the previous version.
+   */
+  findings: string[];
 }
 
 /**
- * Empty response of deleting pack system connection.
+ * Info about the diff between two Pack versions.
  */
-export interface PublicApiDeletePackSystemConnectionResponse {}
+export interface PublicApiPackVersionDiffs {
+  /**
+   * List of changes from the previous version to the next version.
+   */
+  findings: string[];
+}


### PR DESCRIPTION
This switches to the new-style API client from https://github.com/coda/coda/pull/61978. We have to tweak our error handling slightly since the API client now throws instead of returns errors.

PTAL @patrick-codaio @alan-codaio @coda/packs 