### PR TITLE
fix validate no changes to do all commands that generate possible diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ publish-local: build
 	cp -r dist/* ../packs/node_modules/@codahq/packs-sdk/dist/
 
 .PHONY: validate-no-changes
-validate-no-changes: compile
+validate-no-changes: compile docs
 	$(eval UNTRACKED_FILES := $(shell git status --short))
 	$(eval CHANGED_FILES := $(shell git diff --name-only))
 	if [[ -n "${UNTRACKED_FILES}" || -n "${CHANGED_FILES}" ]]; then \


### PR DESCRIPTION
https://github.com/coda/packs-sdk/pull/1417 is failing even though it does not pass `make bs; make build` test locally. This is because our `vaidate-no-changes` step in CI only does `compile` which doesn't actually try to generate docs. Changing to use also do the `docs` step.

validated that on that branch with this step it fails and doesn't without

@jonathan-codaio cc @coda/packs 