### PR TITLE
Allow passing pack builder objects to our execution methods.

### DIFF
--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -1,6 +1,6 @@
 import type {Authentication} from '../types';
+import type {BasicPackDefinition} from '../types';
 import {Client} from '../helpers/external-api/coda';
-import type {PackVersionDefinition} from '../types';
 import path from 'path';
 import {print} from '../testing/helpers';
 import {spawnSync} from 'child_process';
@@ -33,7 +33,7 @@ export function makeManifestFullPath(manifestPath: string): string {
 // in the future, for a use case like a Google Maps pack which allowed a default credential
 // from the pack author to be used up to some rate limit, after which a power user would need
 // to connect their own Maps API credential.
-export function getPackAuth(packDef: PackVersionDefinition): Authentication | undefined {
+export function getPackAuth(packDef: BasicPackDefinition): Authentication | undefined {
   const {defaultAuthentication, systemConnectionAuthentication} = packDef;
   if (defaultAuthentication && systemConnectionAuthentication) {
     print('Both defaultAuthentication & systemConnectionAuthentication are specified.');
@@ -44,7 +44,9 @@ export function getPackAuth(packDef: PackVersionDefinition): Authentication | un
   return defaultAuthentication || (systemConnectionAuthentication as Authentication);
 }
 
-export async function importManifest(bundleFilename: string): Promise<PackVersionDefinition> {
+export async function importManifest<T extends BasicPackDefinition = BasicPackDefinition>(
+  bundleFilename: string,
+): Promise<T> {
   const module = await import(path.resolve(bundleFilename));
   return module.pack || module.manifest;
 }

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -1,4 +1,5 @@
 import type {Arguments} from 'yargs';
+import type {PackVersionDefinition} from '..';
 import {build} from './build';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
@@ -40,11 +41,14 @@ export async function handleRelease({
     );
   }
 
+  // TODO(alan/jonathan): Deal with the case of a pack that doesn't specify a version at all.
+  // Either error out with a useful message about needing to provide a specific version
+  // via the optional second CLI arg, or add a CLI flag --latest that uses the latest version.
   let packVersion = explicitPackVersion;
   if (!packVersion) {
     try {
       const bundleFilename = await build(manifestFile);
-      const manifest = await importManifest(bundleFilename);
+      const manifest = await importManifest<PackVersionDefinition>(bundleFilename);
       packVersion = manifest.version as string;
     } catch (err: any) {
       return printAndExit(`Got an error while building your pack to get the current pack version: ${formatError(err)}`);

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -1,6 +1,7 @@
 import type {Arguments} from 'yargs';
 import type {Logger} from '../api_types';
 import type {PackUpload} from '../compiled_types';
+import type {PackVersionDefinition} from '..';
 import type {PublicApiPackVersionUploadInfo} from '../helpers/external-api/v1';
 import type {TimerShimStrategy} from '../testing/compile';
 import {compilePackBundle} from '../testing/compile';
@@ -79,7 +80,7 @@ export async function handleUpload({
     timerStrategy,
   });
 
-  const manifest = await importManifest(bundlePath);
+  const manifest = await importManifest<PackVersionDefinition>(bundlePath);
 
   // Since package.json isn't in dist, we grab it from the root directory instead.
   const packageJson = await import(isTestCommand() ? '../package.json' : '../../package.json');

--- a/cli/validate.ts
+++ b/cli/validate.ts
@@ -1,5 +1,6 @@
 import type {Arguments} from 'yargs';
 import type {PackMetadataValidationError} from '../testing/upload_validation';
+import type {PackVersionDefinition} from '..';
 import type {PackVersionMetadata} from '../compiled_types';
 import type {ValidationError} from '../testing/types';
 import {compilePackBundle} from '../testing/compile';
@@ -16,7 +17,7 @@ interface ValidateArgs {
 export async function handleValidate({manifestFile}: Arguments<ValidateArgs>) {
   const fullManifestPath = makeManifestFullPath(manifestFile);
   const {bundlePath} = await compilePackBundle({manifestPath: fullManifestPath, minify: false});
-  const manifest = await importManifest(bundlePath);
+  const manifest = await importManifest<PackVersionDefinition>(bundlePath);
 
   // Since it's okay to not specify a version, we inject one if it's not provided.
   if (!manifest.version) {

--- a/dist/cli/helpers.d.ts
+++ b/dist/cli/helpers.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="node" />
 import type { Authentication } from '../types';
+import type { BasicPackDefinition } from '../types';
 import { Client } from '../helpers/external-api/coda';
-import type { PackVersionDefinition } from '../types';
 export declare function spawnProcess(command: string): import("child_process").SpawnSyncReturns<Buffer>;
 export declare function createCodaClient(apiToken: string, protocolAndHost?: string): Client;
 export declare function formatEndpoint(endpoint: string): string;
 export declare function isTestCommand(): boolean;
 export declare function makeManifestFullPath(manifestPath: string): string;
-export declare function getPackAuth(packDef: PackVersionDefinition): Authentication | undefined;
-export declare function importManifest(bundleFilename: string): Promise<PackVersionDefinition>;
+export declare function getPackAuth(packDef: BasicPackDefinition): Authentication | undefined;
+export declare function importManifest<T extends BasicPackDefinition = BasicPackDefinition>(bundleFilename: string): Promise<T>;

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -43,6 +43,9 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
     if (!packId) {
         return (0, helpers_4.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
     }
+    // TODO(alan/jonathan): Deal with the case of a pack that doesn't specify a version at all.
+    // Either error out with a useful message about needing to provide a specific version
+    // via the optional second CLI arg, or add a CLI flag --latest that uses the latest version.
     let packVersion = explicitPackVersion;
     if (!packVersion) {
         try {

--- a/dist/runtime/common/helpers.d.ts
+++ b/dist/runtime/common/helpers.d.ts
@@ -1,7 +1,7 @@
+import type { BasicPackDefinition } from '../../types';
 import type { Formula } from '../../api';
 import type { GenericSyncFormula } from '../../api';
-import type { PackVersionDefinition } from '../../types';
-export declare function findFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula;
-export declare function findSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula;
-export declare function tryFindFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula | undefined;
-export declare function tryFindSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula | undefined;
+export declare function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula;
+export declare function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula;
+export declare function tryFindFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula | undefined;
+export declare function tryFindSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula | undefined;

--- a/dist/runtime/thunk/thunk.d.ts
+++ b/dist/runtime/thunk/thunk.d.ts
@@ -1,10 +1,10 @@
+import type { BasicPackDefinition } from '../../types';
 import type { ExecutionContext } from '../../api_types';
 import type { FetchRequest } from '../../api_types';
 import type { FetchResponse } from '../../api_types';
 import type { FormulaSpecification } from '../types';
 import type { GenericSyncFormulaResult } from '../../api';
 import type { PackFormulaResult } from '../../api_types';
-import type { PackVersionDefinition } from '../../types';
 import type { ParamDefs } from '../../api_types';
 import type { ParamValues } from '../../api_types';
 import type { SyncExecutionContext } from '../../api_types';
@@ -14,7 +14,7 @@ export { unmarshalValue } from '../common/marshaling';
 /**
  * The thunk entrypoint - the first code that runs inside the v8 isolate once control is passed over.
  */
-export declare function findAndExecutePackFunction<T extends FormulaSpecification>(params: ParamValues<ParamDefs>, formulaSpec: T, manifest: PackVersionDefinition, executionContext: ExecutionContext | SyncExecutionContext, shouldWrapError?: boolean): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult>;
+export declare function findAndExecutePackFunction<T extends FormulaSpecification>(params: ParamValues<ParamDefs>, formulaSpec: T, manifest: BasicPackDefinition, executionContext: ExecutionContext | SyncExecutionContext, shouldWrapError?: boolean): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult>;
 export declare function ensureSwitchUnreachable(value: never): never;
 export declare function handleErrorAsync(func: () => Promise<any>): Promise<any>;
 export declare function handleError(func: () => any): any;

--- a/dist/testing/auth.d.ts
+++ b/dist/testing/auth.d.ts
@@ -1,12 +1,12 @@
+import type { BasicPackDefinition } from '../types';
 import type { Credentials } from './auth_types';
-import type { PackVersionDefinition } from '../types';
 interface SetupAuthOptions {
     oauthServerPort?: number;
     extraOAuthScopes?: string;
 }
 export declare const DEFAULT_OAUTH_SERVER_PORT = 3000;
-export declare function setupAuthFromModule(manifestPath: string, manifest: PackVersionDefinition, opts?: SetupAuthOptions): Promise<void>;
-export declare function setupAuth(manifestDir: string, packDef: PackVersionDefinition, opts?: SetupAuthOptions): void;
+export declare function setupAuthFromModule(manifestPath: string, manifest: BasicPackDefinition, opts?: SetupAuthOptions): Promise<void>;
+export declare function setupAuth(manifestDir: string, packDef: BasicPackDefinition, opts?: SetupAuthOptions): void;
 export declare function storeCredential(manifestDir: string, credentials: Credentials): void;
 export declare function readCredentialsFile(manifestDir: string): Credentials | undefined;
 export {};

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -1,10 +1,10 @@
 /// <reference types="node" />
+import type { BasicPackDefinition } from '../types';
 import type { ExecutionContext } from '../api_types';
 import type { GenericSyncFormulaResult } from '../api';
 import type { MetadataContext } from '../api';
 import type { MetadataFormula } from '../api';
 import type { PackFormulaResult } from '../api_types';
-import type { PackVersionDefinition } from '../types';
 import type { ParamDefs } from '../api_types';
 import type { ParamValues } from '../api_types';
 import type { StandardFormulaSpecification } from '../runtime/types';
@@ -19,11 +19,11 @@ export interface ContextOptions {
     useRealFetcher?: boolean;
     manifestPath?: string;
 }
-export declare function executeFormulaFromPackDef<T extends PackFormulaResult | GenericSyncFormulaResult = any>(packDef: PackVersionDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<T>;
+export declare function executeFormulaFromPackDef<T extends PackFormulaResult | GenericSyncFormulaResult = any>(packDef: BasicPackDefinition, formulaNameWithNamespace: string, params: ParamValues<ParamDefs>, context?: ExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<T>;
 export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, manifestPath, vm, dynamicUrl, bundleSourceMapPath, bundlePath, contextOptions, }: {
     formulaName: string;
     params: string[];
-    manifest: PackVersionDefinition;
+    manifest: BasicPackDefinition;
     manifestPath: string;
     vm?: boolean;
     dynamicUrl?: string;
@@ -47,7 +47,7 @@ export declare class VMError {
 export declare function executeFormulaOrSyncWithRawParams<T extends StandardFormulaSpecification | SyncFormulaSpecification>({ formulaSpecification, params: rawParams, manifest, executionContext, }: {
     formulaSpecification: T;
     params: string[];
-    manifest: PackVersionDefinition;
+    manifest: BasicPackDefinition;
     executionContext: SyncExecutionContext;
 }): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult>;
 /**
@@ -62,12 +62,12 @@ export declare function executeFormulaOrSyncWithRawParams<T extends StandardForm
  *
  * For now, use `coda execute --vm` to simulate that level of isolation.
  */
-export declare function executeSyncFormulaFromPackDef<T extends object = any>(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult }?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<T[]>;
+export declare function executeSyncFormulaFromPackDef<T extends object = any>(packDef: BasicPackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, { validateParams: shouldValidateParams, validateResult: shouldValidateResult }?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<T[]>;
 /**
  * Executes a single sync iteration, and returns the return value from the sync formula
  * including the continuation, for inspection.
  */
-export declare function executeSyncFormulaFromPackDefSingleIteration(packDef: PackVersionDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<GenericSyncFormulaResult>;
+export declare function executeSyncFormulaFromPackDefSingleIteration(packDef: BasicPackDefinition, syncFormulaName: string, params: ParamValues<ParamDefs>, context?: SyncExecutionContext, options?: ExecuteOptions, { useRealFetcher, manifestPath }?: ContextOptions): Promise<GenericSyncFormulaResult>;
 export declare function executeMetadataFormula(formula: MetadataFormula, metadataParams?: {
     search?: string;
     formulaContext?: MetadataContext;

--- a/runtime/common/helpers.ts
+++ b/runtime/common/helpers.ts
@@ -1,8 +1,8 @@
+import type {BasicPackDefinition} from '../../types';
 import type {Formula} from '../../api';
 import type {GenericSyncFormula} from '../../api';
-import type {PackVersionDefinition} from '../../types';
 
-export function findFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula {
+export function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula {
   const packFormulas = packDef.formulas;
   if (!packFormulas) {
     throw new Error(`Pack definition has no formulas.`);
@@ -31,7 +31,7 @@ export function findFormula(packDef: PackVersionDefinition, formulaNameWithNames
   throw new Error(`Pack definition has no formula "${name}"${namespace ?? ` in namespace "${namespace}"`}.`);
 }
 
-export function findSyncFormula(packDef: PackVersionDefinition, syncFormulaName: string): GenericSyncFormula {
+export function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula {
   if (!packDef.syncTables) {
     throw new Error(`Pack definition has no sync tables.`);
   }
@@ -48,14 +48,14 @@ export function findSyncFormula(packDef: PackVersionDefinition, syncFormulaName:
   throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
 }
 
-export function tryFindFormula(packDef: PackVersionDefinition, formulaNameWithNamespace: string): Formula | undefined {
+export function tryFindFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula | undefined {
   try {
     return findFormula(packDef, formulaNameWithNamespace);
   } catch (_err) {}
 }
 
 export function tryFindSyncFormula(
-  packDef: PackVersionDefinition,
+  packDef: BasicPackDefinition,
   syncFormulaName: string,
 ): GenericSyncFormula | undefined {
   try {

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -1,4 +1,5 @@
 import {AuthenticationType} from '../../types';
+import type {BasicPackDefinition} from '../../types';
 import type {ExecutionContext} from '../../api_types';
 import type {FetchRequest} from '../../api_types';
 import type {FetchResponse} from '../../api_types';
@@ -8,7 +9,6 @@ import type {GenericSyncFormulaResult} from '../../api';
 import type {MetadataFormula} from '../../api';
 import {MetadataFormulaType} from '../types';
 import type {PackFormulaResult} from '../../api_types';
-import type {PackVersionDefinition} from '../../types';
 import type {ParamDefs} from '../../api_types';
 import type {ParamValues} from '../../api_types';
 import type {ParameterAutocompleteMetadataFormulaSpecification} from '../types';
@@ -33,7 +33,7 @@ export {unmarshalValue} from '../common/marshaling';
 export async function findAndExecutePackFunction<T extends FormulaSpecification>(
   params: ParamValues<ParamDefs>,
   formulaSpec: T,
-  manifest: PackVersionDefinition,
+  manifest: BasicPackDefinition,
   executionContext: ExecutionContext | SyncExecutionContext,
   shouldWrapError: boolean = true,
 ): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult> {
@@ -48,7 +48,7 @@ export async function findAndExecutePackFunction<T extends FormulaSpecification>
 function doFindAndExecutePackFunction<T extends FormulaSpecification>(
   params: ParamValues<ParamDefs>,
   formulaSpec: T,
-  manifest: PackVersionDefinition,
+  manifest: BasicPackDefinition,
   executionContext: ExecutionContext | SyncExecutionContext,
 ): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult> {
   const {syncTables, defaultAuthentication} = manifest;
@@ -159,7 +159,7 @@ function doFindAndExecutePackFunction<T extends FormulaSpecification>(
 }
 
 function findParentFormula(
-  manifest: PackVersionDefinition,
+  manifest: BasicPackDefinition,
   formulaSpec: ParameterAutocompleteMetadataFormulaSpecification,
 ) {
   const {formulas, syncTables} = manifest;

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -1,10 +1,10 @@
 import type {Authentication} from '../types';
 import {AuthenticationType} from '../types';
+import type {BasicPackDefinition} from '../types';
 import type {Credentials} from './auth_types';
 import type {CredentialsFile} from './auth_types';
 import type {MultiQueryParamCredentials} from './auth_types';
 import type {OAuth2Credentials} from './auth_types';
-import type {PackVersionDefinition} from '../types';
 import {assertCondition} from '../helpers/ensure';
 import {ensureExists} from '../helpers/ensure';
 import {ensureNonEmptyString} from '../helpers/ensure';
@@ -29,14 +29,14 @@ export const DEFAULT_OAUTH_SERVER_PORT = 3000;
 
 export async function setupAuthFromModule(
   manifestPath: string,
-  manifest: PackVersionDefinition,
+  manifest: BasicPackDefinition,
   opts: SetupAuthOptions = {},
 ): Promise<void> {
   const manifestDir = path.dirname(manifestPath);
   return setupAuth(manifestDir, manifest, opts);
 }
 
-export function setupAuth(manifestDir: string, packDef: PackVersionDefinition, opts: SetupAuthOptions = {}): void {
+export function setupAuth(manifestDir: string, packDef: BasicPackDefinition, opts: SetupAuthOptions = {}): void {
   const auth = getPackAuth(packDef);
   if (!auth) {
     return printAndExit(

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -1,3 +1,4 @@
+import type {BasicPackDefinition} from '../types';
 import type {Credentials} from './auth_types';
 import type {ExecutionContext} from '../api_types';
 import type {FormulaSpecification} from '../runtime/types';
@@ -6,7 +7,6 @@ import type {GenericSyncFormulaResult} from '../api';
 import type {MetadataContext} from '../api';
 import type {MetadataFormula} from '../api';
 import type {PackFormulaResult} from '../api_types';
-import type {PackVersionDefinition} from '../types';
 import type {ParamDefs} from '../api_types';
 import type {ParamValues} from '../api_types';
 import type {StandardFormulaSpecification} from '../runtime/types';
@@ -65,7 +65,7 @@ function resolveFormulaNameWithNamespace(formulaNameWithNamespace: string): stri
 async function findAndExecutePackFunction<T extends FormulaSpecification>(
   params: ParamValues<ParamDefs>,
   formulaSpec: T,
-  manifest: PackVersionDefinition,
+  manifest: BasicPackDefinition,
   executionContext: ExecutionContext | SyncExecutionContext,
   {validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true}: ExecuteOptions = {},
 ): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult> {
@@ -94,7 +94,7 @@ async function findAndExecutePackFunction<T extends FormulaSpecification>(
 }
 
 export async function executeFormulaFromPackDef<T extends PackFormulaResult | GenericSyncFormulaResult = any>(
-  packDef: PackVersionDefinition,
+  packDef: BasicPackDefinition,
   formulaNameWithNamespace: string,
   params: ParamValues<ParamDefs>,
   context?: ExecutionContext,
@@ -134,7 +134,7 @@ export async function executeFormulaOrSyncFromCLI({
 }: {
   formulaName: string;
   params: string[];
-  manifest: PackVersionDefinition;
+  manifest: BasicPackDefinition;
   manifestPath: string;
   vm?: boolean;
   dynamicUrl?: string;
@@ -290,7 +290,7 @@ export async function executeFormulaOrSyncWithRawParams<
 }: {
   formulaSpecification: T;
   params: string[];
-  manifest: PackVersionDefinition;
+  manifest: BasicPackDefinition;
   executionContext: SyncExecutionContext;
 }): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult> {
   let params: ParamValues<ParamDefs>;
@@ -318,7 +318,7 @@ export async function executeFormulaOrSyncWithRawParams<
  * For now, use `coda execute --vm` to simulate that level of isolation.
  */
 export async function executeSyncFormulaFromPackDef<T extends object = any>(
-  packDef: PackVersionDefinition,
+  packDef: BasicPackDefinition,
   syncFormulaName: string,
   params: ParamValues<ParamDefs>,
   context?: SyncExecutionContext,
@@ -377,7 +377,7 @@ export async function executeSyncFormulaFromPackDef<T extends object = any>(
  * including the continuation, for inspection.
  */
 export async function executeSyncFormulaFromPackDefSingleIteration(
-  packDef: PackVersionDefinition,
+  packDef: BasicPackDefinition,
   syncFormulaName: string,
   params: ParamValues<ParamDefs>,
   context?: SyncExecutionContext,


### PR DESCRIPTION
I'm playing with switching the packs-examples repo to use the builder syntax. The unittest files in that repo all have TS errors because the execution helpers all expect a PackVersionDefinition but the builder is a BasicPackDefinition (i.e. it omits `version`, which isn't relevant for execution).

PTAL @huayang-codaio @patrick-codaio @alan-codaio @coda/packs 