### PR TITLE
Add a script that indicates which identifiers need TypeDoc documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ typedoc:
 	# Most options loaded from typedoc.js.
 	${ROOTDIR}/node_modules/.bin/typedoc index.ts --options typedoc.js --out ${ROOTDIR}/docs/reference/sdk
 
+.PHONY: typedoc-progress
+typedoc-progress:
+	${ROOTDIR}/node_modules/.bin/ts-node scripts/tsdoc_progress.ts
+
 .PHONY: docs
 docs: typedoc generated-documentation
 
@@ -137,7 +141,7 @@ view-docs:
 	PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 expect -c 'spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'
 
 ###############################################################################
-### Deployment of documentation ### 
+### Deployment of documentation ###
 
 # This step generates all the documentation for the SDK using mkdocs and dumps the contents in /site
 .PHONY: build-mkdocs

--- a/scripts/tsdoc_progress.ts
+++ b/scripts/tsdoc_progress.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import os from 'os';
+import * as path from 'path';
+import {spawnSync} from 'child_process';
+
+/**
+ * Outputs all of the identifiers reachable by our TypeDoc config that are lacking documentation.
+ */
+
+// Very partial typing
+interface ReflectionData {
+  name: string;
+  kindString: string;
+  comment?: {
+    shortText: string;
+    text?: string;
+  };
+  sources?: Array<{
+    fileName: string;
+  }>;
+  children?: ReflectionData[];
+}
+
+function getReflectionData() {
+  const tempfile = path.join(os.tmpdir(), `typedoc.json`);
+  const command = `node_modules/.bin/typedoc index.ts --options typedoc.js --json ${tempfile} > /dev/null 2>&1`;
+  spawnSync(command, {
+    shell: true,
+    stdio: 'inherit',
+  });
+  return JSON.parse(fs.readFileSync(tempfile, 'utf-8'));
+}
+
+function traverse(data: ReflectionData): void {
+  if (!data.comment) {
+    logMissing(data);
+  }
+  for (const child of data.children || []) {
+    traverse(child);
+  }
+}
+
+function logMissing(data: ReflectionData): void {
+  // eslint-disable-next-line no-console
+  console.log(`${data.name.padEnd(40)} ${data.kindString.padEnd(30)} ${data.sources?.[0].fileName}`);
+}
+
+function main() {
+  const data = getReflectionData();
+  traverse(data);
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,5 +59,5 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "include": ["./*.d.ts", "./**/*.ts"],
-  "exclude": ["./artifacts", "./node_modules", "./dist/**/*", "./documentation/snippets", "./documentation/examples"]
+  "exclude": ["./artifacts", "./node_modules", "./dist/**/*", "./scripts/*", "./documentation/snippets", "./documentation/examples"]
 }


### PR DESCRIPTION
Output looks like:

```
TemporaryBlobStorage                     Interface                      api_types.ts
storeBlob                                Method                         undefined
storeUrl                                 Method                         undefined
getConnectionName                        Property                       types.ts
getConnectionUserId                      Property                       types.ts
type                                     Property                       types.ts
DefaultValueType                         Type alias                     api_types.ts
ExternalObjectPackFormula                Type alias                     compiled_types.ts
ExternalPackFormat                       Type alias                     compiled_types.ts
```

Only 380 to go! Many are enum members though which hopefully can go fast.

PTAL @ekoleda-codaio @coda/packs 