### PR TITLE
Create a way to store build options in the .coda-pack.json file. Use it to store the timerStrategy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.
 
+- If your pack uses fake timers (to simulate setTimeout) you can now store this as a persistent
+  build option. Previously, you had to remember to include the flag --timerStrategy=fake any time
+  you used any of the `coda` CLI commands. Now you can run
+  `coda setOption path/to/pack.ts timerStrategy fake` and it will store the option persistently
+  in your `.coda-pack.json` file and use it for all builds.
+
 ## 0.5.0
 
 - **Breaking Change** `context.logger` has been removed. It has been redundant with `console.log`

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -10,6 +10,7 @@ import {handleExecute} from './execute';
 import {handleInit} from './init';
 import {handleRegister} from './register';
 import {handleRelease} from './release';
+import {handleSetOption} from './set_option';
 import {handleUpload} from './upload';
 import {handleValidate} from './validate';
 import yargs from 'yargs';
@@ -180,6 +181,15 @@ if (require.main === module) {
         },
       },
       handler: handleRelease,
+    })
+    .command({
+      command: 'setOption <manifestFile> <option> <value>',
+      describe:
+        'Set a persistent build option for the pack. This will store the option alongside the pack id in ' +
+        'the .coda-pack.json file and it will be used for all builds of the pack. ' +
+        'Currently the only supported option is `timerStrategy`. Valid values are "none", "error", or "fake".\n\n' +
+        'Usage: coda setOption path/to/pack.ts timerStrategy fake',
+      handler: handleSetOption,
     })
     .demandCommand()
     .strict()

--- a/cli/set_option.ts
+++ b/cli/set_option.ts
@@ -1,0 +1,40 @@
+import type {Arguments} from 'yargs';
+import {PackOptionKey} from './config_storage';
+import type {PackOptions} from './config_storage';
+import {TimerShimStrategy} from '../testing/compile';
+import {ensureUnreachable} from '..';
+import * as path from 'path';
+import {print} from '../testing/helpers';
+import {printAndExit} from '../testing/helpers';
+import {storePackOptions} from './config_storage';
+
+interface SetOptionArgs {
+  manifestFile: string;
+  option: string;
+  value: string;
+}
+
+export async function handleSetOption({manifestFile, option, value}: Arguments<SetOptionArgs>) {
+  const manifestDir = path.dirname(manifestFile);
+  const options = validateOption(option, value);
+  storePackOptions(manifestDir, options);
+  print('Option stored successfully.');
+}
+
+function validateOption(option: string, value: string): PackOptions {
+  const validOptions = Object.values(PackOptionKey) as string[];
+  if (!validOptions.includes(option)) {
+    return printAndExit(`Unsupported option "${option}". Value options are: ${validOptions.join(', ')}`);
+  }
+  const key = option as PackOptionKey;
+  switch (key) {
+    case PackOptionKey.timerStrategy:
+      const validValues = Object.values(TimerShimStrategy) as string[];
+      if (!validValues.includes(value)) {
+        return printAndExit(`Invalid option value "${value}". Valid values are ${validValues.join(', ')}`);
+      }
+      return {[key]: value as TimerShimStrategy};
+    default:
+      return ensureUnreachable(key);
+  }
+}

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -14,6 +14,7 @@ const execute_1 = require("./execute");
 const init_1 = require("./init");
 const register_1 = require("./register");
 const release_1 = require("./release");
+const set_option_1 = require("./set_option");
 const upload_1 = require("./upload");
 const validate_1 = require("./validate");
 const yargs_1 = __importDefault(require("yargs"));
@@ -181,6 +182,14 @@ if (require.main === module) {
             },
         },
         handler: release_1.handleRelease,
+    })
+        .command({
+        command: 'setOption <manifestFile> <option> <value>',
+        describe: 'Set a persistent build option for the pack. This will store the option alongside the pack id in ' +
+            'the .coda-pack.json file and it will be used for all builds of the pack. ' +
+            'Currently the only supported option is `timerStrategy`. Valid values are "none", "error", or "fake".\n\n' +
+            'Usage: coda setOption path/to/pack.ts timerStrategy fake',
+        handler: set_option_1.handleSetOption,
     })
         .demandCommand()
         .strict()

--- a/dist/cli/config_storage.d.ts
+++ b/dist/cli/config_storage.d.ts
@@ -1,3 +1,4 @@
+import type { TimerShimStrategy } from '../testing/compile';
 export declare const DEFAULT_API_ENDPOINT = "https://coda.io";
 export declare const PACK_ID_FILE_NAME = ".coda-pack.json";
 export interface ApiKeyFile {
@@ -6,8 +7,15 @@ export interface ApiKeyFile {
         [host: string]: string;
     };
 }
+export declare enum PackOptionKey {
+    timerStrategy = "timerStrategy"
+}
+export interface PackOptions {
+    [PackOptionKey.timerStrategy]?: TimerShimStrategy;
+}
 export interface PackIdFile {
     packId: number;
+    options?: PackOptions;
     environmentPackIds?: {
         [host: string]: number;
     };
@@ -16,3 +24,5 @@ export declare function getApiKey(codaApiEndpoint: string): string | undefined;
 export declare function storeCodaApiKey(apiKey: string, projectDir: string | undefined, codaApiEndpoint: string): void;
 export declare function storePackId(manifestDir: string, packId: number, codaApiEndpoint: string): void;
 export declare function getPackId(manifestDir: string, codaApiEndpoint: string): number | undefined;
+export declare function storePackOptions(manifestDir: string, options: PackOptions): void;
+export declare function getPackOptions(manifestDir: string): PackOptions | undefined;

--- a/dist/cli/config_storage.js
+++ b/dist/cli/config_storage.js
@@ -22,7 +22,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getPackId = exports.storePackId = exports.storeCodaApiKey = exports.getApiKey = exports.PACK_ID_FILE_NAME = exports.DEFAULT_API_ENDPOINT = void 0;
+exports.getPackOptions = exports.storePackOptions = exports.getPackId = exports.storePackId = exports.storeCodaApiKey = exports.getApiKey = exports.PackOptionKey = exports.PACK_ID_FILE_NAME = exports.DEFAULT_API_ENDPOINT = void 0;
 const path = __importStar(require("path"));
 const helpers_1 = require("../testing/helpers");
 const url_parse_1 = __importDefault(require("url-parse"));
@@ -30,6 +30,10 @@ const helpers_2 = require("../testing/helpers");
 exports.DEFAULT_API_ENDPOINT = 'https://coda.io';
 const API_KEY_FILE_NAME = '.coda.json';
 exports.PACK_ID_FILE_NAME = '.coda-pack.json';
+var PackOptionKey;
+(function (PackOptionKey) {
+    PackOptionKey["timerStrategy"] = "timerStrategy";
+})(PackOptionKey = exports.PackOptionKey || (exports.PackOptionKey = {}));
 function isDefaultApiEndpoint(apiEndpoint) {
     return apiEndpoint === exports.DEFAULT_API_ENDPOINT;
 }
@@ -101,6 +105,18 @@ function getPackId(manifestDir, codaApiEndpoint) {
     }
 }
 exports.getPackId = getPackId;
+// Merges new options with existing ones, if any.
+function storePackOptions(manifestDir, options) {
+    const fileContents = readPackIdFile(manifestDir) || { packId: -1 };
+    fileContents.options = { ...fileContents.options, ...options };
+    writePacksFile(manifestDir, fileContents);
+}
+exports.storePackOptions = storePackOptions;
+function getPackOptions(manifestDir) {
+    const fileContents = readPackIdFile(manifestDir);
+    return fileContents === null || fileContents === void 0 ? void 0 : fileContents.options;
+}
+exports.getPackOptions = getPackOptions;
 function readPackIdFile(manifestDir) {
     const filename = path.join(manifestDir, exports.PACK_ID_FILE_NAME);
     return (0, helpers_1.readJSONFile)(filename);

--- a/dist/cli/set_option.d.ts
+++ b/dist/cli/set_option.d.ts
@@ -1,0 +1,8 @@
+import type { Arguments } from 'yargs';
+interface SetOptionArgs {
+    manifestFile: string;
+    option: string;
+    value: string;
+}
+export declare function handleSetOption({ manifestFile, option, value }: Arguments<SetOptionArgs>): Promise<void>;
+export {};

--- a/dist/cli/set_option.js
+++ b/dist/cli/set_option.js
@@ -1,0 +1,53 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleSetOption = void 0;
+const config_storage_1 = require("./config_storage");
+const compile_1 = require("../testing/compile");
+const __1 = require("..");
+const path = __importStar(require("path"));
+const helpers_1 = require("../testing/helpers");
+const helpers_2 = require("../testing/helpers");
+const config_storage_2 = require("./config_storage");
+async function handleSetOption({ manifestFile, option, value }) {
+    const manifestDir = path.dirname(manifestFile);
+    const options = validateOption(option, value);
+    (0, config_storage_2.storePackOptions)(manifestDir, options);
+    (0, helpers_1.print)('Option stored successfully.');
+}
+exports.handleSetOption = handleSetOption;
+function validateOption(option, value) {
+    const validOptions = Object.values(config_storage_1.PackOptionKey);
+    if (!validOptions.includes(option)) {
+        return (0, helpers_2.printAndExit)(`Unsupported option "${option}". Value options are: ${validOptions.join(', ')}`);
+    }
+    const key = option;
+    switch (key) {
+        case config_storage_1.PackOptionKey.timerStrategy:
+            const validValues = Object.values(compile_1.TimerShimStrategy);
+            if (!validValues.includes(value)) {
+                return (0, helpers_2.printAndExit)(`Invalid option value "${value}". Valid values are ${validValues.join(', ')}`);
+            }
+            return { [key]: value };
+        default:
+            return (0, __1.ensureUnreachable)(key);
+    }
+}

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -28,6 +28,7 @@ const ensure_1 = require("../helpers/ensure");
 const esbuild = __importStar(require("esbuild"));
 const exorcist_1 = __importDefault(require("exorcist"));
 const fs_1 = __importDefault(require("fs"));
+const config_storage_1 = require("../cli/config_storage");
 const isolated_vm_1 = __importDefault(require("isolated-vm"));
 const os_1 = __importDefault(require("os"));
 const path_1 = __importDefault(require("path"));
@@ -99,8 +100,10 @@ function getTimerShims(timerStrategy) {
             (0, ensure_1.ensureUnreachable)(timerStrategy);
     }
 }
-function getInjections({ timerStrategy = TimerShimStrategy.None }) {
-    const shims = [...getTimerShims(timerStrategy), `${__dirname}/injections/crypto_shim.js`];
+function getInjections({ timerStrategy = TimerShimStrategy.None, manifestPath }) {
+    const options = (0, config_storage_1.getPackOptions)(manifestPath);
+    const timerStrategyToUse = (options === null || options === void 0 ? void 0 : options.timerStrategy) || timerStrategy;
+    const shims = [...getTimerShims(timerStrategyToUse), `${__dirname}/injections/crypto_shim.js`];
     return shims;
 }
 async function buildWithES({ lastBundleFilename, outputBundleFilename, options: buildOptions, }) {

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -101,7 +101,7 @@ function getTimerShims(timerStrategy) {
     }
 }
 function getInjections({ timerStrategy = TimerShimStrategy.None, manifestPath }) {
-    const options = (0, config_storage_1.getPackOptions)(manifestPath);
+    const options = (0, config_storage_1.getPackOptions)(path_1.default.dirname(manifestPath));
     const timerStrategyToUse = (options === null || options === void 0 ? void 0 : options.timerStrategy) || timerStrategy;
     const shims = [...getTimerShims(timerStrategyToUse), `${__dirname}/injections/crypto_shim.js`];
     return shims;

--- a/dist/testing/injections/timers_disabled_shim.js
+++ b/dist/testing/injections/timers_disabled_shim.js
@@ -2,10 +2,10 @@
 // so for now we just have this file in js.
 
 const ErrorMessage =
-  `Please use the --timerStrategy=fake flag to enable shimmed timing primitives. Native node timing ` +
+  `Please use \`coda setOption path/to/pack.ts timerStrategy fake\`. Native node timing ` +
   `primitives like setTimeout or setInternal aren't supported in the pack execution sandbox ` +
   `environment. However, if you are using a library that relies upon them, you can use the ` +
-  `--timerStrategy=fake flag to build your pack with shimmed implementations that approximate the native ` +
+  `set an option to build your pack with shimmed implementations that approximate the native ` +
   `behavior. Because of this, be aware that packs that use timing primitives may not work reliably.`
 
 export function setTimeout() { throw new Error(ErrorMessage); }

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -125,7 +125,7 @@ function getTimerShims(timerStrategy: TimerShimStrategy): string[] {
 }
 
 function getInjections({timerStrategy = TimerShimStrategy.None, manifestPath}: CompilePackBundleOptions): string[] {
-  const options = getPackOptions(manifestPath);
+  const options = getPackOptions(path.dirname(manifestPath));
   const timerStrategyToUse = options?.timerStrategy || timerStrategy;
   const shims = [...getTimerShims(timerStrategyToUse), `${__dirname}/injections/crypto_shim.js`];
 

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -3,6 +3,7 @@ import {ensureUnreachable} from '../helpers/ensure';
 import * as esbuild from 'esbuild';
 import exorcist from 'exorcist';
 import fs from 'fs';
+import {getPackOptions} from '../cli/config_storage';
 import ivm from 'isolated-vm';
 import os from 'os';
 import path from 'path';
@@ -123,8 +124,10 @@ function getTimerShims(timerStrategy: TimerShimStrategy): string[] {
   }
 }
 
-function getInjections({timerStrategy = TimerShimStrategy.None}: CompilePackBundleOptions): string[] {
-  const shims = [...getTimerShims(timerStrategy), `${__dirname}/injections/crypto_shim.js`];
+function getInjections({timerStrategy = TimerShimStrategy.None, manifestPath}: CompilePackBundleOptions): string[] {
+  const options = getPackOptions(manifestPath);
+  const timerStrategyToUse = options?.timerStrategy || timerStrategy;
+  const shims = [...getTimerShims(timerStrategyToUse), `${__dirname}/injections/crypto_shim.js`];
 
   return shims;
 }

--- a/testing/injections/timers_disabled_shim.js
+++ b/testing/injections/timers_disabled_shim.js
@@ -2,10 +2,10 @@
 // so for now we just have this file in js.
 
 const ErrorMessage =
-  `Please use the --timerStrategy=fake flag to enable shimmed timing primitives. Native node timing ` +
+  `Please use \`coda setOption path/to/pack.ts timerStrategy fake\`. Native node timing ` +
   `primitives like setTimeout or setInternal aren't supported in the pack execution sandbox ` +
   `environment. However, if you are using a library that relies upon them, you can use the ` +
-  `--timerStrategy=fake flag to build your pack with shimmed implementations that approximate the native ` +
+  `set an option to build your pack with shimmed implementations that approximate the native ` +
   `behavior. Because of this, be aware that packs that use timing primitives may not work reliably.`
 
 export function setTimeout() { throw new Error(ErrorMessage); }


### PR DESCRIPTION
I tried to add this to the pack definition as discussed on Slack, but unfortunately there's a chicken-and-egg problem with that, because we can't reliably pull values out of the TS until after the bundle is built, but we need the timer strategy as an input to generate the build in the first place.

So since we already have a .coda-pack.json file per pack, I added the ability to store persistent options in that file, and read from that when doing the build.

PTAL @huayang-codaio @patrick-codaio @coda/packs 