### PR TITLE
fix runtime bootstrap upon naming conflict

### DIFF
--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -157,7 +157,7 @@ async function registerBundle(isolate, context, path, stubName) {
     // compiling the bundle allows IVM to map the stack trace.
     const bundle = fs_1.default.readFileSync(path).toString();
     // bundle needs to be converted into a closure to avoid leaking variables to global scope.
-    const script = await isolate.compileScript(`(() => { ${bundle} \n global.${stubName} = exports })()`, {
+    const script = await isolate.compileScript(`(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()`, {
         filename: path,
     });
     await script.run(context);

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -157,7 +157,7 @@ async function registerBundle(isolate, context, path, stubName) {
     // compiling the bundle allows IVM to map the stack trace.
     const bundle = fs_1.default.readFileSync(path).toString();
     // bundle needs to be converted into a closure to avoid leaking variables to global scope.
-    const script = await isolate.compileScript(`(() => { ${bundle} \n ${stubName} = exports })()`, {
+    const script = await isolate.compileScript(`(() => { ${bundle} \n global.${stubName} = exports })()`, {
         filename: path,
     });
     await script.run(context);

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -247,7 +247,7 @@ export async function registerBundle(
   const bundle = fs.readFileSync(path).toString();
 
   // bundle needs to be converted into a closure to avoid leaking variables to global scope.
-  const script = await isolate.compileScript(`(() => { ${bundle} \n ${stubName} = exports })()`, {
+  const script = await isolate.compileScript(`(() => { ${bundle} \n global.${stubName} = exports })()`, {
     filename: path,
   });
   await script.run(context);

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -247,9 +247,12 @@ export async function registerBundle(
   const bundle = fs.readFileSync(path).toString();
 
   // bundle needs to be converted into a closure to avoid leaking variables to global scope.
-  const script = await isolate.compileScript(`(() => { ${bundle} \n global.${stubName} = exports })()`, {
-    filename: path,
-  });
+  const script = await isolate.compileScript(
+    `(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()`,
+    {
+      filename: path,
+    },
+  );
   await script.run(context);
 }
 

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -1,12 +1,12 @@
 import * as coda from '../..';
 
-export const myPack = coda.newPack();
+export const pack = coda.newPack();
 
 function doThrow() {
   throw new Error('test');
 }
 
-myPack.addFormula({
+pack.addFormula({
   name: 'Throw',
   description: 'A Hello World example.',
   parameters: [
@@ -22,5 +22,3 @@ myPack.addFormula({
     return 'Hello ' + name + '!';
   },
 });
-
-export const pack = {...myPack};

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -1,0 +1,26 @@
+import * as coda from '../..';
+
+export const myPack = coda.newPack();
+
+function doThrow() {
+  throw new Error('test');
+}
+
+myPack.addFormula({
+  name: 'Throw',
+  description: 'A Hello World example.',
+  parameters: [
+    coda.makeParameter({
+      type: coda.ParameterType.String,
+      name: 'name',
+      description: 'The name you would like to say hello to.',
+    }),
+  ],
+  resultType: coda.ValueType.String,
+  async execute([name]) {
+    doThrow();
+    return 'Hello ' + name + '!';
+  },
+});
+
+export const pack = {...myPack};

--- a/test/thunk_test.ts
+++ b/test/thunk_test.ts
@@ -20,7 +20,6 @@ describe('Thunk', () => {
     // context is like a container in ivm concept.
     const ivmContext = await isolate.createContext();
     const jail = ivmContext.global;
-    await jail.set('global', jail.derefInto());
     await jail.set('test', undefined, {copy: true});
 
     await registerBundle(isolate, ivmContext, getThunkPath(), 'test');

--- a/test/thunk_test.ts
+++ b/test/thunk_test.ts
@@ -17,10 +17,10 @@ describe('Thunk', () => {
 
   it('should bundle and run in an IVM context', async () => {
     const isolate = new ivm.Isolate({memoryLimit: 128});
-
     // context is like a container in ivm concept.
     const ivmContext = await isolate.createContext();
     const jail = ivmContext.global;
+    await jail.set('global', jail.derefInto());
     await jail.set('test', undefined, {copy: true});
 
     await registerBundle(isolate, ivmContext, getThunkPath(), 'test');

--- a/test/thunk_test.ts
+++ b/test/thunk_test.ts
@@ -17,6 +17,7 @@ describe('Thunk', () => {
 
   it('should bundle and run in an IVM context', async () => {
     const isolate = new ivm.Isolate({memoryLimit: 128});
+
     // context is like a container in ivm concept.
     const ivmContext = await isolate.createContext();
     const jail = ivmContext.global;


### PR DESCRIPTION
This is a tricky bug. if the exported bundle has an export symbol `coda` or `pack`, it will conflict with the global symbol `coda` and `pack` and such confuses `registerBundle`. 

This PR adds `global.` prefix to make sure that the `registerBundle` is setting to the global symbol. (of course if the bundle has an export called global we are screwed. hopefully nobody would do so)

also adding a v2 pack for testing. 