### PR TITLE
More TSDoc, for some enums.

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -3,6 +3,14 @@ import type {ArraySchema} from './schema';
 import type {Continuation} from './api';
 import type {MetadataFormula} from './api';
 
+/**
+ * Markers used internally to represent data types for parameters and return values.
+ * It should not be necessary to ever use these values directly.
+ *
+ * When defining a parameter, use {@link ParameterType}. When defining
+ * a formula return value, or properties within an object return value,
+ * use {@link ValueType}.
+ */
 export enum Type {
   string,
   number,
@@ -82,19 +90,65 @@ export type TypeOf<T extends PackFormulaResult> = T extends number
   ? Type.object
   : never;
 
+/**
+ * Enumeration of types of formula parameters. These describe Coda value types (as opposed to JavaScript value types).
+ */
 export enum ParameterType {
+  /**
+   * Indicates a parameter that is a Coda text value.
+   */
   String = 'string',
+  /**
+   * Indicates a parameter that is a Coda number value.
+   */
   Number = 'number',
+  /**
+   * Indicates a parameter that is a Coda boolean value.
+   */
   Boolean = 'boolean',
+  /**
+   * Indicates a parameter that is a Coda date value (which includes time and datetime values).
+   */
   Date = 'date',
+  /**
+   * Indicates a parameter that is a Coda rich text value that should be passed to the pack as HTML.
+   */
   Html = 'html',
+  /**
+   * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
+   * be passed to the pack as an image URL.
+   */
   Image = 'image',
 
+  /**
+   * Indicates a parameter that is a list of Coda text values.
+   */
   StringArray = 'stringArray',
+  /**
+   * Indicates a parameter that is a list of Coda number values.
+   */
   NumberArray = 'numberArray',
+  /**
+   * Indicates a parameter that is a list of Coda boolean values.
+   */
   BooleanArray = 'booleanArray',
+  /**
+   * Indicates a parameter that is a list of Coda date values (which includes time and datetime values).
+   *
+   * Currently, when such a parameter is used with a sync table formula or an action formula ({@link isAction}),
+   * which will generate a builder UI for selecting parameters, a date array parameter will always render
+   * as a date range selector. A date range will always be passed to a pack formula as a list of two
+   * elements, the beginning of the range and the end of the range.
+   */
   DateArray = 'dateArray',
+  /**
+   * Indicates a parameter that is a list of Coda rich text values that should be passed to the pack as HTML.
+   */
   HtmlArray = 'htmlArray`',
+  /**
+   * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
+   * will be passed to the pack as a list of image URLs.
+   */
   ImageArray = 'imageArray',
 }
 
@@ -370,6 +424,22 @@ export interface SyncExecutionContext extends ExecutionContext {
 
 // A mapping exists in coda that allows these to show up in the UI.
 // If adding new values here, add them to that mapping and vice versa.
+/**
+ * Special "live" date range values that can be used as the {@link defaultValue}
+ * for a date array parameter.
+ *
+ * Date array parameters are meant to represent date ranges. A date range can
+ * be a fixed range, e.g. April 1, 2020 - May 15, 2020, or it can be a "live"
+ * range, like "last 30 days".
+ *
+ * At execution time, a date range will always be passed to a pack as an
+ * array of two specific dates, but for many use cases, it is necessary
+ * to provide a default value that is a "live" range rather than hardcoded
+ * one. For example, if your pack has a table that syncs recent emails,
+ * you might want to have a date range parameter that default to
+ * "last 7 days". Defaulting to a hardcoded date range would not be useful
+ * and requiring the user to always specify a date range may be inconvenient.
+ */
 export enum PrecannedDateRange {
   // Past
   Yesterday = 'yesterday',
@@ -401,5 +471,9 @@ export enum PrecannedDateRange {
   Next6Months = 'next_6_months',
   NextYear = 'next_year',
 
+  /**
+   * Indicates a date range beginning in the very distant past (e.g. 1/1/1, aka 1 A.D.)
+   * and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to change.
+   */
   Everything = 'everything',
 }

--- a/api_types.ts
+++ b/api_types.ts
@@ -115,8 +115,7 @@ export enum ParameterType {
    */
   Html = 'html',
   /**
-   * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
-   * be passed to the pack as an image URL.
+   * Indicates a parameter that is a Coda image. The pack is passed an image URL.
    */
   Image = 'image',
 
@@ -146,8 +145,7 @@ export enum ParameterType {
    */
   HtmlArray = 'htmlArray`',
   /**
-   * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
-   * will be passed to the pack as a list of image URLs.
+   * Indicates a parameter that is a list of Coda image values. The pack is passed a list of image URLs.
    */
   ImageArray = 'imageArray',
 }

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -70,8 +70,7 @@ export declare enum ParameterType {
      */
     Html = "html",
     /**
-     * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
-     * be passed to the pack as an image URL.
+     * Indicates a parameter that is a Coda image. The pack is passed an image URL.
      */
     Image = "image",
     /**
@@ -100,8 +99,7 @@ export declare enum ParameterType {
      */
     HtmlArray = "htmlArray`",
     /**
-     * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
-     * will be passed to the pack as a list of image URLs.
+     * Indicates a parameter that is a list of Coda image values. The pack is passed a list of image URLs.
      */
     ImageArray = "imageArray"
 }

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -3,6 +3,14 @@ import type { $Values } from './type_utils';
 import type { ArraySchema } from './schema';
 import type { Continuation } from './api';
 import type { MetadataFormula } from './api';
+/**
+ * Markers used internally to represent data types for parameters and return values.
+ * It should not be necessary to ever use these values directly.
+ *
+ * When defining a parameter, use {@link ParameterType}. When defining
+ * a formula return value, or properties within an object return value,
+ * use {@link ValueType}.
+ */
 export declare enum Type {
     string = 0,
     number = 1,
@@ -37,18 +45,64 @@ interface TypeMap {
 export declare type PackFormulaValue = $Values<Omit<TypeMap, Type.object>> | PackFormulaValue[];
 export declare type PackFormulaResult = $Values<TypeMap> | PackFormulaResult[];
 export declare type TypeOf<T extends PackFormulaResult> = T extends number ? Type.number : T extends string ? Type.string : T extends boolean ? Type.boolean : T extends Date ? Type.date : T extends object ? Type.object : never;
+/**
+ * Enumeration of types of formula parameters. These describe Coda value types (as opposed to JavaScript value types).
+ */
 export declare enum ParameterType {
+    /**
+     * Indicates a parameter that is a Coda text value.
+     */
     String = "string",
+    /**
+     * Indicates a parameter that is a Coda number value.
+     */
     Number = "number",
+    /**
+     * Indicates a parameter that is a Coda boolean value.
+     */
     Boolean = "boolean",
+    /**
+     * Indicates a parameter that is a Coda date value (which includes time and datetime values).
+     */
     Date = "date",
+    /**
+     * Indicates a parameter that is a Coda rich text value that should be passed to the pack as HTML.
+     */
     Html = "html",
+    /**
+     * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
+     * be passed to the pack as an image URL.
+     */
     Image = "image",
+    /**
+     * Indicates a parameter that is a list of Coda text values.
+     */
     StringArray = "stringArray",
+    /**
+     * Indicates a parameter that is a list of Coda number values.
+     */
     NumberArray = "numberArray",
+    /**
+     * Indicates a parameter that is a list of Coda boolean values.
+     */
     BooleanArray = "booleanArray",
+    /**
+     * Indicates a parameter that is a list of Coda date values (which includes time and datetime values).
+     *
+     * Currently, when such a parameter is used with a sync table formula or an action formula ({@link isAction}),
+     * which will generate a builder UI for selecting parameters, a date array parameter will always render
+     * as a date range selector. A date range will always be passed to a pack formula as a list of two
+     * elements, the beginning of the range and the end of the range.
+     */
     DateArray = "dateArray",
+    /**
+     * Indicates a parameter that is a list of Coda rich text values that should be passed to the pack as HTML.
+     */
     HtmlArray = "htmlArray`",
+    /**
+     * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
+     * will be passed to the pack as a list of image URLs.
+     */
     ImageArray = "imageArray"
 }
 export interface ParameterTypeMap {
@@ -268,6 +322,22 @@ export interface ExecutionContext {
 export interface SyncExecutionContext extends ExecutionContext {
     readonly sync: Sync;
 }
+/**
+ * Special "live" date range values that can be used as the {@link defaultValue}
+ * for a date array parameter.
+ *
+ * Date array parameters are meant to represent date ranges. A date range can
+ * be a fixed range, e.g. April 1, 2020 - May 15, 2020, or it can be a "live"
+ * range, like "last 30 days".
+ *
+ * At execution time, a date range will always be passed to a pack as an
+ * array of two specific dates, but for many use cases, it is necessary
+ * to provide a default value that is a "live" range rather than hardcoded
+ * one. For example, if your pack has a table that syncs recent emails,
+ * you might want to have a date range parameter that default to
+ * "last 7 days". Defaulting to a hardcoded date range would not be useful
+ * and requiring the user to always specify a date range may be inconvenient.
+ */
 export declare enum PrecannedDateRange {
     Yesterday = "yesterday",
     Last7Days = "last_7_days",
@@ -293,6 +363,10 @@ export declare enum PrecannedDateRange {
     Next3Months = "next_3_months",
     Next6Months = "next_6_months",
     NextYear = "next_year",
+    /**
+     * Indicates a date range beginning in the very distant past (e.g. 1/1/1, aka 1 A.D.)
+     * and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to change.
+     */
     Everything = "everything"
 }
 export {};

--- a/dist/api_types.js
+++ b/dist/api_types.js
@@ -1,6 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PrecannedDateRange = exports.NetworkConnection = exports.ConnectionRequirement = exports.ParameterTypeInputMap = exports.ParameterType = exports.imageArray = exports.htmlArray = exports.dateArray = exports.booleanArray = exports.numberArray = exports.stringArray = exports.isArrayType = exports.Type = void 0;
+/**
+ * Markers used internally to represent data types for parameters and return values.
+ * It should not be necessary to ever use these values directly.
+ *
+ * When defining a parameter, use {@link ParameterType}. When defining
+ * a formula return value, or properties within an object return value,
+ * use {@link ValueType}.
+ */
 var Type;
 (function (Type) {
     Type[Type["string"] = 0] = "string";
@@ -39,19 +47,65 @@ exports.imageArray = {
     type: 'array',
     items: Type.image,
 };
+/**
+ * Enumeration of types of formula parameters. These describe Coda value types (as opposed to JavaScript value types).
+ */
 var ParameterType;
 (function (ParameterType) {
+    /**
+     * Indicates a parameter that is a Coda text value.
+     */
     ParameterType["String"] = "string";
+    /**
+     * Indicates a parameter that is a Coda number value.
+     */
     ParameterType["Number"] = "number";
+    /**
+     * Indicates a parameter that is a Coda boolean value.
+     */
     ParameterType["Boolean"] = "boolean";
+    /**
+     * Indicates a parameter that is a Coda date value (which includes time and datetime values).
+     */
     ParameterType["Date"] = "date";
+    /**
+     * Indicates a parameter that is a Coda rich text value that should be passed to the pack as HTML.
+     */
     ParameterType["Html"] = "html";
+    /**
+     * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
+     * be passed to the pack as an image URL.
+     */
     ParameterType["Image"] = "image";
+    /**
+     * Indicates a parameter that is a list of Coda text values.
+     */
     ParameterType["StringArray"] = "stringArray";
+    /**
+     * Indicates a parameter that is a list of Coda number values.
+     */
     ParameterType["NumberArray"] = "numberArray";
+    /**
+     * Indicates a parameter that is a list of Coda boolean values.
+     */
     ParameterType["BooleanArray"] = "booleanArray";
+    /**
+     * Indicates a parameter that is a list of Coda date values (which includes time and datetime values).
+     *
+     * Currently, when such a parameter is used with a sync table formula or an action formula ({@link isAction}),
+     * which will generate a builder UI for selecting parameters, a date array parameter will always render
+     * as a date range selector. A date range will always be passed to a pack formula as a list of two
+     * elements, the beginning of the range and the end of the range.
+     */
     ParameterType["DateArray"] = "dateArray";
+    /**
+     * Indicates a parameter that is a list of Coda rich text values that should be passed to the pack as HTML.
+     */
     ParameterType["HtmlArray"] = "htmlArray`";
+    /**
+     * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
+     * will be passed to the pack as a list of image URLs.
+     */
     ParameterType["ImageArray"] = "imageArray";
 })(ParameterType = exports.ParameterType || (exports.ParameterType = {}));
 exports.ParameterTypeInputMap = {
@@ -104,6 +158,22 @@ var NetworkConnection;
 const ValidFetchMethods = ['GET', 'PATCH', 'POST', 'PUT', 'DELETE'];
 // A mapping exists in coda that allows these to show up in the UI.
 // If adding new values here, add them to that mapping and vice versa.
+/**
+ * Special "live" date range values that can be used as the {@link defaultValue}
+ * for a date array parameter.
+ *
+ * Date array parameters are meant to represent date ranges. A date range can
+ * be a fixed range, e.g. April 1, 2020 - May 15, 2020, or it can be a "live"
+ * range, like "last 30 days".
+ *
+ * At execution time, a date range will always be passed to a pack as an
+ * array of two specific dates, but for many use cases, it is necessary
+ * to provide a default value that is a "live" range rather than hardcoded
+ * one. For example, if your pack has a table that syncs recent emails,
+ * you might want to have a date range parameter that default to
+ * "last 7 days". Defaulting to a hardcoded date range would not be useful
+ * and requiring the user to always specify a date range may be inconvenient.
+ */
 var PrecannedDateRange;
 (function (PrecannedDateRange) {
     // Past
@@ -133,5 +203,9 @@ var PrecannedDateRange;
     PrecannedDateRange["Next3Months"] = "next_3_months";
     PrecannedDateRange["Next6Months"] = "next_6_months";
     PrecannedDateRange["NextYear"] = "next_year";
+    /**
+     * Indicates a date range beginning in the very distant past (e.g. 1/1/1, aka 1 A.D.)
+     * and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to change.
+     */
     PrecannedDateRange["Everything"] = "everything";
 })(PrecannedDateRange = exports.PrecannedDateRange || (exports.PrecannedDateRange = {}));

--- a/dist/api_types.js
+++ b/dist/api_types.js
@@ -73,8 +73,7 @@ var ParameterType;
      */
     ParameterType["Html"] = "html";
     /**
-     * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
-     * be passed to the pack as an image URL.
+     * Indicates a parameter that is a Coda image. The pack is passed an image URL.
      */
     ParameterType["Image"] = "image";
     /**
@@ -103,8 +102,7 @@ var ParameterType;
      */
     ParameterType["HtmlArray"] = "htmlArray`";
     /**
-     * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
-     * will be passed to the pack as a list of image URLs.
+     * Indicates a parameter that is a list of Coda image values. The pack is passed a list of image URLs.
      */
     ParameterType["ImageArray"] = "imageArray";
 })(ParameterType = exports.ParameterType || (exports.ParameterType = {}));

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -247,6 +247,11 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
 	maximum?: number | string;
 	step?: number | string;
 }
+/**
+ * Icons that can be used with a {@link ScaleSchema}.
+ *
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ */
 export declare enum ScaleIconSet {
 	Star = "star",
 	Circle = "circle",
@@ -455,6 +460,14 @@ export declare function makeObjectSchema<K extends string, L extends string, T e
  * schema it provides better code reuse to derive a reference schema instead.
  */
 export declare function makeReferenceSchemaFromObjectSchema(schema: GenericObjectSchema, identityName?: string): GenericObjectSchema;
+/**
+ * Markers used internally to represent data types for parameters and return values.
+ * It should not be necessary to ever use these values directly.
+ *
+ * When defining a parameter, use {@link ParameterType}. When defining
+ * a formula return value, or properties within an object return value,
+ * use {@link ValueType}.
+ */
 export declare enum Type {
 	string = 0,
 	number = 1,
@@ -481,18 +494,64 @@ export interface TypeMap {
 export declare type PackFormulaValue = $Values<Omit<TypeMap, Type.object>> | PackFormulaValue[];
 export declare type PackFormulaResult = $Values<TypeMap> | PackFormulaResult[];
 export declare type TypeOf<T extends PackFormulaResult> = T extends number ? Type.number : T extends string ? Type.string : T extends boolean ? Type.boolean : T extends Date ? Type.date : T extends object ? Type.object : never;
+/**
+ * Enumeration of types of formula parameters. These describe Coda value types (as opposed to JavaScript value types).
+ */
 export declare enum ParameterType {
+	/**
+	 * Indicates a parameter that is a Coda text value.
+	 */
 	String = "string",
+	/**
+	 * Indicates a parameter that is a Coda number value.
+	 */
 	Number = "number",
+	/**
+	 * Indicates a parameter that is a Coda boolean value.
+	 */
 	Boolean = "boolean",
+	/**
+	 * Indicates a parameter that is a Coda date value (which includes time and datetime values).
+	 */
 	Date = "date",
+	/**
+	 * Indicates a parameter that is a Coda rich text value that should be passed to the pack as HTML.
+	 */
 	Html = "html",
+	/**
+	 * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
+	 * be passed to the pack as an image URL.
+	 */
 	Image = "image",
+	/**
+	 * Indicates a parameter that is a list of Coda text values.
+	 */
 	StringArray = "stringArray",
+	/**
+	 * Indicates a parameter that is a list of Coda number values.
+	 */
 	NumberArray = "numberArray",
+	/**
+	 * Indicates a parameter that is a list of Coda boolean values.
+	 */
 	BooleanArray = "booleanArray",
+	/**
+	 * Indicates a parameter that is a list of Coda date values (which includes time and datetime values).
+	 *
+	 * Currently, when such a parameter is used with a sync table formula or an action formula ({@link isAction}),
+	 * which will generate a builder UI for selecting parameters, a date array parameter will always render
+	 * as a date range selector. A date range will always be passed to a pack formula as a list of two
+	 * elements, the beginning of the range and the end of the range.
+	 */
 	DateArray = "dateArray",
+	/**
+	 * Indicates a parameter that is a list of Coda rich text values that should be passed to the pack as HTML.
+	 */
 	HtmlArray = "htmlArray`",
+	/**
+	 * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
+	 * will be passed to the pack as a list of image URLs.
+	 */
 	ImageArray = "imageArray"
 }
 export interface ParameterTypeMap {
@@ -712,6 +771,22 @@ export interface ExecutionContext {
 export interface SyncExecutionContext extends ExecutionContext {
 	readonly sync: Sync;
 }
+/**
+ * Special "live" date range values that can be used as the {@link defaultValue}
+ * for a date array parameter.
+ *
+ * Date array parameters are meant to represent date ranges. A date range can
+ * be a fixed range, e.g. April 1, 2020 - May 15, 2020, or it can be a "live"
+ * range, like "last 30 days".
+ *
+ * At execution time, a date range will always be passed to a pack as an
+ * array of two specific dates, but for many use cases, it is necessary
+ * to provide a default value that is a "live" range rather than hardcoded
+ * one. For example, if your pack has a table that syncs recent emails,
+ * you might want to have a date range parameter that default to
+ * "last 7 days". Defaulting to a hardcoded date range would not be useful
+ * and requiring the user to always specify a date range may be inconvenient.
+ */
 export declare enum PrecannedDateRange {
 	Yesterday = "yesterday",
 	Last7Days = "last_7_days",
@@ -737,6 +812,10 @@ export declare enum PrecannedDateRange {
 	Next3Months = "next_3_months",
 	Next6Months = "next_6_months",
 	NextYear = "next_year",
+	/**
+	 * Indicates a date range beginning in the very distant past (e.g. 1/1/1, aka 1 A.D.)
+	 * and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to change.
+	 */
 	Everything = "everything"
 }
 export declare type ParamMapper<T> = (val: T) => T;

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -250,7 +250,7 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
 /**
  * Icons that can be used with a {@link ScaleSchema}.
  *
- * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: coda.ScaleIconSet.Star`.
  */
 export declare enum ScaleIconSet {
 	Star = "star",
@@ -519,8 +519,7 @@ export declare enum ParameterType {
 	 */
 	Html = "html",
 	/**
-	 * *Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
-	 * be passed to the pack as an image URL.
+	 * Indicates a parameter that is a Coda image. The pack is passed an image URL.
 	 */
 	Image = "image",
 	/**
@@ -549,8 +548,7 @@ export declare enum ParameterType {
 	 */
 	HtmlArray = "htmlArray`",
 	/**
-	 * *Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
-	 * will be passed to the pack as a list of image URLs.
+	 * Indicates a parameter that is a list of Coda image values. The pack is passed a list of image URLs.
 	 */
 	ImageArray = "imageArray"
 }

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -220,6 +220,11 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
     maximum?: number | string;
     step?: number | string;
 }
+/**
+ * Icons that can be used with a {@link ScaleSchema}.
+ *
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ */
 export declare enum ScaleIconSet {
     Star = "star",
     Circle = "circle",

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -223,7 +223,7 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
 /**
  * Icons that can be used with a {@link ScaleSchema}.
  *
- * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: coda.ScaleIconSet.Star`.
  */
 export declare enum ScaleIconSet {
     Star = "star",

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -205,6 +205,11 @@ var CurrencyFormat;
      */
     CurrencyFormat["Financial"] = "financial";
 })(CurrencyFormat = exports.CurrencyFormat || (exports.CurrencyFormat = {}));
+/**
+ * Icons that can be used with a {@link ScaleSchema}.
+ *
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ */
 var ScaleIconSet;
 (function (ScaleIconSet) {
     ScaleIconSet["Star"] = "star";

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -208,7 +208,7 @@ var CurrencyFormat;
 /**
  * Icons that can be used with a {@link ScaleSchema}.
  *
- * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: coda.ScaleIconSet.Star`.
  */
 var ScaleIconSet;
 (function (ScaleIconSet) {

--- a/docs/reference/sdk/enums/AttributionNodeType.md
+++ b/docs/reference/sdk/enums/AttributionNodeType.md
@@ -15,7 +15,7 @@ An image, often a logo of the data source.
 
 #### Defined in
 
-[schema.ts:453](https://github.com/coda/packs-sdk/blob/main/schema.ts#L453)
+[schema.ts:458](https://github.com/coda/packs-sdk/blob/main/schema.ts#L458)
 
 ___
 
@@ -27,7 +27,7 @@ A hyperlink pointing to the data source.
 
 #### Defined in
 
-[schema.ts:449](https://github.com/coda/packs-sdk/blob/main/schema.ts#L449)
+[schema.ts:454](https://github.com/coda/packs-sdk/blob/main/schema.ts#L454)
 
 ___
 
@@ -39,4 +39,4 @@ Text attribution content.
 
 #### Defined in
 
-[schema.ts:445](https://github.com/coda/packs-sdk/blob/main/schema.ts#L445)
+[schema.ts:450](https://github.com/coda/packs-sdk/blob/main/schema.ts#L450)

--- a/docs/reference/sdk/enums/ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/ConnectionRequirement.md
@@ -13,7 +13,7 @@ Indicates this building block does not make use of an account.
 
 #### Defined in
 
-[api_types.ts:321](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L321)
+[api_types.ts:319](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L319)
 
 ___
 
@@ -28,7 +28,7 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
+[api_types.ts:326](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L326)
 
 ___
 
@@ -43,4 +43,4 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:335](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L335)
+[api_types.ts:333](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L333)

--- a/docs/reference/sdk/enums/ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/ConnectionRequirement.md
@@ -13,7 +13,7 @@ Indicates this building block does not make use of an account.
 
 #### Defined in
 
-[api_types.ts:267](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L267)
+[api_types.ts:321](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L321)
 
 ___
 
@@ -28,7 +28,7 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:274](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L274)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -43,4 +43,4 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:281](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L281)
+[api_types.ts:335](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L335)

--- a/docs/reference/sdk/enums/DurationUnit.md
+++ b/docs/reference/sdk/enums/DurationUnit.md
@@ -12,7 +12,7 @@ Indications a duration as a number of days.
 
 #### Defined in
 
-[schema.ts:333](https://github.com/coda/packs-sdk/blob/main/schema.ts#L333)
+[schema.ts:338](https://github.com/coda/packs-sdk/blob/main/schema.ts#L338)
 
 ___
 
@@ -24,7 +24,7 @@ Indications a duration as a number of hours.
 
 #### Defined in
 
-[schema.ts:337](https://github.com/coda/packs-sdk/blob/main/schema.ts#L337)
+[schema.ts:342](https://github.com/coda/packs-sdk/blob/main/schema.ts#L342)
 
 ___
 
@@ -36,7 +36,7 @@ Indications a duration as a number of minutes.
 
 #### Defined in
 
-[schema.ts:341](https://github.com/coda/packs-sdk/blob/main/schema.ts#L341)
+[schema.ts:346](https://github.com/coda/packs-sdk/blob/main/schema.ts#L346)
 
 ___
 
@@ -48,4 +48,4 @@ Indications a duration as a number of seconds.
 
 #### Defined in
 
-[schema.ts:345](https://github.com/coda/packs-sdk/blob/main/schema.ts#L345)
+[schema.ts:350](https://github.com/coda/packs-sdk/blob/main/schema.ts#L350)

--- a/docs/reference/sdk/enums/NetworkConnection.md
+++ b/docs/reference/sdk/enums/NetworkConnection.md
@@ -10,7 +10,7 @@
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -20,7 +20,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:341](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L341)
+[api_types.ts:339](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L339)
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:342](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L342)
+[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)

--- a/docs/reference/sdk/enums/NetworkConnection.md
+++ b/docs/reference/sdk/enums/NetworkConnection.md
@@ -10,7 +10,7 @@
 
 #### Defined in
 
-[api_types.ts:286](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L286)
+[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
 
 ___
 
@@ -20,7 +20,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
+[api_types.ts:341](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L341)
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:288](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288)
+[api_types.ts:342](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L342)

--- a/docs/reference/sdk/enums/ParameterType.md
+++ b/docs/reference/sdk/enums/ParameterType.md
@@ -1,14 +1,18 @@
 # Enumeration: ParameterType
 
+Enumeration of types of formula parameters. These describe Coda value types (as opposed to JavaScript value types).
+
 ## Enumeration members
 
 ### Boolean
 
 • **Boolean** = `"boolean"`
 
+Indicates a parameter that is a Coda boolean value.
+
 #### Defined in
 
-[api_types.ts:88](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L88)
+[api_types.ts:108](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L108)
 
 ___
 
@@ -16,9 +20,11 @@ ___
 
 • **BooleanArray** = `"booleanArray"`
 
+Indicates a parameter that is a list of Coda boolean values.
+
 #### Defined in
 
-[api_types.ts:95](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L95)
+[api_types.ts:134](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L134)
 
 ___
 
@@ -26,9 +32,11 @@ ___
 
 • **Date** = `"date"`
 
+Indicates a parameter that is a Coda date value (which includes time and datetime values).
+
 #### Defined in
 
-[api_types.ts:89](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L89)
+[api_types.ts:112](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L112)
 
 ___
 
@@ -36,9 +44,16 @@ ___
 
 • **DateArray** = `"dateArray"`
 
+Indicates a parameter that is a list of Coda date values (which includes time and datetime values).
+
+Currently, when such a parameter is used with a sync table formula or an action formula ([isAction](../interfaces/EmptyFormulaDef.md#isaction)),
+which will generate a builder UI for selecting parameters, a date array parameter will always render
+as a date range selector. A date range will always be passed to a pack formula as a list of two
+elements, the beginning of the range and the end of the range.
+
 #### Defined in
 
-[api_types.ts:96](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L96)
+[api_types.ts:143](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L143)
 
 ___
 
@@ -46,9 +61,11 @@ ___
 
 • **Html** = `"html"`
 
+Indicates a parameter that is a Coda rich text value that should be passed to the pack as HTML.
+
 #### Defined in
 
-[api_types.ts:90](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L90)
+[api_types.ts:116](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L116)
 
 ___
 
@@ -56,9 +73,11 @@ ___
 
 • **HtmlArray** = `"htmlArray`"`
 
+Indicates a parameter that is a list of Coda rich text values that should be passed to the pack as HTML.
+
 #### Defined in
 
-[api_types.ts:97](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L97)
+[api_types.ts:147](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L147)
 
 ___
 
@@ -66,9 +85,12 @@ ___
 
 • **Image** = `"image"`
 
+*Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
+be passed to the pack as an image URL.
+
 #### Defined in
 
-[api_types.ts:91](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L91)
+[api_types.ts:121](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L121)
 
 ___
 
@@ -76,9 +98,12 @@ ___
 
 • **ImageArray** = `"imageArray"`
 
+*Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
+will be passed to the pack as a list of image URLs.
+
 #### Defined in
 
-[api_types.ts:98](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L98)
+[api_types.ts:152](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L152)
 
 ___
 
@@ -86,9 +111,11 @@ ___
 
 • **Number** = `"number"`
 
+Indicates a parameter that is a Coda number value.
+
 #### Defined in
 
-[api_types.ts:87](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L87)
+[api_types.ts:104](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L104)
 
 ___
 
@@ -96,9 +123,11 @@ ___
 
 • **NumberArray** = `"numberArray"`
 
+Indicates a parameter that is a list of Coda number values.
+
 #### Defined in
 
-[api_types.ts:94](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L94)
+[api_types.ts:130](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L130)
 
 ___
 
@@ -106,9 +135,11 @@ ___
 
 • **String** = `"string"`
 
+Indicates a parameter that is a Coda text value.
+
 #### Defined in
 
-[api_types.ts:86](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L86)
+[api_types.ts:100](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L100)
 
 ___
 
@@ -116,6 +147,8 @@ ___
 
 • **StringArray** = `"stringArray"`
 
+Indicates a parameter that is a list of Coda text values.
+
 #### Defined in
 
-[api_types.ts:93](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L93)
+[api_types.ts:126](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L126)

--- a/docs/reference/sdk/enums/ParameterType.md
+++ b/docs/reference/sdk/enums/ParameterType.md
@@ -24,7 +24,7 @@ Indicates a parameter that is a list of Coda boolean values.
 
 #### Defined in
 
-[api_types.ts:134](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L134)
+[api_types.ts:133](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L133)
 
 ___
 
@@ -53,7 +53,7 @@ elements, the beginning of the range and the end of the range.
 
 #### Defined in
 
-[api_types.ts:143](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L143)
+[api_types.ts:142](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L142)
 
 ___
 
@@ -77,7 +77,7 @@ Indicates a parameter that is a list of Coda rich text values that should be pas
 
 #### Defined in
 
-[api_types.ts:147](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L147)
+[api_types.ts:146](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L146)
 
 ___
 
@@ -85,12 +85,11 @@ ___
 
 • **Image** = `"image"`
 
-*Not yet supported.* Indicates a parameter that is a Coda image. Eventually, such a parameter will
-be passed to the pack as an image URL.
+Indicates a parameter that is a Coda image. The pack is passed an image URL.
 
 #### Defined in
 
-[api_types.ts:121](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L121)
+[api_types.ts:120](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L120)
 
 ___
 
@@ -98,12 +97,11 @@ ___
 
 • **ImageArray** = `"imageArray"`
 
-*Not yet supported.* Indicates a parameter that is a list of Coda image values. Eventually, such a parameter
-will be passed to the pack as a list of image URLs.
+Indicates a parameter that is a list of Coda image values. The pack is passed a list of image URLs.
 
 #### Defined in
 
-[api_types.ts:152](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L152)
+[api_types.ts:150](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L150)
 
 ___
 
@@ -127,7 +125,7 @@ Indicates a parameter that is a list of Coda number values.
 
 #### Defined in
 
-[api_types.ts:130](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L130)
+[api_types.ts:129](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L129)
 
 ___
 
@@ -151,4 +149,4 @@ Indicates a parameter that is a list of Coda text values.
 
 #### Defined in
 
-[api_types.ts:126](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L126)
+[api_types.ts:125](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L125)

--- a/docs/reference/sdk/enums/PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/PrecannedDateRange.md
@@ -1,14 +1,32 @@
 # Enumeration: PrecannedDateRange
 
+Special "live" date range values that can be used as the [defaultValue](../interfaces/ParamDef.md#defaultvalue)
+for a date array parameter.
+
+Date array parameters are meant to represent date ranges. A date range can
+be a fixed range, e.g. April 1, 2020 - May 15, 2020, or it can be a "live"
+range, like "last 30 days".
+
+At execution time, a date range will always be passed to a pack as an
+array of two specific dates, but for many use cases, it is necessary
+to provide a default value that is a "live" range rather than hardcoded
+one. For example, if your pack has a table that syncs recent emails,
+you might want to have a date range parameter that default to
+"last 7 days". Defaulting to a hardcoded date range would not be useful
+and requiring the user to always specify a date range may be inconvenient.
+
 ## Enumeration members
 
 ### Everything
 
 • **Everything** = `"everything"`
 
+Indicates a date range beginning in the very distant past (e.g. 1/1/1, aka 1 A.D.)
+and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to change.
+
 #### Defined in
 
-[api_types.ts:404](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L404)
+[api_types.ts:478](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L478)
 
 ___
 
@@ -18,7 +36,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:377](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L377)
+[api_types.ts:447](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L447)
 
 ___
 
@@ -28,7 +46,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:380](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L380)
+[api_types.ts:450](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L450)
 
 ___
 
@@ -38,7 +56,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:381](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L381)
+[api_types.ts:451](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L451)
 
 ___
 
@@ -48,7 +66,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:376](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L376)
+[api_types.ts:446](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L446)
 
 ___
 
@@ -58,7 +76,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:379](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379)
+[api_types.ts:449](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L449)
 
 ___
 
@@ -68,7 +86,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:378](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L378)
+[api_types.ts:448](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L448)
 
 ___
 
@@ -78,7 +96,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:382](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L382)
+[api_types.ts:452](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L452)
 
 ___
 
@@ -88,7 +106,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:397](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L397)
+[api_types.ts:467](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L467)
 
 ___
 
@@ -98,7 +116,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:400](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L400)
+[api_types.ts:470](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L470)
 
 ___
 
@@ -108,7 +126,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:401](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L401)
+[api_types.ts:471](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L471)
 
 ___
 
@@ -118,7 +136,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:396](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L396)
+[api_types.ts:466](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L466)
 
 ___
 
@@ -128,7 +146,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:399](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L399)
+[api_types.ts:469](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L469)
 
 ___
 
@@ -138,7 +156,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:398](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L398)
+[api_types.ts:468](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L468)
 
 ___
 
@@ -148,7 +166,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:402](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L402)
+[api_types.ts:472](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L472)
 
 ___
 
@@ -158,7 +176,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:388](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L388)
+[api_types.ts:458](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L458)
 
 ___
 
@@ -168,7 +186,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:389](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L389)
+[api_types.ts:459](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L459)
 
 ___
 
@@ -178,7 +196,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:386](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L386)
+[api_types.ts:456](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L456)
 
 ___
 
@@ -188,7 +206,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:387](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L387)
+[api_types.ts:457](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L457)
 
 ___
 
@@ -198,7 +216,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:392](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L392)
+[api_types.ts:462](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L462)
 
 ___
 
@@ -208,7 +226,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:390](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L390)
+[api_types.ts:460](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L460)
 
 ___
 
@@ -218,7 +236,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:385](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L385)
+[api_types.ts:455](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L455)
 
 ___
 
@@ -228,7 +246,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:395](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L395)
+[api_types.ts:465](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L465)
 
 ___
 
@@ -238,7 +256,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:391](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L391)
+[api_types.ts:461](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L461)
 
 ___
 
@@ -248,4 +266,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:375](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L375)
+[api_types.ts:445](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L445)

--- a/docs/reference/sdk/enums/PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/PrecannedDateRange.md
@@ -26,7 +26,7 @@ and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to c
 
 #### Defined in
 
-[api_types.ts:478](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L478)
+[api_types.ts:476](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L476)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:447](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L447)
+[api_types.ts:445](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L445)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:450](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L450)
+[api_types.ts:448](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L448)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:451](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L451)
+[api_types.ts:449](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L449)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:446](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L446)
+[api_types.ts:444](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L444)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:449](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L449)
+[api_types.ts:447](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L447)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:448](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L448)
+[api_types.ts:446](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L446)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:452](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L452)
+[api_types.ts:450](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L450)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:467](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L467)
+[api_types.ts:465](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L465)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:470](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L470)
+[api_types.ts:468](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L468)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:471](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L471)
+[api_types.ts:469](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L469)
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:466](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L466)
+[api_types.ts:464](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L464)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:469](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L469)
+[api_types.ts:467](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L467)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:468](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L468)
+[api_types.ts:466](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L466)
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:472](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L472)
+[api_types.ts:470](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L470)
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:458](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L458)
+[api_types.ts:456](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L456)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:459](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L459)
+[api_types.ts:457](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L457)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:456](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L456)
+[api_types.ts:454](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L454)
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:457](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L457)
+[api_types.ts:455](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L455)
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:462](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L462)
+[api_types.ts:460](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L460)
 
 ___
 
@@ -226,7 +226,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:460](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L460)
+[api_types.ts:458](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L458)
 
 ___
 
@@ -236,7 +236,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:455](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L455)
+[api_types.ts:453](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L453)
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:465](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L465)
+[api_types.ts:463](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L463)
 
 ___
 
@@ -256,7 +256,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:461](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L461)
+[api_types.ts:459](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L459)
 
 ___
 
@@ -266,4 +266,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:445](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L445)
+[api_types.ts:443](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L443)

--- a/docs/reference/sdk/enums/ScaleIconSet.md
+++ b/docs/reference/sdk/enums/ScaleIconSet.md
@@ -1,5 +1,9 @@
 # Enumeration: ScaleIconSet
 
+Icons that can be used with a [ScaleSchema](../interfaces/ScaleSchema.md).
+
+For example, to render a star rating, use a [ScaleSchema](../interfaces/ScaleSchema.md) with `icon: ScaleIconSet.Star`.
+
 ## Enumeration members
 
 ### Battery
@@ -8,7 +12,7 @@
 
 #### Defined in
 
-[schema.ts:292](https://github.com/coda/packs-sdk/blob/main/schema.ts#L292)
+[schema.ts:297](https://github.com/coda/packs-sdk/blob/main/schema.ts#L297)
 
 ___
 
@@ -18,7 +22,7 @@ ___
 
 #### Defined in
 
-[schema.ts:283](https://github.com/coda/packs-sdk/blob/main/schema.ts#L283)
+[schema.ts:288](https://github.com/coda/packs-sdk/blob/main/schema.ts#L288)
 
 ___
 
@@ -28,7 +32,7 @@ ___
 
 #### Defined in
 
-[schema.ts:281](https://github.com/coda/packs-sdk/blob/main/schema.ts#L281)
+[schema.ts:286](https://github.com/coda/packs-sdk/blob/main/schema.ts#L286)
 
 ___
 
@@ -38,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:296](https://github.com/coda/packs-sdk/blob/main/schema.ts#L296)
+[schema.ts:301](https://github.com/coda/packs-sdk/blob/main/schema.ts#L301)
 
 ___
 
@@ -48,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:286](https://github.com/coda/packs-sdk/blob/main/schema.ts#L286)
+[schema.ts:291](https://github.com/coda/packs-sdk/blob/main/schema.ts#L291)
 
 ___
 
@@ -58,7 +62,7 @@ ___
 
 #### Defined in
 
-[schema.ts:279](https://github.com/coda/packs-sdk/blob/main/schema.ts#L279)
+[schema.ts:284](https://github.com/coda/packs-sdk/blob/main/schema.ts#L284)
 
 ___
 
@@ -68,7 +72,7 @@ ___
 
 #### Defined in
 
-[schema.ts:294](https://github.com/coda/packs-sdk/blob/main/schema.ts#L294)
+[schema.ts:299](https://github.com/coda/packs-sdk/blob/main/schema.ts#L299)
 
 ___
 
@@ -78,7 +82,7 @@ ___
 
 #### Defined in
 
-[schema.ts:293](https://github.com/coda/packs-sdk/blob/main/schema.ts#L293)
+[schema.ts:298](https://github.com/coda/packs-sdk/blob/main/schema.ts#L298)
 
 ___
 
@@ -88,7 +92,7 @@ ___
 
 #### Defined in
 
-[schema.ts:290](https://github.com/coda/packs-sdk/blob/main/schema.ts#L290)
+[schema.ts:295](https://github.com/coda/packs-sdk/blob/main/schema.ts#L295)
 
 ___
 
@@ -98,7 +102,7 @@ ___
 
 #### Defined in
 
-[schema.ts:289](https://github.com/coda/packs-sdk/blob/main/schema.ts#L289)
+[schema.ts:294](https://github.com/coda/packs-sdk/blob/main/schema.ts#L294)
 
 ___
 
@@ -108,7 +112,7 @@ ___
 
 #### Defined in
 
-[schema.ts:282](https://github.com/coda/packs-sdk/blob/main/schema.ts#L282)
+[schema.ts:287](https://github.com/coda/packs-sdk/blob/main/schema.ts#L287)
 
 ___
 
@@ -118,7 +122,7 @@ ___
 
 #### Defined in
 
-[schema.ts:280](https://github.com/coda/packs-sdk/blob/main/schema.ts#L280)
+[schema.ts:285](https://github.com/coda/packs-sdk/blob/main/schema.ts#L285)
 
 ___
 
@@ -128,7 +132,7 @@ ___
 
 #### Defined in
 
-[schema.ts:285](https://github.com/coda/packs-sdk/blob/main/schema.ts#L285)
+[schema.ts:290](https://github.com/coda/packs-sdk/blob/main/schema.ts#L290)
 
 ___
 
@@ -138,7 +142,7 @@ ___
 
 #### Defined in
 
-[schema.ts:297](https://github.com/coda/packs-sdk/blob/main/schema.ts#L297)
+[schema.ts:302](https://github.com/coda/packs-sdk/blob/main/schema.ts#L302)
 
 ___
 
@@ -148,7 +152,7 @@ ___
 
 #### Defined in
 
-[schema.ts:288](https://github.com/coda/packs-sdk/blob/main/schema.ts#L288)
+[schema.ts:293](https://github.com/coda/packs-sdk/blob/main/schema.ts#L293)
 
 ___
 
@@ -158,7 +162,7 @@ ___
 
 #### Defined in
 
-[schema.ts:291](https://github.com/coda/packs-sdk/blob/main/schema.ts#L291)
+[schema.ts:296](https://github.com/coda/packs-sdk/blob/main/schema.ts#L296)
 
 ___
 
@@ -168,7 +172,7 @@ ___
 
 #### Defined in
 
-[schema.ts:287](https://github.com/coda/packs-sdk/blob/main/schema.ts#L287)
+[schema.ts:292](https://github.com/coda/packs-sdk/blob/main/schema.ts#L292)
 
 ___
 
@@ -178,7 +182,7 @@ ___
 
 #### Defined in
 
-[schema.ts:278](https://github.com/coda/packs-sdk/blob/main/schema.ts#L278)
+[schema.ts:283](https://github.com/coda/packs-sdk/blob/main/schema.ts#L283)
 
 ___
 
@@ -188,7 +192,7 @@ ___
 
 #### Defined in
 
-[schema.ts:295](https://github.com/coda/packs-sdk/blob/main/schema.ts#L295)
+[schema.ts:300](https://github.com/coda/packs-sdk/blob/main/schema.ts#L300)
 
 ___
 
@@ -198,4 +202,4 @@ ___
 
 #### Defined in
 
-[schema.ts:284](https://github.com/coda/packs-sdk/blob/main/schema.ts#L284)
+[schema.ts:289](https://github.com/coda/packs-sdk/blob/main/schema.ts#L289)

--- a/docs/reference/sdk/enums/ScaleIconSet.md
+++ b/docs/reference/sdk/enums/ScaleIconSet.md
@@ -2,7 +2,7 @@
 
 Icons that can be used with a [ScaleSchema](../interfaces/ScaleSchema.md).
 
-For example, to render a star rating, use a [ScaleSchema](../interfaces/ScaleSchema.md) with `icon: ScaleIconSet.Star`.
+For example, to render a star rating, use a [ScaleSchema](../interfaces/ScaleSchema.md) with `icon: coda.ScaleIconSet.Star`.
 
 ## Enumeration members
 

--- a/docs/reference/sdk/enums/Type.md
+++ b/docs/reference/sdk/enums/Type.md
@@ -1,5 +1,12 @@
 # Enumeration: Type
 
+Markers used internally to represent data types for parameters and return values.
+It should not be necessary to ever use these values directly.
+
+When defining a parameter, use [ParameterType](ParameterType.md). When defining
+a formula return value, or properties within an object return value,
+use [ValueType](ValueType.md).
+
 ## Enumeration members
 
 ### boolean
@@ -8,7 +15,7 @@
 
 #### Defined in
 
-[api_types.ts:10](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L10)
+[api_types.ts:18](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L18)
 
 ___
 
@@ -18,7 +25,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:11](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L11)
+[api_types.ts:19](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L19)
 
 ___
 
@@ -28,7 +35,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:12](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L12)
+[api_types.ts:20](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L20)
 
 ___
 
@@ -38,7 +45,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:13](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L13)
+[api_types.ts:21](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L21)
 
 ___
 
@@ -48,7 +55,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:8](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L8)
+[api_types.ts:16](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L16)
 
 ___
 
@@ -58,7 +65,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:9](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L9)
+[api_types.ts:17](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L17)
 
 ___
 
@@ -68,4 +75,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:7](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L7)
+[api_types.ts:15](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L15)

--- a/docs/reference/sdk/functions/generateSchema.md
+++ b/docs/reference/sdk/functions/generateSchema.md
@@ -14,4 +14,4 @@
 
 #### Defined in
 
-[schema.ts:553](https://github.com/coda/packs-sdk/blob/main/schema.ts#L553)
+[schema.ts:558](https://github.com/coda/packs-sdk/blob/main/schema.ts#L558)

--- a/docs/reference/sdk/functions/makeAttributionNode.md
+++ b/docs/reference/sdk/functions/makeAttributionNode.md
@@ -29,4 +29,4 @@ rendered any time a value with that identity is rendered in a doc.
 
 #### Defined in
 
-[schema.ts:485](https://github.com/coda/packs-sdk/blob/main/schema.ts#L485)
+[schema.ts:490](https://github.com/coda/packs-sdk/blob/main/schema.ts#L490)

--- a/docs/reference/sdk/functions/makeObjectSchema.md
+++ b/docs/reference/sdk/functions/makeObjectSchema.md
@@ -22,4 +22,4 @@
 
 #### Defined in
 
-[schema.ts:589](https://github.com/coda/packs-sdk/blob/main/schema.ts#L589)
+[schema.ts:594](https://github.com/coda/packs-sdk/blob/main/schema.ts#L594)

--- a/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
@@ -21,4 +21,4 @@ schema it provides better code reuse to derive a reference schema instead.
 
 #### Defined in
 
-[schema.ts:689](https://github.com/coda/packs-sdk/blob/main/schema.ts#L689)
+[schema.ts:694](https://github.com/coda/packs-sdk/blob/main/schema.ts#L694)

--- a/docs/reference/sdk/functions/makeSchema.md
+++ b/docs/reference/sdk/functions/makeSchema.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[schema.ts:583](https://github.com/coda/packs-sdk/blob/main/schema.ts#L583)
+[schema.ts:588](https://github.com/coda/packs-sdk/blob/main/schema.ts#L588)

--- a/docs/reference/sdk/interfaces/ArraySchema.md
+++ b/docs/reference/sdk/interfaces/ArraySchema.md
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[schema.ts:384](https://github.com/coda/packs-sdk/blob/main/schema.ts#L384)
+[schema.ts:389](https://github.com/coda/packs-sdk/blob/main/schema.ts#L389)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[schema.ts:383](https://github.com/coda/packs-sdk/blob/main/schema.ts#L383)
+[schema.ts:388](https://github.com/coda/packs-sdk/blob/main/schema.ts#L388)

--- a/docs/reference/sdk/interfaces/ArrayType.md
+++ b/docs/reference/sdk/interfaces/ArrayType.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api_types.ts:20](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L20)
+[api_types.ts:28](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L28)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:19](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L19)
+[api_types.ts:27](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L27)

--- a/docs/reference/sdk/interfaces/DurationSchema.md
+++ b/docs/reference/sdk/interfaces/DurationSchema.md
@@ -18,7 +18,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:355](https://github.com/coda/packs-sdk/blob/main/schema.ts#L355)
+[schema.ts:360](https://github.com/coda/packs-sdk/blob/main/schema.ts#L360)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:350](https://github.com/coda/packs-sdk/blob/main/schema.ts#L350)
+[schema.ts:355](https://github.com/coda/packs-sdk/blob/main/schema.ts#L355)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:349](https://github.com/coda/packs-sdk/blob/main/schema.ts#L349)
+[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
 
 ___
 
@@ -66,4 +66,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
+[schema.ts:359](https://github.com/coda/packs-sdk/blob/main/schema.ts#L359)

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -26,7 +26,7 @@ Omit.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:288](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288)
+[api_types.ts:286](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L286)
 
 ___
 
@@ -42,7 +42,7 @@ Omit.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:280](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L280)
+[api_types.ts:278](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L278)
 
 ___
 
@@ -58,7 +58,7 @@ Omit.description
 
 #### Defined in
 
-[api_types.ts:254](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L254)
+[api_types.ts:252](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L252)
 
 ___
 
@@ -74,7 +74,7 @@ Omit.examples
 
 #### Defined in
 
-[api_types.ts:269](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269)
+[api_types.ts:267](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L267)
 
 ___
 
@@ -95,7 +95,7 @@ Omit.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -112,7 +112,7 @@ Omit.isAction
 
 #### Defined in
 
-[api_types.ts:275](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275)
+[api_types.ts:273](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L273)
 
 ___
 
@@ -129,7 +129,7 @@ Omit.isExperimental
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)
 
 ___
 
@@ -146,7 +146,7 @@ Omit.isSystem
 
 #### Defined in
 
-[api_types.ts:300](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L300)
+[api_types.ts:298](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L298)
 
 ___
 
@@ -162,7 +162,7 @@ Omit.name
 
 #### Defined in
 
-[api_types.ts:249](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L249)
+[api_types.ts:247](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247)
 
 ___
 
@@ -178,7 +178,7 @@ Omit.network
 
 #### Defined in
 
-[api_types.ts:283](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L283)
+[api_types.ts:281](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L281)
 
 ___
 
@@ -194,7 +194,7 @@ Omit.parameters
 
 #### Defined in
 
-[api_types.ts:259](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L259)
+[api_types.ts:257](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257)
 
 ___
 
@@ -221,4 +221,4 @@ Omit.varargParameters
 
 #### Defined in
 
-[api_types.ts:264](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L264)
+[api_types.ts:262](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L262)

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -26,7 +26,7 @@ Omit.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:234](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L234)
+[api_types.ts:288](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288)
 
 ___
 
@@ -42,7 +42,7 @@ Omit.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:226](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L226)
+[api_types.ts:280](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L280)
 
 ___
 
@@ -58,7 +58,7 @@ Omit.description
 
 #### Defined in
 
-[api_types.ts:200](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L200)
+[api_types.ts:254](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L254)
 
 ___
 
@@ -74,7 +74,7 @@ Omit.examples
 
 #### Defined in
 
-[api_types.ts:215](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L215)
+[api_types.ts:269](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269)
 
 ___
 
@@ -95,7 +95,7 @@ Omit.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:256](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L256)
+[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
 
 ___
 
@@ -112,7 +112,7 @@ Omit.isAction
 
 #### Defined in
 
-[api_types.ts:221](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L221)
+[api_types.ts:275](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275)
 
 ___
 
@@ -129,7 +129,7 @@ Omit.isExperimental
 
 #### Defined in
 
-[api_types.ts:240](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L240)
+[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
 
 ___
 
@@ -146,7 +146,7 @@ Omit.isSystem
 
 #### Defined in
 
-[api_types.ts:246](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L246)
+[api_types.ts:300](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L300)
 
 ___
 
@@ -162,7 +162,7 @@ Omit.name
 
 #### Defined in
 
-[api_types.ts:195](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L195)
+[api_types.ts:249](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L249)
 
 ___
 
@@ -178,7 +178,7 @@ Omit.network
 
 #### Defined in
 
-[api_types.ts:229](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L229)
+[api_types.ts:283](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L283)
 
 ___
 
@@ -194,7 +194,7 @@ Omit.parameters
 
 #### Defined in
 
-[api_types.ts:205](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L205)
+[api_types.ts:259](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L259)
 
 ___
 
@@ -221,4 +221,4 @@ Omit.varargParameters
 
 #### Defined in
 
-[api_types.ts:210](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L210)
+[api_types.ts:264](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L264)

--- a/docs/reference/sdk/interfaces/ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/ExecutionContext.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api_types.ts:357](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L357)
+[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:355](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L355)
+[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
+[api_types.ts:412](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L412)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:363](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L363)
+[api_types.ts:417](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L417)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:364](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L364)
+[api_types.ts:418](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L418)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:356](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L356)
+[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:359](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359)
+[api_types.ts:413](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L413)

--- a/docs/reference/sdk/interfaces/ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/ExecutionContext.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)
+[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
+[api_types.ts:407](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L407)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:412](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L412)
+[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:417](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L417)
+[api_types.ts:415](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L415)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:418](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L418)
+[api_types.ts:416](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L416)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
+[api_types.ts:408](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L408)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:413](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L413)
+[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)

--- a/docs/reference/sdk/interfaces/FetchRequest.md
+++ b/docs/reference/sdk/interfaces/FetchRequest.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[api_types.ts:360](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L360)
+[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
 
 ___
 
@@ -18,7 +18,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:364](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L364)
+[api_types.ts:362](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L362)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:368](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368)
+[api_types.ts:366](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L366)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:361](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L361)
+[api_types.ts:359](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:362](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L362)
+[api_types.ts:360](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L360)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:366](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L366)
+[api_types.ts:364](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L364)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
+[api_types.ts:356](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L356)
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:359](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359)
+[api_types.ts:357](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L357)

--- a/docs/reference/sdk/interfaces/FetchRequest.md
+++ b/docs/reference/sdk/interfaces/FetchRequest.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[api_types.ts:306](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L306)
+[api_types.ts:360](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L360)
 
 ___
 
@@ -18,7 +18,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:364](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L364)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:314](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L314)
+[api_types.ts:368](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:307](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L307)
+[api_types.ts:361](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L361)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
+[api_types.ts:362](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L362)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:312](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L312)
+[api_types.ts:366](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L366)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:304](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L304)
+[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:359](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359)

--- a/docs/reference/sdk/interfaces/FetchResponse.md
+++ b/docs/reference/sdk/interfaces/FetchResponse.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api_types.ts:374](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L374)
+[api_types.ts:372](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L372)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:375](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L375)
+[api_types.ts:373](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L373)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:373](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L373)
+[api_types.ts:371](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L371)

--- a/docs/reference/sdk/interfaces/FetchResponse.md
+++ b/docs/reference/sdk/interfaces/FetchResponse.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[api_types.ts:320](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L320)
+[api_types.ts:374](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L374)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:321](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L321)
+[api_types.ts:375](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L375)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:319](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L319)
+[api_types.ts:373](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L373)

--- a/docs/reference/sdk/interfaces/Fetcher.md
+++ b/docs/reference/sdk/interfaces/Fetcher.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[api_types.ts:325](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L325)
+[api_types.ts:379](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379)

--- a/docs/reference/sdk/interfaces/Fetcher.md
+++ b/docs/reference/sdk/interfaces/Fetcher.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[api_types.ts:379](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379)
+[api_types.ts:377](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L377)

--- a/docs/reference/sdk/interfaces/Identity.md
+++ b/docs/reference/sdk/interfaces/Identity.md
@@ -22,7 +22,7 @@ See [makeAttributionNode](../functions/makeAttributionNode.md).
 
 #### Defined in
 
-[schema.ts:406](https://github.com/coda/packs-sdk/blob/main/schema.ts#L406)
+[schema.ts:411](https://github.com/coda/packs-sdk/blob/main/schema.ts#L411)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[schema.ts:400](https://github.com/coda/packs-sdk/blob/main/schema.ts#L400)
+[schema.ts:405](https://github.com/coda/packs-sdk/blob/main/schema.ts#L405)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[schema.ts:399](https://github.com/coda/packs-sdk/blob/main/schema.ts#L399)
+[schema.ts:404](https://github.com/coda/packs-sdk/blob/main/schema.ts#L404)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[schema.ts:412](https://github.com/coda/packs-sdk/blob/main/schema.ts#L412)
+[schema.ts:417](https://github.com/coda/packs-sdk/blob/main/schema.ts#L417)

--- a/docs/reference/sdk/interfaces/IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/IdentityDefinition.md
@@ -18,7 +18,7 @@ See [makeAttributionNode](../functions/makeAttributionNode.md).
 
 #### Defined in
 
-[schema.ts:406](https://github.com/coda/packs-sdk/blob/main/schema.ts#L406)
+[schema.ts:411](https://github.com/coda/packs-sdk/blob/main/schema.ts#L411)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[schema.ts:400](https://github.com/coda/packs-sdk/blob/main/schema.ts#L400)
+[schema.ts:405](https://github.com/coda/packs-sdk/blob/main/schema.ts#L405)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[schema.ts:399](https://github.com/coda/packs-sdk/blob/main/schema.ts#L399)
+[schema.ts:404](https://github.com/coda/packs-sdk/blob/main/schema.ts#L404)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[schema.ts:408](https://github.com/coda/packs-sdk/blob/main/schema.ts#L408)
+[schema.ts:413](https://github.com/coda/packs-sdk/blob/main/schema.ts#L413)

--- a/docs/reference/sdk/interfaces/Network.md
+++ b/docs/reference/sdk/interfaces/Network.md
@@ -10,7 +10,7 @@
 
 #### Defined in
 
-[api_types.ts:295](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L295)
+[api_types.ts:349](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L349)
 
 ___
 
@@ -20,7 +20,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:293](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L293)
+[api_types.ts:347](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L347)
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:348](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L348)

--- a/docs/reference/sdk/interfaces/Network.md
+++ b/docs/reference/sdk/interfaces/Network.md
@@ -10,7 +10,7 @@
 
 #### Defined in
 
-[api_types.ts:349](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L349)
+[api_types.ts:347](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L347)
 
 ___
 
@@ -20,7 +20,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:347](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L347)
+[api_types.ts:345](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L345)
 
 ___
 
@@ -30,4 +30,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:348](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L348)
+[api_types.ts:346](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L346)

--- a/docs/reference/sdk/interfaces/ObjectSchema.md
+++ b/docs/reference/sdk/interfaces/ObjectSchema.md
@@ -25,7 +25,7 @@ ObjectSchemaDefinition.codaType
 
 #### Defined in
 
-[schema.ts:420](https://github.com/coda/packs-sdk/blob/main/schema.ts#L420)
+[schema.ts:425](https://github.com/coda/packs-sdk/blob/main/schema.ts#L425)
 
 ___
 
@@ -53,7 +53,7 @@ ObjectSchemaDefinition.featured
 
 #### Defined in
 
-[schema.ts:421](https://github.com/coda/packs-sdk/blob/main/schema.ts#L421)
+[schema.ts:426](https://github.com/coda/packs-sdk/blob/main/schema.ts#L426)
 
 ___
 
@@ -67,7 +67,7 @@ ObjectSchemaDefinition.id
 
 #### Defined in
 
-[schema.ts:418](https://github.com/coda/packs-sdk/blob/main/schema.ts#L418)
+[schema.ts:423](https://github.com/coda/packs-sdk/blob/main/schema.ts#L423)
 
 ___
 
@@ -81,7 +81,7 @@ ObjectSchemaDefinition.identity
 
 #### Defined in
 
-[schema.ts:432](https://github.com/coda/packs-sdk/blob/main/schema.ts#L432)
+[schema.ts:437](https://github.com/coda/packs-sdk/blob/main/schema.ts#L437)
 
 ___
 
@@ -95,7 +95,7 @@ ObjectSchemaDefinition.primary
 
 #### Defined in
 
-[schema.ts:419](https://github.com/coda/packs-sdk/blob/main/schema.ts#L419)
+[schema.ts:424](https://github.com/coda/packs-sdk/blob/main/schema.ts#L424)
 
 ___
 
@@ -109,7 +109,7 @@ ObjectSchemaDefinition.properties
 
 #### Defined in
 
-[schema.ts:417](https://github.com/coda/packs-sdk/blob/main/schema.ts#L417)
+[schema.ts:422](https://github.com/coda/packs-sdk/blob/main/schema.ts#L422)
 
 ___
 
@@ -123,4 +123,4 @@ ObjectSchemaDefinition.type
 
 #### Defined in
 
-[schema.ts:416](https://github.com/coda/packs-sdk/blob/main/schema.ts#L416)
+[schema.ts:421](https://github.com/coda/packs-sdk/blob/main/schema.ts#L421)

--- a/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
@@ -8,7 +8,7 @@
 
 #### Defined in
 
-[schema.ts:388](https://github.com/coda/packs-sdk/blob/main/schema.ts#L388)
+[schema.ts:393](https://github.com/coda/packs-sdk/blob/main/schema.ts#L393)
 
 ___
 
@@ -18,4 +18,4 @@ ___
 
 #### Defined in
 
-[schema.ts:389](https://github.com/coda/packs-sdk/blob/main/schema.ts#L389)
+[schema.ts:394](https://github.com/coda/packs-sdk/blob/main/schema.ts#L394)

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -27,7 +27,7 @@ CommonPackFormulaDef.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:234](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L234)
+[api_types.ts:288](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288)
 
 ___
 
@@ -43,7 +43,7 @@ CommonPackFormulaDef.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:226](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L226)
+[api_types.ts:280](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L280)
 
 ___
 
@@ -59,7 +59,7 @@ CommonPackFormulaDef.description
 
 #### Defined in
 
-[api_types.ts:200](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L200)
+[api_types.ts:254](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L254)
 
 ___
 
@@ -75,7 +75,7 @@ CommonPackFormulaDef.examples
 
 #### Defined in
 
-[api_types.ts:215](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L215)
+[api_types.ts:269](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269)
 
 ___
 
@@ -96,7 +96,7 @@ CommonPackFormulaDef.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:256](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L256)
+[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
 
 ___
 
@@ -113,7 +113,7 @@ CommonPackFormulaDef.isAction
 
 #### Defined in
 
-[api_types.ts:221](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L221)
+[api_types.ts:275](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275)
 
 ___
 
@@ -130,7 +130,7 @@ CommonPackFormulaDef.isExperimental
 
 #### Defined in
 
-[api_types.ts:240](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L240)
+[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
 
 ___
 
@@ -147,7 +147,7 @@ CommonPackFormulaDef.isSystem
 
 #### Defined in
 
-[api_types.ts:246](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L246)
+[api_types.ts:300](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L300)
 
 ___
 
@@ -163,7 +163,7 @@ CommonPackFormulaDef.name
 
 #### Defined in
 
-[api_types.ts:195](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L195)
+[api_types.ts:249](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L249)
 
 ___
 
@@ -179,7 +179,7 @@ CommonPackFormulaDef.network
 
 #### Defined in
 
-[api_types.ts:229](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L229)
+[api_types.ts:283](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L283)
 
 ___
 
@@ -195,7 +195,7 @@ CommonPackFormulaDef.parameters
 
 #### Defined in
 
-[api_types.ts:205](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L205)
+[api_types.ts:259](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L259)
 
 ___
 
@@ -212,7 +212,7 @@ CommonPackFormulaDef.varargParameters
 
 #### Defined in
 
-[api_types.ts:210](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L210)
+[api_types.ts:264](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L264)
 
 ## Methods
 

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -27,7 +27,7 @@ CommonPackFormulaDef.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:288](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L288)
+[api_types.ts:286](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L286)
 
 ___
 
@@ -43,7 +43,7 @@ CommonPackFormulaDef.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:280](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L280)
+[api_types.ts:278](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L278)
 
 ___
 
@@ -59,7 +59,7 @@ CommonPackFormulaDef.description
 
 #### Defined in
 
-[api_types.ts:254](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L254)
+[api_types.ts:252](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L252)
 
 ___
 
@@ -75,7 +75,7 @@ CommonPackFormulaDef.examples
 
 #### Defined in
 
-[api_types.ts:269](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L269)
+[api_types.ts:267](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L267)
 
 ___
 
@@ -96,7 +96,7 @@ CommonPackFormulaDef.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -113,7 +113,7 @@ CommonPackFormulaDef.isAction
 
 #### Defined in
 
-[api_types.ts:275](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L275)
+[api_types.ts:273](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L273)
 
 ___
 
@@ -130,7 +130,7 @@ CommonPackFormulaDef.isExperimental
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)
 
 ___
 
@@ -147,7 +147,7 @@ CommonPackFormulaDef.isSystem
 
 #### Defined in
 
-[api_types.ts:300](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L300)
+[api_types.ts:298](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L298)
 
 ___
 
@@ -163,7 +163,7 @@ CommonPackFormulaDef.name
 
 #### Defined in
 
-[api_types.ts:249](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L249)
+[api_types.ts:247](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L247)
 
 ___
 
@@ -179,7 +179,7 @@ CommonPackFormulaDef.network
 
 #### Defined in
 
-[api_types.ts:283](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L283)
+[api_types.ts:281](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L281)
 
 ___
 
@@ -195,7 +195,7 @@ CommonPackFormulaDef.parameters
 
 #### Defined in
 
-[api_types.ts:259](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L259)
+[api_types.ts:257](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L257)
 
 ___
 
@@ -212,7 +212,7 @@ CommonPackFormulaDef.varargParameters
 
 #### Defined in
 
-[api_types.ts:264](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L264)
+[api_types.ts:262](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L262)
 
 ## Methods
 

--- a/docs/reference/sdk/interfaces/ParamDef.md
+++ b/docs/reference/sdk/interfaces/ParamDef.md
@@ -23,7 +23,7 @@ If you have a hardcoded list of valid values, you would only need to use
 
 #### Defined in
 
-[api_types.ts:164](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L164)
+[api_types.ts:218](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L218)
 
 ___
 
@@ -35,7 +35,7 @@ The default value to be used for this parameter if it is not specified by the us
 
 #### Defined in
 
-[api_types.ts:168](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L168)
+[api_types.ts:222](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222)
 
 ___
 
@@ -47,7 +47,7 @@ A brief description of what this parameter is used for, shown to the user when i
 
 #### Defined in
 
-[api_types.ts:145](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L145)
+[api_types.ts:199](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L199)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:151](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L151)
+[api_types.ts:205](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L205)
 
 ___
 
@@ -69,7 +69,7 @@ The name of the parameter, which will be shown to the user when invoking this fo
 
 #### Defined in
 
-[api_types.ts:137](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L137)
+[api_types.ts:191](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L191)
 
 ___
 
@@ -82,7 +82,7 @@ All optional parameters must come after all non-optional parameters.
 
 #### Defined in
 
-[api_types.ts:150](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L150)
+[api_types.ts:204](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L204)
 
 ___
 
@@ -94,4 +94,4 @@ The data type of this parameter (string, number, etc).
 
 #### Defined in
 
-[api_types.ts:141](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L141)
+[api_types.ts:195](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L195)

--- a/docs/reference/sdk/interfaces/ParamDef.md
+++ b/docs/reference/sdk/interfaces/ParamDef.md
@@ -23,7 +23,7 @@ If you have a hardcoded list of valid values, you would only need to use
 
 #### Defined in
 
-[api_types.ts:218](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L218)
+[api_types.ts:216](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L216)
 
 ___
 
@@ -35,7 +35,7 @@ The default value to be used for this parameter if it is not specified by the us
 
 #### Defined in
 
-[api_types.ts:222](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L222)
+[api_types.ts:220](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L220)
 
 ___
 
@@ -47,7 +47,7 @@ A brief description of what this parameter is used for, shown to the user when i
 
 #### Defined in
 
-[api_types.ts:199](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L199)
+[api_types.ts:197](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L197)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:205](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L205)
+[api_types.ts:203](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L203)
 
 ___
 
@@ -69,7 +69,7 @@ The name of the parameter, which will be shown to the user when invoking this fo
 
 #### Defined in
 
-[api_types.ts:191](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L191)
+[api_types.ts:189](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L189)
 
 ___
 
@@ -82,7 +82,7 @@ All optional parameters must come after all non-optional parameters.
 
 #### Defined in
 
-[api_types.ts:204](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L204)
+[api_types.ts:202](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L202)
 
 ___
 
@@ -94,4 +94,4 @@ The data type of this parameter (string, number, etc).
 
 #### Defined in
 
-[api_types.ts:195](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L195)
+[api_types.ts:193](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L193)

--- a/docs/reference/sdk/interfaces/ScaleSchema.md
+++ b/docs/reference/sdk/interfaces/ScaleSchema.md
@@ -18,7 +18,7 @@ BaseNumberSchema.codaType
 
 #### Defined in
 
-[schema.ts:301](https://github.com/coda/packs-sdk/blob/main/schema.ts#L301)
+[schema.ts:306](https://github.com/coda/packs-sdk/blob/main/schema.ts#L306)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:303](https://github.com/coda/packs-sdk/blob/main/schema.ts#L303)
+[schema.ts:308](https://github.com/coda/packs-sdk/blob/main/schema.ts#L308)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:302](https://github.com/coda/packs-sdk/blob/main/schema.ts#L302)
+[schema.ts:307](https://github.com/coda/packs-sdk/blob/main/schema.ts#L307)
 
 ___
 

--- a/docs/reference/sdk/interfaces/SimpleStringSchema.md
+++ b/docs/reference/sdk/interfaces/SimpleStringSchema.md
@@ -24,7 +24,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:355](https://github.com/coda/packs-sdk/blob/main/schema.ts#L355)
+[schema.ts:360](https://github.com/coda/packs-sdk/blob/main/schema.ts#L360)
 
 ___
 
@@ -52,4 +52,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
+[schema.ts:359](https://github.com/coda/packs-sdk/blob/main/schema.ts#L359)

--- a/docs/reference/sdk/interfaces/StringDateSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateSchema.md
@@ -18,7 +18,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:307](https://github.com/coda/packs-sdk/blob/main/schema.ts#L307)
+[schema.ts:312](https://github.com/coda/packs-sdk/blob/main/schema.ts#L312)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:309](https://github.com/coda/packs-sdk/blob/main/schema.ts#L309)
+[schema.ts:314](https://github.com/coda/packs-sdk/blob/main/schema.ts#L314)
 
 ___
 
@@ -56,4 +56,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
+[schema.ts:359](https://github.com/coda/packs-sdk/blob/main/schema.ts#L359)

--- a/docs/reference/sdk/interfaces/StringDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateTimeSchema.md
@@ -18,7 +18,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:319](https://github.com/coda/packs-sdk/blob/main/schema.ts#L319)
+[schema.ts:324](https://github.com/coda/packs-sdk/blob/main/schema.ts#L324)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[schema.ts:321](https://github.com/coda/packs-sdk/blob/main/schema.ts#L321)
+[schema.ts:326](https://github.com/coda/packs-sdk/blob/main/schema.ts#L326)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[schema.ts:323](https://github.com/coda/packs-sdk/blob/main/schema.ts#L323)
+[schema.ts:328](https://github.com/coda/packs-sdk/blob/main/schema.ts#L328)
 
 ___
 
@@ -66,4 +66,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
+[schema.ts:359](https://github.com/coda/packs-sdk/blob/main/schema.ts#L359)

--- a/docs/reference/sdk/interfaces/StringTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringTimeSchema.md
@@ -18,7 +18,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:313](https://github.com/coda/packs-sdk/blob/main/schema.ts#L313)
+[schema.ts:318](https://github.com/coda/packs-sdk/blob/main/schema.ts#L318)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[schema.ts:315](https://github.com/coda/packs-sdk/blob/main/schema.ts#L315)
+[schema.ts:320](https://github.com/coda/packs-sdk/blob/main/schema.ts#L320)
 
 ___
 
@@ -56,4 +56,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:354](https://github.com/coda/packs-sdk/blob/main/schema.ts#L354)
+[schema.ts:359](https://github.com/coda/packs-sdk/blob/main/schema.ts#L359)

--- a/docs/reference/sdk/interfaces/SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/SyncExecutionContext.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[api_types.ts:357](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L357)
+[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:355](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L355)
+[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
+[api_types.ts:412](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L412)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:363](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L363)
+[api_types.ts:417](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L417)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:368](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368)
+[api_types.ts:422](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L422)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:356](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L356)
+[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
 
 ___
 
@@ -102,4 +102,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:359](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L359)
+[api_types.ts:413](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L413)

--- a/docs/reference/sdk/interfaces/SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/SyncExecutionContext.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)
+[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
+[api_types.ts:407](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L407)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:412](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L412)
+[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:417](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L417)
+[api_types.ts:415](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L415)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:422](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L422)
+[api_types.ts:420](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L420)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:410](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L410)
+[api_types.ts:408](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L408)
 
 ___
 
@@ -102,4 +102,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:413](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L413)
+[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)

--- a/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:384](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L384)
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:329](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L329)
+[api_types.ts:383](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383)

--- a/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[api_types.ts:384](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L384)
+[api_types.ts:382](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L382)
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:383](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383)
+[api_types.ts:381](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L381)

--- a/docs/reference/sdk/types/DefaultValueType.md
+++ b/docs/reference/sdk/types/DefaultValueType.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[api_types.ts:187](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L187)
+[api_types.ts:241](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241)

--- a/docs/reference/sdk/types/DefaultValueType.md
+++ b/docs/reference/sdk/types/DefaultValueType.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[api_types.ts:241](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L241)
+[api_types.ts:239](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L239)

--- a/docs/reference/sdk/types/FetchMethodType.md
+++ b/docs/reference/sdk/types/FetchMethodType.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:354](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L354)
+[api_types.ts:352](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L352)

--- a/docs/reference/sdk/types/FetchMethodType.md
+++ b/docs/reference/sdk/types/FetchMethodType.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:300](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L300)
+[api_types.ts:354](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L354)

--- a/docs/reference/sdk/types/GenericObjectSchema.md
+++ b/docs/reference/sdk/types/GenericObjectSchema.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[schema.ts:396](https://github.com/coda/packs-sdk/blob/main/schema.ts#L396)
+[schema.ts:401](https://github.com/coda/packs-sdk/blob/main/schema.ts#L401)

--- a/docs/reference/sdk/types/ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/ObjectSchemaProperties.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[schema.ts:392](https://github.com/coda/packs-sdk/blob/main/schema.ts#L392)
+[schema.ts:397](https://github.com/coda/packs-sdk/blob/main/schema.ts#L397)

--- a/docs/reference/sdk/types/PackFormulaResult.md
+++ b/docs/reference/sdk/types/PackFormulaResult.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:71](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L71)
+[api_types.ts:79](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L79)

--- a/docs/reference/sdk/types/PackFormulaValue.md
+++ b/docs/reference/sdk/types/PackFormulaValue.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:70](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L70)
+[api_types.ts:78](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L78)

--- a/docs/reference/sdk/types/ParamDefs.md
+++ b/docs/reference/sdk/types/ParamDefs.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:227](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227)
+[api_types.ts:225](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L225)

--- a/docs/reference/sdk/types/ParamDefs.md
+++ b/docs/reference/sdk/types/ParamDefs.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:173](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L173)
+[api_types.ts:227](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227)

--- a/docs/reference/sdk/types/ParamValues.md
+++ b/docs/reference/sdk/types/ParamValues.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[api_types.ts:237](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L237)
+[api_types.ts:235](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235)

--- a/docs/reference/sdk/types/ParamValues.md
+++ b/docs/reference/sdk/types/ParamValues.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[api_types.ts:183](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L183)
+[api_types.ts:237](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L237)

--- a/docs/reference/sdk/types/ParamsList.md
+++ b/docs/reference/sdk/types/ParamsList.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:175](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L175)
+[api_types.ts:229](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L229)

--- a/docs/reference/sdk/types/ParamsList.md
+++ b/docs/reference/sdk/types/ParamsList.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[api_types.ts:229](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L229)
+[api_types.ts:227](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L227)

--- a/docs/reference/sdk/types/Schema.md
+++ b/docs/reference/sdk/types/Schema.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[schema.ts:489](https://github.com/coda/packs-sdk/blob/main/schema.ts#L489)
+[schema.ts:494](https://github.com/coda/packs-sdk/blob/main/schema.ts#L494)

--- a/docs/reference/sdk/types/SchemaType.md
+++ b/docs/reference/sdk/types/SchemaType.md
@@ -10,4 +10,4 @@
 
 #### Defined in
 
-[schema.ts:539](https://github.com/coda/packs-sdk/blob/main/schema.ts#L539)
+[schema.ts:544](https://github.com/coda/packs-sdk/blob/main/schema.ts#L544)

--- a/docs/reference/sdk/types/StringSchema.md
+++ b/docs/reference/sdk/types/StringSchema.md
@@ -4,4 +4,4 @@
 
 #### Defined in
 
-[schema.ts:375](https://github.com/coda/packs-sdk/blob/main/schema.ts#L375)
+[schema.ts:380](https://github.com/coda/packs-sdk/blob/main/schema.ts#L380)

--- a/schema.ts
+++ b/schema.ts
@@ -274,6 +274,11 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
   step?: number | string;
 }
 
+/**
+ * Icons that can be used with a {@link ScaleSchema}.
+ *
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ */
 export enum ScaleIconSet {
   Star = 'star',
   Circle = 'circle',

--- a/schema.ts
+++ b/schema.ts
@@ -277,7 +277,7 @@ export interface SliderSchema extends BaseNumberSchema<ValueHintType.Slider> {
 /**
  * Icons that can be used with a {@link ScaleSchema}.
  *
- * For example, to render a star rating, use a {@link ScaleSchema} with `icon: ScaleIconSet.Star`.
+ * For example, to render a star rating, use a {@link ScaleSchema} with `icon: coda.ScaleIconSet.Star`.
  */
 export enum ScaleIconSet {
   Star = 'star',

--- a/scripts/tsdoc_progress.ts
+++ b/scripts/tsdoc_progress.ts
@@ -14,6 +14,10 @@ interface ReflectionData {
   comment?: {
     shortText: string;
     text?: string;
+    tags?: Array<{
+      tag: string;
+      text?: string;
+    }>;
   };
   sources?: Array<{
     fileName: string;
@@ -34,6 +38,14 @@ function getReflectionData() {
 function traverse(data: ReflectionData): void {
   if (!data.comment) {
     logMissing(data);
+  }
+  if (data.comment?.tags?.find(t => t.tag === 'deprecated')) {
+    return;
+  }
+  // We don't care about traversing children for these nodes.
+  const terminalNames = ['PrecannedDateRange', 'ScaleIconSet', 'Type'];
+  if (terminalNames.includes(data.name)) {
+    return;
   }
   for (const child of data.children || []) {
     traverse(child);


### PR DESCRIPTION
Another small pass.

I also exempted some enum values where it seemed redundant to document the individual values, which seemed relatively self-explanatory.

PTAL @ekoleda-codaio @coda/packs 