### PR TITLE
add noindex meta tag to docs while in testing

### DIFF
--- a/documentation/theme/main.html
+++ b/documentation/theme/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+<!-- TODO(spencer): remove this after we launch hosted documentation -->
+{% block extrahead %}
+  <meta name="robots" content="noindex">
+{% endblock %}
+
 {% block announce %}
   The Packs SDK is currently only available to a limited set of partners.
   If you are interested in becoming a partner, contact us at <a href="mailto:partners@coda.io">partners@coda.io</a>.


### PR DESCRIPTION
context: https://github.com/coda/infra/pull/2136#discussion_r731438563

this produces in every index.html page generated: 
![image](https://user-images.githubusercontent.com/81383639/137985946-b62ef726-d3cb-48a4-945c-59ea5505bfad.png)

