### PR TITLE
Add a prompt to release the latest version for `coda release` if one is not provided by the manifest or the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Bug fix: Numeric and string `codaType` properties are no longer erroneously removed in upload validation.
 
+- CLI: `coda release` no longer requires an explicit Pack version to release a Pack version (if no Pack version is supplied, the latest version is marked for release instead).
+
 ## 0.4.6
 
 - Bug fix: Executing sync table formulas via CLI now validates results correctly.

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -45,15 +45,14 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
         return (0, helpers_4.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
     }
     const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
-    // TODO(alan/jonathan): Deal with the case of a pack that doesn't specify a version at all.
-    // Either error out with a useful message about needing to provide a specific version
-    // via the optional second CLI arg, or add a CLI flag --latest that uses the latest version.
     let packVersion = explicitPackVersion;
     if (!packVersion) {
         try {
             const bundleFilename = await (0, build_1.build)(manifestFile);
             const manifest = await (0, helpers_3.importManifest)(bundleFilename);
-            packVersion = manifest.version;
+            if ('version' in manifest) {
+                packVersion = manifest.version;
+            }
         }
         catch (err) {
             return (0, helpers_4.printAndExit)(`Got an error while building your pack to get the current pack version: ${(0, errors_1.formatError)(err)}`);
@@ -61,9 +60,12 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
     }
     if (!packVersion) {
         const { items: versions } = await codaClient.listPackVersions(packId, { limit: 1 });
+        if (!versions.length) {
+            (0, helpers_4.printAndExit)('No version was found to release for your Pack.');
+        }
         const [latestPackVersionData] = versions;
         const { packVersion: latestPackVersion } = latestPackVersionData;
-        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/n)`);
+        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/n)\n`);
         if (!shouldReleaseLatestPackVersion.toLocaleLowerCase().startsWith('y')) {
             return process.exit(1);
         }

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -31,6 +31,7 @@ const helpers_3 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
 const helpers_4 = require("../testing/helpers");
+const helpers_5 = require("../testing/helpers");
 const errors_3 = require("./errors");
 async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }) {
     const manifestDir = path.dirname(manifestFile);
@@ -43,6 +44,7 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
     if (!packId) {
         return (0, helpers_4.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
     }
+    const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     // TODO(alan/jonathan): Deal with the case of a pack that doesn't specify a version at all.
     // Either error out with a useful message about needing to provide a specific version
     // via the optional second CLI arg, or add a CLI flag --latest that uses the latest version.
@@ -57,7 +59,16 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
             return (0, helpers_4.printAndExit)(`Got an error while building your pack to get the current pack version: ${(0, errors_1.formatError)(err)}`);
         }
     }
-    const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    if (!packVersion) {
+        const { items: versions } = await codaClient.listPackVersions(packId, { limit: 1 });
+        const [latestPackVersionData] = versions;
+        const { packVersion: latestPackVersion } = latestPackVersionData;
+        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/n)`);
+        if (!shouldReleaseLatestPackVersion.toLocaleLowerCase().startsWith('y')) {
+            return process.exit(1);
+        }
+        packVersion = latestPackVersion;
+    }
     await handleResponse(codaClient.createPackRelease(packId, {}, { packVersion, releaseNotes: notes }));
     return (0, helpers_4.printAndExit)('Success!', 0);
 }


### PR DESCRIPTION
Now that it's possible to have versionless manifests, we need to handle this edge case in `coda release` where a version is not supplied on the CLI nor is one supplied by the manifest. In this case we grab the latest Pack version and attempt to release that instead.

I wonder if we should just make the manifest an optional argument now?

Tested output:
```
ts-node ../packs-sdk/cli/coda.ts release manifest.ts 
No version specified in your manifest. Do you want to release the latest version of the Pack (0.0.2)? (y/n)
n
```