### PR TITLE
remove unused hasDyanmicSchema from fakeDefinitionToMetadata that causes validation failure

### DIFF
--- a/helpers/sample_utils.ts
+++ b/helpers/sample_utils.ts
@@ -62,7 +62,7 @@ export function fakeDefinitionToMetadata(def: FakePackDefinition): PackMetadata 
   const syncTables: PackSyncTable[] = [];
   for (const {getter, getSchema, ...others} of originalSyncTables || []) {
     const {execute, ...otherGetter} = getter;
-    syncTables.push({getter: {...otherGetter}, hasDynamicSchema: Boolean(getSchema), ...others});
+    syncTables.push({getter: {...otherGetter}, ...others});
   }
   return {
     formulas,


### PR DESCRIPTION
this is only used in testing code. 