### PR TITLE
Allow RegExp objects in column matchers

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1497,7 +1497,7 @@ export interface Format {
 	 * A list of regular expressions that match URLs that the formula implementing this format
 	 * is capable of handling. As described in {@link Format}, this is a discovery mechanism.
 	 */
-	matchers?: string[];
+	matchers?: Array<string | RegExp>;
 	/**
 	 * @deprecated Currently unused.
 	 */

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -518,7 +518,7 @@ export interface Format {
      * A list of regular expressions that match URLs that the formula implementing this format
      * is capable of handling. As described in {@link Format}, this is a discovery mechanism.
      */
-    matchers?: string[];
+    matchers?: Array<string | RegExp>;
     /**
      * @deprecated Currently unused.
      */

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -80,7 +80,7 @@ ___
 
 ### matchers
 
-• `Optional` **matchers**: `string`[]
+• `Optional` **matchers**: (`string` \| `RegExp`)[]
 
 A list of regular expressions that match URLs that the formula implementing this format
 is capable of handling. As described in [Format](Format.md), this is a discovery mechanism.

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -1,9 +1,11 @@
 [
   {
     "name": "addColumnFormat()",
-    "triggerTokens": ["addColumnFormat"],
+    "triggerTokens": [
+      "addColumnFormat"
+    ],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addColumnFormat",
-    "content": "A **column format** is a custom column type that you apply to any column in any Coda table. A column format tells Coda to interpret the value in a cell by executing a **formula** using that value, typically looking up data related to that value from a third-party API.\n\nFor example, the Weather pack has a column format `Current Weather`; when applied to a column, if you type a city or address into a cell in that column, that location will be used an input to a formula that fetches the current weather at that location, and the resulting object with weather info will be shown in the cell.",
+    "content": "A **column format** is a custom column type that you apply to any column in any Coda table. A column format& tells Coda to interpret the value in a cell by executing a **formula** using that value, typically looking up data related to that value from a third-party API.\n\nFor example, the Weather pack has a column format `Current Weather`; when applied to a column, if you type a city or address into a cell in that column, that location will be used an input to a formula that fetches the current weather at that location, and the resulting object with weather info will be shown in the cell.",
     "exampleSnippets": [
       {
         "name": "Column Format with No Matchers",
@@ -14,7 +16,10 @@
   },
   {
     "name": "Authentication",
-    "triggerTokens": ["setSystemAuthentication", "setUserAuthentication"],
+    "triggerTokens": [
+      "setSystemAuthentication",
+      "setUserAuthentication"
+    ],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#setSystemAuthentication",
     "content": "The SDK broadly divides authentication into two categories: authentication that is tied to the user of the pack vs authentication that is managed by the system, aka the pack author. In the pack definition the former is known as `defaultAuthentication` and the latter `systemConnectionAuthentication`. You will typically specify one or the other in your pack definition, or neither if your pack does not make http requests or those requests do not require authentication.\n\nDefault authentication is the most common. Specify this if each user of your pack should log in with OAuth, or have their own API key, or whatever user-specific token is necessary for the pack to be able to retrieve data that is specific to that user.\n\nUse system authentication if you as the pack author will provide the necessary tokens to successfully make http requests within your pack. An example would be if your pack returns weather forecasts and the API involved requires an API key, but individual users need not provide their own API key. You as the pack author will register an API key and provide it to Coda, and Coda will apply it to all pack requests regardless of the user.",
     "exampleSnippets": [
@@ -32,7 +37,9 @@
   },
   {
     "name": "addDynamicSyncTable()",
-    "triggerTokens": ["addDynamicSyncTable"],
+    "triggerTokens": [
+      "addDynamicSyncTable"
+    ],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addDynamicSyncTable",
     "content": "Most sync tables have schemas that can be statically defined. For example, if you're writing a sync of a user's Google Calendar events, the structure of an Event from the Google Calendar API is well-known and you can write a schema for what your table should contain.\n\nIn certain cases, you may want to sync data whose structure is not known in advance and may depend on the user doing the sync. For example, Coda's Jira pack allows users to sync data from their Jira instance, but Jira lets users create arbitrary custom fields for their Issue objects. So the schema of the Issues sync table is not known in advance; it depends on the Jira account that the user is syncing from.\n\nCoda supports \"dynamic\" sync tables for cases like these. Instead of including a static schema in your sync table definition, you include a formula that returns a schema. This formula can use the fetcher to make authenticated http requests to your pack's API so that you may retrieve any necessary info from that third-party service needed to construct an appropriate schema.\n\nTo define a dynamic schema, use the `makeDynamicSyncTable()` wrapper function. You will provide a `getSchema` formula that returns a schema definition. You'll also provide some supporting formulas like `getName`, to return a name in the UI for the table, in case even the name of the entities being synced is dynamic.\n\nThere are two subtle variants of dynamic sync tables. A sync table can be dynamic simply because the shape of the entities being synced vary based on who the current user is. For example, in the Jira example, Jira Issues are synced by hitting the same static Jira API url for Issues, but the schema of the issues returned will be different depending on the configuration of the Jira instance of the calling user.\n\nAlternatively, a sync table can be dynamic because the data source is specific to each instance of the table. If you were building a sync table to sync data from a Google Sheet, the data source would be the API url of a specific sheet. In this case, the sync table will be bound to a `dynamicUrl` that defines the data source. This url will be available to all of the formulas to implement the sync table in the sync context, as `context.sync.dynamicUrl`. To create a sync table that uses dynamic urls, you must implement the `listDynamicUrls` metadata formula in your dynamic sync table definition.",
     "exampleSnippets": [
@@ -45,7 +52,9 @@
   },
   {
     "name": "addFormula()",
-    "triggerTokens": ["addFormula"],
+    "triggerTokens": [
+      "addFormula"
+    ],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addFormula",
     "content": "A **formula (including a button)** is a JavaScript function that will be exposed as a Coda formula, that you can use anywhere in a Coda doc that you can use any normal formula. Formulas take basic Coda types as input, like strings, numbers, dates, booleans, and arrays of these types, and return any of these types or objects whose properties are any of these types. Buttons are just a flavor of a formula with the flag `isAction` activated.",
     "exampleSnippets": [
@@ -58,7 +67,9 @@
   },
   {
     "name": "addSyncTable()",
-    "triggerTokens": ["addSyncTable"],
+    "triggerTokens": [
+      "addSyncTable"
+    ],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addSyncTable",
     "content": "A **sync table** is how to bring structured data from a third-party into Coda. A sync table is a table that you can add to a Coda doc that gets its rows from a third-party data source, that can be refreshed regularly to pull in new or updated data. A sync table is powered by a **formula** that takes parameters that represent sync options and returns an array of objects representing row data. A sync table also includes a schema describing the structure of the returned objects.",
     "exampleSnippets": [

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -1,11 +1,9 @@
 [
   {
     "name": "addColumnFormat()",
-    "triggerTokens": [
-      "addColumnFormat"
-    ],
+    "triggerTokens": ["addColumnFormat"],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addColumnFormat",
-    "content": "A **column format** is a custom column type that you apply to any column in any Coda table. A column format& tells Coda to interpret the value in a cell by executing a **formula** using that value, typically looking up data related to that value from a third-party API.\n\nFor example, the Weather pack has a column format `Current Weather`; when applied to a column, if you type a city or address into a cell in that column, that location will be used an input to a formula that fetches the current weather at that location, and the resulting object with weather info will be shown in the cell.",
+    "content": "A **column format** is a custom column type that you apply to any column in any Coda table. A column format tells Coda to interpret the value in a cell by executing a **formula** using that value, typically looking up data related to that value from a third-party API.\n\nFor example, the Weather pack has a column format `Current Weather`; when applied to a column, if you type a city or address into a cell in that column, that location will be used an input to a formula that fetches the current weather at that location, and the resulting object with weather info will be shown in the cell.",
     "exampleSnippets": [
       {
         "name": "Column Format with No Matchers",
@@ -16,10 +14,7 @@
   },
   {
     "name": "Authentication",
-    "triggerTokens": [
-      "setSystemAuthentication",
-      "setUserAuthentication"
-    ],
+    "triggerTokens": ["setSystemAuthentication", "setUserAuthentication"],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#setSystemAuthentication",
     "content": "The SDK broadly divides authentication into two categories: authentication that is tied to the user of the pack vs authentication that is managed by the system, aka the pack author. In the pack definition the former is known as `defaultAuthentication` and the latter `systemConnectionAuthentication`. You will typically specify one or the other in your pack definition, or neither if your pack does not make http requests or those requests do not require authentication.\n\nDefault authentication is the most common. Specify this if each user of your pack should log in with OAuth, or have their own API key, or whatever user-specific token is necessary for the pack to be able to retrieve data that is specific to that user.\n\nUse system authentication if you as the pack author will provide the necessary tokens to successfully make http requests within your pack. An example would be if your pack returns weather forecasts and the API involved requires an API key, but individual users need not provide their own API key. You as the pack author will register an API key and provide it to Coda, and Coda will apply it to all pack requests regardless of the user.",
     "exampleSnippets": [
@@ -37,9 +32,7 @@
   },
   {
     "name": "addDynamicSyncTable()",
-    "triggerTokens": [
-      "addDynamicSyncTable"
-    ],
+    "triggerTokens": ["addDynamicSyncTable"],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addDynamicSyncTable",
     "content": "Most sync tables have schemas that can be statically defined. For example, if you're writing a sync of a user's Google Calendar events, the structure of an Event from the Google Calendar API is well-known and you can write a schema for what your table should contain.\n\nIn certain cases, you may want to sync data whose structure is not known in advance and may depend on the user doing the sync. For example, Coda's Jira pack allows users to sync data from their Jira instance, but Jira lets users create arbitrary custom fields for their Issue objects. So the schema of the Issues sync table is not known in advance; it depends on the Jira account that the user is syncing from.\n\nCoda supports \"dynamic\" sync tables for cases like these. Instead of including a static schema in your sync table definition, you include a formula that returns a schema. This formula can use the fetcher to make authenticated http requests to your pack's API so that you may retrieve any necessary info from that third-party service needed to construct an appropriate schema.\n\nTo define a dynamic schema, use the `makeDynamicSyncTable()` wrapper function. You will provide a `getSchema` formula that returns a schema definition. You'll also provide some supporting formulas like `getName`, to return a name in the UI for the table, in case even the name of the entities being synced is dynamic.\n\nThere are two subtle variants of dynamic sync tables. A sync table can be dynamic simply because the shape of the entities being synced vary based on who the current user is. For example, in the Jira example, Jira Issues are synced by hitting the same static Jira API url for Issues, but the schema of the issues returned will be different depending on the configuration of the Jira instance of the calling user.\n\nAlternatively, a sync table can be dynamic because the data source is specific to each instance of the table. If you were building a sync table to sync data from a Google Sheet, the data source would be the API url of a specific sheet. In this case, the sync table will be bound to a `dynamicUrl` that defines the data source. This url will be available to all of the formulas to implement the sync table in the sync context, as `context.sync.dynamicUrl`. To create a sync table that uses dynamic urls, you must implement the `listDynamicUrls` metadata formula in your dynamic sync table definition.",
     "exampleSnippets": [
@@ -52,9 +45,7 @@
   },
   {
     "name": "addFormula()",
-    "triggerTokens": [
-      "addFormula"
-    ],
+    "triggerTokens": ["addFormula"],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addFormula",
     "content": "A **formula (including a button)** is a JavaScript function that will be exposed as a Coda formula, that you can use anywhere in a Coda doc that you can use any normal formula. Formulas take basic Coda types as input, like strings, numbers, dates, booleans, and arrays of these types, and return any of these types or objects whose properties are any of these types. Buttons are just a flavor of a formula with the flag `isAction` activated.",
     "exampleSnippets": [
@@ -67,9 +58,7 @@
   },
   {
     "name": "addSyncTable()",
-    "triggerTokens": [
-      "addSyncTable"
-    ],
+    "triggerTokens": ["addSyncTable"],
     "exampleFooterLink": "https://coda.github.io/packs-sdk/reference/sdk/classes/PackDefinitionBuilder#addSyncTable",
     "content": "A **sync table** is how to bring structured data from a third-party into Coda. A sync table is a table that you can add to a Coda doc that gets its rows from a third-party data source, that can be refreshed regularly to pull in new or updated data. A sync table is powered by a **formula** that takes parameters that represent sync options and returns an array of objects representing row data. A sync table also includes a schema describing the structure of the returned objects.",
     "exampleSnippets": [

--- a/types.ts
+++ b/types.ts
@@ -589,7 +589,7 @@ export interface Format {
    * A list of regular expressions that match URLs that the formula implementing this format
    * is capable of handling. As described in {@link Format}, this is a discovery mechanism.
    */
-  matchers?: string[];
+  matchers?: Array<string | RegExp>;
   /**
    * @deprecated Currently unused.
    */


### PR DESCRIPTION
This is an intermediate state, we will eventually remove the ability to have Strings in this field.

Planned sequence:
- Merge this SDK update
- Update SDK in Coda app
- Update all existing Coda packs to use RegExp objects (with a careful release of the updates)
- Announce to pack beta devs that the String option is going away
- Remove the String option from matchers type