### PR TITLE
Switch to iife format for pack and thunk bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/test
 yarn-error.log
 local-docs
 site
+.coda-pack.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.7.0
-- Pack bundle format is changed to IIFE. Previously compiled bundles will still be supported.
+- Pack bundle format is changed to IIFE to fix occasional stacktrace misinterpretation. Previously compiled bundles will still be supported but may suffer from inaccurate sourcemap issue until the pack is built with the new SDK.
 
 ## 0.6.0
 - **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.7.0
-- **Breaking Change** Pack bundle format is changed to IIFE. Previously compiled bundles will still be supported for a short period of time.
+- Pack bundle format is changed to IIFE. Previously compiled bundles will still be supported.
 
 ## 0.6.0
 - **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.6.0
+## 0.7.0
+- **Breaking Change** Pack bundle format is changed to IIFE. Previously compiled bundles will still be supported for a short period of time.
 
+## 0.6.0
 - **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.
 
 ## 0.5.0

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -1,4933 +1,4938 @@
 'use strict';
-var __create = Object.create;
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getProtoOf = Object.getPrototypeOf;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __esm = (fn, res) => function __init() {
-  return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res;
-};
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
-};
-var __export = (target, all) => {
-  __markAsModule(target);
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
-var __reExport = (target, module2, desc) => {
-  if (module2 && typeof module2 === "object" || typeof module2 === "function") {
-    for (let key of __getOwnPropNames(module2))
-      if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
-  }
-  return target;
-};
-var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
-};
+var module = module || {};
+module.exports = (() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+  var __esm = (fn, res) => function __init() {
+    return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res;
+  };
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __export = (target, all) => {
+    __markAsModule(target);
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __reExport = (target, module, desc) => {
+    if (module && typeof module === "object" || typeof module === "function") {
+      for (let key of __getOwnPropNames(module))
+        if (!__hasOwnProp.call(target, key) && key !== "default")
+          __defProp(target, key, { get: () => module[key], enumerable: !(desc = __getOwnPropDesc(module, key)) || desc.enumerable });
+    }
+    return target;
+  };
+  var __toModule = (module) => {
+    return __reExport(__markAsModule(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", module && module.__esModule && "default" in module ? { get: () => module.default, enumerable: true } : { value: module, enumerable: true })), module);
+  };
 
-// node_modules/base64-js/index.js
-var require_base64_js = __commonJS({
-  "node_modules/base64-js/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    exports.byteLength = byteLength;
-    exports.toByteArray = toByteArray;
-    exports.fromByteArray = fromByteArray;
-    var lookup = [];
-    var revLookup = [];
-    var Arr = typeof Uint8Array !== "undefined" ? Uint8Array : Array;
-    var code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    for (i = 0, len = code.length; i < len; ++i) {
-      lookup[i] = code[i];
-      revLookup[code.charCodeAt(i)] = i;
-    }
-    var i;
-    var len;
-    revLookup["-".charCodeAt(0)] = 62;
-    revLookup["_".charCodeAt(0)] = 63;
-    function getLens(b64) {
-      var len2 = b64.length;
-      if (len2 % 4 > 0) {
-        throw new Error("Invalid string. Length must be a multiple of 4");
+  // node_modules/base64-js/index.js
+  var require_base64_js = __commonJS({
+    "node_modules/base64-js/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      exports.byteLength = byteLength;
+      exports.toByteArray = toByteArray;
+      exports.fromByteArray = fromByteArray;
+      var lookup = [];
+      var revLookup = [];
+      var Arr = typeof Uint8Array !== "undefined" ? Uint8Array : Array;
+      var code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+      for (i = 0, len = code.length; i < len; ++i) {
+        lookup[i] = code[i];
+        revLookup[code.charCodeAt(i)] = i;
       }
-      var validLen = b64.indexOf("=");
-      if (validLen === -1)
-        validLen = len2;
-      var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
-      return [validLen, placeHoldersLen];
-    }
-    function byteLength(b64) {
-      var lens = getLens(b64);
-      var validLen = lens[0];
-      var placeHoldersLen = lens[1];
-      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
-    }
-    function _byteLength(b64, validLen, placeHoldersLen) {
-      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
-    }
-    function toByteArray(b64) {
-      var tmp;
-      var lens = getLens(b64);
-      var validLen = lens[0];
-      var placeHoldersLen = lens[1];
-      var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
-      var curByte = 0;
-      var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
-      var i2;
-      for (i2 = 0; i2 < len2; i2 += 4) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
-        arr[curByte++] = tmp >> 16 & 255;
-        arr[curByte++] = tmp >> 8 & 255;
-        arr[curByte++] = tmp & 255;
-      }
-      if (placeHoldersLen === 2) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
-        arr[curByte++] = tmp & 255;
-      }
-      if (placeHoldersLen === 1) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
-        arr[curByte++] = tmp >> 8 & 255;
-        arr[curByte++] = tmp & 255;
-      }
-      return arr;
-    }
-    function tripletToBase64(num) {
-      return lookup[num >> 18 & 63] + lookup[num >> 12 & 63] + lookup[num >> 6 & 63] + lookup[num & 63];
-    }
-    function encodeChunk(uint8, start, end) {
-      var tmp;
-      var output = [];
-      for (var i2 = start; i2 < end; i2 += 3) {
-        tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
-        output.push(tripletToBase64(tmp));
-      }
-      return output.join("");
-    }
-    function fromByteArray(uint8) {
-      var tmp;
-      var len2 = uint8.length;
-      var extraBytes = len2 % 3;
-      var parts = [];
-      var maxChunkLength = 16383;
-      for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
-        parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
-      }
-      if (extraBytes === 1) {
-        tmp = uint8[len2 - 1];
-        parts.push(lookup[tmp >> 2] + lookup[tmp << 4 & 63] + "==");
-      } else if (extraBytes === 2) {
-        tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
-        parts.push(lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + "=");
-      }
-      return parts.join("");
-    }
-  }
-});
-
-// node_modules/ieee754/index.js
-var require_ieee754 = __commonJS({
-  "node_modules/ieee754/index.js"(exports) {
-    init_buffer_shim();
-    exports.read = function(buffer, offset, isLE, mLen, nBytes) {
-      var e, m;
-      var eLen = nBytes * 8 - mLen - 1;
-      var eMax = (1 << eLen) - 1;
-      var eBias = eMax >> 1;
-      var nBits = -7;
-      var i = isLE ? nBytes - 1 : 0;
-      var d = isLE ? -1 : 1;
-      var s = buffer[offset + i];
-      i += d;
-      e = s & (1 << -nBits) - 1;
-      s >>= -nBits;
-      nBits += eLen;
-      for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
-      }
-      m = e & (1 << -nBits) - 1;
-      e >>= -nBits;
-      nBits += mLen;
-      for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
-      }
-      if (e === 0) {
-        e = 1 - eBias;
-      } else if (e === eMax) {
-        return m ? NaN : (s ? -1 : 1) * Infinity;
-      } else {
-        m = m + Math.pow(2, mLen);
-        e = e - eBias;
-      }
-      return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
-    };
-    exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
-      var e, m, c;
-      var eLen = nBytes * 8 - mLen - 1;
-      var eMax = (1 << eLen) - 1;
-      var eBias = eMax >> 1;
-      var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
-      var i = isLE ? 0 : nBytes - 1;
-      var d = isLE ? 1 : -1;
-      var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
-      value = Math.abs(value);
-      if (isNaN(value) || value === Infinity) {
-        m = isNaN(value) ? 1 : 0;
-        e = eMax;
-      } else {
-        e = Math.floor(Math.log(value) / Math.LN2);
-        if (value * (c = Math.pow(2, -e)) < 1) {
-          e--;
-          c *= 2;
+      var i;
+      var len;
+      revLookup["-".charCodeAt(0)] = 62;
+      revLookup["_".charCodeAt(0)] = 63;
+      function getLens(b64) {
+        var len2 = b64.length;
+        if (len2 % 4 > 0) {
+          throw new Error("Invalid string. Length must be a multiple of 4");
         }
-        if (e + eBias >= 1) {
-          value += rt / c;
+        var validLen = b64.indexOf("=");
+        if (validLen === -1)
+          validLen = len2;
+        var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
+        return [validLen, placeHoldersLen];
+      }
+      function byteLength(b64) {
+        var lens = getLens(b64);
+        var validLen = lens[0];
+        var placeHoldersLen = lens[1];
+        return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+      }
+      function _byteLength(b64, validLen, placeHoldersLen) {
+        return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+      }
+      function toByteArray(b64) {
+        var tmp;
+        var lens = getLens(b64);
+        var validLen = lens[0];
+        var placeHoldersLen = lens[1];
+        var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
+        var curByte = 0;
+        var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
+        var i2;
+        for (i2 = 0; i2 < len2; i2 += 4) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
+          arr[curByte++] = tmp >> 16 & 255;
+          arr[curByte++] = tmp >> 8 & 255;
+          arr[curByte++] = tmp & 255;
+        }
+        if (placeHoldersLen === 2) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
+          arr[curByte++] = tmp & 255;
+        }
+        if (placeHoldersLen === 1) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
+          arr[curByte++] = tmp >> 8 & 255;
+          arr[curByte++] = tmp & 255;
+        }
+        return arr;
+      }
+      function tripletToBase64(num) {
+        return lookup[num >> 18 & 63] + lookup[num >> 12 & 63] + lookup[num >> 6 & 63] + lookup[num & 63];
+      }
+      function encodeChunk(uint8, start, end) {
+        var tmp;
+        var output = [];
+        for (var i2 = start; i2 < end; i2 += 3) {
+          tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
+          output.push(tripletToBase64(tmp));
+        }
+        return output.join("");
+      }
+      function fromByteArray(uint8) {
+        var tmp;
+        var len2 = uint8.length;
+        var extraBytes = len2 % 3;
+        var parts = [];
+        var maxChunkLength = 16383;
+        for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
+          parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
+        }
+        if (extraBytes === 1) {
+          tmp = uint8[len2 - 1];
+          parts.push(lookup[tmp >> 2] + lookup[tmp << 4 & 63] + "==");
+        } else if (extraBytes === 2) {
+          tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
+          parts.push(lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + "=");
+        }
+        return parts.join("");
+      }
+    }
+  });
+
+  // node_modules/ieee754/index.js
+  var require_ieee754 = __commonJS({
+    "node_modules/ieee754/index.js"(exports) {
+      init_buffer_shim();
+      exports.read = function(buffer, offset, isLE, mLen, nBytes) {
+        var e, m;
+        var eLen = nBytes * 8 - mLen - 1;
+        var eMax = (1 << eLen) - 1;
+        var eBias = eMax >> 1;
+        var nBits = -7;
+        var i = isLE ? nBytes - 1 : 0;
+        var d = isLE ? -1 : 1;
+        var s = buffer[offset + i];
+        i += d;
+        e = s & (1 << -nBits) - 1;
+        s >>= -nBits;
+        nBits += eLen;
+        for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
+        }
+        m = e & (1 << -nBits) - 1;
+        e >>= -nBits;
+        nBits += mLen;
+        for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
+        }
+        if (e === 0) {
+          e = 1 - eBias;
+        } else if (e === eMax) {
+          return m ? NaN : (s ? -1 : 1) * Infinity;
         } else {
-          value += rt * Math.pow(2, 1 - eBias);
+          m = m + Math.pow(2, mLen);
+          e = e - eBias;
         }
-        if (value * c >= 2) {
-          e++;
-          c /= 2;
-        }
-        if (e + eBias >= eMax) {
-          m = 0;
+        return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
+      };
+      exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
+        var e, m, c;
+        var eLen = nBytes * 8 - mLen - 1;
+        var eMax = (1 << eLen) - 1;
+        var eBias = eMax >> 1;
+        var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
+        var i = isLE ? 0 : nBytes - 1;
+        var d = isLE ? 1 : -1;
+        var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
+        value = Math.abs(value);
+        if (isNaN(value) || value === Infinity) {
+          m = isNaN(value) ? 1 : 0;
           e = eMax;
-        } else if (e + eBias >= 1) {
-          m = (value * c - 1) * Math.pow(2, mLen);
-          e = e + eBias;
         } else {
-          m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
-          e = 0;
+          e = Math.floor(Math.log(value) / Math.LN2);
+          if (value * (c = Math.pow(2, -e)) < 1) {
+            e--;
+            c *= 2;
+          }
+          if (e + eBias >= 1) {
+            value += rt / c;
+          } else {
+            value += rt * Math.pow(2, 1 - eBias);
+          }
+          if (value * c >= 2) {
+            e++;
+            c /= 2;
+          }
+          if (e + eBias >= eMax) {
+            m = 0;
+            e = eMax;
+          } else if (e + eBias >= 1) {
+            m = (value * c - 1) * Math.pow(2, mLen);
+            e = e + eBias;
+          } else {
+            m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
+            e = 0;
+          }
         }
-      }
-      for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
-      }
-      e = e << mLen | m;
-      eLen += mLen;
-      for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
-      }
-      buffer[offset + i - d] |= s * 128;
-    };
-  }
-});
+        for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
+        }
+        e = e << mLen | m;
+        eLen += mLen;
+        for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
+        }
+        buffer[offset + i - d] |= s * 128;
+      };
+    }
+  });
 
-// node_modules/buffer/index.js
-var require_buffer = __commonJS({
-  "node_modules/buffer/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    var base64 = require_base64_js();
-    var ieee754 = require_ieee754();
-    var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
-    exports.Buffer = Buffer3;
-    exports.SlowBuffer = SlowBuffer;
-    exports.INSPECT_MAX_BYTES = 50;
-    var K_MAX_LENGTH = 2147483647;
-    exports.kMaxLength = K_MAX_LENGTH;
-    Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
-    if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
-      console.error("This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.");
-    }
-    function typedArraySupport() {
-      try {
-        const arr = new Uint8Array(1);
-        const proto = { foo: function() {
-          return 42;
-        } };
-        Object.setPrototypeOf(proto, Uint8Array.prototype);
-        Object.setPrototypeOf(arr, proto);
-        return arr.foo() === 42;
-      } catch (e) {
-        return false;
+  // node_modules/buffer/index.js
+  var require_buffer = __commonJS({
+    "node_modules/buffer/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      var base64 = require_base64_js();
+      var ieee754 = require_ieee754();
+      var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
+      exports.Buffer = Buffer3;
+      exports.SlowBuffer = SlowBuffer;
+      exports.INSPECT_MAX_BYTES = 50;
+      var K_MAX_LENGTH = 2147483647;
+      exports.kMaxLength = K_MAX_LENGTH;
+      Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
+      if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
+        console.error("This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.");
       }
-    }
-    Object.defineProperty(Buffer3.prototype, "parent", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer3.isBuffer(this))
-          return void 0;
-        return this.buffer;
-      }
-    });
-    Object.defineProperty(Buffer3.prototype, "offset", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer3.isBuffer(this))
-          return void 0;
-        return this.byteOffset;
-      }
-    });
-    function createBuffer(length) {
-      if (length > K_MAX_LENGTH) {
-        throw new RangeError('The value "' + length + '" is invalid for option "size"');
-      }
-      const buf = new Uint8Array(length);
-      Object.setPrototypeOf(buf, Buffer3.prototype);
-      return buf;
-    }
-    function Buffer3(arg, encodingOrOffset, length) {
-      if (typeof arg === "number") {
-        if (typeof encodingOrOffset === "string") {
-          throw new TypeError('The "string" argument must be of type string. Received type number');
+      function typedArraySupport() {
+        try {
+          const arr = new Uint8Array(1);
+          const proto = { foo: function() {
+            return 42;
+          } };
+          Object.setPrototypeOf(proto, Uint8Array.prototype);
+          Object.setPrototypeOf(arr, proto);
+          return arr.foo() === 42;
+        } catch (e) {
+          return false;
         }
-        return allocUnsafe(arg);
       }
-      return from(arg, encodingOrOffset, length);
-    }
-    Buffer3.poolSize = 8192;
-    function from(value, encodingOrOffset, length) {
-      if (typeof value === "string") {
-        return fromString(value, encodingOrOffset);
-      }
-      if (ArrayBuffer.isView(value)) {
-        return fromArrayView(value);
-      }
-      if (value == null) {
-        throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
-      }
-      if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof value === "number") {
-        throw new TypeError('The "value" argument must not be of type number. Received type number');
-      }
-      const valueOf = value.valueOf && value.valueOf();
-      if (valueOf != null && valueOf !== value) {
-        return Buffer3.from(valueOf, encodingOrOffset, length);
-      }
-      const b = fromObject(value);
-      if (b)
-        return b;
-      if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
-        return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
-      }
-      throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
-    }
-    Buffer3.from = function(value, encodingOrOffset, length) {
-      return from(value, encodingOrOffset, length);
-    };
-    Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
-    Object.setPrototypeOf(Buffer3, Uint8Array);
-    function assertSize(size) {
-      if (typeof size !== "number") {
-        throw new TypeError('"size" argument must be of type number');
-      } else if (size < 0) {
-        throw new RangeError('The value "' + size + '" is invalid for option "size"');
-      }
-    }
-    function alloc(size, fill, encoding) {
-      assertSize(size);
-      if (size <= 0) {
-        return createBuffer(size);
-      }
-      if (fill !== void 0) {
-        return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
-      }
-      return createBuffer(size);
-    }
-    Buffer3.alloc = function(size, fill, encoding) {
-      return alloc(size, fill, encoding);
-    };
-    function allocUnsafe(size) {
-      assertSize(size);
-      return createBuffer(size < 0 ? 0 : checked(size) | 0);
-    }
-    Buffer3.allocUnsafe = function(size) {
-      return allocUnsafe(size);
-    };
-    Buffer3.allocUnsafeSlow = function(size) {
-      return allocUnsafe(size);
-    };
-    function fromString(string, encoding) {
-      if (typeof encoding !== "string" || encoding === "") {
-        encoding = "utf8";
-      }
-      if (!Buffer3.isEncoding(encoding)) {
-        throw new TypeError("Unknown encoding: " + encoding);
-      }
-      const length = byteLength(string, encoding) | 0;
-      let buf = createBuffer(length);
-      const actual = buf.write(string, encoding);
-      if (actual !== length) {
-        buf = buf.slice(0, actual);
-      }
-      return buf;
-    }
-    function fromArrayLike(array) {
-      const length = array.length < 0 ? 0 : checked(array.length) | 0;
-      const buf = createBuffer(length);
-      for (let i = 0; i < length; i += 1) {
-        buf[i] = array[i] & 255;
-      }
-      return buf;
-    }
-    function fromArrayView(arrayView) {
-      if (isInstance(arrayView, Uint8Array)) {
-        const copy = new Uint8Array(arrayView);
-        return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
-      }
-      return fromArrayLike(arrayView);
-    }
-    function fromArrayBuffer(array, byteOffset, length) {
-      if (byteOffset < 0 || array.byteLength < byteOffset) {
-        throw new RangeError('"offset" is outside of buffer bounds');
-      }
-      if (array.byteLength < byteOffset + (length || 0)) {
-        throw new RangeError('"length" is outside of buffer bounds');
-      }
-      let buf;
-      if (byteOffset === void 0 && length === void 0) {
-        buf = new Uint8Array(array);
-      } else if (length === void 0) {
-        buf = new Uint8Array(array, byteOffset);
-      } else {
-        buf = new Uint8Array(array, byteOffset, length);
-      }
-      Object.setPrototypeOf(buf, Buffer3.prototype);
-      return buf;
-    }
-    function fromObject(obj) {
-      if (Buffer3.isBuffer(obj)) {
-        const len = checked(obj.length) | 0;
-        const buf = createBuffer(len);
-        if (buf.length === 0) {
-          return buf;
+      Object.defineProperty(Buffer3.prototype, "parent", {
+        enumerable: true,
+        get: function() {
+          if (!Buffer3.isBuffer(this))
+            return void 0;
+          return this.buffer;
         }
-        obj.copy(buf, 0, 0, len);
+      });
+      Object.defineProperty(Buffer3.prototype, "offset", {
+        enumerable: true,
+        get: function() {
+          if (!Buffer3.isBuffer(this))
+            return void 0;
+          return this.byteOffset;
+        }
+      });
+      function createBuffer(length) {
+        if (length > K_MAX_LENGTH) {
+          throw new RangeError('The value "' + length + '" is invalid for option "size"');
+        }
+        const buf = new Uint8Array(length);
+        Object.setPrototypeOf(buf, Buffer3.prototype);
         return buf;
       }
-      if (obj.length !== void 0) {
-        if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
-          return createBuffer(0);
-        }
-        return fromArrayLike(obj);
-      }
-      if (obj.type === "Buffer" && Array.isArray(obj.data)) {
-        return fromArrayLike(obj.data);
-      }
-    }
-    function checked(length) {
-      if (length >= K_MAX_LENGTH) {
-        throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
-      }
-      return length | 0;
-    }
-    function SlowBuffer(length) {
-      if (+length != length) {
-        length = 0;
-      }
-      return Buffer3.alloc(+length);
-    }
-    Buffer3.isBuffer = function isBuffer(b) {
-      return b != null && b._isBuffer === true && b !== Buffer3.prototype;
-    };
-    Buffer3.compare = function compare(a, b) {
-      if (isInstance(a, Uint8Array))
-        a = Buffer3.from(a, a.offset, a.byteLength);
-      if (isInstance(b, Uint8Array))
-        b = Buffer3.from(b, b.offset, b.byteLength);
-      if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b)) {
-        throw new TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
-      }
-      if (a === b)
-        return 0;
-      let x = a.length;
-      let y = b.length;
-      for (let i = 0, len = Math.min(x, y); i < len; ++i) {
-        if (a[i] !== b[i]) {
-          x = a[i];
-          y = b[i];
-          break;
-        }
-      }
-      if (x < y)
-        return -1;
-      if (y < x)
-        return 1;
-      return 0;
-    };
-    Buffer3.isEncoding = function isEncoding(encoding) {
-      switch (String(encoding).toLowerCase()) {
-        case "hex":
-        case "utf8":
-        case "utf-8":
-        case "ascii":
-        case "latin1":
-        case "binary":
-        case "base64":
-        case "ucs2":
-        case "ucs-2":
-        case "utf16le":
-        case "utf-16le":
-          return true;
-        default:
-          return false;
-      }
-    };
-    Buffer3.concat = function concat(list, length) {
-      if (!Array.isArray(list)) {
-        throw new TypeError('"list" argument must be an Array of Buffers');
-      }
-      if (list.length === 0) {
-        return Buffer3.alloc(0);
-      }
-      let i;
-      if (length === void 0) {
-        length = 0;
-        for (i = 0; i < list.length; ++i) {
-          length += list[i].length;
-        }
-      }
-      const buffer = Buffer3.allocUnsafe(length);
-      let pos = 0;
-      for (i = 0; i < list.length; ++i) {
-        let buf = list[i];
-        if (isInstance(buf, Uint8Array)) {
-          if (pos + buf.length > buffer.length) {
-            if (!Buffer3.isBuffer(buf))
-              buf = Buffer3.from(buf);
-            buf.copy(buffer, pos);
-          } else {
-            Uint8Array.prototype.set.call(buffer, buf, pos);
+      function Buffer3(arg, encodingOrOffset, length) {
+        if (typeof arg === "number") {
+          if (typeof encodingOrOffset === "string") {
+            throw new TypeError('The "string" argument must be of type string. Received type number');
           }
-        } else if (!Buffer3.isBuffer(buf)) {
-          throw new TypeError('"list" argument must be an Array of Buffers');
-        } else {
-          buf.copy(buffer, pos);
+          return allocUnsafe(arg);
         }
-        pos += buf.length;
+        return from(arg, encodingOrOffset, length);
       }
-      return buffer;
-    };
-    function byteLength(string, encoding) {
-      if (Buffer3.isBuffer(string)) {
-        return string.length;
-      }
-      if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
-        return string.byteLength;
-      }
-      if (typeof string !== "string") {
-        throw new TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
-      }
-      const len = string.length;
-      const mustMatch = arguments.length > 2 && arguments[2] === true;
-      if (!mustMatch && len === 0)
-        return 0;
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return len;
-          case "utf8":
-          case "utf-8":
-            return utf8ToBytes(string).length;
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return len * 2;
-          case "hex":
-            return len >>> 1;
-          case "base64":
-            return base64ToBytes(string).length;
-          default:
-            if (loweredCase) {
-              return mustMatch ? -1 : utf8ToBytes(string).length;
-            }
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
+      Buffer3.poolSize = 8192;
+      function from(value, encodingOrOffset, length) {
+        if (typeof value === "string") {
+          return fromString(value, encodingOrOffset);
         }
-      }
-    }
-    Buffer3.byteLength = byteLength;
-    function slowToString(encoding, start, end) {
-      let loweredCase = false;
-      if (start === void 0 || start < 0) {
-        start = 0;
-      }
-      if (start > this.length) {
-        return "";
-      }
-      if (end === void 0 || end > this.length) {
-        end = this.length;
-      }
-      if (end <= 0) {
-        return "";
-      }
-      end >>>= 0;
-      start >>>= 0;
-      if (end <= start) {
-        return "";
-      }
-      if (!encoding)
-        encoding = "utf8";
-      while (true) {
-        switch (encoding) {
-          case "hex":
-            return hexSlice(this, start, end);
-          case "utf8":
-          case "utf-8":
-            return utf8Slice(this, start, end);
-          case "ascii":
-            return asciiSlice(this, start, end);
-          case "latin1":
-          case "binary":
-            return latin1Slice(this, start, end);
-          case "base64":
-            return base64Slice(this, start, end);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return utf16leSlice(this, start, end);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = (encoding + "").toLowerCase();
-            loweredCase = true;
+        if (ArrayBuffer.isView(value)) {
+          return fromArrayView(value);
         }
-      }
-    }
-    Buffer3.prototype._isBuffer = true;
-    function swap(b, n, m) {
-      const i = b[n];
-      b[n] = b[m];
-      b[m] = i;
-    }
-    Buffer3.prototype.swap16 = function swap16() {
-      const len = this.length;
-      if (len % 2 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 16-bits");
-      }
-      for (let i = 0; i < len; i += 2) {
-        swap(this, i, i + 1);
-      }
-      return this;
-    };
-    Buffer3.prototype.swap32 = function swap32() {
-      const len = this.length;
-      if (len % 4 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 32-bits");
-      }
-      for (let i = 0; i < len; i += 4) {
-        swap(this, i, i + 3);
-        swap(this, i + 1, i + 2);
-      }
-      return this;
-    };
-    Buffer3.prototype.swap64 = function swap64() {
-      const len = this.length;
-      if (len % 8 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 64-bits");
-      }
-      for (let i = 0; i < len; i += 8) {
-        swap(this, i, i + 7);
-        swap(this, i + 1, i + 6);
-        swap(this, i + 2, i + 5);
-        swap(this, i + 3, i + 4);
-      }
-      return this;
-    };
-    Buffer3.prototype.toString = function toString() {
-      const length = this.length;
-      if (length === 0)
-        return "";
-      if (arguments.length === 0)
-        return utf8Slice(this, 0, length);
-      return slowToString.apply(this, arguments);
-    };
-    Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
-    Buffer3.prototype.equals = function equals(b) {
-      if (!Buffer3.isBuffer(b))
-        throw new TypeError("Argument must be a Buffer");
-      if (this === b)
-        return true;
-      return Buffer3.compare(this, b) === 0;
-    };
-    Buffer3.prototype.inspect = function inspect() {
-      let str = "";
-      const max = exports.INSPECT_MAX_BYTES;
-      str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
-      if (this.length > max)
-        str += " ... ";
-      return "<Buffer " + str + ">";
-    };
-    if (customInspectSymbol) {
-      Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
-    }
-    Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
-      if (isInstance(target, Uint8Array)) {
-        target = Buffer3.from(target, target.offset, target.byteLength);
-      }
-      if (!Buffer3.isBuffer(target)) {
-        throw new TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
-      }
-      if (start === void 0) {
-        start = 0;
-      }
-      if (end === void 0) {
-        end = target ? target.length : 0;
-      }
-      if (thisStart === void 0) {
-        thisStart = 0;
-      }
-      if (thisEnd === void 0) {
-        thisEnd = this.length;
-      }
-      if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
-        throw new RangeError("out of range index");
-      }
-      if (thisStart >= thisEnd && start >= end) {
-        return 0;
-      }
-      if (thisStart >= thisEnd) {
-        return -1;
-      }
-      if (start >= end) {
-        return 1;
-      }
-      start >>>= 0;
-      end >>>= 0;
-      thisStart >>>= 0;
-      thisEnd >>>= 0;
-      if (this === target)
-        return 0;
-      let x = thisEnd - thisStart;
-      let y = end - start;
-      const len = Math.min(x, y);
-      const thisCopy = this.slice(thisStart, thisEnd);
-      const targetCopy = target.slice(start, end);
-      for (let i = 0; i < len; ++i) {
-        if (thisCopy[i] !== targetCopy[i]) {
-          x = thisCopy[i];
-          y = targetCopy[i];
-          break;
+        if (value == null) {
+          throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
         }
-      }
-      if (x < y)
-        return -1;
-      if (y < x)
-        return 1;
-      return 0;
-    };
-    function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
-      if (buffer.length === 0)
-        return -1;
-      if (typeof byteOffset === "string") {
-        encoding = byteOffset;
-        byteOffset = 0;
-      } else if (byteOffset > 2147483647) {
-        byteOffset = 2147483647;
-      } else if (byteOffset < -2147483648) {
-        byteOffset = -2147483648;
-      }
-      byteOffset = +byteOffset;
-      if (numberIsNaN(byteOffset)) {
-        byteOffset = dir ? 0 : buffer.length - 1;
-      }
-      if (byteOffset < 0)
-        byteOffset = buffer.length + byteOffset;
-      if (byteOffset >= buffer.length) {
-        if (dir)
-          return -1;
-        else
-          byteOffset = buffer.length - 1;
-      } else if (byteOffset < 0) {
-        if (dir)
-          byteOffset = 0;
-        else
-          return -1;
-      }
-      if (typeof val === "string") {
-        val = Buffer3.from(val, encoding);
-      }
-      if (Buffer3.isBuffer(val)) {
-        if (val.length === 0) {
-          return -1;
+        if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
+          return fromArrayBuffer(value, encodingOrOffset, length);
         }
-        return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
-      } else if (typeof val === "number") {
-        val = val & 255;
-        if (typeof Uint8Array.prototype.indexOf === "function") {
-          if (dir) {
-            return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
-          } else {
-            return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
-          }
+        if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
+          return fromArrayBuffer(value, encodingOrOffset, length);
         }
-        return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
-      }
-      throw new TypeError("val must be string, number or Buffer");
-    }
-    function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
-      let indexSize = 1;
-      let arrLength = arr.length;
-      let valLength = val.length;
-      if (encoding !== void 0) {
-        encoding = String(encoding).toLowerCase();
-        if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
-          if (arr.length < 2 || val.length < 2) {
-            return -1;
-          }
-          indexSize = 2;
-          arrLength /= 2;
-          valLength /= 2;
-          byteOffset /= 2;
+        if (typeof value === "number") {
+          throw new TypeError('The "value" argument must not be of type number. Received type number');
         }
-      }
-      function read(buf, i2) {
-        if (indexSize === 1) {
-          return buf[i2];
-        } else {
-          return buf.readUInt16BE(i2 * indexSize);
+        const valueOf = value.valueOf && value.valueOf();
+        if (valueOf != null && valueOf !== value) {
+          return Buffer3.from(valueOf, encodingOrOffset, length);
         }
-      }
-      let i;
-      if (dir) {
-        let foundIndex = -1;
-        for (i = byteOffset; i < arrLength; i++) {
-          if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
-            if (foundIndex === -1)
-              foundIndex = i;
-            if (i - foundIndex + 1 === valLength)
-              return foundIndex * indexSize;
-          } else {
-            if (foundIndex !== -1)
-              i -= i - foundIndex;
-            foundIndex = -1;
-          }
+        const b = fromObject(value);
+        if (b)
+          return b;
+        if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
+          return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
         }
-      } else {
-        if (byteOffset + valLength > arrLength)
-          byteOffset = arrLength - valLength;
-        for (i = byteOffset; i >= 0; i--) {
-          let found = true;
-          for (let j = 0; j < valLength; j++) {
-            if (read(arr, i + j) !== read(val, j)) {
-              found = false;
-              break;
-            }
-          }
-          if (found)
-            return i;
-        }
+        throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
       }
-      return -1;
-    }
-    Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
-      return this.indexOf(val, byteOffset, encoding) !== -1;
-    };
-    Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
-    };
-    Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
-    };
-    function hexWrite(buf, string, offset, length) {
-      offset = Number(offset) || 0;
-      const remaining = buf.length - offset;
-      if (!length) {
-        length = remaining;
-      } else {
-        length = Number(length);
-        if (length > remaining) {
-          length = remaining;
-        }
-      }
-      const strLen = string.length;
-      if (length > strLen / 2) {
-        length = strLen / 2;
-      }
-      let i;
-      for (i = 0; i < length; ++i) {
-        const parsed = parseInt(string.substr(i * 2, 2), 16);
-        if (numberIsNaN(parsed))
-          return i;
-        buf[offset + i] = parsed;
-      }
-      return i;
-    }
-    function utf8Write(buf, string, offset, length) {
-      return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    function asciiWrite(buf, string, offset, length) {
-      return blitBuffer(asciiToBytes(string), buf, offset, length);
-    }
-    function base64Write(buf, string, offset, length) {
-      return blitBuffer(base64ToBytes(string), buf, offset, length);
-    }
-    function ucs2Write(buf, string, offset, length) {
-      return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    Buffer3.prototype.write = function write(string, offset, length, encoding) {
-      if (offset === void 0) {
-        encoding = "utf8";
-        length = this.length;
-        offset = 0;
-      } else if (length === void 0 && typeof offset === "string") {
-        encoding = offset;
-        length = this.length;
-        offset = 0;
-      } else if (isFinite(offset)) {
-        offset = offset >>> 0;
-        if (isFinite(length)) {
-          length = length >>> 0;
-          if (encoding === void 0)
-            encoding = "utf8";
-        } else {
-          encoding = length;
-          length = void 0;
-        }
-      } else {
-        throw new Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
-      }
-      const remaining = this.length - offset;
-      if (length === void 0 || length > remaining)
-        length = remaining;
-      if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
-        throw new RangeError("Attempt to write outside buffer bounds");
-      }
-      if (!encoding)
-        encoding = "utf8";
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "hex":
-            return hexWrite(this, string, offset, length);
-          case "utf8":
-          case "utf-8":
-            return utf8Write(this, string, offset, length);
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return asciiWrite(this, string, offset, length);
-          case "base64":
-            return base64Write(this, string, offset, length);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return ucs2Write(this, string, offset, length);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
-        }
-      }
-    };
-    Buffer3.prototype.toJSON = function toJSON() {
-      return {
-        type: "Buffer",
-        data: Array.prototype.slice.call(this._arr || this, 0)
+      Buffer3.from = function(value, encodingOrOffset, length) {
+        return from(value, encodingOrOffset, length);
       };
-    };
-    function base64Slice(buf, start, end) {
-      if (start === 0 && end === buf.length) {
-        return base64.fromByteArray(buf);
-      } else {
-        return base64.fromByteArray(buf.slice(start, end));
-      }
-    }
-    function utf8Slice(buf, start, end) {
-      end = Math.min(buf.length, end);
-      const res = [];
-      let i = start;
-      while (i < end) {
-        const firstByte = buf[i];
-        let codePoint = null;
-        let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
-        if (i + bytesPerSequence <= end) {
-          let secondByte, thirdByte, fourthByte, tempCodePoint;
-          switch (bytesPerSequence) {
-            case 1:
-              if (firstByte < 128) {
-                codePoint = firstByte;
-              }
-              break;
-            case 2:
-              secondByte = buf[i + 1];
-              if ((secondByte & 192) === 128) {
-                tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
-                if (tempCodePoint > 127) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 3:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
-                if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 4:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              fourthByte = buf[i + 3];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
-                if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
-                  codePoint = tempCodePoint;
-                }
-              }
-          }
+      Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
+      Object.setPrototypeOf(Buffer3, Uint8Array);
+      function assertSize(size) {
+        if (typeof size !== "number") {
+          throw new TypeError('"size" argument must be of type number');
+        } else if (size < 0) {
+          throw new RangeError('The value "' + size + '" is invalid for option "size"');
         }
-        if (codePoint === null) {
-          codePoint = 65533;
-          bytesPerSequence = 1;
-        } else if (codePoint > 65535) {
-          codePoint -= 65536;
-          res.push(codePoint >>> 10 & 1023 | 55296);
-          codePoint = 56320 | codePoint & 1023;
+      }
+      function alloc(size, fill, encoding) {
+        assertSize(size);
+        if (size <= 0) {
+          return createBuffer(size);
         }
-        res.push(codePoint);
-        i += bytesPerSequence;
-      }
-      return decodeCodePointsArray(res);
-    }
-    var MAX_ARGUMENTS_LENGTH = 4096;
-    function decodeCodePointsArray(codePoints) {
-      const len = codePoints.length;
-      if (len <= MAX_ARGUMENTS_LENGTH) {
-        return String.fromCharCode.apply(String, codePoints);
-      }
-      let res = "";
-      let i = 0;
-      while (i < len) {
-        res += String.fromCharCode.apply(String, codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH));
-      }
-      return res;
-    }
-    function asciiSlice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i] & 127);
-      }
-      return ret;
-    }
-    function latin1Slice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i]);
-      }
-      return ret;
-    }
-    function hexSlice(buf, start, end) {
-      const len = buf.length;
-      if (!start || start < 0)
-        start = 0;
-      if (!end || end < 0 || end > len)
-        end = len;
-      let out = "";
-      for (let i = start; i < end; ++i) {
-        out += hexSliceLookupTable[buf[i]];
-      }
-      return out;
-    }
-    function utf16leSlice(buf, start, end) {
-      const bytes = buf.slice(start, end);
-      let res = "";
-      for (let i = 0; i < bytes.length - 1; i += 2) {
-        res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
-      }
-      return res;
-    }
-    Buffer3.prototype.slice = function slice(start, end) {
-      const len = this.length;
-      start = ~~start;
-      end = end === void 0 ? len : ~~end;
-      if (start < 0) {
-        start += len;
-        if (start < 0)
-          start = 0;
-      } else if (start > len) {
-        start = len;
-      }
-      if (end < 0) {
-        end += len;
-        if (end < 0)
-          end = 0;
-      } else if (end > len) {
-        end = len;
-      }
-      if (end < start)
-        end = start;
-      const newBuf = this.subarray(start, end);
-      Object.setPrototypeOf(newBuf, Buffer3.prototype);
-      return newBuf;
-    };
-    function checkOffset(offset, ext, length) {
-      if (offset % 1 !== 0 || offset < 0)
-        throw new RangeError("offset is not uint");
-      if (offset + ext > length)
-        throw new RangeError("Trying to access beyond buffer length");
-    }
-    Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      return val;
-    };
-    Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        checkOffset(offset, byteLength2, this.length);
-      }
-      let val = this[offset + --byteLength2];
-      let mul = 1;
-      while (byteLength2 > 0 && (mul *= 256)) {
-        val += this[offset + --byteLength2] * mul;
-      }
-      return val;
-    };
-    Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      return this[offset];
-    };
-    Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] | this[offset + 1] << 8;
-    };
-    Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] << 8 | this[offset + 1];
-    };
-    Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
-    };
-    Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
-    };
-    Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
-      const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
-      return BigInt(lo) + (BigInt(hi) << BigInt(32));
-    });
-    Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
-      return (BigInt(hi) << BigInt(32)) + BigInt(lo);
-    });
-    Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let i = byteLength2;
-      let mul = 1;
-      let val = this[offset + --i];
-      while (i > 0 && (mul *= 256)) {
-        val += this[offset + --i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      if (!(this[offset] & 128))
-        return this[offset];
-      return (255 - this[offset] + 1) * -1;
-    };
-    Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset] | this[offset + 1] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset + 1] | this[offset] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
-    };
-    Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
-    };
-    Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
-      return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
-    });
-    Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = (first << 24) + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
-    });
-    Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, true, 23, 4);
-    };
-    Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, false, 23, 4);
-    };
-    Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, true, 52, 8);
-    };
-    Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, false, 52, 8);
-    };
-    function checkInt(buf, value, offset, ext, max, min) {
-      if (!Buffer3.isBuffer(buf))
-        throw new TypeError('"buffer" argument must be a Buffer instance');
-      if (value > max || value < min)
-        throw new RangeError('"value" argument is out of bounds');
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-    }
-    Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let mul = 1;
-      let i = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 255, 0);
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset + 3] = value >>> 24;
-      this[offset + 2] = value >>> 16;
-      this[offset + 1] = value >>> 8;
-      this[offset] = value & 255;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    function wrtBigUInt64LE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      return offset;
-    }
-    function wrtBigUInt64BE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset + 7] = lo;
-      lo = lo >> 8;
-      buf[offset + 6] = lo;
-      lo = lo >> 8;
-      buf[offset + 5] = lo;
-      lo = lo >> 8;
-      buf[offset + 4] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset + 3] = hi;
-      hi = hi >> 8;
-      buf[offset + 2] = hi;
-      hi = hi >> 8;
-      buf[offset + 1] = hi;
-      hi = hi >> 8;
-      buf[offset] = hi;
-      return offset + 8;
-    }
-    Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
-      }
-      let i = 0;
-      let mul = 1;
-      let sub = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
-          sub = 1;
+        if (fill !== void 0) {
+          return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
         }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
+        return createBuffer(size);
       }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      Buffer3.alloc = function(size, fill, encoding) {
+        return alloc(size, fill, encoding);
+      };
+      function allocUnsafe(size) {
+        assertSize(size);
+        return createBuffer(size < 0 ? 0 : checked(size) | 0);
       }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      let sub = 0;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
-          sub = 1;
+      Buffer3.allocUnsafe = function(size) {
+        return allocUnsafe(size);
+      };
+      Buffer3.allocUnsafeSlow = function(size) {
+        return allocUnsafe(size);
+      };
+      function fromString(string, encoding) {
+        if (typeof encoding !== "string" || encoding === "") {
+          encoding = "utf8";
         }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 127, -128);
-      if (value < 0)
-        value = 255 + value + 1;
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      this[offset + 2] = value >>> 16;
-      this[offset + 3] = value >>> 24;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      if (value < 0)
-        value = 4294967295 + value + 1;
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    function checkIEEE754(buf, value, offset, ext, max, min) {
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-      if (offset < 0)
-        throw new RangeError("Index out of range");
-    }
-    function writeFloat(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 23, 4);
-      return offset + 4;
-    }
-    Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, true, noAssert);
-    };
-    Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, false, noAssert);
-    };
-    function writeDouble(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 52, 8);
-      return offset + 8;
-    }
-    Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, true, noAssert);
-    };
-    Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, false, noAssert);
-    };
-    Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
-      if (!Buffer3.isBuffer(target))
-        throw new TypeError("argument should be a Buffer");
-      if (!start)
-        start = 0;
-      if (!end && end !== 0)
-        end = this.length;
-      if (targetStart >= target.length)
-        targetStart = target.length;
-      if (!targetStart)
-        targetStart = 0;
-      if (end > 0 && end < start)
-        end = start;
-      if (end === start)
-        return 0;
-      if (target.length === 0 || this.length === 0)
-        return 0;
-      if (targetStart < 0) {
-        throw new RangeError("targetStart out of bounds");
-      }
-      if (start < 0 || start >= this.length)
-        throw new RangeError("Index out of range");
-      if (end < 0)
-        throw new RangeError("sourceEnd out of bounds");
-      if (end > this.length)
-        end = this.length;
-      if (target.length - targetStart < end - start) {
-        end = target.length - targetStart + start;
-      }
-      const len = end - start;
-      if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
-        this.copyWithin(targetStart, start, end);
-      } else {
-        Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
-      }
-      return len;
-    };
-    Buffer3.prototype.fill = function fill(val, start, end, encoding) {
-      if (typeof val === "string") {
-        if (typeof start === "string") {
-          encoding = start;
-          start = 0;
-          end = this.length;
-        } else if (typeof end === "string") {
-          encoding = end;
-          end = this.length;
-        }
-        if (encoding !== void 0 && typeof encoding !== "string") {
-          throw new TypeError("encoding must be a string");
-        }
-        if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
+        if (!Buffer3.isEncoding(encoding)) {
           throw new TypeError("Unknown encoding: " + encoding);
         }
-        if (val.length === 1) {
-          const code = val.charCodeAt(0);
-          if (encoding === "utf8" && code < 128 || encoding === "latin1") {
-            val = code;
+        const length = byteLength(string, encoding) | 0;
+        let buf = createBuffer(length);
+        const actual = buf.write(string, encoding);
+        if (actual !== length) {
+          buf = buf.slice(0, actual);
+        }
+        return buf;
+      }
+      function fromArrayLike(array) {
+        const length = array.length < 0 ? 0 : checked(array.length) | 0;
+        const buf = createBuffer(length);
+        for (let i = 0; i < length; i += 1) {
+          buf[i] = array[i] & 255;
+        }
+        return buf;
+      }
+      function fromArrayView(arrayView) {
+        if (isInstance(arrayView, Uint8Array)) {
+          const copy = new Uint8Array(arrayView);
+          return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
+        }
+        return fromArrayLike(arrayView);
+      }
+      function fromArrayBuffer(array, byteOffset, length) {
+        if (byteOffset < 0 || array.byteLength < byteOffset) {
+          throw new RangeError('"offset" is outside of buffer bounds');
+        }
+        if (array.byteLength < byteOffset + (length || 0)) {
+          throw new RangeError('"length" is outside of buffer bounds');
+        }
+        let buf;
+        if (byteOffset === void 0 && length === void 0) {
+          buf = new Uint8Array(array);
+        } else if (length === void 0) {
+          buf = new Uint8Array(array, byteOffset);
+        } else {
+          buf = new Uint8Array(array, byteOffset, length);
+        }
+        Object.setPrototypeOf(buf, Buffer3.prototype);
+        return buf;
+      }
+      function fromObject(obj) {
+        if (Buffer3.isBuffer(obj)) {
+          const len = checked(obj.length) | 0;
+          const buf = createBuffer(len);
+          if (buf.length === 0) {
+            return buf;
+          }
+          obj.copy(buf, 0, 0, len);
+          return buf;
+        }
+        if (obj.length !== void 0) {
+          if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
+            return createBuffer(0);
+          }
+          return fromArrayLike(obj);
+        }
+        if (obj.type === "Buffer" && Array.isArray(obj.data)) {
+          return fromArrayLike(obj.data);
+        }
+      }
+      function checked(length) {
+        if (length >= K_MAX_LENGTH) {
+          throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
+        }
+        return length | 0;
+      }
+      function SlowBuffer(length) {
+        if (+length != length) {
+          length = 0;
+        }
+        return Buffer3.alloc(+length);
+      }
+      Buffer3.isBuffer = function isBuffer(b) {
+        return b != null && b._isBuffer === true && b !== Buffer3.prototype;
+      };
+      Buffer3.compare = function compare(a, b) {
+        if (isInstance(a, Uint8Array))
+          a = Buffer3.from(a, a.offset, a.byteLength);
+        if (isInstance(b, Uint8Array))
+          b = Buffer3.from(b, b.offset, b.byteLength);
+        if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b)) {
+          throw new TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
+        }
+        if (a === b)
+          return 0;
+        let x = a.length;
+        let y = b.length;
+        for (let i = 0, len = Math.min(x, y); i < len; ++i) {
+          if (a[i] !== b[i]) {
+            x = a[i];
+            y = b[i];
+            break;
           }
         }
-      } else if (typeof val === "number") {
-        val = val & 255;
-      } else if (typeof val === "boolean") {
-        val = Number(val);
-      }
-      if (start < 0 || this.length < start || this.length < end) {
-        throw new RangeError("Out of range index");
-      }
-      if (end <= start) {
-        return this;
-      }
-      start = start >>> 0;
-      end = end === void 0 ? this.length : end >>> 0;
-      if (!val)
-        val = 0;
-      let i;
-      if (typeof val === "number") {
-        for (i = start; i < end; ++i) {
-          this[i] = val;
-        }
-      } else {
-        const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
-        const len = bytes.length;
-        if (len === 0) {
-          throw new TypeError('The value "' + val + '" is invalid for argument "value"');
-        }
-        for (i = 0; i < end - start; ++i) {
-          this[i + start] = bytes[i % len];
-        }
-      }
-      return this;
-    };
-    var errors = {};
-    function E(sym, getMessage, Base) {
-      errors[sym] = class NodeError extends Base {
-        constructor() {
-          super();
-          Object.defineProperty(this, "message", {
-            value: getMessage.apply(this, arguments),
-            writable: true,
-            configurable: true
-          });
-          this.name = `${this.name} [${sym}]`;
-          this.stack;
-          delete this.name;
-        }
-        get code() {
-          return sym;
-        }
-        set code(value) {
-          Object.defineProperty(this, "code", {
-            configurable: true,
-            enumerable: true,
-            value,
-            writable: true
-          });
-        }
-        toString() {
-          return `${this.name} [${sym}]: ${this.message}`;
+        if (x < y)
+          return -1;
+        if (y < x)
+          return 1;
+        return 0;
+      };
+      Buffer3.isEncoding = function isEncoding(encoding) {
+        switch (String(encoding).toLowerCase()) {
+          case "hex":
+          case "utf8":
+          case "utf-8":
+          case "ascii":
+          case "latin1":
+          case "binary":
+          case "base64":
+          case "ucs2":
+          case "ucs-2":
+          case "utf16le":
+          case "utf-16le":
+            return true;
+          default:
+            return false;
         }
       };
-    }
-    E("ERR_BUFFER_OUT_OF_BOUNDS", function(name) {
-      if (name) {
-        return `${name} is outside of buffer bounds`;
-      }
-      return "Attempt to access memory outside buffer bounds";
-    }, RangeError);
-    E("ERR_INVALID_ARG_TYPE", function(name, actual) {
-      return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
-    }, TypeError);
-    E("ERR_OUT_OF_RANGE", function(str, range, input) {
-      let msg = `The value of "${str}" is out of range.`;
-      let received = input;
-      if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
-        received = addNumericalSeparator(String(input));
-      } else if (typeof input === "bigint") {
-        received = String(input);
-        if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
-          received = addNumericalSeparator(received);
+      Buffer3.concat = function concat(list, length) {
+        if (!Array.isArray(list)) {
+          throw new TypeError('"list" argument must be an Array of Buffers');
         }
-        received += "n";
-      }
-      msg += ` It must be ${range}. Received ${received}`;
-      return msg;
-    }, RangeError);
-    function addNumericalSeparator(val) {
-      let res = "";
-      let i = val.length;
-      const start = val[0] === "-" ? 1 : 0;
-      for (; i >= start + 4; i -= 3) {
-        res = `_${val.slice(i - 3, i)}${res}`;
-      }
-      return `${val.slice(0, i)}${res}`;
-    }
-    function checkBounds(buf, offset, byteLength2) {
-      validateNumber(offset, "offset");
-      if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
-        boundsError(offset, buf.length - (byteLength2 + 1));
-      }
-    }
-    function checkIntBI(value, min, max, buf, offset, byteLength2) {
-      if (value > max || value < min) {
-        const n = typeof min === "bigint" ? "n" : "";
-        let range;
-        if (byteLength2 > 3) {
-          if (min === 0 || min === BigInt(0)) {
-            range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
+        if (list.length === 0) {
+          return Buffer3.alloc(0);
+        }
+        let i;
+        if (length === void 0) {
+          length = 0;
+          for (i = 0; i < list.length; ++i) {
+            length += list[i].length;
+          }
+        }
+        const buffer = Buffer3.allocUnsafe(length);
+        let pos = 0;
+        for (i = 0; i < list.length; ++i) {
+          let buf = list[i];
+          if (isInstance(buf, Uint8Array)) {
+            if (pos + buf.length > buffer.length) {
+              if (!Buffer3.isBuffer(buf))
+                buf = Buffer3.from(buf);
+              buf.copy(buffer, pos);
+            } else {
+              Uint8Array.prototype.set.call(buffer, buf, pos);
+            }
+          } else if (!Buffer3.isBuffer(buf)) {
+            throw new TypeError('"list" argument must be an Array of Buffers');
           } else {
-            range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
+            buf.copy(buffer, pos);
+          }
+          pos += buf.length;
+        }
+        return buffer;
+      };
+      function byteLength(string, encoding) {
+        if (Buffer3.isBuffer(string)) {
+          return string.length;
+        }
+        if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
+          return string.byteLength;
+        }
+        if (typeof string !== "string") {
+          throw new TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
+        }
+        const len = string.length;
+        const mustMatch = arguments.length > 2 && arguments[2] === true;
+        if (!mustMatch && len === 0)
+          return 0;
+        let loweredCase = false;
+        for (; ; ) {
+          switch (encoding) {
+            case "ascii":
+            case "latin1":
+            case "binary":
+              return len;
+            case "utf8":
+            case "utf-8":
+              return utf8ToBytes(string).length;
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return len * 2;
+            case "hex":
+              return len >>> 1;
+            case "base64":
+              return base64ToBytes(string).length;
+            default:
+              if (loweredCase) {
+                return mustMatch ? -1 : utf8ToBytes(string).length;
+              }
+              encoding = ("" + encoding).toLowerCase();
+              loweredCase = true;
+          }
+        }
+      }
+      Buffer3.byteLength = byteLength;
+      function slowToString(encoding, start, end) {
+        let loweredCase = false;
+        if (start === void 0 || start < 0) {
+          start = 0;
+        }
+        if (start > this.length) {
+          return "";
+        }
+        if (end === void 0 || end > this.length) {
+          end = this.length;
+        }
+        if (end <= 0) {
+          return "";
+        }
+        end >>>= 0;
+        start >>>= 0;
+        if (end <= start) {
+          return "";
+        }
+        if (!encoding)
+          encoding = "utf8";
+        while (true) {
+          switch (encoding) {
+            case "hex":
+              return hexSlice(this, start, end);
+            case "utf8":
+            case "utf-8":
+              return utf8Slice(this, start, end);
+            case "ascii":
+              return asciiSlice(this, start, end);
+            case "latin1":
+            case "binary":
+              return latin1Slice(this, start, end);
+            case "base64":
+              return base64Slice(this, start, end);
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return utf16leSlice(this, start, end);
+            default:
+              if (loweredCase)
+                throw new TypeError("Unknown encoding: " + encoding);
+              encoding = (encoding + "").toLowerCase();
+              loweredCase = true;
+          }
+        }
+      }
+      Buffer3.prototype._isBuffer = true;
+      function swap(b, n, m) {
+        const i = b[n];
+        b[n] = b[m];
+        b[m] = i;
+      }
+      Buffer3.prototype.swap16 = function swap16() {
+        const len = this.length;
+        if (len % 2 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 16-bits");
+        }
+        for (let i = 0; i < len; i += 2) {
+          swap(this, i, i + 1);
+        }
+        return this;
+      };
+      Buffer3.prototype.swap32 = function swap32() {
+        const len = this.length;
+        if (len % 4 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 32-bits");
+        }
+        for (let i = 0; i < len; i += 4) {
+          swap(this, i, i + 3);
+          swap(this, i + 1, i + 2);
+        }
+        return this;
+      };
+      Buffer3.prototype.swap64 = function swap64() {
+        const len = this.length;
+        if (len % 8 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 64-bits");
+        }
+        for (let i = 0; i < len; i += 8) {
+          swap(this, i, i + 7);
+          swap(this, i + 1, i + 6);
+          swap(this, i + 2, i + 5);
+          swap(this, i + 3, i + 4);
+        }
+        return this;
+      };
+      Buffer3.prototype.toString = function toString() {
+        const length = this.length;
+        if (length === 0)
+          return "";
+        if (arguments.length === 0)
+          return utf8Slice(this, 0, length);
+        return slowToString.apply(this, arguments);
+      };
+      Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
+      Buffer3.prototype.equals = function equals(b) {
+        if (!Buffer3.isBuffer(b))
+          throw new TypeError("Argument must be a Buffer");
+        if (this === b)
+          return true;
+        return Buffer3.compare(this, b) === 0;
+      };
+      Buffer3.prototype.inspect = function inspect() {
+        let str = "";
+        const max = exports.INSPECT_MAX_BYTES;
+        str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
+        if (this.length > max)
+          str += " ... ";
+        return "<Buffer " + str + ">";
+      };
+      if (customInspectSymbol) {
+        Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
+      }
+      Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
+        if (isInstance(target, Uint8Array)) {
+          target = Buffer3.from(target, target.offset, target.byteLength);
+        }
+        if (!Buffer3.isBuffer(target)) {
+          throw new TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
+        }
+        if (start === void 0) {
+          start = 0;
+        }
+        if (end === void 0) {
+          end = target ? target.length : 0;
+        }
+        if (thisStart === void 0) {
+          thisStart = 0;
+        }
+        if (thisEnd === void 0) {
+          thisEnd = this.length;
+        }
+        if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+          throw new RangeError("out of range index");
+        }
+        if (thisStart >= thisEnd && start >= end) {
+          return 0;
+        }
+        if (thisStart >= thisEnd) {
+          return -1;
+        }
+        if (start >= end) {
+          return 1;
+        }
+        start >>>= 0;
+        end >>>= 0;
+        thisStart >>>= 0;
+        thisEnd >>>= 0;
+        if (this === target)
+          return 0;
+        let x = thisEnd - thisStart;
+        let y = end - start;
+        const len = Math.min(x, y);
+        const thisCopy = this.slice(thisStart, thisEnd);
+        const targetCopy = target.slice(start, end);
+        for (let i = 0; i < len; ++i) {
+          if (thisCopy[i] !== targetCopy[i]) {
+            x = thisCopy[i];
+            y = targetCopy[i];
+            break;
+          }
+        }
+        if (x < y)
+          return -1;
+        if (y < x)
+          return 1;
+        return 0;
+      };
+      function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
+        if (buffer.length === 0)
+          return -1;
+        if (typeof byteOffset === "string") {
+          encoding = byteOffset;
+          byteOffset = 0;
+        } else if (byteOffset > 2147483647) {
+          byteOffset = 2147483647;
+        } else if (byteOffset < -2147483648) {
+          byteOffset = -2147483648;
+        }
+        byteOffset = +byteOffset;
+        if (numberIsNaN(byteOffset)) {
+          byteOffset = dir ? 0 : buffer.length - 1;
+        }
+        if (byteOffset < 0)
+          byteOffset = buffer.length + byteOffset;
+        if (byteOffset >= buffer.length) {
+          if (dir)
+            return -1;
+          else
+            byteOffset = buffer.length - 1;
+        } else if (byteOffset < 0) {
+          if (dir)
+            byteOffset = 0;
+          else
+            return -1;
+        }
+        if (typeof val === "string") {
+          val = Buffer3.from(val, encoding);
+        }
+        if (Buffer3.isBuffer(val)) {
+          if (val.length === 0) {
+            return -1;
+          }
+          return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
+        } else if (typeof val === "number") {
+          val = val & 255;
+          if (typeof Uint8Array.prototype.indexOf === "function") {
+            if (dir) {
+              return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
+            } else {
+              return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
+            }
+          }
+          return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
+        }
+        throw new TypeError("val must be string, number or Buffer");
+      }
+      function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
+        let indexSize = 1;
+        let arrLength = arr.length;
+        let valLength = val.length;
+        if (encoding !== void 0) {
+          encoding = String(encoding).toLowerCase();
+          if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
+            if (arr.length < 2 || val.length < 2) {
+              return -1;
+            }
+            indexSize = 2;
+            arrLength /= 2;
+            valLength /= 2;
+            byteOffset /= 2;
+          }
+        }
+        function read(buf, i2) {
+          if (indexSize === 1) {
+            return buf[i2];
+          } else {
+            return buf.readUInt16BE(i2 * indexSize);
+          }
+        }
+        let i;
+        if (dir) {
+          let foundIndex = -1;
+          for (i = byteOffset; i < arrLength; i++) {
+            if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+              if (foundIndex === -1)
+                foundIndex = i;
+              if (i - foundIndex + 1 === valLength)
+                return foundIndex * indexSize;
+            } else {
+              if (foundIndex !== -1)
+                i -= i - foundIndex;
+              foundIndex = -1;
+            }
           }
         } else {
-          range = `>= ${min}${n} and <= ${max}${n}`;
-        }
-        throw new errors.ERR_OUT_OF_RANGE("value", range, value);
-      }
-      checkBounds(buf, offset, byteLength2);
-    }
-    function validateNumber(value, name) {
-      if (typeof value !== "number") {
-        throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
-      }
-    }
-    function boundsError(value, length, type) {
-      if (Math.floor(value) !== value) {
-        validateNumber(value, type);
-        throw new errors.ERR_OUT_OF_RANGE(type || "offset", "an integer", value);
-      }
-      if (length < 0) {
-        throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
-      }
-      throw new errors.ERR_OUT_OF_RANGE(type || "offset", `>= ${type ? 1 : 0} and <= ${length}`, value);
-    }
-    var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
-    function base64clean(str) {
-      str = str.split("=")[0];
-      str = str.trim().replace(INVALID_BASE64_RE, "");
-      if (str.length < 2)
-        return "";
-      while (str.length % 4 !== 0) {
-        str = str + "=";
-      }
-      return str;
-    }
-    function utf8ToBytes(string, units) {
-      units = units || Infinity;
-      let codePoint;
-      const length = string.length;
-      let leadSurrogate = null;
-      const bytes = [];
-      for (let i = 0; i < length; ++i) {
-        codePoint = string.charCodeAt(i);
-        if (codePoint > 55295 && codePoint < 57344) {
-          if (!leadSurrogate) {
-            if (codePoint > 56319) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
-            } else if (i + 1 === length) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
+          if (byteOffset + valLength > arrLength)
+            byteOffset = arrLength - valLength;
+          for (i = byteOffset; i >= 0; i--) {
+            let found = true;
+            for (let j = 0; j < valLength; j++) {
+              if (read(arr, i + j) !== read(val, j)) {
+                found = false;
+                break;
+              }
             }
-            leadSurrogate = codePoint;
-            continue;
+            if (found)
+              return i;
           }
-          if (codePoint < 56320) {
-            if ((units -= 3) > -1)
-              bytes.push(239, 191, 189);
-            leadSurrogate = codePoint;
-            continue;
-          }
-          codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
-        } else if (leadSurrogate) {
-          if ((units -= 3) > -1)
-            bytes.push(239, 191, 189);
         }
-        leadSurrogate = null;
-        if (codePoint < 128) {
-          if ((units -= 1) < 0)
-            break;
-          bytes.push(codePoint);
-        } else if (codePoint < 2048) {
-          if ((units -= 2) < 0)
-            break;
-          bytes.push(codePoint >> 6 | 192, codePoint & 63 | 128);
-        } else if (codePoint < 65536) {
-          if ((units -= 3) < 0)
-            break;
-          bytes.push(codePoint >> 12 | 224, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
-        } else if (codePoint < 1114112) {
-          if ((units -= 4) < 0)
-            break;
-          bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+        return -1;
+      }
+      Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
+        return this.indexOf(val, byteOffset, encoding) !== -1;
+      };
+      Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+        return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
+      };
+      Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+        return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
+      };
+      function hexWrite(buf, string, offset, length) {
+        offset = Number(offset) || 0;
+        const remaining = buf.length - offset;
+        if (!length) {
+          length = remaining;
         } else {
-          throw new Error("Invalid code point");
-        }
-      }
-      return bytes;
-    }
-    function asciiToBytes(str) {
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        byteArray.push(str.charCodeAt(i) & 255);
-      }
-      return byteArray;
-    }
-    function utf16leToBytes(str, units) {
-      let c, hi, lo;
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        if ((units -= 2) < 0)
-          break;
-        c = str.charCodeAt(i);
-        hi = c >> 8;
-        lo = c % 256;
-        byteArray.push(lo);
-        byteArray.push(hi);
-      }
-      return byteArray;
-    }
-    function base64ToBytes(str) {
-      return base64.toByteArray(base64clean(str));
-    }
-    function blitBuffer(src, dst, offset, length) {
-      let i;
-      for (i = 0; i < length; ++i) {
-        if (i + offset >= dst.length || i >= src.length)
-          break;
-        dst[i + offset] = src[i];
-      }
-      return i;
-    }
-    function isInstance(obj, type) {
-      return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
-    }
-    function numberIsNaN(obj) {
-      return obj !== obj;
-    }
-    var hexSliceLookupTable = function() {
-      const alphabet = "0123456789abcdef";
-      const table = new Array(256);
-      for (let i = 0; i < 16; ++i) {
-        const i16 = i * 16;
-        for (let j = 0; j < 16; ++j) {
-          table[i16 + j] = alphabet[i] + alphabet[j];
-        }
-      }
-      return table;
-    }();
-    function defineBigIntMethod(fn) {
-      return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
-    }
-    function BufferBigIntNotDefined() {
-      throw new Error("BigInt not supported");
-    }
-  }
-});
-
-// testing/injections/buffer_shim.js
-var Buffer2;
-var init_buffer_shim = __esm({
-  "testing/injections/buffer_shim.js"() {
-    Buffer2 = require_buffer().Buffer;
-  }
-});
-
-// node_modules/pascalcase/index.js
-var require_pascalcase = __commonJS({
-  "node_modules/pascalcase/index.js"(exports, module2) {
-    init_buffer_shim();
-    var titlecase = (input) => input[0].toLocaleUpperCase() + input.slice(1);
-    module2.exports = (value) => {
-      if (value === null || value === void 0)
-        return "";
-      if (typeof value.toString !== "function")
-        return "";
-      let input = value.toString().trim();
-      if (input === "")
-        return "";
-      if (input.length === 1)
-        return input.toLocaleUpperCase();
-      let match = input.match(/[a-zA-Z0-9]+/g);
-      if (match) {
-        return match.map((m) => titlecase(m)).join("");
-      }
-      return input;
-    };
-  }
-});
-
-// node_modules/clone/clone.js
-var require_clone = __commonJS({
-  "node_modules/clone/clone.js"(exports, module2) {
-    init_buffer_shim();
-    var clone2 = function() {
-      "use strict";
-      function _instanceof(obj, type) {
-        return type != null && obj instanceof type;
-      }
-      var nativeMap;
-      try {
-        nativeMap = Map;
-      } catch (_) {
-        nativeMap = function() {
-        };
-      }
-      var nativeSet;
-      try {
-        nativeSet = Set;
-      } catch (_) {
-        nativeSet = function() {
-        };
-      }
-      var nativePromise;
-      try {
-        nativePromise = Promise;
-      } catch (_) {
-        nativePromise = function() {
-        };
-      }
-      function clone3(parent, circular, depth, prototype, includeNonEnumerable) {
-        if (typeof circular === "object") {
-          depth = circular.depth;
-          prototype = circular.prototype;
-          includeNonEnumerable = circular.includeNonEnumerable;
-          circular = circular.circular;
-        }
-        var allParents = [];
-        var allChildren = [];
-        var useBuffer = typeof Buffer2 != "undefined";
-        if (typeof circular == "undefined")
-          circular = true;
-        if (typeof depth == "undefined")
-          depth = Infinity;
-        function _clone(parent2, depth2) {
-          if (parent2 === null)
-            return null;
-          if (depth2 === 0)
-            return parent2;
-          var child;
-          var proto;
-          if (typeof parent2 != "object") {
-            return parent2;
+          length = Number(length);
+          if (length > remaining) {
+            length = remaining;
           }
-          if (_instanceof(parent2, nativeMap)) {
-            child = new nativeMap();
-          } else if (_instanceof(parent2, nativeSet)) {
-            child = new nativeSet();
-          } else if (_instanceof(parent2, nativePromise)) {
-            child = new nativePromise(function(resolve, reject) {
-              parent2.then(function(value) {
-                resolve(_clone(value, depth2 - 1));
-              }, function(err) {
-                reject(_clone(err, depth2 - 1));
-              });
-            });
-          } else if (clone3.__isArray(parent2)) {
-            child = [];
-          } else if (clone3.__isRegExp(parent2)) {
-            child = new RegExp(parent2.source, __getRegExpFlags(parent2));
-            if (parent2.lastIndex)
-              child.lastIndex = parent2.lastIndex;
-          } else if (clone3.__isDate(parent2)) {
-            child = new Date(parent2.getTime());
-          } else if (useBuffer && Buffer2.isBuffer(parent2)) {
-            if (Buffer2.allocUnsafe) {
-              child = Buffer2.allocUnsafe(parent2.length);
-            } else {
-              child = new Buffer2(parent2.length);
-            }
-            parent2.copy(child);
-            return child;
-          } else if (_instanceof(parent2, Error)) {
-            child = Object.create(parent2);
+        }
+        const strLen = string.length;
+        if (length > strLen / 2) {
+          length = strLen / 2;
+        }
+        let i;
+        for (i = 0; i < length; ++i) {
+          const parsed = parseInt(string.substr(i * 2, 2), 16);
+          if (numberIsNaN(parsed))
+            return i;
+          buf[offset + i] = parsed;
+        }
+        return i;
+      }
+      function utf8Write(buf, string, offset, length) {
+        return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
+      }
+      function asciiWrite(buf, string, offset, length) {
+        return blitBuffer(asciiToBytes(string), buf, offset, length);
+      }
+      function base64Write(buf, string, offset, length) {
+        return blitBuffer(base64ToBytes(string), buf, offset, length);
+      }
+      function ucs2Write(buf, string, offset, length) {
+        return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
+      }
+      Buffer3.prototype.write = function write(string, offset, length, encoding) {
+        if (offset === void 0) {
+          encoding = "utf8";
+          length = this.length;
+          offset = 0;
+        } else if (length === void 0 && typeof offset === "string") {
+          encoding = offset;
+          length = this.length;
+          offset = 0;
+        } else if (isFinite(offset)) {
+          offset = offset >>> 0;
+          if (isFinite(length)) {
+            length = length >>> 0;
+            if (encoding === void 0)
+              encoding = "utf8";
           } else {
-            if (typeof prototype == "undefined") {
-              proto = Object.getPrototypeOf(parent2);
-              child = Object.create(proto);
+            encoding = length;
+            length = void 0;
+          }
+        } else {
+          throw new Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
+        }
+        const remaining = this.length - offset;
+        if (length === void 0 || length > remaining)
+          length = remaining;
+        if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
+          throw new RangeError("Attempt to write outside buffer bounds");
+        }
+        if (!encoding)
+          encoding = "utf8";
+        let loweredCase = false;
+        for (; ; ) {
+          switch (encoding) {
+            case "hex":
+              return hexWrite(this, string, offset, length);
+            case "utf8":
+            case "utf-8":
+              return utf8Write(this, string, offset, length);
+            case "ascii":
+            case "latin1":
+            case "binary":
+              return asciiWrite(this, string, offset, length);
+            case "base64":
+              return base64Write(this, string, offset, length);
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return ucs2Write(this, string, offset, length);
+            default:
+              if (loweredCase)
+                throw new TypeError("Unknown encoding: " + encoding);
+              encoding = ("" + encoding).toLowerCase();
+              loweredCase = true;
+          }
+        }
+      };
+      Buffer3.prototype.toJSON = function toJSON() {
+        return {
+          type: "Buffer",
+          data: Array.prototype.slice.call(this._arr || this, 0)
+        };
+      };
+      function base64Slice(buf, start, end) {
+        if (start === 0 && end === buf.length) {
+          return base64.fromByteArray(buf);
+        } else {
+          return base64.fromByteArray(buf.slice(start, end));
+        }
+      }
+      function utf8Slice(buf, start, end) {
+        end = Math.min(buf.length, end);
+        const res = [];
+        let i = start;
+        while (i < end) {
+          const firstByte = buf[i];
+          let codePoint = null;
+          let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
+          if (i + bytesPerSequence <= end) {
+            let secondByte, thirdByte, fourthByte, tempCodePoint;
+            switch (bytesPerSequence) {
+              case 1:
+                if (firstByte < 128) {
+                  codePoint = firstByte;
+                }
+                break;
+              case 2:
+                secondByte = buf[i + 1];
+                if ((secondByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
+                  if (tempCodePoint > 127) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+                break;
+              case 3:
+                secondByte = buf[i + 1];
+                thirdByte = buf[i + 2];
+                if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
+                  if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+                break;
+              case 4:
+                secondByte = buf[i + 1];
+                thirdByte = buf[i + 2];
+                fourthByte = buf[i + 3];
+                if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
+                  if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+            }
+          }
+          if (codePoint === null) {
+            codePoint = 65533;
+            bytesPerSequence = 1;
+          } else if (codePoint > 65535) {
+            codePoint -= 65536;
+            res.push(codePoint >>> 10 & 1023 | 55296);
+            codePoint = 56320 | codePoint & 1023;
+          }
+          res.push(codePoint);
+          i += bytesPerSequence;
+        }
+        return decodeCodePointsArray(res);
+      }
+      var MAX_ARGUMENTS_LENGTH = 4096;
+      function decodeCodePointsArray(codePoints) {
+        const len = codePoints.length;
+        if (len <= MAX_ARGUMENTS_LENGTH) {
+          return String.fromCharCode.apply(String, codePoints);
+        }
+        let res = "";
+        let i = 0;
+        while (i < len) {
+          res += String.fromCharCode.apply(String, codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH));
+        }
+        return res;
+      }
+      function asciiSlice(buf, start, end) {
+        let ret = "";
+        end = Math.min(buf.length, end);
+        for (let i = start; i < end; ++i) {
+          ret += String.fromCharCode(buf[i] & 127);
+        }
+        return ret;
+      }
+      function latin1Slice(buf, start, end) {
+        let ret = "";
+        end = Math.min(buf.length, end);
+        for (let i = start; i < end; ++i) {
+          ret += String.fromCharCode(buf[i]);
+        }
+        return ret;
+      }
+      function hexSlice(buf, start, end) {
+        const len = buf.length;
+        if (!start || start < 0)
+          start = 0;
+        if (!end || end < 0 || end > len)
+          end = len;
+        let out = "";
+        for (let i = start; i < end; ++i) {
+          out += hexSliceLookupTable[buf[i]];
+        }
+        return out;
+      }
+      function utf16leSlice(buf, start, end) {
+        const bytes = buf.slice(start, end);
+        let res = "";
+        for (let i = 0; i < bytes.length - 1; i += 2) {
+          res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
+        }
+        return res;
+      }
+      Buffer3.prototype.slice = function slice(start, end) {
+        const len = this.length;
+        start = ~~start;
+        end = end === void 0 ? len : ~~end;
+        if (start < 0) {
+          start += len;
+          if (start < 0)
+            start = 0;
+        } else if (start > len) {
+          start = len;
+        }
+        if (end < 0) {
+          end += len;
+          if (end < 0)
+            end = 0;
+        } else if (end > len) {
+          end = len;
+        }
+        if (end < start)
+          end = start;
+        const newBuf = this.subarray(start, end);
+        Object.setPrototypeOf(newBuf, Buffer3.prototype);
+        return newBuf;
+      };
+      function checkOffset(offset, ext, length) {
+        if (offset % 1 !== 0 || offset < 0)
+          throw new RangeError("offset is not uint");
+        if (offset + ext > length)
+          throw new RangeError("Trying to access beyond buffer length");
+      }
+      Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let val = this[offset];
+        let mul = 1;
+        let i = 0;
+        while (++i < byteLength2 && (mul *= 256)) {
+          val += this[offset + i] * mul;
+        }
+        return val;
+      };
+      Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          checkOffset(offset, byteLength2, this.length);
+        }
+        let val = this[offset + --byteLength2];
+        let mul = 1;
+        while (byteLength2 > 0 && (mul *= 256)) {
+          val += this[offset + --byteLength2] * mul;
+        }
+        return val;
+      };
+      Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 1, this.length);
+        return this[offset];
+      };
+      Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        return this[offset] | this[offset + 1] << 8;
+      };
+      Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        return this[offset] << 8 | this[offset + 1];
+      };
+      Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
+      };
+      Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
+      };
+      Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
+        const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
+        return BigInt(lo) + (BigInt(hi) << BigInt(32));
+      });
+      Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+        const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
+        return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+      });
+      Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let val = this[offset];
+        let mul = 1;
+        let i = 0;
+        while (++i < byteLength2 && (mul *= 256)) {
+          val += this[offset + i] * mul;
+        }
+        mul *= 128;
+        if (val >= mul)
+          val -= Math.pow(2, 8 * byteLength2);
+        return val;
+      };
+      Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let i = byteLength2;
+        let mul = 1;
+        let val = this[offset + --i];
+        while (i > 0 && (mul *= 256)) {
+          val += this[offset + --i] * mul;
+        }
+        mul *= 128;
+        if (val >= mul)
+          val -= Math.pow(2, 8 * byteLength2);
+        return val;
+      };
+      Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 1, this.length);
+        if (!(this[offset] & 128))
+          return this[offset];
+        return (255 - this[offset] + 1) * -1;
+      };
+      Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        const val = this[offset] | this[offset + 1] << 8;
+        return val & 32768 ? val | 4294901760 : val;
+      };
+      Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        const val = this[offset + 1] | this[offset] << 8;
+        return val & 32768 ? val | 4294901760 : val;
+      };
+      Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
+      };
+      Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
+      };
+      Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
+        return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
+      });
+      Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const val = (first << 24) + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+        return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
+      });
+      Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return ieee754.read(this, offset, true, 23, 4);
+      };
+      Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return ieee754.read(this, offset, false, 23, 4);
+      };
+      Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 8, this.length);
+        return ieee754.read(this, offset, true, 52, 8);
+      };
+      Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 8, this.length);
+        return ieee754.read(this, offset, false, 52, 8);
+      };
+      function checkInt(buf, value, offset, ext, max, min) {
+        if (!Buffer3.isBuffer(buf))
+          throw new TypeError('"buffer" argument must be a Buffer instance');
+        if (value > max || value < min)
+          throw new RangeError('"value" argument is out of bounds');
+        if (offset + ext > buf.length)
+          throw new RangeError("Index out of range");
+      }
+      Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+          checkInt(this, value, offset, byteLength2, maxBytes, 0);
+        }
+        let mul = 1;
+        let i = 0;
+        this[offset] = value & 255;
+        while (++i < byteLength2 && (mul *= 256)) {
+          this[offset + i] = value / mul & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+          checkInt(this, value, offset, byteLength2, maxBytes, 0);
+        }
+        let i = byteLength2 - 1;
+        let mul = 1;
+        this[offset + i] = value & 255;
+        while (--i >= 0 && (mul *= 256)) {
+          this[offset + i] = value / mul & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 1, 255, 0);
+        this[offset] = value & 255;
+        return offset + 1;
+      };
+      Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 65535, 0);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 65535, 0);
+        this[offset] = value >>> 8;
+        this[offset + 1] = value & 255;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 4294967295, 0);
+        this[offset + 3] = value >>> 24;
+        this[offset + 2] = value >>> 16;
+        this[offset + 1] = value >>> 8;
+        this[offset] = value & 255;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 4294967295, 0);
+        this[offset] = value >>> 24;
+        this[offset + 1] = value >>> 16;
+        this[offset + 2] = value >>> 8;
+        this[offset + 3] = value & 255;
+        return offset + 4;
+      };
+      function wrtBigUInt64LE(buf, value, offset, min, max) {
+        checkIntBI(value, min, max, buf, offset, 7);
+        let lo = Number(value & BigInt(4294967295));
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        return offset;
+      }
+      function wrtBigUInt64BE(buf, value, offset, min, max) {
+        checkIntBI(value, min, max, buf, offset, 7);
+        let lo = Number(value & BigInt(4294967295));
+        buf[offset + 7] = lo;
+        lo = lo >> 8;
+        buf[offset + 6] = lo;
+        lo = lo >> 8;
+        buf[offset + 5] = lo;
+        lo = lo >> 8;
+        buf[offset + 4] = lo;
+        let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+        buf[offset + 3] = hi;
+        hi = hi >> 8;
+        buf[offset + 2] = hi;
+        hi = hi >> 8;
+        buf[offset + 1] = hi;
+        hi = hi >> 8;
+        buf[offset] = hi;
+        return offset + 8;
+      }
+      Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+        return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+      });
+      Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+        return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+      });
+      Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          const limit = Math.pow(2, 8 * byteLength2 - 1);
+          checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+        }
+        let i = 0;
+        let mul = 1;
+        let sub = 0;
+        this[offset] = value & 255;
+        while (++i < byteLength2 && (mul *= 256)) {
+          if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+            sub = 1;
+          }
+          this[offset + i] = (value / mul >> 0) - sub & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          const limit = Math.pow(2, 8 * byteLength2 - 1);
+          checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+        }
+        let i = byteLength2 - 1;
+        let mul = 1;
+        let sub = 0;
+        this[offset + i] = value & 255;
+        while (--i >= 0 && (mul *= 256)) {
+          if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+            sub = 1;
+          }
+          this[offset + i] = (value / mul >> 0) - sub & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 1, 127, -128);
+        if (value < 0)
+          value = 255 + value + 1;
+        this[offset] = value & 255;
+        return offset + 1;
+      };
+      Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 32767, -32768);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 32767, -32768);
+        this[offset] = value >>> 8;
+        this[offset + 1] = value & 255;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 2147483647, -2147483648);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        this[offset + 2] = value >>> 16;
+        this[offset + 3] = value >>> 24;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 2147483647, -2147483648);
+        if (value < 0)
+          value = 4294967295 + value + 1;
+        this[offset] = value >>> 24;
+        this[offset + 1] = value >>> 16;
+        this[offset + 2] = value >>> 8;
+        this[offset + 3] = value & 255;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+        return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+      });
+      Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+        return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+      });
+      function checkIEEE754(buf, value, offset, ext, max, min) {
+        if (offset + ext > buf.length)
+          throw new RangeError("Index out of range");
+        if (offset < 0)
+          throw new RangeError("Index out of range");
+      }
+      function writeFloat(buf, value, offset, littleEndian, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
+        }
+        ieee754.write(buf, value, offset, littleEndian, 23, 4);
+        return offset + 4;
+      }
+      Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+        return writeFloat(this, value, offset, true, noAssert);
+      };
+      Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+        return writeFloat(this, value, offset, false, noAssert);
+      };
+      function writeDouble(buf, value, offset, littleEndian, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
+        }
+        ieee754.write(buf, value, offset, littleEndian, 52, 8);
+        return offset + 8;
+      }
+      Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+        return writeDouble(this, value, offset, true, noAssert);
+      };
+      Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+        return writeDouble(this, value, offset, false, noAssert);
+      };
+      Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
+        if (!Buffer3.isBuffer(target))
+          throw new TypeError("argument should be a Buffer");
+        if (!start)
+          start = 0;
+        if (!end && end !== 0)
+          end = this.length;
+        if (targetStart >= target.length)
+          targetStart = target.length;
+        if (!targetStart)
+          targetStart = 0;
+        if (end > 0 && end < start)
+          end = start;
+        if (end === start)
+          return 0;
+        if (target.length === 0 || this.length === 0)
+          return 0;
+        if (targetStart < 0) {
+          throw new RangeError("targetStart out of bounds");
+        }
+        if (start < 0 || start >= this.length)
+          throw new RangeError("Index out of range");
+        if (end < 0)
+          throw new RangeError("sourceEnd out of bounds");
+        if (end > this.length)
+          end = this.length;
+        if (target.length - targetStart < end - start) {
+          end = target.length - targetStart + start;
+        }
+        const len = end - start;
+        if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
+          this.copyWithin(targetStart, start, end);
+        } else {
+          Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
+        }
+        return len;
+      };
+      Buffer3.prototype.fill = function fill(val, start, end, encoding) {
+        if (typeof val === "string") {
+          if (typeof start === "string") {
+            encoding = start;
+            start = 0;
+            end = this.length;
+          } else if (typeof end === "string") {
+            encoding = end;
+            end = this.length;
+          }
+          if (encoding !== void 0 && typeof encoding !== "string") {
+            throw new TypeError("encoding must be a string");
+          }
+          if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
+            throw new TypeError("Unknown encoding: " + encoding);
+          }
+          if (val.length === 1) {
+            const code = val.charCodeAt(0);
+            if (encoding === "utf8" && code < 128 || encoding === "latin1") {
+              val = code;
+            }
+          }
+        } else if (typeof val === "number") {
+          val = val & 255;
+        } else if (typeof val === "boolean") {
+          val = Number(val);
+        }
+        if (start < 0 || this.length < start || this.length < end) {
+          throw new RangeError("Out of range index");
+        }
+        if (end <= start) {
+          return this;
+        }
+        start = start >>> 0;
+        end = end === void 0 ? this.length : end >>> 0;
+        if (!val)
+          val = 0;
+        let i;
+        if (typeof val === "number") {
+          for (i = start; i < end; ++i) {
+            this[i] = val;
+          }
+        } else {
+          const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
+          const len = bytes.length;
+          if (len === 0) {
+            throw new TypeError('The value "' + val + '" is invalid for argument "value"');
+          }
+          for (i = 0; i < end - start; ++i) {
+            this[i + start] = bytes[i % len];
+          }
+        }
+        return this;
+      };
+      var errors = {};
+      function E(sym, getMessage, Base) {
+        errors[sym] = class NodeError extends Base {
+          constructor() {
+            super();
+            Object.defineProperty(this, "message", {
+              value: getMessage.apply(this, arguments),
+              writable: true,
+              configurable: true
+            });
+            this.name = `${this.name} [${sym}]`;
+            this.stack;
+            delete this.name;
+          }
+          get code() {
+            return sym;
+          }
+          set code(value) {
+            Object.defineProperty(this, "code", {
+              configurable: true,
+              enumerable: true,
+              value,
+              writable: true
+            });
+          }
+          toString() {
+            return `${this.name} [${sym}]: ${this.message}`;
+          }
+        };
+      }
+      E("ERR_BUFFER_OUT_OF_BOUNDS", function(name) {
+        if (name) {
+          return `${name} is outside of buffer bounds`;
+        }
+        return "Attempt to access memory outside buffer bounds";
+      }, RangeError);
+      E("ERR_INVALID_ARG_TYPE", function(name, actual) {
+        return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
+      }, TypeError);
+      E("ERR_OUT_OF_RANGE", function(str, range, input) {
+        let msg = `The value of "${str}" is out of range.`;
+        let received = input;
+        if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
+          received = addNumericalSeparator(String(input));
+        } else if (typeof input === "bigint") {
+          received = String(input);
+          if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
+            received = addNumericalSeparator(received);
+          }
+          received += "n";
+        }
+        msg += ` It must be ${range}. Received ${received}`;
+        return msg;
+      }, RangeError);
+      function addNumericalSeparator(val) {
+        let res = "";
+        let i = val.length;
+        const start = val[0] === "-" ? 1 : 0;
+        for (; i >= start + 4; i -= 3) {
+          res = `_${val.slice(i - 3, i)}${res}`;
+        }
+        return `${val.slice(0, i)}${res}`;
+      }
+      function checkBounds(buf, offset, byteLength2) {
+        validateNumber(offset, "offset");
+        if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
+          boundsError(offset, buf.length - (byteLength2 + 1));
+        }
+      }
+      function checkIntBI(value, min, max, buf, offset, byteLength2) {
+        if (value > max || value < min) {
+          const n = typeof min === "bigint" ? "n" : "";
+          let range;
+          if (byteLength2 > 3) {
+            if (min === 0 || min === BigInt(0)) {
+              range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
             } else {
-              child = Object.create(prototype);
-              proto = prototype;
+              range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
             }
+          } else {
+            range = `>= ${min}${n} and <= ${max}${n}`;
           }
-          if (circular) {
-            var index = allParents.indexOf(parent2);
-            if (index != -1) {
-              return allChildren[index];
-            }
-            allParents.push(parent2);
-            allChildren.push(child);
-          }
-          if (_instanceof(parent2, nativeMap)) {
-            parent2.forEach(function(value, key) {
-              var keyChild = _clone(key, depth2 - 1);
-              var valueChild = _clone(value, depth2 - 1);
-              child.set(keyChild, valueChild);
-            });
-          }
-          if (_instanceof(parent2, nativeSet)) {
-            parent2.forEach(function(value) {
-              var entryChild = _clone(value, depth2 - 1);
-              child.add(entryChild);
-            });
-          }
-          for (var i in parent2) {
-            var attrs;
-            if (proto) {
-              attrs = Object.getOwnPropertyDescriptor(proto, i);
-            }
-            if (attrs && attrs.set == null) {
-              continue;
-            }
-            child[i] = _clone(parent2[i], depth2 - 1);
-          }
-          if (Object.getOwnPropertySymbols) {
-            var symbols = Object.getOwnPropertySymbols(parent2);
-            for (var i = 0; i < symbols.length; i++) {
-              var symbol = symbols[i];
-              var descriptor = Object.getOwnPropertyDescriptor(parent2, symbol);
-              if (descriptor && !descriptor.enumerable && !includeNonEnumerable) {
+          throw new errors.ERR_OUT_OF_RANGE("value", range, value);
+        }
+        checkBounds(buf, offset, byteLength2);
+      }
+      function validateNumber(value, name) {
+        if (typeof value !== "number") {
+          throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
+        }
+      }
+      function boundsError(value, length, type) {
+        if (Math.floor(value) !== value) {
+          validateNumber(value, type);
+          throw new errors.ERR_OUT_OF_RANGE(type || "offset", "an integer", value);
+        }
+        if (length < 0) {
+          throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
+        }
+        throw new errors.ERR_OUT_OF_RANGE(type || "offset", `>= ${type ? 1 : 0} and <= ${length}`, value);
+      }
+      var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
+      function base64clean(str) {
+        str = str.split("=")[0];
+        str = str.trim().replace(INVALID_BASE64_RE, "");
+        if (str.length < 2)
+          return "";
+        while (str.length % 4 !== 0) {
+          str = str + "=";
+        }
+        return str;
+      }
+      function utf8ToBytes(string, units) {
+        units = units || Infinity;
+        let codePoint;
+        const length = string.length;
+        let leadSurrogate = null;
+        const bytes = [];
+        for (let i = 0; i < length; ++i) {
+          codePoint = string.charCodeAt(i);
+          if (codePoint > 55295 && codePoint < 57344) {
+            if (!leadSurrogate) {
+              if (codePoint > 56319) {
+                if ((units -= 3) > -1)
+                  bytes.push(239, 191, 189);
+                continue;
+              } else if (i + 1 === length) {
+                if ((units -= 3) > -1)
+                  bytes.push(239, 191, 189);
                 continue;
               }
-              child[symbol] = _clone(parent2[symbol], depth2 - 1);
-              if (!descriptor.enumerable) {
-                Object.defineProperty(child, symbol, {
+              leadSurrogate = codePoint;
+              continue;
+            }
+            if (codePoint < 56320) {
+              if ((units -= 3) > -1)
+                bytes.push(239, 191, 189);
+              leadSurrogate = codePoint;
+              continue;
+            }
+            codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
+          } else if (leadSurrogate) {
+            if ((units -= 3) > -1)
+              bytes.push(239, 191, 189);
+          }
+          leadSurrogate = null;
+          if (codePoint < 128) {
+            if ((units -= 1) < 0)
+              break;
+            bytes.push(codePoint);
+          } else if (codePoint < 2048) {
+            if ((units -= 2) < 0)
+              break;
+            bytes.push(codePoint >> 6 | 192, codePoint & 63 | 128);
+          } else if (codePoint < 65536) {
+            if ((units -= 3) < 0)
+              break;
+            bytes.push(codePoint >> 12 | 224, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+          } else if (codePoint < 1114112) {
+            if ((units -= 4) < 0)
+              break;
+            bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+          } else {
+            throw new Error("Invalid code point");
+          }
+        }
+        return bytes;
+      }
+      function asciiToBytes(str) {
+        const byteArray = [];
+        for (let i = 0; i < str.length; ++i) {
+          byteArray.push(str.charCodeAt(i) & 255);
+        }
+        return byteArray;
+      }
+      function utf16leToBytes(str, units) {
+        let c, hi, lo;
+        const byteArray = [];
+        for (let i = 0; i < str.length; ++i) {
+          if ((units -= 2) < 0)
+            break;
+          c = str.charCodeAt(i);
+          hi = c >> 8;
+          lo = c % 256;
+          byteArray.push(lo);
+          byteArray.push(hi);
+        }
+        return byteArray;
+      }
+      function base64ToBytes(str) {
+        return base64.toByteArray(base64clean(str));
+      }
+      function blitBuffer(src, dst, offset, length) {
+        let i;
+        for (i = 0; i < length; ++i) {
+          if (i + offset >= dst.length || i >= src.length)
+            break;
+          dst[i + offset] = src[i];
+        }
+        return i;
+      }
+      function isInstance(obj, type) {
+        return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
+      }
+      function numberIsNaN(obj) {
+        return obj !== obj;
+      }
+      var hexSliceLookupTable = function() {
+        const alphabet = "0123456789abcdef";
+        const table = new Array(256);
+        for (let i = 0; i < 16; ++i) {
+          const i16 = i * 16;
+          for (let j = 0; j < 16; ++j) {
+            table[i16 + j] = alphabet[i] + alphabet[j];
+          }
+        }
+        return table;
+      }();
+      function defineBigIntMethod(fn) {
+        return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
+      }
+      function BufferBigIntNotDefined() {
+        throw new Error("BigInt not supported");
+      }
+    }
+  });
+
+  // testing/injections/buffer_shim.js
+  var Buffer2;
+  var init_buffer_shim = __esm({
+    "testing/injections/buffer_shim.js"() {
+      Buffer2 = require_buffer().Buffer;
+    }
+  });
+
+  // node_modules/pascalcase/index.js
+  var require_pascalcase = __commonJS({
+    "node_modules/pascalcase/index.js"(exports, module) {
+      init_buffer_shim();
+      var titlecase = (input) => input[0].toLocaleUpperCase() + input.slice(1);
+      module.exports = (value) => {
+        if (value === null || value === void 0)
+          return "";
+        if (typeof value.toString !== "function")
+          return "";
+        let input = value.toString().trim();
+        if (input === "")
+          return "";
+        if (input.length === 1)
+          return input.toLocaleUpperCase();
+        let match = input.match(/[a-zA-Z0-9]+/g);
+        if (match) {
+          return match.map((m) => titlecase(m)).join("");
+        }
+        return input;
+      };
+    }
+  });
+
+  // node_modules/clone/clone.js
+  var require_clone = __commonJS({
+    "node_modules/clone/clone.js"(exports, module) {
+      init_buffer_shim();
+      var clone2 = function() {
+        "use strict";
+        function _instanceof(obj, type) {
+          return type != null && obj instanceof type;
+        }
+        var nativeMap;
+        try {
+          nativeMap = Map;
+        } catch (_) {
+          nativeMap = function() {
+          };
+        }
+        var nativeSet;
+        try {
+          nativeSet = Set;
+        } catch (_) {
+          nativeSet = function() {
+          };
+        }
+        var nativePromise;
+        try {
+          nativePromise = Promise;
+        } catch (_) {
+          nativePromise = function() {
+          };
+        }
+        function clone3(parent, circular, depth, prototype, includeNonEnumerable) {
+          if (typeof circular === "object") {
+            depth = circular.depth;
+            prototype = circular.prototype;
+            includeNonEnumerable = circular.includeNonEnumerable;
+            circular = circular.circular;
+          }
+          var allParents = [];
+          var allChildren = [];
+          var useBuffer = typeof Buffer2 != "undefined";
+          if (typeof circular == "undefined")
+            circular = true;
+          if (typeof depth == "undefined")
+            depth = Infinity;
+          function _clone(parent2, depth2) {
+            if (parent2 === null)
+              return null;
+            if (depth2 === 0)
+              return parent2;
+            var child;
+            var proto;
+            if (typeof parent2 != "object") {
+              return parent2;
+            }
+            if (_instanceof(parent2, nativeMap)) {
+              child = new nativeMap();
+            } else if (_instanceof(parent2, nativeSet)) {
+              child = new nativeSet();
+            } else if (_instanceof(parent2, nativePromise)) {
+              child = new nativePromise(function(resolve, reject) {
+                parent2.then(function(value) {
+                  resolve(_clone(value, depth2 - 1));
+                }, function(err) {
+                  reject(_clone(err, depth2 - 1));
+                });
+              });
+            } else if (clone3.__isArray(parent2)) {
+              child = [];
+            } else if (clone3.__isRegExp(parent2)) {
+              child = new RegExp(parent2.source, __getRegExpFlags(parent2));
+              if (parent2.lastIndex)
+                child.lastIndex = parent2.lastIndex;
+            } else if (clone3.__isDate(parent2)) {
+              child = new Date(parent2.getTime());
+            } else if (useBuffer && Buffer2.isBuffer(parent2)) {
+              if (Buffer2.allocUnsafe) {
+                child = Buffer2.allocUnsafe(parent2.length);
+              } else {
+                child = new Buffer2(parent2.length);
+              }
+              parent2.copy(child);
+              return child;
+            } else if (_instanceof(parent2, Error)) {
+              child = Object.create(parent2);
+            } else {
+              if (typeof prototype == "undefined") {
+                proto = Object.getPrototypeOf(parent2);
+                child = Object.create(proto);
+              } else {
+                child = Object.create(prototype);
+                proto = prototype;
+              }
+            }
+            if (circular) {
+              var index = allParents.indexOf(parent2);
+              if (index != -1) {
+                return allChildren[index];
+              }
+              allParents.push(parent2);
+              allChildren.push(child);
+            }
+            if (_instanceof(parent2, nativeMap)) {
+              parent2.forEach(function(value, key) {
+                var keyChild = _clone(key, depth2 - 1);
+                var valueChild = _clone(value, depth2 - 1);
+                child.set(keyChild, valueChild);
+              });
+            }
+            if (_instanceof(parent2, nativeSet)) {
+              parent2.forEach(function(value) {
+                var entryChild = _clone(value, depth2 - 1);
+                child.add(entryChild);
+              });
+            }
+            for (var i in parent2) {
+              var attrs;
+              if (proto) {
+                attrs = Object.getOwnPropertyDescriptor(proto, i);
+              }
+              if (attrs && attrs.set == null) {
+                continue;
+              }
+              child[i] = _clone(parent2[i], depth2 - 1);
+            }
+            if (Object.getOwnPropertySymbols) {
+              var symbols = Object.getOwnPropertySymbols(parent2);
+              for (var i = 0; i < symbols.length; i++) {
+                var symbol = symbols[i];
+                var descriptor = Object.getOwnPropertyDescriptor(parent2, symbol);
+                if (descriptor && !descriptor.enumerable && !includeNonEnumerable) {
+                  continue;
+                }
+                child[symbol] = _clone(parent2[symbol], depth2 - 1);
+                if (!descriptor.enumerable) {
+                  Object.defineProperty(child, symbol, {
+                    enumerable: false
+                  });
+                }
+              }
+            }
+            if (includeNonEnumerable) {
+              var allPropertyNames = Object.getOwnPropertyNames(parent2);
+              for (var i = 0; i < allPropertyNames.length; i++) {
+                var propertyName = allPropertyNames[i];
+                var descriptor = Object.getOwnPropertyDescriptor(parent2, propertyName);
+                if (descriptor && descriptor.enumerable) {
+                  continue;
+                }
+                child[propertyName] = _clone(parent2[propertyName], depth2 - 1);
+                Object.defineProperty(child, propertyName, {
                   enumerable: false
                 });
               }
             }
+            return child;
           }
-          if (includeNonEnumerable) {
-            var allPropertyNames = Object.getOwnPropertyNames(parent2);
-            for (var i = 0; i < allPropertyNames.length; i++) {
-              var propertyName = allPropertyNames[i];
-              var descriptor = Object.getOwnPropertyDescriptor(parent2, propertyName);
-              if (descriptor && descriptor.enumerable) {
-                continue;
-              }
-              child[propertyName] = _clone(parent2[propertyName], depth2 - 1);
-              Object.defineProperty(child, propertyName, {
-                enumerable: false
-              });
-            }
-          }
-          return child;
+          return _clone(parent, depth);
         }
-        return _clone(parent, depth);
-      }
-      clone3.clonePrototype = function clonePrototype(parent) {
-        if (parent === null)
-          return null;
-        var c = function() {
+        clone3.clonePrototype = function clonePrototype(parent) {
+          if (parent === null)
+            return null;
+          var c = function() {
+          };
+          c.prototype = parent;
+          return new c();
         };
-        c.prototype = parent;
-        return new c();
-      };
-      function __objToStr(o) {
-        return Object.prototype.toString.call(o);
+        function __objToStr(o) {
+          return Object.prototype.toString.call(o);
+        }
+        clone3.__objToStr = __objToStr;
+        function __isDate(o) {
+          return typeof o === "object" && __objToStr(o) === "[object Date]";
+        }
+        clone3.__isDate = __isDate;
+        function __isArray(o) {
+          return typeof o === "object" && __objToStr(o) === "[object Array]";
+        }
+        clone3.__isArray = __isArray;
+        function __isRegExp(o) {
+          return typeof o === "object" && __objToStr(o) === "[object RegExp]";
+        }
+        clone3.__isRegExp = __isRegExp;
+        function __getRegExpFlags(re) {
+          var flags = "";
+          if (re.global)
+            flags += "g";
+          if (re.ignoreCase)
+            flags += "i";
+          if (re.multiline)
+            flags += "m";
+          return flags;
+        }
+        clone3.__getRegExpFlags = __getRegExpFlags;
+        return clone3;
+      }();
+      if (typeof module === "object" && module.exports) {
+        module.exports = clone2;
       }
-      clone3.__objToStr = __objToStr;
-      function __isDate(o) {
-        return typeof o === "object" && __objToStr(o) === "[object Date]";
-      }
-      clone3.__isDate = __isDate;
-      function __isArray(o) {
-        return typeof o === "object" && __objToStr(o) === "[object Array]";
-      }
-      clone3.__isArray = __isArray;
-      function __isRegExp(o) {
-        return typeof o === "object" && __objToStr(o) === "[object RegExp]";
-      }
-      clone3.__isRegExp = __isRegExp;
-      function __getRegExpFlags(re) {
-        var flags = "";
-        if (re.global)
-          flags += "g";
-        if (re.ignoreCase)
-          flags += "i";
-        if (re.multiline)
-          flags += "m";
-        return flags;
-      }
-      clone3.__getRegExpFlags = __getRegExpFlags;
-      return clone3;
-    }();
-    if (typeof module2 === "object" && module2.exports) {
-      module2.exports = clone2;
     }
-  }
-});
+  });
 
-// node_modules/has-symbols/shams.js
-var require_shams = __commonJS({
-  "node_modules/has-symbols/shams.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    module2.exports = function hasSymbols() {
-      if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function") {
-        return false;
-      }
-      if (typeof Symbol.iterator === "symbol") {
-        return true;
-      }
-      var obj = {};
-      var sym = Symbol("test");
-      var symObj = Object(sym);
-      if (typeof sym === "string") {
-        return false;
-      }
-      if (Object.prototype.toString.call(sym) !== "[object Symbol]") {
-        return false;
-      }
-      if (Object.prototype.toString.call(symObj) !== "[object Symbol]") {
-        return false;
-      }
-      var symVal = 42;
-      obj[sym] = symVal;
-      for (sym in obj) {
-        return false;
-      }
-      if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
-        return false;
-      }
-      if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0) {
-        return false;
-      }
-      var syms = Object.getOwnPropertySymbols(obj);
-      if (syms.length !== 1 || syms[0] !== sym) {
-        return false;
-      }
-      if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) {
-        return false;
-      }
-      if (typeof Object.getOwnPropertyDescriptor === "function") {
-        var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
-        if (descriptor.value !== symVal || descriptor.enumerable !== true) {
+  // node_modules/has-symbols/shams.js
+  var require_shams = __commonJS({
+    "node_modules/has-symbols/shams.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      module.exports = function hasSymbols() {
+        if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function") {
           return false;
         }
-      }
-      return true;
-    };
-  }
-});
-
-// node_modules/has-symbols/index.js
-var require_has_symbols = __commonJS({
-  "node_modules/has-symbols/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var origSymbol = typeof Symbol !== "undefined" && Symbol;
-    var hasSymbolSham = require_shams();
-    module2.exports = function hasNativeSymbols() {
-      if (typeof origSymbol !== "function") {
-        return false;
-      }
-      if (typeof Symbol !== "function") {
-        return false;
-      }
-      if (typeof origSymbol("foo") !== "symbol") {
-        return false;
-      }
-      if (typeof Symbol("bar") !== "symbol") {
-        return false;
-      }
-      return hasSymbolSham();
-    };
-  }
-});
-
-// node_modules/function-bind/implementation.js
-var require_implementation = __commonJS({
-  "node_modules/function-bind/implementation.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
-    var slice = Array.prototype.slice;
-    var toStr = Object.prototype.toString;
-    var funcType = "[object Function]";
-    module2.exports = function bind(that) {
-      var target = this;
-      if (typeof target !== "function" || toStr.call(target) !== funcType) {
-        throw new TypeError(ERROR_MESSAGE + target);
-      }
-      var args = slice.call(arguments, 1);
-      var bound;
-      var binder = function() {
-        if (this instanceof bound) {
-          var result = target.apply(this, args.concat(slice.call(arguments)));
-          if (Object(result) === result) {
-            return result;
+        if (typeof Symbol.iterator === "symbol") {
+          return true;
+        }
+        var obj = {};
+        var sym = Symbol("test");
+        var symObj = Object(sym);
+        if (typeof sym === "string") {
+          return false;
+        }
+        if (Object.prototype.toString.call(sym) !== "[object Symbol]") {
+          return false;
+        }
+        if (Object.prototype.toString.call(symObj) !== "[object Symbol]") {
+          return false;
+        }
+        var symVal = 42;
+        obj[sym] = symVal;
+        for (sym in obj) {
+          return false;
+        }
+        if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
+          return false;
+        }
+        if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0) {
+          return false;
+        }
+        var syms = Object.getOwnPropertySymbols(obj);
+        if (syms.length !== 1 || syms[0] !== sym) {
+          return false;
+        }
+        if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) {
+          return false;
+        }
+        if (typeof Object.getOwnPropertyDescriptor === "function") {
+          var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
+          if (descriptor.value !== symVal || descriptor.enumerable !== true) {
+            return false;
           }
-          return this;
-        } else {
-          return target.apply(that, args.concat(slice.call(arguments)));
+        }
+        return true;
+      };
+    }
+  });
+
+  // node_modules/has-symbols/index.js
+  var require_has_symbols = __commonJS({
+    "node_modules/has-symbols/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var origSymbol = typeof Symbol !== "undefined" && Symbol;
+      var hasSymbolSham = require_shams();
+      module.exports = function hasNativeSymbols() {
+        if (typeof origSymbol !== "function") {
+          return false;
+        }
+        if (typeof Symbol !== "function") {
+          return false;
+        }
+        if (typeof origSymbol("foo") !== "symbol") {
+          return false;
+        }
+        if (typeof Symbol("bar") !== "symbol") {
+          return false;
+        }
+        return hasSymbolSham();
+      };
+    }
+  });
+
+  // node_modules/function-bind/implementation.js
+  var require_implementation = __commonJS({
+    "node_modules/function-bind/implementation.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
+      var slice = Array.prototype.slice;
+      var toStr = Object.prototype.toString;
+      var funcType = "[object Function]";
+      module.exports = function bind(that) {
+        var target = this;
+        if (typeof target !== "function" || toStr.call(target) !== funcType) {
+          throw new TypeError(ERROR_MESSAGE + target);
+        }
+        var args = slice.call(arguments, 1);
+        var bound;
+        var binder = function() {
+          if (this instanceof bound) {
+            var result = target.apply(this, args.concat(slice.call(arguments)));
+            if (Object(result) === result) {
+              return result;
+            }
+            return this;
+          } else {
+            return target.apply(that, args.concat(slice.call(arguments)));
+          }
+        };
+        var boundLength = Math.max(0, target.length - args.length);
+        var boundArgs = [];
+        for (var i = 0; i < boundLength; i++) {
+          boundArgs.push("$" + i);
+        }
+        bound = Function("binder", "return function (" + boundArgs.join(",") + "){ return binder.apply(this,arguments); }")(binder);
+        if (target.prototype) {
+          var Empty = function Empty2() {
+          };
+          Empty.prototype = target.prototype;
+          bound.prototype = new Empty();
+          Empty.prototype = null;
+        }
+        return bound;
+      };
+    }
+  });
+
+  // node_modules/function-bind/index.js
+  var require_function_bind = __commonJS({
+    "node_modules/function-bind/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var implementation = require_implementation();
+      module.exports = Function.prototype.bind || implementation;
+    }
+  });
+
+  // node_modules/has/src/index.js
+  var require_src = __commonJS({
+    "node_modules/has/src/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var bind = require_function_bind();
+      module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+    }
+  });
+
+  // node_modules/get-intrinsic/index.js
+  var require_get_intrinsic = __commonJS({
+    "node_modules/get-intrinsic/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var undefined2;
+      var $SyntaxError = SyntaxError;
+      var $Function = Function;
+      var $TypeError = TypeError;
+      var getEvalledConstructor = function(expressionSyntax) {
+        try {
+          return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
+        } catch (e) {
         }
       };
-      var boundLength = Math.max(0, target.length - args.length);
-      var boundArgs = [];
-      for (var i = 0; i < boundLength; i++) {
-        boundArgs.push("$" + i);
-      }
-      bound = Function("binder", "return function (" + boundArgs.join(",") + "){ return binder.apply(this,arguments); }")(binder);
-      if (target.prototype) {
-        var Empty = function Empty2() {
-        };
-        Empty.prototype = target.prototype;
-        bound.prototype = new Empty();
-        Empty.prototype = null;
-      }
-      return bound;
-    };
-  }
-});
-
-// node_modules/function-bind/index.js
-var require_function_bind = __commonJS({
-  "node_modules/function-bind/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var implementation = require_implementation();
-    module2.exports = Function.prototype.bind || implementation;
-  }
-});
-
-// node_modules/has/src/index.js
-var require_src = __commonJS({
-  "node_modules/has/src/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var bind = require_function_bind();
-    module2.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
-  }
-});
-
-// node_modules/get-intrinsic/index.js
-var require_get_intrinsic = __commonJS({
-  "node_modules/get-intrinsic/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var undefined2;
-    var $SyntaxError = SyntaxError;
-    var $Function = Function;
-    var $TypeError = TypeError;
-    var getEvalledConstructor = function(expressionSyntax) {
-      try {
-        return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
-      } catch (e) {
-      }
-    };
-    var $gOPD = Object.getOwnPropertyDescriptor;
-    if ($gOPD) {
-      try {
-        $gOPD({}, "");
-      } catch (e) {
-        $gOPD = null;
-      }
-    }
-    var throwTypeError = function() {
-      throw new $TypeError();
-    };
-    var ThrowTypeError = $gOPD ? function() {
-      try {
-        arguments.callee;
-        return throwTypeError;
-      } catch (calleeThrows) {
+      var $gOPD = Object.getOwnPropertyDescriptor;
+      if ($gOPD) {
         try {
-          return $gOPD(arguments, "callee").get;
-        } catch (gOPDthrows) {
+          $gOPD({}, "");
+        } catch (e) {
+          $gOPD = null;
+        }
+      }
+      var throwTypeError = function() {
+        throw new $TypeError();
+      };
+      var ThrowTypeError = $gOPD ? function() {
+        try {
+          arguments.callee;
           return throwTypeError;
-        }
-      }
-    }() : throwTypeError;
-    var hasSymbols = require_has_symbols()();
-    var getProto = Object.getPrototypeOf || function(x) {
-      return x.__proto__;
-    };
-    var needsEval = {};
-    var TypedArray = typeof Uint8Array === "undefined" ? undefined2 : getProto(Uint8Array);
-    var INTRINSICS = {
-      "%AggregateError%": typeof AggregateError === "undefined" ? undefined2 : AggregateError,
-      "%Array%": Array,
-      "%ArrayBuffer%": typeof ArrayBuffer === "undefined" ? undefined2 : ArrayBuffer,
-      "%ArrayIteratorPrototype%": hasSymbols ? getProto([][Symbol.iterator]()) : undefined2,
-      "%AsyncFromSyncIteratorPrototype%": undefined2,
-      "%AsyncFunction%": needsEval,
-      "%AsyncGenerator%": needsEval,
-      "%AsyncGeneratorFunction%": needsEval,
-      "%AsyncIteratorPrototype%": needsEval,
-      "%Atomics%": typeof Atomics === "undefined" ? undefined2 : Atomics,
-      "%BigInt%": typeof BigInt === "undefined" ? undefined2 : BigInt,
-      "%Boolean%": Boolean,
-      "%DataView%": typeof DataView === "undefined" ? undefined2 : DataView,
-      "%Date%": Date,
-      "%decodeURI%": decodeURI,
-      "%decodeURIComponent%": decodeURIComponent,
-      "%encodeURI%": encodeURI,
-      "%encodeURIComponent%": encodeURIComponent,
-      "%Error%": Error,
-      "%eval%": eval,
-      "%EvalError%": EvalError,
-      "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
-      "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
-      "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
-      "%Function%": $Function,
-      "%GeneratorFunction%": needsEval,
-      "%Int8Array%": typeof Int8Array === "undefined" ? undefined2 : Int8Array,
-      "%Int16Array%": typeof Int16Array === "undefined" ? undefined2 : Int16Array,
-      "%Int32Array%": typeof Int32Array === "undefined" ? undefined2 : Int32Array,
-      "%isFinite%": isFinite,
-      "%isNaN%": isNaN,
-      "%IteratorPrototype%": hasSymbols ? getProto(getProto([][Symbol.iterator]())) : undefined2,
-      "%JSON%": typeof JSON === "object" ? JSON : undefined2,
-      "%Map%": typeof Map === "undefined" ? undefined2 : Map,
-      "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols ? undefined2 : getProto(new Map()[Symbol.iterator]()),
-      "%Math%": Math,
-      "%Number%": Number,
-      "%Object%": Object,
-      "%parseFloat%": parseFloat,
-      "%parseInt%": parseInt,
-      "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
-      "%Proxy%": typeof Proxy === "undefined" ? undefined2 : Proxy,
-      "%RangeError%": RangeError,
-      "%ReferenceError%": ReferenceError,
-      "%Reflect%": typeof Reflect === "undefined" ? undefined2 : Reflect,
-      "%RegExp%": RegExp,
-      "%Set%": typeof Set === "undefined" ? undefined2 : Set,
-      "%SetIteratorPrototype%": typeof Set === "undefined" || !hasSymbols ? undefined2 : getProto(new Set()[Symbol.iterator]()),
-      "%SharedArrayBuffer%": typeof SharedArrayBuffer === "undefined" ? undefined2 : SharedArrayBuffer,
-      "%String%": String,
-      "%StringIteratorPrototype%": hasSymbols ? getProto(""[Symbol.iterator]()) : undefined2,
-      "%Symbol%": hasSymbols ? Symbol : undefined2,
-      "%SyntaxError%": $SyntaxError,
-      "%ThrowTypeError%": ThrowTypeError,
-      "%TypedArray%": TypedArray,
-      "%TypeError%": $TypeError,
-      "%Uint8Array%": typeof Uint8Array === "undefined" ? undefined2 : Uint8Array,
-      "%Uint8ClampedArray%": typeof Uint8ClampedArray === "undefined" ? undefined2 : Uint8ClampedArray,
-      "%Uint16Array%": typeof Uint16Array === "undefined" ? undefined2 : Uint16Array,
-      "%Uint32Array%": typeof Uint32Array === "undefined" ? undefined2 : Uint32Array,
-      "%URIError%": URIError,
-      "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
-      "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
-      "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet
-    };
-    var doEval = function doEval2(name) {
-      var value;
-      if (name === "%AsyncFunction%") {
-        value = getEvalledConstructor("async function () {}");
-      } else if (name === "%GeneratorFunction%") {
-        value = getEvalledConstructor("function* () {}");
-      } else if (name === "%AsyncGeneratorFunction%") {
-        value = getEvalledConstructor("async function* () {}");
-      } else if (name === "%AsyncGenerator%") {
-        var fn = doEval2("%AsyncGeneratorFunction%");
-        if (fn) {
-          value = fn.prototype;
-        }
-      } else if (name === "%AsyncIteratorPrototype%") {
-        var gen = doEval2("%AsyncGenerator%");
-        if (gen) {
-          value = getProto(gen.prototype);
-        }
-      }
-      INTRINSICS[name] = value;
-      return value;
-    };
-    var LEGACY_ALIASES = {
-      "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"],
-      "%ArrayPrototype%": ["Array", "prototype"],
-      "%ArrayProto_entries%": ["Array", "prototype", "entries"],
-      "%ArrayProto_forEach%": ["Array", "prototype", "forEach"],
-      "%ArrayProto_keys%": ["Array", "prototype", "keys"],
-      "%ArrayProto_values%": ["Array", "prototype", "values"],
-      "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"],
-      "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"],
-      "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"],
-      "%BooleanPrototype%": ["Boolean", "prototype"],
-      "%DataViewPrototype%": ["DataView", "prototype"],
-      "%DatePrototype%": ["Date", "prototype"],
-      "%ErrorPrototype%": ["Error", "prototype"],
-      "%EvalErrorPrototype%": ["EvalError", "prototype"],
-      "%Float32ArrayPrototype%": ["Float32Array", "prototype"],
-      "%Float64ArrayPrototype%": ["Float64Array", "prototype"],
-      "%FunctionPrototype%": ["Function", "prototype"],
-      "%Generator%": ["GeneratorFunction", "prototype"],
-      "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"],
-      "%Int8ArrayPrototype%": ["Int8Array", "prototype"],
-      "%Int16ArrayPrototype%": ["Int16Array", "prototype"],
-      "%Int32ArrayPrototype%": ["Int32Array", "prototype"],
-      "%JSONParse%": ["JSON", "parse"],
-      "%JSONStringify%": ["JSON", "stringify"],
-      "%MapPrototype%": ["Map", "prototype"],
-      "%NumberPrototype%": ["Number", "prototype"],
-      "%ObjectPrototype%": ["Object", "prototype"],
-      "%ObjProto_toString%": ["Object", "prototype", "toString"],
-      "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"],
-      "%PromisePrototype%": ["Promise", "prototype"],
-      "%PromiseProto_then%": ["Promise", "prototype", "then"],
-      "%Promise_all%": ["Promise", "all"],
-      "%Promise_reject%": ["Promise", "reject"],
-      "%Promise_resolve%": ["Promise", "resolve"],
-      "%RangeErrorPrototype%": ["RangeError", "prototype"],
-      "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"],
-      "%RegExpPrototype%": ["RegExp", "prototype"],
-      "%SetPrototype%": ["Set", "prototype"],
-      "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"],
-      "%StringPrototype%": ["String", "prototype"],
-      "%SymbolPrototype%": ["Symbol", "prototype"],
-      "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"],
-      "%TypedArrayPrototype%": ["TypedArray", "prototype"],
-      "%TypeErrorPrototype%": ["TypeError", "prototype"],
-      "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"],
-      "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"],
-      "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"],
-      "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"],
-      "%URIErrorPrototype%": ["URIError", "prototype"],
-      "%WeakMapPrototype%": ["WeakMap", "prototype"],
-      "%WeakSetPrototype%": ["WeakSet", "prototype"]
-    };
-    var bind = require_function_bind();
-    var hasOwn = require_src();
-    var $concat = bind.call(Function.call, Array.prototype.concat);
-    var $spliceApply = bind.call(Function.apply, Array.prototype.splice);
-    var $replace = bind.call(Function.call, String.prototype.replace);
-    var $strSlice = bind.call(Function.call, String.prototype.slice);
-    var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
-    var reEscapeChar = /\\(\\)?/g;
-    var stringToPath = function stringToPath2(string) {
-      var first = $strSlice(string, 0, 1);
-      var last = $strSlice(string, -1);
-      if (first === "%" && last !== "%") {
-        throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
-      } else if (last === "%" && first !== "%") {
-        throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
-      }
-      var result = [];
-      $replace(string, rePropName, function(match, number, quote, subString) {
-        result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
-      });
-      return result;
-    };
-    var getBaseIntrinsic = function getBaseIntrinsic2(name, allowMissing) {
-      var intrinsicName = name;
-      var alias;
-      if (hasOwn(LEGACY_ALIASES, intrinsicName)) {
-        alias = LEGACY_ALIASES[intrinsicName];
-        intrinsicName = "%" + alias[0] + "%";
-      }
-      if (hasOwn(INTRINSICS, intrinsicName)) {
-        var value = INTRINSICS[intrinsicName];
-        if (value === needsEval) {
-          value = doEval(intrinsicName);
-        }
-        if (typeof value === "undefined" && !allowMissing) {
-          throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
-        }
-        return {
-          alias,
-          name: intrinsicName,
-          value
-        };
-      }
-      throw new $SyntaxError("intrinsic " + name + " does not exist!");
-    };
-    module2.exports = function GetIntrinsic(name, allowMissing) {
-      if (typeof name !== "string" || name.length === 0) {
-        throw new $TypeError("intrinsic name must be a non-empty string");
-      }
-      if (arguments.length > 1 && typeof allowMissing !== "boolean") {
-        throw new $TypeError('"allowMissing" argument must be a boolean');
-      }
-      var parts = stringToPath(name);
-      var intrinsicBaseName = parts.length > 0 ? parts[0] : "";
-      var intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing);
-      var intrinsicRealName = intrinsic.name;
-      var value = intrinsic.value;
-      var skipFurtherCaching = false;
-      var alias = intrinsic.alias;
-      if (alias) {
-        intrinsicBaseName = alias[0];
-        $spliceApply(parts, $concat([0, 1], alias));
-      }
-      for (var i = 1, isOwn = true; i < parts.length; i += 1) {
-        var part = parts[i];
-        var first = $strSlice(part, 0, 1);
-        var last = $strSlice(part, -1);
-        if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last) {
-          throw new $SyntaxError("property names with quotes must have matching quotes");
-        }
-        if (part === "constructor" || !isOwn) {
-          skipFurtherCaching = true;
-        }
-        intrinsicBaseName += "." + part;
-        intrinsicRealName = "%" + intrinsicBaseName + "%";
-        if (hasOwn(INTRINSICS, intrinsicRealName)) {
-          value = INTRINSICS[intrinsicRealName];
-        } else if (value != null) {
-          if (!(part in value)) {
-            if (!allowMissing) {
-              throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
-            }
-            return void 0;
+        } catch (calleeThrows) {
+          try {
+            return $gOPD(arguments, "callee").get;
+          } catch (gOPDthrows) {
+            return throwTypeError;
           }
-          if ($gOPD && i + 1 >= parts.length) {
-            var desc = $gOPD(value, part);
-            isOwn = !!desc;
-            if (isOwn && "get" in desc && !("originalValue" in desc.get)) {
-              value = desc.get;
+        }
+      }() : throwTypeError;
+      var hasSymbols = require_has_symbols()();
+      var getProto = Object.getPrototypeOf || function(x) {
+        return x.__proto__;
+      };
+      var needsEval = {};
+      var TypedArray = typeof Uint8Array === "undefined" ? undefined2 : getProto(Uint8Array);
+      var INTRINSICS = {
+        "%AggregateError%": typeof AggregateError === "undefined" ? undefined2 : AggregateError,
+        "%Array%": Array,
+        "%ArrayBuffer%": typeof ArrayBuffer === "undefined" ? undefined2 : ArrayBuffer,
+        "%ArrayIteratorPrototype%": hasSymbols ? getProto([][Symbol.iterator]()) : undefined2,
+        "%AsyncFromSyncIteratorPrototype%": undefined2,
+        "%AsyncFunction%": needsEval,
+        "%AsyncGenerator%": needsEval,
+        "%AsyncGeneratorFunction%": needsEval,
+        "%AsyncIteratorPrototype%": needsEval,
+        "%Atomics%": typeof Atomics === "undefined" ? undefined2 : Atomics,
+        "%BigInt%": typeof BigInt === "undefined" ? undefined2 : BigInt,
+        "%Boolean%": Boolean,
+        "%DataView%": typeof DataView === "undefined" ? undefined2 : DataView,
+        "%Date%": Date,
+        "%decodeURI%": decodeURI,
+        "%decodeURIComponent%": decodeURIComponent,
+        "%encodeURI%": encodeURI,
+        "%encodeURIComponent%": encodeURIComponent,
+        "%Error%": Error,
+        "%eval%": eval,
+        "%EvalError%": EvalError,
+        "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
+        "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
+        "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
+        "%Function%": $Function,
+        "%GeneratorFunction%": needsEval,
+        "%Int8Array%": typeof Int8Array === "undefined" ? undefined2 : Int8Array,
+        "%Int16Array%": typeof Int16Array === "undefined" ? undefined2 : Int16Array,
+        "%Int32Array%": typeof Int32Array === "undefined" ? undefined2 : Int32Array,
+        "%isFinite%": isFinite,
+        "%isNaN%": isNaN,
+        "%IteratorPrototype%": hasSymbols ? getProto(getProto([][Symbol.iterator]())) : undefined2,
+        "%JSON%": typeof JSON === "object" ? JSON : undefined2,
+        "%Map%": typeof Map === "undefined" ? undefined2 : Map,
+        "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols ? undefined2 : getProto(new Map()[Symbol.iterator]()),
+        "%Math%": Math,
+        "%Number%": Number,
+        "%Object%": Object,
+        "%parseFloat%": parseFloat,
+        "%parseInt%": parseInt,
+        "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
+        "%Proxy%": typeof Proxy === "undefined" ? undefined2 : Proxy,
+        "%RangeError%": RangeError,
+        "%ReferenceError%": ReferenceError,
+        "%Reflect%": typeof Reflect === "undefined" ? undefined2 : Reflect,
+        "%RegExp%": RegExp,
+        "%Set%": typeof Set === "undefined" ? undefined2 : Set,
+        "%SetIteratorPrototype%": typeof Set === "undefined" || !hasSymbols ? undefined2 : getProto(new Set()[Symbol.iterator]()),
+        "%SharedArrayBuffer%": typeof SharedArrayBuffer === "undefined" ? undefined2 : SharedArrayBuffer,
+        "%String%": String,
+        "%StringIteratorPrototype%": hasSymbols ? getProto(""[Symbol.iterator]()) : undefined2,
+        "%Symbol%": hasSymbols ? Symbol : undefined2,
+        "%SyntaxError%": $SyntaxError,
+        "%ThrowTypeError%": ThrowTypeError,
+        "%TypedArray%": TypedArray,
+        "%TypeError%": $TypeError,
+        "%Uint8Array%": typeof Uint8Array === "undefined" ? undefined2 : Uint8Array,
+        "%Uint8ClampedArray%": typeof Uint8ClampedArray === "undefined" ? undefined2 : Uint8ClampedArray,
+        "%Uint16Array%": typeof Uint16Array === "undefined" ? undefined2 : Uint16Array,
+        "%Uint32Array%": typeof Uint32Array === "undefined" ? undefined2 : Uint32Array,
+        "%URIError%": URIError,
+        "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
+        "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
+        "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet
+      };
+      var doEval = function doEval2(name) {
+        var value;
+        if (name === "%AsyncFunction%") {
+          value = getEvalledConstructor("async function () {}");
+        } else if (name === "%GeneratorFunction%") {
+          value = getEvalledConstructor("function* () {}");
+        } else if (name === "%AsyncGeneratorFunction%") {
+          value = getEvalledConstructor("async function* () {}");
+        } else if (name === "%AsyncGenerator%") {
+          var fn = doEval2("%AsyncGeneratorFunction%");
+          if (fn) {
+            value = fn.prototype;
+          }
+        } else if (name === "%AsyncIteratorPrototype%") {
+          var gen = doEval2("%AsyncGenerator%");
+          if (gen) {
+            value = getProto(gen.prototype);
+          }
+        }
+        INTRINSICS[name] = value;
+        return value;
+      };
+      var LEGACY_ALIASES = {
+        "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"],
+        "%ArrayPrototype%": ["Array", "prototype"],
+        "%ArrayProto_entries%": ["Array", "prototype", "entries"],
+        "%ArrayProto_forEach%": ["Array", "prototype", "forEach"],
+        "%ArrayProto_keys%": ["Array", "prototype", "keys"],
+        "%ArrayProto_values%": ["Array", "prototype", "values"],
+        "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"],
+        "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"],
+        "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"],
+        "%BooleanPrototype%": ["Boolean", "prototype"],
+        "%DataViewPrototype%": ["DataView", "prototype"],
+        "%DatePrototype%": ["Date", "prototype"],
+        "%ErrorPrototype%": ["Error", "prototype"],
+        "%EvalErrorPrototype%": ["EvalError", "prototype"],
+        "%Float32ArrayPrototype%": ["Float32Array", "prototype"],
+        "%Float64ArrayPrototype%": ["Float64Array", "prototype"],
+        "%FunctionPrototype%": ["Function", "prototype"],
+        "%Generator%": ["GeneratorFunction", "prototype"],
+        "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"],
+        "%Int8ArrayPrototype%": ["Int8Array", "prototype"],
+        "%Int16ArrayPrototype%": ["Int16Array", "prototype"],
+        "%Int32ArrayPrototype%": ["Int32Array", "prototype"],
+        "%JSONParse%": ["JSON", "parse"],
+        "%JSONStringify%": ["JSON", "stringify"],
+        "%MapPrototype%": ["Map", "prototype"],
+        "%NumberPrototype%": ["Number", "prototype"],
+        "%ObjectPrototype%": ["Object", "prototype"],
+        "%ObjProto_toString%": ["Object", "prototype", "toString"],
+        "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"],
+        "%PromisePrototype%": ["Promise", "prototype"],
+        "%PromiseProto_then%": ["Promise", "prototype", "then"],
+        "%Promise_all%": ["Promise", "all"],
+        "%Promise_reject%": ["Promise", "reject"],
+        "%Promise_resolve%": ["Promise", "resolve"],
+        "%RangeErrorPrototype%": ["RangeError", "prototype"],
+        "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"],
+        "%RegExpPrototype%": ["RegExp", "prototype"],
+        "%SetPrototype%": ["Set", "prototype"],
+        "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"],
+        "%StringPrototype%": ["String", "prototype"],
+        "%SymbolPrototype%": ["Symbol", "prototype"],
+        "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"],
+        "%TypedArrayPrototype%": ["TypedArray", "prototype"],
+        "%TypeErrorPrototype%": ["TypeError", "prototype"],
+        "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"],
+        "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"],
+        "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"],
+        "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"],
+        "%URIErrorPrototype%": ["URIError", "prototype"],
+        "%WeakMapPrototype%": ["WeakMap", "prototype"],
+        "%WeakSetPrototype%": ["WeakSet", "prototype"]
+      };
+      var bind = require_function_bind();
+      var hasOwn = require_src();
+      var $concat = bind.call(Function.call, Array.prototype.concat);
+      var $spliceApply = bind.call(Function.apply, Array.prototype.splice);
+      var $replace = bind.call(Function.call, String.prototype.replace);
+      var $strSlice = bind.call(Function.call, String.prototype.slice);
+      var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
+      var reEscapeChar = /\\(\\)?/g;
+      var stringToPath = function stringToPath2(string) {
+        var first = $strSlice(string, 0, 1);
+        var last = $strSlice(string, -1);
+        if (first === "%" && last !== "%") {
+          throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
+        } else if (last === "%" && first !== "%") {
+          throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
+        }
+        var result = [];
+        $replace(string, rePropName, function(match, number, quote, subString) {
+          result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
+        });
+        return result;
+      };
+      var getBaseIntrinsic = function getBaseIntrinsic2(name, allowMissing) {
+        var intrinsicName = name;
+        var alias;
+        if (hasOwn(LEGACY_ALIASES, intrinsicName)) {
+          alias = LEGACY_ALIASES[intrinsicName];
+          intrinsicName = "%" + alias[0] + "%";
+        }
+        if (hasOwn(INTRINSICS, intrinsicName)) {
+          var value = INTRINSICS[intrinsicName];
+          if (value === needsEval) {
+            value = doEval(intrinsicName);
+          }
+          if (typeof value === "undefined" && !allowMissing) {
+            throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
+          }
+          return {
+            alias,
+            name: intrinsicName,
+            value
+          };
+        }
+        throw new $SyntaxError("intrinsic " + name + " does not exist!");
+      };
+      module.exports = function GetIntrinsic(name, allowMissing) {
+        if (typeof name !== "string" || name.length === 0) {
+          throw new $TypeError("intrinsic name must be a non-empty string");
+        }
+        if (arguments.length > 1 && typeof allowMissing !== "boolean") {
+          throw new $TypeError('"allowMissing" argument must be a boolean');
+        }
+        var parts = stringToPath(name);
+        var intrinsicBaseName = parts.length > 0 ? parts[0] : "";
+        var intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing);
+        var intrinsicRealName = intrinsic.name;
+        var value = intrinsic.value;
+        var skipFurtherCaching = false;
+        var alias = intrinsic.alias;
+        if (alias) {
+          intrinsicBaseName = alias[0];
+          $spliceApply(parts, $concat([0, 1], alias));
+        }
+        for (var i = 1, isOwn = true; i < parts.length; i += 1) {
+          var part = parts[i];
+          var first = $strSlice(part, 0, 1);
+          var last = $strSlice(part, -1);
+          if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last) {
+            throw new $SyntaxError("property names with quotes must have matching quotes");
+          }
+          if (part === "constructor" || !isOwn) {
+            skipFurtherCaching = true;
+          }
+          intrinsicBaseName += "." + part;
+          intrinsicRealName = "%" + intrinsicBaseName + "%";
+          if (hasOwn(INTRINSICS, intrinsicRealName)) {
+            value = INTRINSICS[intrinsicRealName];
+          } else if (value != null) {
+            if (!(part in value)) {
+              if (!allowMissing) {
+                throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
+              }
+              return void 0;
+            }
+            if ($gOPD && i + 1 >= parts.length) {
+              var desc = $gOPD(value, part);
+              isOwn = !!desc;
+              if (isOwn && "get" in desc && !("originalValue" in desc.get)) {
+                value = desc.get;
+              } else {
+                value = value[part];
+              }
             } else {
+              isOwn = hasOwn(value, part);
               value = value[part];
             }
-          } else {
-            isOwn = hasOwn(value, part);
-            value = value[part];
-          }
-          if (isOwn && !skipFurtherCaching) {
-            INTRINSICS[intrinsicRealName] = value;
+            if (isOwn && !skipFurtherCaching) {
+              INTRINSICS[intrinsicRealName] = value;
+            }
           }
         }
-      }
-      return value;
-    };
-  }
-});
-
-// node_modules/call-bind/index.js
-var require_call_bind = __commonJS({
-  "node_modules/call-bind/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var bind = require_function_bind();
-    var GetIntrinsic = require_get_intrinsic();
-    var $apply = GetIntrinsic("%Function.prototype.apply%");
-    var $call = GetIntrinsic("%Function.prototype.call%");
-    var $reflectApply = GetIntrinsic("%Reflect.apply%", true) || bind.call($call, $apply);
-    var $gOPD = GetIntrinsic("%Object.getOwnPropertyDescriptor%", true);
-    var $defineProperty = GetIntrinsic("%Object.defineProperty%", true);
-    var $max = GetIntrinsic("%Math.max%");
-    if ($defineProperty) {
-      try {
-        $defineProperty({}, "a", { value: 1 });
-      } catch (e) {
-        $defineProperty = null;
-      }
+        return value;
+      };
     }
-    module2.exports = function callBind(originalFunction) {
-      var func = $reflectApply(bind, $call, arguments);
-      if ($gOPD && $defineProperty) {
-        var desc = $gOPD(func, "length");
-        if (desc.configurable) {
-          $defineProperty(func, "length", { value: 1 + $max(0, originalFunction.length - (arguments.length - 1)) });
+  });
+
+  // node_modules/call-bind/index.js
+  var require_call_bind = __commonJS({
+    "node_modules/call-bind/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var bind = require_function_bind();
+      var GetIntrinsic = require_get_intrinsic();
+      var $apply = GetIntrinsic("%Function.prototype.apply%");
+      var $call = GetIntrinsic("%Function.prototype.call%");
+      var $reflectApply = GetIntrinsic("%Reflect.apply%", true) || bind.call($call, $apply);
+      var $gOPD = GetIntrinsic("%Object.getOwnPropertyDescriptor%", true);
+      var $defineProperty = GetIntrinsic("%Object.defineProperty%", true);
+      var $max = GetIntrinsic("%Math.max%");
+      if ($defineProperty) {
+        try {
+          $defineProperty({}, "a", { value: 1 });
+        } catch (e) {
+          $defineProperty = null;
         }
       }
-      return func;
-    };
-    var applyBind = function applyBind2() {
-      return $reflectApply(bind, $apply, arguments);
-    };
-    if ($defineProperty) {
-      $defineProperty(module2.exports, "apply", { value: applyBind });
-    } else {
-      module2.exports.apply = applyBind;
+      module.exports = function callBind(originalFunction) {
+        var func = $reflectApply(bind, $call, arguments);
+        if ($gOPD && $defineProperty) {
+          var desc = $gOPD(func, "length");
+          if (desc.configurable) {
+            $defineProperty(func, "length", { value: 1 + $max(0, originalFunction.length - (arguments.length - 1)) });
+          }
+        }
+        return func;
+      };
+      var applyBind = function applyBind2() {
+        return $reflectApply(bind, $apply, arguments);
+      };
+      if ($defineProperty) {
+        $defineProperty(module.exports, "apply", { value: applyBind });
+      } else {
+        module.exports.apply = applyBind;
+      }
     }
-  }
-});
+  });
 
-// node_modules/call-bind/callBound.js
-var require_callBound = __commonJS({
-  "node_modules/call-bind/callBound.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var callBind = require_call_bind();
-    var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
-    module2.exports = function callBoundIntrinsic(name, allowMissing) {
-      var intrinsic = GetIntrinsic(name, !!allowMissing);
-      if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
-        return callBind(intrinsic);
-      }
-      return intrinsic;
-    };
-  }
-});
+  // node_modules/call-bind/callBound.js
+  var require_callBound = __commonJS({
+    "node_modules/call-bind/callBound.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var GetIntrinsic = require_get_intrinsic();
+      var callBind = require_call_bind();
+      var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
+      module.exports = function callBoundIntrinsic(name, allowMissing) {
+        var intrinsic = GetIntrinsic(name, !!allowMissing);
+        if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
+          return callBind(intrinsic);
+        }
+        return intrinsic;
+      };
+    }
+  });
 
-// (disabled):node_modules/object-inspect/util.inspect
-var require_util = __commonJS({
-  "(disabled):node_modules/object-inspect/util.inspect"() {
-    init_buffer_shim();
-  }
-});
+  // (disabled):node_modules/object-inspect/util.inspect
+  var require_util = __commonJS({
+    "(disabled):node_modules/object-inspect/util.inspect"() {
+      init_buffer_shim();
+    }
+  });
 
-// node_modules/object-inspect/index.js
-var require_object_inspect = __commonJS({
-  "node_modules/object-inspect/index.js"(exports, module2) {
-    init_buffer_shim();
-    var hasMap = typeof Map === "function" && Map.prototype;
-    var mapSizeDescriptor = Object.getOwnPropertyDescriptor && hasMap ? Object.getOwnPropertyDescriptor(Map.prototype, "size") : null;
-    var mapSize = hasMap && mapSizeDescriptor && typeof mapSizeDescriptor.get === "function" ? mapSizeDescriptor.get : null;
-    var mapForEach = hasMap && Map.prototype.forEach;
-    var hasSet = typeof Set === "function" && Set.prototype;
-    var setSizeDescriptor = Object.getOwnPropertyDescriptor && hasSet ? Object.getOwnPropertyDescriptor(Set.prototype, "size") : null;
-    var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === "function" ? setSizeDescriptor.get : null;
-    var setForEach = hasSet && Set.prototype.forEach;
-    var hasWeakMap = typeof WeakMap === "function" && WeakMap.prototype;
-    var weakMapHas = hasWeakMap ? WeakMap.prototype.has : null;
-    var hasWeakSet = typeof WeakSet === "function" && WeakSet.prototype;
-    var weakSetHas = hasWeakSet ? WeakSet.prototype.has : null;
-    var hasWeakRef = typeof WeakRef === "function" && WeakRef.prototype;
-    var weakRefDeref = hasWeakRef ? WeakRef.prototype.deref : null;
-    var booleanValueOf = Boolean.prototype.valueOf;
-    var objectToString = Object.prototype.toString;
-    var functionToString = Function.prototype.toString;
-    var match = String.prototype.match;
-    var bigIntValueOf = typeof BigInt === "function" ? BigInt.prototype.valueOf : null;
-    var gOPS = Object.getOwnPropertySymbols;
-    var symToString = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? Symbol.prototype.toString : null;
-    var hasShammedSymbols = typeof Symbol === "function" && typeof Symbol.iterator === "object";
-    var isEnumerable = Object.prototype.propertyIsEnumerable;
-    var gPO = (typeof Reflect === "function" ? Reflect.getPrototypeOf : Object.getPrototypeOf) || ([].__proto__ === Array.prototype ? function(O) {
-      return O.__proto__;
-    } : null);
-    var inspectCustom = require_util().custom;
-    var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
-    var toStringTag = typeof Symbol === "function" && typeof Symbol.toStringTag !== "undefined" ? Symbol.toStringTag : null;
-    module2.exports = function inspect_(obj, options, depth, seen) {
-      var opts = options || {};
-      if (has(opts, "quoteStyle") && (opts.quoteStyle !== "single" && opts.quoteStyle !== "double")) {
-        throw new TypeError('option "quoteStyle" must be "single" or "double"');
-      }
-      if (has(opts, "maxStringLength") && (typeof opts.maxStringLength === "number" ? opts.maxStringLength < 0 && opts.maxStringLength !== Infinity : opts.maxStringLength !== null)) {
-        throw new TypeError('option "maxStringLength", if provided, must be a positive integer, Infinity, or `null`');
-      }
-      var customInspect = has(opts, "customInspect") ? opts.customInspect : true;
-      if (typeof customInspect !== "boolean") {
-        throw new TypeError('option "customInspect", if provided, must be `true` or `false`');
-      }
-      if (has(opts, "indent") && opts.indent !== null && opts.indent !== "	" && !(parseInt(opts.indent, 10) === opts.indent && opts.indent > 0)) {
-        throw new TypeError('options "indent" must be "\\t", an integer > 0, or `null`');
-      }
-      if (typeof obj === "undefined") {
-        return "undefined";
-      }
-      if (obj === null) {
-        return "null";
-      }
-      if (typeof obj === "boolean") {
-        return obj ? "true" : "false";
-      }
-      if (typeof obj === "string") {
-        return inspectString(obj, opts);
-      }
-      if (typeof obj === "number") {
-        if (obj === 0) {
-          return Infinity / obj > 0 ? "0" : "-0";
+  // node_modules/object-inspect/index.js
+  var require_object_inspect = __commonJS({
+    "node_modules/object-inspect/index.js"(exports, module) {
+      init_buffer_shim();
+      var hasMap = typeof Map === "function" && Map.prototype;
+      var mapSizeDescriptor = Object.getOwnPropertyDescriptor && hasMap ? Object.getOwnPropertyDescriptor(Map.prototype, "size") : null;
+      var mapSize = hasMap && mapSizeDescriptor && typeof mapSizeDescriptor.get === "function" ? mapSizeDescriptor.get : null;
+      var mapForEach = hasMap && Map.prototype.forEach;
+      var hasSet = typeof Set === "function" && Set.prototype;
+      var setSizeDescriptor = Object.getOwnPropertyDescriptor && hasSet ? Object.getOwnPropertyDescriptor(Set.prototype, "size") : null;
+      var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === "function" ? setSizeDescriptor.get : null;
+      var setForEach = hasSet && Set.prototype.forEach;
+      var hasWeakMap = typeof WeakMap === "function" && WeakMap.prototype;
+      var weakMapHas = hasWeakMap ? WeakMap.prototype.has : null;
+      var hasWeakSet = typeof WeakSet === "function" && WeakSet.prototype;
+      var weakSetHas = hasWeakSet ? WeakSet.prototype.has : null;
+      var hasWeakRef = typeof WeakRef === "function" && WeakRef.prototype;
+      var weakRefDeref = hasWeakRef ? WeakRef.prototype.deref : null;
+      var booleanValueOf = Boolean.prototype.valueOf;
+      var objectToString = Object.prototype.toString;
+      var functionToString = Function.prototype.toString;
+      var match = String.prototype.match;
+      var bigIntValueOf = typeof BigInt === "function" ? BigInt.prototype.valueOf : null;
+      var gOPS = Object.getOwnPropertySymbols;
+      var symToString = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? Symbol.prototype.toString : null;
+      var hasShammedSymbols = typeof Symbol === "function" && typeof Symbol.iterator === "object";
+      var isEnumerable = Object.prototype.propertyIsEnumerable;
+      var gPO = (typeof Reflect === "function" ? Reflect.getPrototypeOf : Object.getPrototypeOf) || ([].__proto__ === Array.prototype ? function(O) {
+        return O.__proto__;
+      } : null);
+      var inspectCustom = require_util().custom;
+      var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
+      var toStringTag = typeof Symbol === "function" && typeof Symbol.toStringTag !== "undefined" ? Symbol.toStringTag : null;
+      module.exports = function inspect_(obj, options, depth, seen) {
+        var opts = options || {};
+        if (has(opts, "quoteStyle") && (opts.quoteStyle !== "single" && opts.quoteStyle !== "double")) {
+          throw new TypeError('option "quoteStyle" must be "single" or "double"');
+        }
+        if (has(opts, "maxStringLength") && (typeof opts.maxStringLength === "number" ? opts.maxStringLength < 0 && opts.maxStringLength !== Infinity : opts.maxStringLength !== null)) {
+          throw new TypeError('option "maxStringLength", if provided, must be a positive integer, Infinity, or `null`');
+        }
+        var customInspect = has(opts, "customInspect") ? opts.customInspect : true;
+        if (typeof customInspect !== "boolean") {
+          throw new TypeError('option "customInspect", if provided, must be `true` or `false`');
+        }
+        if (has(opts, "indent") && opts.indent !== null && opts.indent !== "	" && !(parseInt(opts.indent, 10) === opts.indent && opts.indent > 0)) {
+          throw new TypeError('options "indent" must be "\\t", an integer > 0, or `null`');
+        }
+        if (typeof obj === "undefined") {
+          return "undefined";
+        }
+        if (obj === null) {
+          return "null";
+        }
+        if (typeof obj === "boolean") {
+          return obj ? "true" : "false";
+        }
+        if (typeof obj === "string") {
+          return inspectString(obj, opts);
+        }
+        if (typeof obj === "number") {
+          if (obj === 0) {
+            return Infinity / obj > 0 ? "0" : "-0";
+          }
+          return String(obj);
+        }
+        if (typeof obj === "bigint") {
+          return String(obj) + "n";
+        }
+        var maxDepth = typeof opts.depth === "undefined" ? 5 : opts.depth;
+        if (typeof depth === "undefined") {
+          depth = 0;
+        }
+        if (depth >= maxDepth && maxDepth > 0 && typeof obj === "object") {
+          return isArray2(obj) ? "[Array]" : "[Object]";
+        }
+        var indent = getIndent(opts, depth);
+        if (typeof seen === "undefined") {
+          seen = [];
+        } else if (indexOf(seen, obj) >= 0) {
+          return "[Circular]";
+        }
+        function inspect(value, from, noIndent) {
+          if (from) {
+            seen = seen.slice();
+            seen.push(from);
+          }
+          if (noIndent) {
+            var newOpts = {
+              depth: opts.depth
+            };
+            if (has(opts, "quoteStyle")) {
+              newOpts.quoteStyle = opts.quoteStyle;
+            }
+            return inspect_(value, newOpts, depth + 1, seen);
+          }
+          return inspect_(value, opts, depth + 1, seen);
+        }
+        if (typeof obj === "function") {
+          var name = nameOf(obj);
+          var keys = arrObjKeys(obj, inspect);
+          return "[Function" + (name ? ": " + name : " (anonymous)") + "]" + (keys.length > 0 ? " { " + keys.join(", ") + " }" : "");
+        }
+        if (isSymbol(obj)) {
+          var symString = hasShammedSymbols ? String(obj).replace(/^(Symbol\(.*\))_[^)]*$/, "$1") : symToString.call(obj);
+          return typeof obj === "object" && !hasShammedSymbols ? markBoxed(symString) : symString;
+        }
+        if (isElement(obj)) {
+          var s = "<" + String(obj.nodeName).toLowerCase();
+          var attrs = obj.attributes || [];
+          for (var i = 0; i < attrs.length; i++) {
+            s += " " + attrs[i].name + "=" + wrapQuotes(quote(attrs[i].value), "double", opts);
+          }
+          s += ">";
+          if (obj.childNodes && obj.childNodes.length) {
+            s += "...";
+          }
+          s += "</" + String(obj.nodeName).toLowerCase() + ">";
+          return s;
+        }
+        if (isArray2(obj)) {
+          if (obj.length === 0) {
+            return "[]";
+          }
+          var xs = arrObjKeys(obj, inspect);
+          if (indent && !singleLineValues(xs)) {
+            return "[" + indentedJoin(xs, indent) + "]";
+          }
+          return "[ " + xs.join(", ") + " ]";
+        }
+        if (isError(obj)) {
+          var parts = arrObjKeys(obj, inspect);
+          if (parts.length === 0) {
+            return "[" + String(obj) + "]";
+          }
+          return "{ [" + String(obj) + "] " + parts.join(", ") + " }";
+        }
+        if (typeof obj === "object" && customInspect) {
+          if (inspectSymbol && typeof obj[inspectSymbol] === "function") {
+            return obj[inspectSymbol]();
+          } else if (typeof obj.inspect === "function") {
+            return obj.inspect();
+          }
+        }
+        if (isMap(obj)) {
+          var mapParts = [];
+          mapForEach.call(obj, function(value, key) {
+            mapParts.push(inspect(key, obj, true) + " => " + inspect(value, obj));
+          });
+          return collectionOf("Map", mapSize.call(obj), mapParts, indent);
+        }
+        if (isSet(obj)) {
+          var setParts = [];
+          setForEach.call(obj, function(value) {
+            setParts.push(inspect(value, obj));
+          });
+          return collectionOf("Set", setSize.call(obj), setParts, indent);
+        }
+        if (isWeakMap(obj)) {
+          return weakCollectionOf("WeakMap");
+        }
+        if (isWeakSet(obj)) {
+          return weakCollectionOf("WeakSet");
+        }
+        if (isWeakRef(obj)) {
+          return weakCollectionOf("WeakRef");
+        }
+        if (isNumber(obj)) {
+          return markBoxed(inspect(Number(obj)));
+        }
+        if (isBigInt(obj)) {
+          return markBoxed(inspect(bigIntValueOf.call(obj)));
+        }
+        if (isBoolean(obj)) {
+          return markBoxed(booleanValueOf.call(obj));
+        }
+        if (isString(obj)) {
+          return markBoxed(inspect(String(obj)));
+        }
+        if (!isDate(obj) && !isRegExp(obj)) {
+          var ys = arrObjKeys(obj, inspect);
+          var isPlainObject = gPO ? gPO(obj) === Object.prototype : obj instanceof Object || obj.constructor === Object;
+          var protoTag = obj instanceof Object ? "" : "null prototype";
+          var stringTag = !isPlainObject && toStringTag && Object(obj) === obj && toStringTag in obj ? toStr(obj).slice(8, -1) : protoTag ? "Object" : "";
+          var constructorTag = isPlainObject || typeof obj.constructor !== "function" ? "" : obj.constructor.name ? obj.constructor.name + " " : "";
+          var tag = constructorTag + (stringTag || protoTag ? "[" + [].concat(stringTag || [], protoTag || []).join(": ") + "] " : "");
+          if (ys.length === 0) {
+            return tag + "{}";
+          }
+          if (indent) {
+            return tag + "{" + indentedJoin(ys, indent) + "}";
+          }
+          return tag + "{ " + ys.join(", ") + " }";
         }
         return String(obj);
+      };
+      function wrapQuotes(s, defaultStyle, opts) {
+        var quoteChar = (opts.quoteStyle || defaultStyle) === "double" ? '"' : "'";
+        return quoteChar + s + quoteChar;
       }
-      if (typeof obj === "bigint") {
-        return String(obj) + "n";
+      function quote(s) {
+        return String(s).replace(/"/g, "&quot;");
       }
-      var maxDepth = typeof opts.depth === "undefined" ? 5 : opts.depth;
-      if (typeof depth === "undefined") {
-        depth = 0;
+      function isArray2(obj) {
+        return toStr(obj) === "[object Array]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      if (depth >= maxDepth && maxDepth > 0 && typeof obj === "object") {
-        return isArray2(obj) ? "[Array]" : "[Object]";
+      function isDate(obj) {
+        return toStr(obj) === "[object Date]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      var indent = getIndent(opts, depth);
-      if (typeof seen === "undefined") {
-        seen = [];
-      } else if (indexOf(seen, obj) >= 0) {
-        return "[Circular]";
+      function isRegExp(obj) {
+        return toStr(obj) === "[object RegExp]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      function inspect(value, from, noIndent) {
-        if (from) {
-          seen = seen.slice();
-          seen.push(from);
+      function isError(obj) {
+        return toStr(obj) === "[object Error]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isString(obj) {
+        return toStr(obj) === "[object String]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isNumber(obj) {
+        return toStr(obj) === "[object Number]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isBoolean(obj) {
+        return toStr(obj) === "[object Boolean]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isSymbol(obj) {
+        if (hasShammedSymbols) {
+          return obj && typeof obj === "object" && obj instanceof Symbol;
         }
-        if (noIndent) {
-          var newOpts = {
-            depth: opts.depth
-          };
-          if (has(opts, "quoteStyle")) {
-            newOpts.quoteStyle = opts.quoteStyle;
+        if (typeof obj === "symbol") {
+          return true;
+        }
+        if (!obj || typeof obj !== "object" || !symToString) {
+          return false;
+        }
+        try {
+          symToString.call(obj);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isBigInt(obj) {
+        if (!obj || typeof obj !== "object" || !bigIntValueOf) {
+          return false;
+        }
+        try {
+          bigIntValueOf.call(obj);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      var hasOwn = Object.prototype.hasOwnProperty || function(key) {
+        return key in this;
+      };
+      function has(obj, key) {
+        return hasOwn.call(obj, key);
+      }
+      function toStr(obj) {
+        return objectToString.call(obj);
+      }
+      function nameOf(f) {
+        if (f.name) {
+          return f.name;
+        }
+        var m = match.call(functionToString.call(f), /^function\s*([\w$]+)/);
+        if (m) {
+          return m[1];
+        }
+        return null;
+      }
+      function indexOf(xs, x) {
+        if (xs.indexOf) {
+          return xs.indexOf(x);
+        }
+        for (var i = 0, l = xs.length; i < l; i++) {
+          if (xs[i] === x) {
+            return i;
           }
-          return inspect_(value, newOpts, depth + 1, seen);
         }
-        return inspect_(value, opts, depth + 1, seen);
+        return -1;
       }
-      if (typeof obj === "function") {
-        var name = nameOf(obj);
-        var keys = arrObjKeys(obj, inspect);
-        return "[Function" + (name ? ": " + name : " (anonymous)") + "]" + (keys.length > 0 ? " { " + keys.join(", ") + " }" : "");
-      }
-      if (isSymbol(obj)) {
-        var symString = hasShammedSymbols ? String(obj).replace(/^(Symbol\(.*\))_[^)]*$/, "$1") : symToString.call(obj);
-        return typeof obj === "object" && !hasShammedSymbols ? markBoxed(symString) : symString;
-      }
-      if (isElement(obj)) {
-        var s = "<" + String(obj.nodeName).toLowerCase();
-        var attrs = obj.attributes || [];
-        for (var i = 0; i < attrs.length; i++) {
-          s += " " + attrs[i].name + "=" + wrapQuotes(quote(attrs[i].value), "double", opts);
+      function isMap(x) {
+        if (!mapSize || !x || typeof x !== "object") {
+          return false;
         }
-        s += ">";
-        if (obj.childNodes && obj.childNodes.length) {
-          s += "...";
-        }
-        s += "</" + String(obj.nodeName).toLowerCase() + ">";
-        return s;
-      }
-      if (isArray2(obj)) {
-        if (obj.length === 0) {
-          return "[]";
-        }
-        var xs = arrObjKeys(obj, inspect);
-        if (indent && !singleLineValues(xs)) {
-          return "[" + indentedJoin(xs, indent) + "]";
-        }
-        return "[ " + xs.join(", ") + " ]";
-      }
-      if (isError(obj)) {
-        var parts = arrObjKeys(obj, inspect);
-        if (parts.length === 0) {
-          return "[" + String(obj) + "]";
-        }
-        return "{ [" + String(obj) + "] " + parts.join(", ") + " }";
-      }
-      if (typeof obj === "object" && customInspect) {
-        if (inspectSymbol && typeof obj[inspectSymbol] === "function") {
-          return obj[inspectSymbol]();
-        } else if (typeof obj.inspect === "function") {
-          return obj.inspect();
-        }
-      }
-      if (isMap(obj)) {
-        var mapParts = [];
-        mapForEach.call(obj, function(value, key) {
-          mapParts.push(inspect(key, obj, true) + " => " + inspect(value, obj));
-        });
-        return collectionOf("Map", mapSize.call(obj), mapParts, indent);
-      }
-      if (isSet(obj)) {
-        var setParts = [];
-        setForEach.call(obj, function(value) {
-          setParts.push(inspect(value, obj));
-        });
-        return collectionOf("Set", setSize.call(obj), setParts, indent);
-      }
-      if (isWeakMap(obj)) {
-        return weakCollectionOf("WeakMap");
-      }
-      if (isWeakSet(obj)) {
-        return weakCollectionOf("WeakSet");
-      }
-      if (isWeakRef(obj)) {
-        return weakCollectionOf("WeakRef");
-      }
-      if (isNumber(obj)) {
-        return markBoxed(inspect(Number(obj)));
-      }
-      if (isBigInt(obj)) {
-        return markBoxed(inspect(bigIntValueOf.call(obj)));
-      }
-      if (isBoolean(obj)) {
-        return markBoxed(booleanValueOf.call(obj));
-      }
-      if (isString(obj)) {
-        return markBoxed(inspect(String(obj)));
-      }
-      if (!isDate(obj) && !isRegExp(obj)) {
-        var ys = arrObjKeys(obj, inspect);
-        var isPlainObject = gPO ? gPO(obj) === Object.prototype : obj instanceof Object || obj.constructor === Object;
-        var protoTag = obj instanceof Object ? "" : "null prototype";
-        var stringTag = !isPlainObject && toStringTag && Object(obj) === obj && toStringTag in obj ? toStr(obj).slice(8, -1) : protoTag ? "Object" : "";
-        var constructorTag = isPlainObject || typeof obj.constructor !== "function" ? "" : obj.constructor.name ? obj.constructor.name + " " : "";
-        var tag = constructorTag + (stringTag || protoTag ? "[" + [].concat(stringTag || [], protoTag || []).join(": ") + "] " : "");
-        if (ys.length === 0) {
-          return tag + "{}";
-        }
-        if (indent) {
-          return tag + "{" + indentedJoin(ys, indent) + "}";
-        }
-        return tag + "{ " + ys.join(", ") + " }";
-      }
-      return String(obj);
-    };
-    function wrapQuotes(s, defaultStyle, opts) {
-      var quoteChar = (opts.quoteStyle || defaultStyle) === "double" ? '"' : "'";
-      return quoteChar + s + quoteChar;
-    }
-    function quote(s) {
-      return String(s).replace(/"/g, "&quot;");
-    }
-    function isArray2(obj) {
-      return toStr(obj) === "[object Array]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isDate(obj) {
-      return toStr(obj) === "[object Date]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isRegExp(obj) {
-      return toStr(obj) === "[object RegExp]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isError(obj) {
-      return toStr(obj) === "[object Error]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isString(obj) {
-      return toStr(obj) === "[object String]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isNumber(obj) {
-      return toStr(obj) === "[object Number]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isBoolean(obj) {
-      return toStr(obj) === "[object Boolean]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isSymbol(obj) {
-      if (hasShammedSymbols) {
-        return obj && typeof obj === "object" && obj instanceof Symbol;
-      }
-      if (typeof obj === "symbol") {
-        return true;
-      }
-      if (!obj || typeof obj !== "object" || !symToString) {
-        return false;
-      }
-      try {
-        symToString.call(obj);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isBigInt(obj) {
-      if (!obj || typeof obj !== "object" || !bigIntValueOf) {
-        return false;
-      }
-      try {
-        bigIntValueOf.call(obj);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    var hasOwn = Object.prototype.hasOwnProperty || function(key) {
-      return key in this;
-    };
-    function has(obj, key) {
-      return hasOwn.call(obj, key);
-    }
-    function toStr(obj) {
-      return objectToString.call(obj);
-    }
-    function nameOf(f) {
-      if (f.name) {
-        return f.name;
-      }
-      var m = match.call(functionToString.call(f), /^function\s*([\w$]+)/);
-      if (m) {
-        return m[1];
-      }
-      return null;
-    }
-    function indexOf(xs, x) {
-      if (xs.indexOf) {
-        return xs.indexOf(x);
-      }
-      for (var i = 0, l = xs.length; i < l; i++) {
-        if (xs[i] === x) {
-          return i;
-        }
-      }
-      return -1;
-    }
-    function isMap(x) {
-      if (!mapSize || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        mapSize.call(x);
-        try {
-          setSize.call(x);
-        } catch (s) {
-          return true;
-        }
-        return x instanceof Map;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakMap(x) {
-      if (!weakMapHas || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        weakMapHas.call(x, weakMapHas);
-        try {
-          weakSetHas.call(x, weakSetHas);
-        } catch (s) {
-          return true;
-        }
-        return x instanceof WeakMap;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakRef(x) {
-      if (!weakRefDeref || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        weakRefDeref.call(x);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isSet(x) {
-      if (!setSize || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        setSize.call(x);
         try {
           mapSize.call(x);
-        } catch (m) {
-          return true;
+          try {
+            setSize.call(x);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof Map;
+        } catch (e) {
         }
-        return x instanceof Set;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakSet(x) {
-      if (!weakSetHas || !x || typeof x !== "object") {
         return false;
       }
-      try {
-        weakSetHas.call(x, weakSetHas);
+      function isWeakMap(x) {
+        if (!weakMapHas || !x || typeof x !== "object") {
+          return false;
+        }
         try {
           weakMapHas.call(x, weakMapHas);
-        } catch (s) {
+          try {
+            weakSetHas.call(x, weakSetHas);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof WeakMap;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isWeakRef(x) {
+        if (!weakRefDeref || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          weakRefDeref.call(x);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isSet(x) {
+        if (!setSize || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          setSize.call(x);
+          try {
+            mapSize.call(x);
+          } catch (m) {
+            return true;
+          }
+          return x instanceof Set;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isWeakSet(x) {
+        if (!weakSetHas || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          weakSetHas.call(x, weakSetHas);
+          try {
+            weakMapHas.call(x, weakMapHas);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof WeakSet;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isElement(x) {
+        if (!x || typeof x !== "object") {
+          return false;
+        }
+        if (typeof HTMLElement !== "undefined" && x instanceof HTMLElement) {
           return true;
         }
-        return x instanceof WeakSet;
-      } catch (e) {
+        return typeof x.nodeName === "string" && typeof x.getAttribute === "function";
       }
-      return false;
-    }
-    function isElement(x) {
-      if (!x || typeof x !== "object") {
-        return false;
+      function inspectString(str, opts) {
+        if (str.length > opts.maxStringLength) {
+          var remaining = str.length - opts.maxStringLength;
+          var trailer = "... " + remaining + " more character" + (remaining > 1 ? "s" : "");
+          return inspectString(str.slice(0, opts.maxStringLength), opts) + trailer;
+        }
+        var s = str.replace(/(['\\])/g, "\\$1").replace(/[\x00-\x1f]/g, lowbyte);
+        return wrapQuotes(s, "single", opts);
       }
-      if (typeof HTMLElement !== "undefined" && x instanceof HTMLElement) {
+      function lowbyte(c) {
+        var n = c.charCodeAt(0);
+        var x = {
+          8: "b",
+          9: "t",
+          10: "n",
+          12: "f",
+          13: "r"
+        }[n];
+        if (x) {
+          return "\\" + x;
+        }
+        return "\\x" + (n < 16 ? "0" : "") + n.toString(16).toUpperCase();
+      }
+      function markBoxed(str) {
+        return "Object(" + str + ")";
+      }
+      function weakCollectionOf(type) {
+        return type + " { ? }";
+      }
+      function collectionOf(type, size, entries, indent) {
+        var joinedEntries = indent ? indentedJoin(entries, indent) : entries.join(", ");
+        return type + " (" + size + ") {" + joinedEntries + "}";
+      }
+      function singleLineValues(xs) {
+        for (var i = 0; i < xs.length; i++) {
+          if (indexOf(xs[i], "\n") >= 0) {
+            return false;
+          }
+        }
         return true;
       }
-      return typeof x.nodeName === "string" && typeof x.getAttribute === "function";
-    }
-    function inspectString(str, opts) {
-      if (str.length > opts.maxStringLength) {
-        var remaining = str.length - opts.maxStringLength;
-        var trailer = "... " + remaining + " more character" + (remaining > 1 ? "s" : "");
-        return inspectString(str.slice(0, opts.maxStringLength), opts) + trailer;
-      }
-      var s = str.replace(/(['\\])/g, "\\$1").replace(/[\x00-\x1f]/g, lowbyte);
-      return wrapQuotes(s, "single", opts);
-    }
-    function lowbyte(c) {
-      var n = c.charCodeAt(0);
-      var x = {
-        8: "b",
-        9: "t",
-        10: "n",
-        12: "f",
-        13: "r"
-      }[n];
-      if (x) {
-        return "\\" + x;
-      }
-      return "\\x" + (n < 16 ? "0" : "") + n.toString(16).toUpperCase();
-    }
-    function markBoxed(str) {
-      return "Object(" + str + ")";
-    }
-    function weakCollectionOf(type) {
-      return type + " { ? }";
-    }
-    function collectionOf(type, size, entries, indent) {
-      var joinedEntries = indent ? indentedJoin(entries, indent) : entries.join(", ");
-      return type + " (" + size + ") {" + joinedEntries + "}";
-    }
-    function singleLineValues(xs) {
-      for (var i = 0; i < xs.length; i++) {
-        if (indexOf(xs[i], "\n") >= 0) {
-          return false;
-        }
-      }
-      return true;
-    }
-    function getIndent(opts, depth) {
-      var baseIndent;
-      if (opts.indent === "	") {
-        baseIndent = "	";
-      } else if (typeof opts.indent === "number" && opts.indent > 0) {
-        baseIndent = Array(opts.indent + 1).join(" ");
-      } else {
-        return null;
-      }
-      return {
-        base: baseIndent,
-        prev: Array(depth + 1).join(baseIndent)
-      };
-    }
-    function indentedJoin(xs, indent) {
-      if (xs.length === 0) {
-        return "";
-      }
-      var lineJoiner = "\n" + indent.prev + indent.base;
-      return lineJoiner + xs.join("," + lineJoiner) + "\n" + indent.prev;
-    }
-    function arrObjKeys(obj, inspect) {
-      var isArr = isArray2(obj);
-      var xs = [];
-      if (isArr) {
-        xs.length = obj.length;
-        for (var i = 0; i < obj.length; i++) {
-          xs[i] = has(obj, i) ? inspect(obj[i], obj) : "";
-        }
-      }
-      var syms = typeof gOPS === "function" ? gOPS(obj) : [];
-      var symMap;
-      if (hasShammedSymbols) {
-        symMap = {};
-        for (var k = 0; k < syms.length; k++) {
-          symMap["$" + syms[k]] = syms[k];
-        }
-      }
-      for (var key in obj) {
-        if (!has(obj, key)) {
-          continue;
-        }
-        if (isArr && String(Number(key)) === key && key < obj.length) {
-          continue;
-        }
-        if (hasShammedSymbols && symMap["$" + key] instanceof Symbol) {
-          continue;
-        } else if (/[^\w$]/.test(key)) {
-          xs.push(inspect(key, obj) + ": " + inspect(obj[key], obj));
+      function getIndent(opts, depth) {
+        var baseIndent;
+        if (opts.indent === "	") {
+          baseIndent = "	";
+        } else if (typeof opts.indent === "number" && opts.indent > 0) {
+          baseIndent = Array(opts.indent + 1).join(" ");
         } else {
-          xs.push(key + ": " + inspect(obj[key], obj));
+          return null;
         }
-      }
-      if (typeof gOPS === "function") {
-        for (var j = 0; j < syms.length; j++) {
-          if (isEnumerable.call(obj, syms[j])) {
-            xs.push("[" + inspect(syms[j]) + "]: " + inspect(obj[syms[j]], obj));
-          }
-        }
-      }
-      return xs;
-    }
-  }
-});
-
-// node_modules/side-channel/index.js
-var require_side_channel = __commonJS({
-  "node_modules/side-channel/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var callBound = require_callBound();
-    var inspect = require_object_inspect();
-    var $TypeError = GetIntrinsic("%TypeError%");
-    var $WeakMap = GetIntrinsic("%WeakMap%", true);
-    var $Map = GetIntrinsic("%Map%", true);
-    var $weakMapGet = callBound("WeakMap.prototype.get", true);
-    var $weakMapSet = callBound("WeakMap.prototype.set", true);
-    var $weakMapHas = callBound("WeakMap.prototype.has", true);
-    var $mapGet = callBound("Map.prototype.get", true);
-    var $mapSet = callBound("Map.prototype.set", true);
-    var $mapHas = callBound("Map.prototype.has", true);
-    var listGetNode = function(list, key) {
-      for (var prev = list, curr; (curr = prev.next) !== null; prev = curr) {
-        if (curr.key === key) {
-          prev.next = curr.next;
-          curr.next = list.next;
-          list.next = curr;
-          return curr;
-        }
-      }
-    };
-    var listGet = function(objects, key) {
-      var node = listGetNode(objects, key);
-      return node && node.value;
-    };
-    var listSet = function(objects, key, value) {
-      var node = listGetNode(objects, key);
-      if (node) {
-        node.value = value;
-      } else {
-        objects.next = {
-          key,
-          next: objects.next,
-          value
+        return {
+          base: baseIndent,
+          prev: Array(depth + 1).join(baseIndent)
         };
       }
-    };
-    var listHas = function(objects, key) {
-      return !!listGetNode(objects, key);
-    };
-    module2.exports = function getSideChannel() {
-      var $wm;
-      var $m;
-      var $o;
-      var channel = {
-        assert: function(key) {
-          if (!channel.has(key)) {
-            throw new $TypeError("Side channel does not contain " + inspect(key));
+      function indentedJoin(xs, indent) {
+        if (xs.length === 0) {
+          return "";
+        }
+        var lineJoiner = "\n" + indent.prev + indent.base;
+        return lineJoiner + xs.join("," + lineJoiner) + "\n" + indent.prev;
+      }
+      function arrObjKeys(obj, inspect) {
+        var isArr = isArray2(obj);
+        var xs = [];
+        if (isArr) {
+          xs.length = obj.length;
+          for (var i = 0; i < obj.length; i++) {
+            xs[i] = has(obj, i) ? inspect(obj[i], obj) : "";
           }
-        },
-        get: function(key) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if ($wm) {
-              return $weakMapGet($wm, key);
-            }
-          } else if ($Map) {
-            if ($m) {
-              return $mapGet($m, key);
-            }
+        }
+        var syms = typeof gOPS === "function" ? gOPS(obj) : [];
+        var symMap;
+        if (hasShammedSymbols) {
+          symMap = {};
+          for (var k = 0; k < syms.length; k++) {
+            symMap["$" + syms[k]] = syms[k];
+          }
+        }
+        for (var key in obj) {
+          if (!has(obj, key)) {
+            continue;
+          }
+          if (isArr && String(Number(key)) === key && key < obj.length) {
+            continue;
+          }
+          if (hasShammedSymbols && symMap["$" + key] instanceof Symbol) {
+            continue;
+          } else if (/[^\w$]/.test(key)) {
+            xs.push(inspect(key, obj) + ": " + inspect(obj[key], obj));
           } else {
-            if ($o) {
-              return listGet($o, key);
+            xs.push(key + ": " + inspect(obj[key], obj));
+          }
+        }
+        if (typeof gOPS === "function") {
+          for (var j = 0; j < syms.length; j++) {
+            if (isEnumerable.call(obj, syms[j])) {
+              xs.push("[" + inspect(syms[j]) + "]: " + inspect(obj[syms[j]], obj));
             }
           }
-        },
-        has: function(key) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if ($wm) {
-              return $weakMapHas($wm, key);
-            }
-          } else if ($Map) {
-            if ($m) {
-              return $mapHas($m, key);
-            }
-          } else {
-            if ($o) {
-              return listHas($o, key);
-            }
-          }
-          return false;
-        },
-        set: function(key, value) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if (!$wm) {
-              $wm = new $WeakMap();
-            }
-            $weakMapSet($wm, key, value);
-          } else if ($Map) {
-            if (!$m) {
-              $m = new $Map();
-            }
-            $mapSet($m, key, value);
-          } else {
-            if (!$o) {
-              $o = { key: {}, next: null };
-            }
-            listSet($o, key, value);
+        }
+        return xs;
+      }
+    }
+  });
+
+  // node_modules/side-channel/index.js
+  var require_side_channel = __commonJS({
+    "node_modules/side-channel/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var GetIntrinsic = require_get_intrinsic();
+      var callBound = require_callBound();
+      var inspect = require_object_inspect();
+      var $TypeError = GetIntrinsic("%TypeError%");
+      var $WeakMap = GetIntrinsic("%WeakMap%", true);
+      var $Map = GetIntrinsic("%Map%", true);
+      var $weakMapGet = callBound("WeakMap.prototype.get", true);
+      var $weakMapSet = callBound("WeakMap.prototype.set", true);
+      var $weakMapHas = callBound("WeakMap.prototype.has", true);
+      var $mapGet = callBound("Map.prototype.get", true);
+      var $mapSet = callBound("Map.prototype.set", true);
+      var $mapHas = callBound("Map.prototype.has", true);
+      var listGetNode = function(list, key) {
+        for (var prev = list, curr; (curr = prev.next) !== null; prev = curr) {
+          if (curr.key === key) {
+            prev.next = curr.next;
+            curr.next = list.next;
+            list.next = curr;
+            return curr;
           }
         }
       };
-      return channel;
-    };
-  }
-});
-
-// node_modules/qs/lib/formats.js
-var require_formats = __commonJS({
-  "node_modules/qs/lib/formats.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var replace = String.prototype.replace;
-    var percentTwenties = /%20/g;
-    var Format = {
-      RFC1738: "RFC1738",
-      RFC3986: "RFC3986"
-    };
-    module2.exports = {
-      "default": Format.RFC3986,
-      formatters: {
-        RFC1738: function(value) {
-          return replace.call(value, percentTwenties, "+");
-        },
-        RFC3986: function(value) {
-          return String(value);
-        }
-      },
-      RFC1738: Format.RFC1738,
-      RFC3986: Format.RFC3986
-    };
-  }
-});
-
-// node_modules/qs/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/qs/lib/utils.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var formats = require_formats();
-    var has = Object.prototype.hasOwnProperty;
-    var isArray2 = Array.isArray;
-    var hexTable = function() {
-      var array = [];
-      for (var i = 0; i < 256; ++i) {
-        array.push("%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase());
-      }
-      return array;
-    }();
-    var compactQueue = function compactQueue2(queue) {
-      while (queue.length > 1) {
-        var item = queue.pop();
-        var obj = item.obj[item.prop];
-        if (isArray2(obj)) {
-          var compacted = [];
-          for (var j = 0; j < obj.length; ++j) {
-            if (typeof obj[j] !== "undefined") {
-              compacted.push(obj[j]);
-            }
-          }
-          item.obj[item.prop] = compacted;
-        }
-      }
-    };
-    var arrayToObject = function arrayToObject2(source, options) {
-      var obj = options && options.plainObjects ? Object.create(null) : {};
-      for (var i = 0; i < source.length; ++i) {
-        if (typeof source[i] !== "undefined") {
-          obj[i] = source[i];
-        }
-      }
-      return obj;
-    };
-    var merge = function merge2(target, source, options) {
-      if (!source) {
-        return target;
-      }
-      if (typeof source !== "object") {
-        if (isArray2(target)) {
-          target.push(source);
-        } else if (target && typeof target === "object") {
-          if (options && (options.plainObjects || options.allowPrototypes) || !has.call(Object.prototype, source)) {
-            target[source] = true;
-          }
+      var listGet = function(objects, key) {
+        var node = listGetNode(objects, key);
+        return node && node.value;
+      };
+      var listSet = function(objects, key, value) {
+        var node = listGetNode(objects, key);
+        if (node) {
+          node.value = value;
         } else {
-          return [target, source];
+          objects.next = {
+            key,
+            next: objects.next,
+            value
+          };
         }
-        return target;
-      }
-      if (!target || typeof target !== "object") {
-        return [target].concat(source);
-      }
-      var mergeTarget = target;
-      if (isArray2(target) && !isArray2(source)) {
-        mergeTarget = arrayToObject(target, options);
-      }
-      if (isArray2(target) && isArray2(source)) {
-        source.forEach(function(item, i) {
-          if (has.call(target, i)) {
-            var targetItem = target[i];
-            if (targetItem && typeof targetItem === "object" && item && typeof item === "object") {
-              target[i] = merge2(targetItem, item, options);
+      };
+      var listHas = function(objects, key) {
+        return !!listGetNode(objects, key);
+      };
+      module.exports = function getSideChannel() {
+        var $wm;
+        var $m;
+        var $o;
+        var channel = {
+          assert: function(key) {
+            if (!channel.has(key)) {
+              throw new $TypeError("Side channel does not contain " + inspect(key));
+            }
+          },
+          get: function(key) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if ($wm) {
+                return $weakMapGet($wm, key);
+              }
+            } else if ($Map) {
+              if ($m) {
+                return $mapGet($m, key);
+              }
             } else {
-              target.push(item);
+              if ($o) {
+                return listGet($o, key);
+              }
+            }
+          },
+          has: function(key) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if ($wm) {
+                return $weakMapHas($wm, key);
+              }
+            } else if ($Map) {
+              if ($m) {
+                return $mapHas($m, key);
+              }
+            } else {
+              if ($o) {
+                return listHas($o, key);
+              }
+            }
+            return false;
+          },
+          set: function(key, value) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if (!$wm) {
+                $wm = new $WeakMap();
+              }
+              $weakMapSet($wm, key, value);
+            } else if ($Map) {
+              if (!$m) {
+                $m = new $Map();
+              }
+              $mapSet($m, key, value);
+            } else {
+              if (!$o) {
+                $o = { key: {}, next: null };
+              }
+              listSet($o, key, value);
+            }
+          }
+        };
+        return channel;
+      };
+    }
+  });
+
+  // node_modules/qs/lib/formats.js
+  var require_formats = __commonJS({
+    "node_modules/qs/lib/formats.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var replace = String.prototype.replace;
+      var percentTwenties = /%20/g;
+      var Format = {
+        RFC1738: "RFC1738",
+        RFC3986: "RFC3986"
+      };
+      module.exports = {
+        "default": Format.RFC3986,
+        formatters: {
+          RFC1738: function(value) {
+            return replace.call(value, percentTwenties, "+");
+          },
+          RFC3986: function(value) {
+            return String(value);
+          }
+        },
+        RFC1738: Format.RFC1738,
+        RFC3986: Format.RFC3986
+      };
+    }
+  });
+
+  // node_modules/qs/lib/utils.js
+  var require_utils = __commonJS({
+    "node_modules/qs/lib/utils.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var formats = require_formats();
+      var has = Object.prototype.hasOwnProperty;
+      var isArray2 = Array.isArray;
+      var hexTable = function() {
+        var array = [];
+        for (var i = 0; i < 256; ++i) {
+          array.push("%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase());
+        }
+        return array;
+      }();
+      var compactQueue = function compactQueue2(queue) {
+        while (queue.length > 1) {
+          var item = queue.pop();
+          var obj = item.obj[item.prop];
+          if (isArray2(obj)) {
+            var compacted = [];
+            for (var j = 0; j < obj.length; ++j) {
+              if (typeof obj[j] !== "undefined") {
+                compacted.push(obj[j]);
+              }
+            }
+            item.obj[item.prop] = compacted;
+          }
+        }
+      };
+      var arrayToObject = function arrayToObject2(source, options) {
+        var obj = options && options.plainObjects ? Object.create(null) : {};
+        for (var i = 0; i < source.length; ++i) {
+          if (typeof source[i] !== "undefined") {
+            obj[i] = source[i];
+          }
+        }
+        return obj;
+      };
+      var merge = function merge2(target, source, options) {
+        if (!source) {
+          return target;
+        }
+        if (typeof source !== "object") {
+          if (isArray2(target)) {
+            target.push(source);
+          } else if (target && typeof target === "object") {
+            if (options && (options.plainObjects || options.allowPrototypes) || !has.call(Object.prototype, source)) {
+              target[source] = true;
             }
           } else {
-            target[i] = item;
+            return [target, source];
           }
-        });
-        return target;
-      }
-      return Object.keys(source).reduce(function(acc, key) {
-        var value = source[key];
-        if (has.call(acc, key)) {
-          acc[key] = merge2(acc[key], value, options);
-        } else {
-          acc[key] = value;
+          return target;
         }
-        return acc;
-      }, mergeTarget);
-    };
-    var assign = function assignSingleSource(target, source) {
-      return Object.keys(source).reduce(function(acc, key) {
-        acc[key] = source[key];
-        return acc;
-      }, target);
-    };
-    var decode = function(str, decoder, charset) {
-      var strWithoutPlus = str.replace(/\+/g, " ");
-      if (charset === "iso-8859-1") {
-        return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
-      }
-      try {
-        return decodeURIComponent(strWithoutPlus);
-      } catch (e) {
-        return strWithoutPlus;
-      }
-    };
-    var encode = function encode2(str, defaultEncoder, charset, kind, format) {
-      if (str.length === 0) {
-        return str;
-      }
-      var string = str;
-      if (typeof str === "symbol") {
-        string = Symbol.prototype.toString.call(str);
-      } else if (typeof str !== "string") {
-        string = String(str);
-      }
-      if (charset === "iso-8859-1") {
-        return escape(string).replace(/%u[0-9a-f]{4}/gi, function($0) {
-          return "%26%23" + parseInt($0.slice(2), 16) + "%3B";
-        });
-      }
-      var out = "";
-      for (var i = 0; i < string.length; ++i) {
-        var c = string.charCodeAt(i);
-        if (c === 45 || c === 46 || c === 95 || c === 126 || c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || format === formats.RFC1738 && (c === 40 || c === 41)) {
-          out += string.charAt(i);
-          continue;
+        if (!target || typeof target !== "object") {
+          return [target].concat(source);
         }
-        if (c < 128) {
-          out = out + hexTable[c];
-          continue;
+        var mergeTarget = target;
+        if (isArray2(target) && !isArray2(source)) {
+          mergeTarget = arrayToObject(target, options);
         }
-        if (c < 2048) {
-          out = out + (hexTable[192 | c >> 6] + hexTable[128 | c & 63]);
-          continue;
-        }
-        if (c < 55296 || c >= 57344) {
-          out = out + (hexTable[224 | c >> 12] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63]);
-          continue;
-        }
-        i += 1;
-        c = 65536 + ((c & 1023) << 10 | string.charCodeAt(i) & 1023);
-        out += hexTable[240 | c >> 18] + hexTable[128 | c >> 12 & 63] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63];
-      }
-      return out;
-    };
-    var compact = function compact2(value) {
-      var queue = [{ obj: { o: value }, prop: "o" }];
-      var refs = [];
-      for (var i = 0; i < queue.length; ++i) {
-        var item = queue[i];
-        var obj = item.obj[item.prop];
-        var keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; ++j) {
-          var key = keys[j];
-          var val = obj[key];
-          if (typeof val === "object" && val !== null && refs.indexOf(val) === -1) {
-            queue.push({ obj, prop: key });
-            refs.push(val);
-          }
-        }
-      }
-      compactQueue(queue);
-      return value;
-    };
-    var isRegExp = function isRegExp2(obj) {
-      return Object.prototype.toString.call(obj) === "[object RegExp]";
-    };
-    var isBuffer = function isBuffer2(obj) {
-      if (!obj || typeof obj !== "object") {
-        return false;
-      }
-      return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
-    };
-    var combine = function combine2(a, b) {
-      return [].concat(a, b);
-    };
-    var maybeMap = function maybeMap2(val, fn) {
-      if (isArray2(val)) {
-        var mapped = [];
-        for (var i = 0; i < val.length; i += 1) {
-          mapped.push(fn(val[i]));
-        }
-        return mapped;
-      }
-      return fn(val);
-    };
-    module2.exports = {
-      arrayToObject,
-      assign,
-      combine,
-      compact,
-      decode,
-      encode,
-      isBuffer,
-      isRegExp,
-      maybeMap,
-      merge
-    };
-  }
-});
-
-// node_modules/qs/lib/stringify.js
-var require_stringify = __commonJS({
-  "node_modules/qs/lib/stringify.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var getSideChannel = require_side_channel();
-    var utils = require_utils();
-    var formats = require_formats();
-    var has = Object.prototype.hasOwnProperty;
-    var arrayPrefixGenerators = {
-      brackets: function brackets(prefix) {
-        return prefix + "[]";
-      },
-      comma: "comma",
-      indices: function indices(prefix, key) {
-        return prefix + "[" + key + "]";
-      },
-      repeat: function repeat(prefix) {
-        return prefix;
-      }
-    };
-    var isArray2 = Array.isArray;
-    var push = Array.prototype.push;
-    var pushToArray = function(arr, valueOrArray) {
-      push.apply(arr, isArray2(valueOrArray) ? valueOrArray : [valueOrArray]);
-    };
-    var toISO = Date.prototype.toISOString;
-    var defaultFormat = formats["default"];
-    var defaults = {
-      addQueryPrefix: false,
-      allowDots: false,
-      charset: "utf-8",
-      charsetSentinel: false,
-      delimiter: "&",
-      encode: true,
-      encoder: utils.encode,
-      encodeValuesOnly: false,
-      format: defaultFormat,
-      formatter: formats.formatters[defaultFormat],
-      indices: false,
-      serializeDate: function serializeDate(date) {
-        return toISO.call(date);
-      },
-      skipNulls: false,
-      strictNullHandling: false
-    };
-    var isNonNullishPrimitive = function isNonNullishPrimitive2(v) {
-      return typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "symbol" || typeof v === "bigint";
-    };
-    var stringify = function stringify2(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, sideChannel) {
-      var obj = object;
-      if (sideChannel.has(object)) {
-        throw new RangeError("Cyclic object value");
-      }
-      if (typeof filter === "function") {
-        obj = filter(prefix, obj);
-      } else if (obj instanceof Date) {
-        obj = serializeDate(obj);
-      } else if (generateArrayPrefix === "comma" && isArray2(obj)) {
-        obj = utils.maybeMap(obj, function(value2) {
-          if (value2 instanceof Date) {
-            return serializeDate(value2);
-          }
-          return value2;
-        });
-      }
-      if (obj === null) {
-        if (strictNullHandling) {
-          return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix;
-        }
-        obj = "";
-      }
-      if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
-        if (encoder) {
-          var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, "key", format);
-          return [formatter(keyValue) + "=" + formatter(encoder(obj, defaults.encoder, charset, "value", format))];
-        }
-        return [formatter(prefix) + "=" + formatter(String(obj))];
-      }
-      var values = [];
-      if (typeof obj === "undefined") {
-        return values;
-      }
-      var objKeys;
-      if (generateArrayPrefix === "comma" && isArray2(obj)) {
-        objKeys = [{ value: obj.length > 0 ? obj.join(",") || null : void 0 }];
-      } else if (isArray2(filter)) {
-        objKeys = filter;
-      } else {
-        var keys = Object.keys(obj);
-        objKeys = sort ? keys.sort(sort) : keys;
-      }
-      for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-        var value = typeof key === "object" && key.value !== void 0 ? key.value : obj[key];
-        if (skipNulls && value === null) {
-          continue;
-        }
-        var keyPrefix = isArray2(obj) ? typeof generateArrayPrefix === "function" ? generateArrayPrefix(prefix, key) : prefix : prefix + (allowDots ? "." + key : "[" + key + "]");
-        sideChannel.set(object, true);
-        var valueSideChannel = getSideChannel();
-        pushToArray(values, stringify2(value, keyPrefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, valueSideChannel));
-      }
-      return values;
-    };
-    var normalizeStringifyOptions = function normalizeStringifyOptions2(opts) {
-      if (!opts) {
-        return defaults;
-      }
-      if (opts.encoder !== null && opts.encoder !== void 0 && typeof opts.encoder !== "function") {
-        throw new TypeError("Encoder has to be a function.");
-      }
-      var charset = opts.charset || defaults.charset;
-      if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
-        throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
-      }
-      var format = formats["default"];
-      if (typeof opts.format !== "undefined") {
-        if (!has.call(formats.formatters, opts.format)) {
-          throw new TypeError("Unknown format option provided.");
-        }
-        format = opts.format;
-      }
-      var formatter = formats.formatters[format];
-      var filter = defaults.filter;
-      if (typeof opts.filter === "function" || isArray2(opts.filter)) {
-        filter = opts.filter;
-      }
-      return {
-        addQueryPrefix: typeof opts.addQueryPrefix === "boolean" ? opts.addQueryPrefix : defaults.addQueryPrefix,
-        allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
-        charset,
-        charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
-        delimiter: typeof opts.delimiter === "undefined" ? defaults.delimiter : opts.delimiter,
-        encode: typeof opts.encode === "boolean" ? opts.encode : defaults.encode,
-        encoder: typeof opts.encoder === "function" ? opts.encoder : defaults.encoder,
-        encodeValuesOnly: typeof opts.encodeValuesOnly === "boolean" ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
-        filter,
-        format,
-        formatter,
-        serializeDate: typeof opts.serializeDate === "function" ? opts.serializeDate : defaults.serializeDate,
-        skipNulls: typeof opts.skipNulls === "boolean" ? opts.skipNulls : defaults.skipNulls,
-        sort: typeof opts.sort === "function" ? opts.sort : null,
-        strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
-      };
-    };
-    module2.exports = function(object, opts) {
-      var obj = object;
-      var options = normalizeStringifyOptions(opts);
-      var objKeys;
-      var filter;
-      if (typeof options.filter === "function") {
-        filter = options.filter;
-        obj = filter("", obj);
-      } else if (isArray2(options.filter)) {
-        filter = options.filter;
-        objKeys = filter;
-      }
-      var keys = [];
-      if (typeof obj !== "object" || obj === null) {
-        return "";
-      }
-      var arrayFormat;
-      if (opts && opts.arrayFormat in arrayPrefixGenerators) {
-        arrayFormat = opts.arrayFormat;
-      } else if (opts && "indices" in opts) {
-        arrayFormat = opts.indices ? "indices" : "repeat";
-      } else {
-        arrayFormat = "indices";
-      }
-      var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
-      if (!objKeys) {
-        objKeys = Object.keys(obj);
-      }
-      if (options.sort) {
-        objKeys.sort(options.sort);
-      }
-      var sideChannel = getSideChannel();
-      for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-        if (options.skipNulls && obj[key] === null) {
-          continue;
-        }
-        pushToArray(keys, stringify(obj[key], key, generateArrayPrefix, options.strictNullHandling, options.skipNulls, options.encode ? options.encoder : null, options.filter, options.sort, options.allowDots, options.serializeDate, options.format, options.formatter, options.encodeValuesOnly, options.charset, sideChannel));
-      }
-      var joined = keys.join(options.delimiter);
-      var prefix = options.addQueryPrefix === true ? "?" : "";
-      if (options.charsetSentinel) {
-        if (options.charset === "iso-8859-1") {
-          prefix += "utf8=%26%2310003%3B&";
-        } else {
-          prefix += "utf8=%E2%9C%93&";
-        }
-      }
-      return joined.length > 0 ? prefix + joined : "";
-    };
-  }
-});
-
-// node_modules/qs/lib/parse.js
-var require_parse = __commonJS({
-  "node_modules/qs/lib/parse.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var utils = require_utils();
-    var has = Object.prototype.hasOwnProperty;
-    var isArray2 = Array.isArray;
-    var defaults = {
-      allowDots: false,
-      allowPrototypes: false,
-      allowSparse: false,
-      arrayLimit: 20,
-      charset: "utf-8",
-      charsetSentinel: false,
-      comma: false,
-      decoder: utils.decode,
-      delimiter: "&",
-      depth: 5,
-      ignoreQueryPrefix: false,
-      interpretNumericEntities: false,
-      parameterLimit: 1e3,
-      parseArrays: true,
-      plainObjects: false,
-      strictNullHandling: false
-    };
-    var interpretNumericEntities = function(str) {
-      return str.replace(/&#(\d+);/g, function($0, numberStr) {
-        return String.fromCharCode(parseInt(numberStr, 10));
-      });
-    };
-    var parseArrayValue = function(val, options) {
-      if (val && typeof val === "string" && options.comma && val.indexOf(",") > -1) {
-        return val.split(",");
-      }
-      return val;
-    };
-    var isoSentinel = "utf8=%26%2310003%3B";
-    var charsetSentinel = "utf8=%E2%9C%93";
-    var parseValues = function parseQueryStringValues(str, options) {
-      var obj = {};
-      var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, "") : str;
-      var limit = options.parameterLimit === Infinity ? void 0 : options.parameterLimit;
-      var parts = cleanStr.split(options.delimiter, limit);
-      var skipIndex = -1;
-      var i;
-      var charset = options.charset;
-      if (options.charsetSentinel) {
-        for (i = 0; i < parts.length; ++i) {
-          if (parts[i].indexOf("utf8=") === 0) {
-            if (parts[i] === charsetSentinel) {
-              charset = "utf-8";
-            } else if (parts[i] === isoSentinel) {
-              charset = "iso-8859-1";
+        if (isArray2(target) && isArray2(source)) {
+          source.forEach(function(item, i) {
+            if (has.call(target, i)) {
+              var targetItem = target[i];
+              if (targetItem && typeof targetItem === "object" && item && typeof item === "object") {
+                target[i] = merge2(targetItem, item, options);
+              } else {
+                target.push(item);
+              }
+            } else {
+              target[i] = item;
             }
-            skipIndex = i;
-            i = parts.length;
+          });
+          return target;
+        }
+        return Object.keys(source).reduce(function(acc, key) {
+          var value = source[key];
+          if (has.call(acc, key)) {
+            acc[key] = merge2(acc[key], value, options);
+          } else {
+            acc[key] = value;
           }
+          return acc;
+        }, mergeTarget);
+      };
+      var assign = function assignSingleSource(target, source) {
+        return Object.keys(source).reduce(function(acc, key) {
+          acc[key] = source[key];
+          return acc;
+        }, target);
+      };
+      var decode = function(str, decoder, charset) {
+        var strWithoutPlus = str.replace(/\+/g, " ");
+        if (charset === "iso-8859-1") {
+          return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
         }
-      }
-      for (i = 0; i < parts.length; ++i) {
-        if (i === skipIndex) {
-          continue;
+        try {
+          return decodeURIComponent(strWithoutPlus);
+        } catch (e) {
+          return strWithoutPlus;
         }
-        var part = parts[i];
-        var bracketEqualsPos = part.indexOf("]=");
-        var pos = bracketEqualsPos === -1 ? part.indexOf("=") : bracketEqualsPos + 1;
-        var key, val;
-        if (pos === -1) {
-          key = options.decoder(part, defaults.decoder, charset, "key");
-          val = options.strictNullHandling ? null : "";
-        } else {
-          key = options.decoder(part.slice(0, pos), defaults.decoder, charset, "key");
-          val = utils.maybeMap(parseArrayValue(part.slice(pos + 1), options), function(encodedVal) {
-            return options.decoder(encodedVal, defaults.decoder, charset, "value");
+      };
+      var encode = function encode2(str, defaultEncoder, charset, kind, format) {
+        if (str.length === 0) {
+          return str;
+        }
+        var string = str;
+        if (typeof str === "symbol") {
+          string = Symbol.prototype.toString.call(str);
+        } else if (typeof str !== "string") {
+          string = String(str);
+        }
+        if (charset === "iso-8859-1") {
+          return escape(string).replace(/%u[0-9a-f]{4}/gi, function($0) {
+            return "%26%23" + parseInt($0.slice(2), 16) + "%3B";
           });
         }
-        if (val && options.interpretNumericEntities && charset === "iso-8859-1") {
-          val = interpretNumericEntities(val);
-        }
-        if (part.indexOf("[]=") > -1) {
-          val = isArray2(val) ? [val] : val;
-        }
-        if (has.call(obj, key)) {
-          obj[key] = utils.combine(obj[key], val);
-        } else {
-          obj[key] = val;
-        }
-      }
-      return obj;
-    };
-    var parseObject = function(chain, val, options, valuesParsed) {
-      var leaf = valuesParsed ? val : parseArrayValue(val, options);
-      for (var i = chain.length - 1; i >= 0; --i) {
-        var obj;
-        var root = chain[i];
-        if (root === "[]" && options.parseArrays) {
-          obj = [].concat(leaf);
-        } else {
-          obj = options.plainObjects ? Object.create(null) : {};
-          var cleanRoot = root.charAt(0) === "[" && root.charAt(root.length - 1) === "]" ? root.slice(1, -1) : root;
-          var index = parseInt(cleanRoot, 10);
-          if (!options.parseArrays && cleanRoot === "") {
-            obj = { 0: leaf };
-          } else if (!isNaN(index) && root !== cleanRoot && String(index) === cleanRoot && index >= 0 && (options.parseArrays && index <= options.arrayLimit)) {
-            obj = [];
-            obj[index] = leaf;
-          } else {
-            obj[cleanRoot] = leaf;
-          }
-        }
-        leaf = obj;
-      }
-      return leaf;
-    };
-    var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {
-      if (!givenKey) {
-        return;
-      }
-      var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, "[$1]") : givenKey;
-      var brackets = /(\[[^[\]]*])/;
-      var child = /(\[[^[\]]*])/g;
-      var segment = options.depth > 0 && brackets.exec(key);
-      var parent = segment ? key.slice(0, segment.index) : key;
-      var keys = [];
-      if (parent) {
-        if (!options.plainObjects && has.call(Object.prototype, parent)) {
-          if (!options.allowPrototypes) {
-            return;
-          }
-        }
-        keys.push(parent);
-      }
-      var i = 0;
-      while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
-        i += 1;
-        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
-          if (!options.allowPrototypes) {
-            return;
-          }
-        }
-        keys.push(segment[1]);
-      }
-      if (segment) {
-        keys.push("[" + key.slice(segment.index) + "]");
-      }
-      return parseObject(keys, val, options, valuesParsed);
-    };
-    var normalizeParseOptions = function normalizeParseOptions2(opts) {
-      if (!opts) {
-        return defaults;
-      }
-      if (opts.decoder !== null && opts.decoder !== void 0 && typeof opts.decoder !== "function") {
-        throw new TypeError("Decoder has to be a function.");
-      }
-      if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
-        throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
-      }
-      var charset = typeof opts.charset === "undefined" ? defaults.charset : opts.charset;
-      return {
-        allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
-        allowPrototypes: typeof opts.allowPrototypes === "boolean" ? opts.allowPrototypes : defaults.allowPrototypes,
-        allowSparse: typeof opts.allowSparse === "boolean" ? opts.allowSparse : defaults.allowSparse,
-        arrayLimit: typeof opts.arrayLimit === "number" ? opts.arrayLimit : defaults.arrayLimit,
-        charset,
-        charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
-        comma: typeof opts.comma === "boolean" ? opts.comma : defaults.comma,
-        decoder: typeof opts.decoder === "function" ? opts.decoder : defaults.decoder,
-        delimiter: typeof opts.delimiter === "string" || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        depth: typeof opts.depth === "number" || opts.depth === false ? +opts.depth : defaults.depth,
-        ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
-        interpretNumericEntities: typeof opts.interpretNumericEntities === "boolean" ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
-        parameterLimit: typeof opts.parameterLimit === "number" ? opts.parameterLimit : defaults.parameterLimit,
-        parseArrays: opts.parseArrays !== false,
-        plainObjects: typeof opts.plainObjects === "boolean" ? opts.plainObjects : defaults.plainObjects,
-        strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
-      };
-    };
-    module2.exports = function(str, opts) {
-      var options = normalizeParseOptions(opts);
-      if (str === "" || str === null || typeof str === "undefined") {
-        return options.plainObjects ? Object.create(null) : {};
-      }
-      var tempObj = typeof str === "string" ? parseValues(str, options) : str;
-      var obj = options.plainObjects ? Object.create(null) : {};
-      var keys = Object.keys(tempObj);
-      for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var newObj = parseKeys(key, tempObj[key], options, typeof str === "string");
-        obj = utils.merge(obj, newObj, options);
-      }
-      if (options.allowSparse === true) {
-        return obj;
-      }
-      return utils.compact(obj);
-    };
-  }
-});
-
-// node_modules/qs/lib/index.js
-var require_lib = __commonJS({
-  "node_modules/qs/lib/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var stringify = require_stringify();
-    var parse = require_parse();
-    var formats = require_formats();
-    module2.exports = {
-      formats,
-      parse,
-      stringify
-    };
-  }
-});
-
-// node_modules/requires-port/index.js
-var require_requires_port = __commonJS({
-  "node_modules/requires-port/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    module2.exports = function required(port, protocol) {
-      protocol = protocol.split(":")[0];
-      port = +port;
-      if (!port)
-        return false;
-      switch (protocol) {
-        case "http":
-        case "ws":
-          return port !== 80;
-        case "https":
-        case "wss":
-          return port !== 443;
-        case "ftp":
-          return port !== 21;
-        case "gopher":
-          return port !== 70;
-        case "file":
-          return false;
-      }
-      return port !== 0;
-    };
-  }
-});
-
-// node_modules/querystringify/index.js
-var require_querystringify = __commonJS({
-  "node_modules/querystringify/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    var has = Object.prototype.hasOwnProperty;
-    var undef;
-    function decode(input) {
-      try {
-        return decodeURIComponent(input.replace(/\+/g, " "));
-      } catch (e) {
-        return null;
-      }
-    }
-    function encode(input) {
-      try {
-        return encodeURIComponent(input);
-      } catch (e) {
-        return null;
-      }
-    }
-    function querystring(query) {
-      var parser = /([^=?#&]+)=?([^&]*)/g, result = {}, part;
-      while (part = parser.exec(query)) {
-        var key = decode(part[1]), value = decode(part[2]);
-        if (key === null || value === null || key in result)
-          continue;
-        result[key] = value;
-      }
-      return result;
-    }
-    function querystringify(obj, prefix) {
-      prefix = prefix || "";
-      var pairs = [], value, key;
-      if (typeof prefix !== "string")
-        prefix = "?";
-      for (key in obj) {
-        if (has.call(obj, key)) {
-          value = obj[key];
-          if (!value && (value === null || value === undef || isNaN(value))) {
-            value = "";
-          }
-          key = encode(key);
-          value = encode(value);
-          if (key === null || value === null)
+        var out = "";
+        for (var i = 0; i < string.length; ++i) {
+          var c = string.charCodeAt(i);
+          if (c === 45 || c === 46 || c === 95 || c === 126 || c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || format === formats.RFC1738 && (c === 40 || c === 41)) {
+            out += string.charAt(i);
             continue;
-          pairs.push(key + "=" + value);
-        }
-      }
-      return pairs.length ? prefix + pairs.join("&") : "";
-    }
-    exports.stringify = querystringify;
-    exports.parse = querystring;
-  }
-});
-
-// node_modules/url-parse/index.js
-var require_url_parse = __commonJS({
-  "node_modules/url-parse/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var required = require_requires_port();
-    var qs2 = require_querystringify();
-    var slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//;
-    var protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\\/]+)?([\S\s]*)/i;
-    var windowsDriveLetter = /^[a-zA-Z]:/;
-    var whitespace = "[\\x09\\x0A\\x0B\\x0C\\x0D\\x20\\xA0\\u1680\\u180E\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000\\u2028\\u2029\\uFEFF]";
-    var left = new RegExp("^" + whitespace + "+");
-    function trimLeft(str) {
-      return (str ? str : "").toString().replace(left, "");
-    }
-    var rules = [
-      ["#", "hash"],
-      ["?", "query"],
-      function sanitize(address, url) {
-        return isSpecial(url.protocol) ? address.replace(/\\/g, "/") : address;
-      },
-      ["/", "pathname"],
-      ["@", "auth", 1],
-      [NaN, "host", void 0, 1, 1],
-      [/:(\d+)$/, "port", void 0, 1],
-      [NaN, "hostname", void 0, 1, 1]
-    ];
-    var ignore = { hash: 1, query: 1 };
-    function lolcation(loc) {
-      var globalVar;
-      if (typeof window !== "undefined")
-        globalVar = window;
-      else if (typeof global !== "undefined")
-        globalVar = global;
-      else if (typeof self !== "undefined")
-        globalVar = self;
-      else
-        globalVar = {};
-      var location = globalVar.location || {};
-      loc = loc || location;
-      var finaldestination = {}, type = typeof loc, key;
-      if (loc.protocol === "blob:") {
-        finaldestination = new Url(unescape(loc.pathname), {});
-      } else if (type === "string") {
-        finaldestination = new Url(loc, {});
-        for (key in ignore)
-          delete finaldestination[key];
-      } else if (type === "object") {
-        for (key in loc) {
-          if (key in ignore)
+          }
+          if (c < 128) {
+            out = out + hexTable[c];
             continue;
-          finaldestination[key] = loc[key];
+          }
+          if (c < 2048) {
+            out = out + (hexTable[192 | c >> 6] + hexTable[128 | c & 63]);
+            continue;
+          }
+          if (c < 55296 || c >= 57344) {
+            out = out + (hexTable[224 | c >> 12] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63]);
+            continue;
+          }
+          i += 1;
+          c = 65536 + ((c & 1023) << 10 | string.charCodeAt(i) & 1023);
+          out += hexTable[240 | c >> 18] + hexTable[128 | c >> 12 & 63] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63];
         }
-        if (finaldestination.slashes === void 0) {
-          finaldestination.slashes = slashes.test(loc.href);
-        }
-      }
-      return finaldestination;
-    }
-    function isSpecial(scheme) {
-      return scheme === "file:" || scheme === "ftp:" || scheme === "http:" || scheme === "https:" || scheme === "ws:" || scheme === "wss:";
-    }
-    function extractProtocol(address, location) {
-      address = trimLeft(address);
-      location = location || {};
-      var match = protocolre.exec(address);
-      var protocol = match[1] ? match[1].toLowerCase() : "";
-      var forwardSlashes = !!match[2];
-      var otherSlashes = !!match[3];
-      var slashesCount = 0;
-      var rest;
-      if (forwardSlashes) {
-        if (otherSlashes) {
-          rest = match[2] + match[3] + match[4];
-          slashesCount = match[2].length + match[3].length;
-        } else {
-          rest = match[2] + match[4];
-          slashesCount = match[2].length;
-        }
-      } else {
-        if (otherSlashes) {
-          rest = match[3] + match[4];
-          slashesCount = match[3].length;
-        } else {
-          rest = match[4];
-        }
-      }
-      if (protocol === "file:") {
-        if (slashesCount >= 2) {
-          rest = rest.slice(2);
-        }
-      } else if (isSpecial(protocol)) {
-        rest = match[4];
-      } else if (protocol) {
-        if (forwardSlashes) {
-          rest = rest.slice(2);
-        }
-      } else if (slashesCount >= 2 && isSpecial(location.protocol)) {
-        rest = match[4];
-      }
-      return {
-        protocol,
-        slashes: forwardSlashes || isSpecial(protocol),
-        slashesCount,
-        rest
+        return out;
       };
-    }
-    function resolve(relative, base) {
-      if (relative === "")
-        return base;
-      var path = (base || "/").split("/").slice(0, -1).concat(relative.split("/")), i = path.length, last = path[i - 1], unshift = false, up = 0;
-      while (i--) {
-        if (path[i] === ".") {
-          path.splice(i, 1);
-        } else if (path[i] === "..") {
-          path.splice(i, 1);
-          up++;
-        } else if (up) {
-          if (i === 0)
-            unshift = true;
-          path.splice(i, 1);
-          up--;
-        }
-      }
-      if (unshift)
-        path.unshift("");
-      if (last === "." || last === "..")
-        path.push("");
-      return path.join("/");
-    }
-    function Url(address, location, parser) {
-      address = trimLeft(address);
-      if (!(this instanceof Url)) {
-        return new Url(address, location, parser);
-      }
-      var relative, extracted, parse, instruction, index, key, instructions = rules.slice(), type = typeof location, url = this, i = 0;
-      if (type !== "object" && type !== "string") {
-        parser = location;
-        location = null;
-      }
-      if (parser && typeof parser !== "function")
-        parser = qs2.parse;
-      location = lolcation(location);
-      extracted = extractProtocol(address || "", location);
-      relative = !extracted.protocol && !extracted.slashes;
-      url.slashes = extracted.slashes || relative && location.slashes;
-      url.protocol = extracted.protocol || location.protocol || "";
-      address = extracted.rest;
-      if (extracted.protocol === "file:" && (extracted.slashesCount !== 2 || windowsDriveLetter.test(address)) || !extracted.slashes && (extracted.protocol || extracted.slashesCount < 2 || !isSpecial(url.protocol))) {
-        instructions[3] = [/(.*)/, "pathname"];
-      }
-      for (; i < instructions.length; i++) {
-        instruction = instructions[i];
-        if (typeof instruction === "function") {
-          address = instruction(address, url);
-          continue;
-        }
-        parse = instruction[0];
-        key = instruction[1];
-        if (parse !== parse) {
-          url[key] = address;
-        } else if (typeof parse === "string") {
-          if (~(index = address.indexOf(parse))) {
-            if (typeof instruction[2] === "number") {
-              url[key] = address.slice(0, index);
-              address = address.slice(index + instruction[2]);
-            } else {
-              url[key] = address.slice(index);
-              address = address.slice(0, index);
+      var compact = function compact2(value) {
+        var queue = [{ obj: { o: value }, prop: "o" }];
+        var refs = [];
+        for (var i = 0; i < queue.length; ++i) {
+          var item = queue[i];
+          var obj = item.obj[item.prop];
+          var keys = Object.keys(obj);
+          for (var j = 0; j < keys.length; ++j) {
+            var key = keys[j];
+            var val = obj[key];
+            if (typeof val === "object" && val !== null && refs.indexOf(val) === -1) {
+              queue.push({ obj, prop: key });
+              refs.push(val);
             }
           }
-        } else if (index = parse.exec(address)) {
-          url[key] = index[1];
-          address = address.slice(0, index.index);
         }
-        url[key] = url[key] || (relative && instruction[3] ? location[key] || "" : "");
-        if (instruction[4])
-          url[key] = url[key].toLowerCase();
-      }
-      if (parser)
-        url.query = parser(url.query);
-      if (relative && location.slashes && url.pathname.charAt(0) !== "/" && (url.pathname !== "" || location.pathname !== "")) {
-        url.pathname = resolve(url.pathname, location.pathname);
-      }
-      if (url.pathname.charAt(0) !== "/" && isSpecial(url.protocol)) {
-        url.pathname = "/" + url.pathname;
-      }
-      if (!required(url.port, url.protocol)) {
-        url.host = url.hostname;
-        url.port = "";
-      }
-      url.username = url.password = "";
-      if (url.auth) {
-        instruction = url.auth.split(":");
-        url.username = instruction[0] || "";
-        url.password = instruction[1] || "";
-      }
-      url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
-      url.href = url.toString();
+        compactQueue(queue);
+        return value;
+      };
+      var isRegExp = function isRegExp2(obj) {
+        return Object.prototype.toString.call(obj) === "[object RegExp]";
+      };
+      var isBuffer = function isBuffer2(obj) {
+        if (!obj || typeof obj !== "object") {
+          return false;
+        }
+        return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
+      };
+      var combine = function combine2(a, b) {
+        return [].concat(a, b);
+      };
+      var maybeMap = function maybeMap2(val, fn) {
+        if (isArray2(val)) {
+          var mapped = [];
+          for (var i = 0; i < val.length; i += 1) {
+            mapped.push(fn(val[i]));
+          }
+          return mapped;
+        }
+        return fn(val);
+      };
+      module.exports = {
+        arrayToObject,
+        assign,
+        combine,
+        compact,
+        decode,
+        encode,
+        isBuffer,
+        isRegExp,
+        maybeMap,
+        merge
+      };
     }
-    function set(part, value, fn) {
-      var url = this;
-      switch (part) {
-        case "query":
-          if (typeof value === "string" && value.length) {
-            value = (fn || qs2.parse)(value);
+  });
+
+  // node_modules/qs/lib/stringify.js
+  var require_stringify = __commonJS({
+    "node_modules/qs/lib/stringify.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var getSideChannel = require_side_channel();
+      var utils = require_utils();
+      var formats = require_formats();
+      var has = Object.prototype.hasOwnProperty;
+      var arrayPrefixGenerators = {
+        brackets: function brackets(prefix) {
+          return prefix + "[]";
+        },
+        comma: "comma",
+        indices: function indices(prefix, key) {
+          return prefix + "[" + key + "]";
+        },
+        repeat: function repeat(prefix) {
+          return prefix;
+        }
+      };
+      var isArray2 = Array.isArray;
+      var push = Array.prototype.push;
+      var pushToArray = function(arr, valueOrArray) {
+        push.apply(arr, isArray2(valueOrArray) ? valueOrArray : [valueOrArray]);
+      };
+      var toISO = Date.prototype.toISOString;
+      var defaultFormat = formats["default"];
+      var defaults = {
+        addQueryPrefix: false,
+        allowDots: false,
+        charset: "utf-8",
+        charsetSentinel: false,
+        delimiter: "&",
+        encode: true,
+        encoder: utils.encode,
+        encodeValuesOnly: false,
+        format: defaultFormat,
+        formatter: formats.formatters[defaultFormat],
+        indices: false,
+        serializeDate: function serializeDate(date) {
+          return toISO.call(date);
+        },
+        skipNulls: false,
+        strictNullHandling: false
+      };
+      var isNonNullishPrimitive = function isNonNullishPrimitive2(v) {
+        return typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "symbol" || typeof v === "bigint";
+      };
+      var stringify = function stringify2(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, sideChannel) {
+        var obj = object;
+        if (sideChannel.has(object)) {
+          throw new RangeError("Cyclic object value");
+        }
+        if (typeof filter === "function") {
+          obj = filter(prefix, obj);
+        } else if (obj instanceof Date) {
+          obj = serializeDate(obj);
+        } else if (generateArrayPrefix === "comma" && isArray2(obj)) {
+          obj = utils.maybeMap(obj, function(value2) {
+            if (value2 instanceof Date) {
+              return serializeDate(value2);
+            }
+            return value2;
+          });
+        }
+        if (obj === null) {
+          if (strictNullHandling) {
+            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix;
           }
-          url[part] = value;
-          break;
-        case "port":
-          url[part] = value;
-          if (!required(value, url.protocol)) {
-            url.host = url.hostname;
-            url[part] = "";
-          } else if (value) {
-            url.host = url.hostname + ":" + value;
+          obj = "";
+        }
+        if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
+          if (encoder) {
+            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, "key", format);
+            return [formatter(keyValue) + "=" + formatter(encoder(obj, defaults.encoder, charset, "value", format))];
           }
-          break;
-        case "hostname":
-          url[part] = value;
-          if (url.port)
-            value += ":" + url.port;
-          url.host = value;
-          break;
-        case "host":
-          url[part] = value;
-          if (/:\d+$/.test(value)) {
-            value = value.split(":");
-            url.port = value.pop();
-            url.hostname = value.join(":");
+          return [formatter(prefix) + "=" + formatter(String(obj))];
+        }
+        var values = [];
+        if (typeof obj === "undefined") {
+          return values;
+        }
+        var objKeys;
+        if (generateArrayPrefix === "comma" && isArray2(obj)) {
+          objKeys = [{ value: obj.length > 0 ? obj.join(",") || null : void 0 }];
+        } else if (isArray2(filter)) {
+          objKeys = filter;
+        } else {
+          var keys = Object.keys(obj);
+          objKeys = sort ? keys.sort(sort) : keys;
+        }
+        for (var i = 0; i < objKeys.length; ++i) {
+          var key = objKeys[i];
+          var value = typeof key === "object" && key.value !== void 0 ? key.value : obj[key];
+          if (skipNulls && value === null) {
+            continue;
+          }
+          var keyPrefix = isArray2(obj) ? typeof generateArrayPrefix === "function" ? generateArrayPrefix(prefix, key) : prefix : prefix + (allowDots ? "." + key : "[" + key + "]");
+          sideChannel.set(object, true);
+          var valueSideChannel = getSideChannel();
+          pushToArray(values, stringify2(value, keyPrefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, valueSideChannel));
+        }
+        return values;
+      };
+      var normalizeStringifyOptions = function normalizeStringifyOptions2(opts) {
+        if (!opts) {
+          return defaults;
+        }
+        if (opts.encoder !== null && opts.encoder !== void 0 && typeof opts.encoder !== "function") {
+          throw new TypeError("Encoder has to be a function.");
+        }
+        var charset = opts.charset || defaults.charset;
+        if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
+          throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
+        }
+        var format = formats["default"];
+        if (typeof opts.format !== "undefined") {
+          if (!has.call(formats.formatters, opts.format)) {
+            throw new TypeError("Unknown format option provided.");
+          }
+          format = opts.format;
+        }
+        var formatter = formats.formatters[format];
+        var filter = defaults.filter;
+        if (typeof opts.filter === "function" || isArray2(opts.filter)) {
+          filter = opts.filter;
+        }
+        return {
+          addQueryPrefix: typeof opts.addQueryPrefix === "boolean" ? opts.addQueryPrefix : defaults.addQueryPrefix,
+          allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
+          charset,
+          charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
+          delimiter: typeof opts.delimiter === "undefined" ? defaults.delimiter : opts.delimiter,
+          encode: typeof opts.encode === "boolean" ? opts.encode : defaults.encode,
+          encoder: typeof opts.encoder === "function" ? opts.encoder : defaults.encoder,
+          encodeValuesOnly: typeof opts.encodeValuesOnly === "boolean" ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
+          filter,
+          format,
+          formatter,
+          serializeDate: typeof opts.serializeDate === "function" ? opts.serializeDate : defaults.serializeDate,
+          skipNulls: typeof opts.skipNulls === "boolean" ? opts.skipNulls : defaults.skipNulls,
+          sort: typeof opts.sort === "function" ? opts.sort : null,
+          strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
+        };
+      };
+      module.exports = function(object, opts) {
+        var obj = object;
+        var options = normalizeStringifyOptions(opts);
+        var objKeys;
+        var filter;
+        if (typeof options.filter === "function") {
+          filter = options.filter;
+          obj = filter("", obj);
+        } else if (isArray2(options.filter)) {
+          filter = options.filter;
+          objKeys = filter;
+        }
+        var keys = [];
+        if (typeof obj !== "object" || obj === null) {
+          return "";
+        }
+        var arrayFormat;
+        if (opts && opts.arrayFormat in arrayPrefixGenerators) {
+          arrayFormat = opts.arrayFormat;
+        } else if (opts && "indices" in opts) {
+          arrayFormat = opts.indices ? "indices" : "repeat";
+        } else {
+          arrayFormat = "indices";
+        }
+        var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+        if (!objKeys) {
+          objKeys = Object.keys(obj);
+        }
+        if (options.sort) {
+          objKeys.sort(options.sort);
+        }
+        var sideChannel = getSideChannel();
+        for (var i = 0; i < objKeys.length; ++i) {
+          var key = objKeys[i];
+          if (options.skipNulls && obj[key] === null) {
+            continue;
+          }
+          pushToArray(keys, stringify(obj[key], key, generateArrayPrefix, options.strictNullHandling, options.skipNulls, options.encode ? options.encoder : null, options.filter, options.sort, options.allowDots, options.serializeDate, options.format, options.formatter, options.encodeValuesOnly, options.charset, sideChannel));
+        }
+        var joined = keys.join(options.delimiter);
+        var prefix = options.addQueryPrefix === true ? "?" : "";
+        if (options.charsetSentinel) {
+          if (options.charset === "iso-8859-1") {
+            prefix += "utf8=%26%2310003%3B&";
           } else {
-            url.hostname = value;
-            url.port = "";
+            prefix += "utf8=%E2%9C%93&";
           }
-          break;
-        case "protocol":
-          url.protocol = value.toLowerCase();
-          url.slashes = !fn;
-          break;
-        case "pathname":
-        case "hash":
-          if (value) {
-            var char = part === "pathname" ? "/" : "#";
-            url[part] = value.charAt(0) !== char ? char + value : value;
+        }
+        return joined.length > 0 ? prefix + joined : "";
+      };
+    }
+  });
+
+  // node_modules/qs/lib/parse.js
+  var require_parse = __commonJS({
+    "node_modules/qs/lib/parse.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var utils = require_utils();
+      var has = Object.prototype.hasOwnProperty;
+      var isArray2 = Array.isArray;
+      var defaults = {
+        allowDots: false,
+        allowPrototypes: false,
+        allowSparse: false,
+        arrayLimit: 20,
+        charset: "utf-8",
+        charsetSentinel: false,
+        comma: false,
+        decoder: utils.decode,
+        delimiter: "&",
+        depth: 5,
+        ignoreQueryPrefix: false,
+        interpretNumericEntities: false,
+        parameterLimit: 1e3,
+        parseArrays: true,
+        plainObjects: false,
+        strictNullHandling: false
+      };
+      var interpretNumericEntities = function(str) {
+        return str.replace(/&#(\d+);/g, function($0, numberStr) {
+          return String.fromCharCode(parseInt(numberStr, 10));
+        });
+      };
+      var parseArrayValue = function(val, options) {
+        if (val && typeof val === "string" && options.comma && val.indexOf(",") > -1) {
+          return val.split(",");
+        }
+        return val;
+      };
+      var isoSentinel = "utf8=%26%2310003%3B";
+      var charsetSentinel = "utf8=%E2%9C%93";
+      var parseValues = function parseQueryStringValues(str, options) {
+        var obj = {};
+        var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, "") : str;
+        var limit = options.parameterLimit === Infinity ? void 0 : options.parameterLimit;
+        var parts = cleanStr.split(options.delimiter, limit);
+        var skipIndex = -1;
+        var i;
+        var charset = options.charset;
+        if (options.charsetSentinel) {
+          for (i = 0; i < parts.length; ++i) {
+            if (parts[i].indexOf("utf8=") === 0) {
+              if (parts[i] === charsetSentinel) {
+                charset = "utf-8";
+              } else if (parts[i] === isoSentinel) {
+                charset = "iso-8859-1";
+              }
+              skipIndex = i;
+              i = parts.length;
+            }
+          }
+        }
+        for (i = 0; i < parts.length; ++i) {
+          if (i === skipIndex) {
+            continue;
+          }
+          var part = parts[i];
+          var bracketEqualsPos = part.indexOf("]=");
+          var pos = bracketEqualsPos === -1 ? part.indexOf("=") : bracketEqualsPos + 1;
+          var key, val;
+          if (pos === -1) {
+            key = options.decoder(part, defaults.decoder, charset, "key");
+            val = options.strictNullHandling ? null : "";
           } else {
+            key = options.decoder(part.slice(0, pos), defaults.decoder, charset, "key");
+            val = utils.maybeMap(parseArrayValue(part.slice(pos + 1), options), function(encodedVal) {
+              return options.decoder(encodedVal, defaults.decoder, charset, "value");
+            });
+          }
+          if (val && options.interpretNumericEntities && charset === "iso-8859-1") {
+            val = interpretNumericEntities(val);
+          }
+          if (part.indexOf("[]=") > -1) {
+            val = isArray2(val) ? [val] : val;
+          }
+          if (has.call(obj, key)) {
+            obj[key] = utils.combine(obj[key], val);
+          } else {
+            obj[key] = val;
+          }
+        }
+        return obj;
+      };
+      var parseObject = function(chain, val, options, valuesParsed) {
+        var leaf = valuesParsed ? val : parseArrayValue(val, options);
+        for (var i = chain.length - 1; i >= 0; --i) {
+          var obj;
+          var root = chain[i];
+          if (root === "[]" && options.parseArrays) {
+            obj = [].concat(leaf);
+          } else {
+            obj = options.plainObjects ? Object.create(null) : {};
+            var cleanRoot = root.charAt(0) === "[" && root.charAt(root.length - 1) === "]" ? root.slice(1, -1) : root;
+            var index = parseInt(cleanRoot, 10);
+            if (!options.parseArrays && cleanRoot === "") {
+              obj = { 0: leaf };
+            } else if (!isNaN(index) && root !== cleanRoot && String(index) === cleanRoot && index >= 0 && (options.parseArrays && index <= options.arrayLimit)) {
+              obj = [];
+              obj[index] = leaf;
+            } else {
+              obj[cleanRoot] = leaf;
+            }
+          }
+          leaf = obj;
+        }
+        return leaf;
+      };
+      var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {
+        if (!givenKey) {
+          return;
+        }
+        var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, "[$1]") : givenKey;
+        var brackets = /(\[[^[\]]*])/;
+        var child = /(\[[^[\]]*])/g;
+        var segment = options.depth > 0 && brackets.exec(key);
+        var parent = segment ? key.slice(0, segment.index) : key;
+        var keys = [];
+        if (parent) {
+          if (!options.plainObjects && has.call(Object.prototype, parent)) {
+            if (!options.allowPrototypes) {
+              return;
+            }
+          }
+          keys.push(parent);
+        }
+        var i = 0;
+        while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
+          i += 1;
+          if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+            if (!options.allowPrototypes) {
+              return;
+            }
+          }
+          keys.push(segment[1]);
+        }
+        if (segment) {
+          keys.push("[" + key.slice(segment.index) + "]");
+        }
+        return parseObject(keys, val, options, valuesParsed);
+      };
+      var normalizeParseOptions = function normalizeParseOptions2(opts) {
+        if (!opts) {
+          return defaults;
+        }
+        if (opts.decoder !== null && opts.decoder !== void 0 && typeof opts.decoder !== "function") {
+          throw new TypeError("Decoder has to be a function.");
+        }
+        if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
+          throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
+        }
+        var charset = typeof opts.charset === "undefined" ? defaults.charset : opts.charset;
+        return {
+          allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
+          allowPrototypes: typeof opts.allowPrototypes === "boolean" ? opts.allowPrototypes : defaults.allowPrototypes,
+          allowSparse: typeof opts.allowSparse === "boolean" ? opts.allowSparse : defaults.allowSparse,
+          arrayLimit: typeof opts.arrayLimit === "number" ? opts.arrayLimit : defaults.arrayLimit,
+          charset,
+          charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
+          comma: typeof opts.comma === "boolean" ? opts.comma : defaults.comma,
+          decoder: typeof opts.decoder === "function" ? opts.decoder : defaults.decoder,
+          delimiter: typeof opts.delimiter === "string" || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
+          depth: typeof opts.depth === "number" || opts.depth === false ? +opts.depth : defaults.depth,
+          ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
+          interpretNumericEntities: typeof opts.interpretNumericEntities === "boolean" ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
+          parameterLimit: typeof opts.parameterLimit === "number" ? opts.parameterLimit : defaults.parameterLimit,
+          parseArrays: opts.parseArrays !== false,
+          plainObjects: typeof opts.plainObjects === "boolean" ? opts.plainObjects : defaults.plainObjects,
+          strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
+        };
+      };
+      module.exports = function(str, opts) {
+        var options = normalizeParseOptions(opts);
+        if (str === "" || str === null || typeof str === "undefined") {
+          return options.plainObjects ? Object.create(null) : {};
+        }
+        var tempObj = typeof str === "string" ? parseValues(str, options) : str;
+        var obj = options.plainObjects ? Object.create(null) : {};
+        var keys = Object.keys(tempObj);
+        for (var i = 0; i < keys.length; ++i) {
+          var key = keys[i];
+          var newObj = parseKeys(key, tempObj[key], options, typeof str === "string");
+          obj = utils.merge(obj, newObj, options);
+        }
+        if (options.allowSparse === true) {
+          return obj;
+        }
+        return utils.compact(obj);
+      };
+    }
+  });
+
+  // node_modules/qs/lib/index.js
+  var require_lib = __commonJS({
+    "node_modules/qs/lib/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var stringify = require_stringify();
+      var parse = require_parse();
+      var formats = require_formats();
+      module.exports = {
+        formats,
+        parse,
+        stringify
+      };
+    }
+  });
+
+  // node_modules/requires-port/index.js
+  var require_requires_port = __commonJS({
+    "node_modules/requires-port/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      module.exports = function required(port, protocol) {
+        protocol = protocol.split(":")[0];
+        port = +port;
+        if (!port)
+          return false;
+        switch (protocol) {
+          case "http":
+          case "ws":
+            return port !== 80;
+          case "https":
+          case "wss":
+            return port !== 443;
+          case "ftp":
+            return port !== 21;
+          case "gopher":
+            return port !== 70;
+          case "file":
+            return false;
+        }
+        return port !== 0;
+      };
+    }
+  });
+
+  // node_modules/querystringify/index.js
+  var require_querystringify = __commonJS({
+    "node_modules/querystringify/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      var has = Object.prototype.hasOwnProperty;
+      var undef;
+      function decode(input) {
+        try {
+          return decodeURIComponent(input.replace(/\+/g, " "));
+        } catch (e) {
+          return null;
+        }
+      }
+      function encode(input) {
+        try {
+          return encodeURIComponent(input);
+        } catch (e) {
+          return null;
+        }
+      }
+      function querystring(query) {
+        var parser = /([^=?#&]+)=?([^&]*)/g, result = {}, part;
+        while (part = parser.exec(query)) {
+          var key = decode(part[1]), value = decode(part[2]);
+          if (key === null || value === null || key in result)
+            continue;
+          result[key] = value;
+        }
+        return result;
+      }
+      function querystringify(obj, prefix) {
+        prefix = prefix || "";
+        var pairs = [], value, key;
+        if (typeof prefix !== "string")
+          prefix = "?";
+        for (key in obj) {
+          if (has.call(obj, key)) {
+            value = obj[key];
+            if (!value && (value === null || value === undef || isNaN(value))) {
+              value = "";
+            }
+            key = encode(key);
+            value = encode(value);
+            if (key === null || value === null)
+              continue;
+            pairs.push(key + "=" + value);
+          }
+        }
+        return pairs.length ? prefix + pairs.join("&") : "";
+      }
+      exports.stringify = querystringify;
+      exports.parse = querystring;
+    }
+  });
+
+  // node_modules/url-parse/index.js
+  var require_url_parse = __commonJS({
+    "node_modules/url-parse/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var required = require_requires_port();
+      var qs2 = require_querystringify();
+      var slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//;
+      var protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\\/]+)?([\S\s]*)/i;
+      var windowsDriveLetter = /^[a-zA-Z]:/;
+      var whitespace = "[\\x09\\x0A\\x0B\\x0C\\x0D\\x20\\xA0\\u1680\\u180E\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000\\u2028\\u2029\\uFEFF]";
+      var left = new RegExp("^" + whitespace + "+");
+      function trimLeft(str) {
+        return (str ? str : "").toString().replace(left, "");
+      }
+      var rules = [
+        ["#", "hash"],
+        ["?", "query"],
+        function sanitize(address, url) {
+          return isSpecial(url.protocol) ? address.replace(/\\/g, "/") : address;
+        },
+        ["/", "pathname"],
+        ["@", "auth", 1],
+        [NaN, "host", void 0, 1, 1],
+        [/:(\d+)$/, "port", void 0, 1],
+        [NaN, "hostname", void 0, 1, 1]
+      ];
+      var ignore = { hash: 1, query: 1 };
+      function lolcation(loc) {
+        var globalVar;
+        if (typeof window !== "undefined")
+          globalVar = window;
+        else if (typeof global !== "undefined")
+          globalVar = global;
+        else if (typeof self !== "undefined")
+          globalVar = self;
+        else
+          globalVar = {};
+        var location = globalVar.location || {};
+        loc = loc || location;
+        var finaldestination = {}, type = typeof loc, key;
+        if (loc.protocol === "blob:") {
+          finaldestination = new Url(unescape(loc.pathname), {});
+        } else if (type === "string") {
+          finaldestination = new Url(loc, {});
+          for (key in ignore)
+            delete finaldestination[key];
+        } else if (type === "object") {
+          for (key in loc) {
+            if (key in ignore)
+              continue;
+            finaldestination[key] = loc[key];
+          }
+          if (finaldestination.slashes === void 0) {
+            finaldestination.slashes = slashes.test(loc.href);
+          }
+        }
+        return finaldestination;
+      }
+      function isSpecial(scheme) {
+        return scheme === "file:" || scheme === "ftp:" || scheme === "http:" || scheme === "https:" || scheme === "ws:" || scheme === "wss:";
+      }
+      function extractProtocol(address, location) {
+        address = trimLeft(address);
+        location = location || {};
+        var match = protocolre.exec(address);
+        var protocol = match[1] ? match[1].toLowerCase() : "";
+        var forwardSlashes = !!match[2];
+        var otherSlashes = !!match[3];
+        var slashesCount = 0;
+        var rest;
+        if (forwardSlashes) {
+          if (otherSlashes) {
+            rest = match[2] + match[3] + match[4];
+            slashesCount = match[2].length + match[3].length;
+          } else {
+            rest = match[2] + match[4];
+            slashesCount = match[2].length;
+          }
+        } else {
+          if (otherSlashes) {
+            rest = match[3] + match[4];
+            slashesCount = match[3].length;
+          } else {
+            rest = match[4];
+          }
+        }
+        if (protocol === "file:") {
+          if (slashesCount >= 2) {
+            rest = rest.slice(2);
+          }
+        } else if (isSpecial(protocol)) {
+          rest = match[4];
+        } else if (protocol) {
+          if (forwardSlashes) {
+            rest = rest.slice(2);
+          }
+        } else if (slashesCount >= 2 && isSpecial(location.protocol)) {
+          rest = match[4];
+        }
+        return {
+          protocol,
+          slashes: forwardSlashes || isSpecial(protocol),
+          slashesCount,
+          rest
+        };
+      }
+      function resolve(relative, base) {
+        if (relative === "")
+          return base;
+        var path = (base || "/").split("/").slice(0, -1).concat(relative.split("/")), i = path.length, last = path[i - 1], unshift = false, up = 0;
+        while (i--) {
+          if (path[i] === ".") {
+            path.splice(i, 1);
+          } else if (path[i] === "..") {
+            path.splice(i, 1);
+            up++;
+          } else if (up) {
+            if (i === 0)
+              unshift = true;
+            path.splice(i, 1);
+            up--;
+          }
+        }
+        if (unshift)
+          path.unshift("");
+        if (last === "." || last === "..")
+          path.push("");
+        return path.join("/");
+      }
+      function Url(address, location, parser) {
+        address = trimLeft(address);
+        if (!(this instanceof Url)) {
+          return new Url(address, location, parser);
+        }
+        var relative, extracted, parse, instruction, index, key, instructions = rules.slice(), type = typeof location, url = this, i = 0;
+        if (type !== "object" && type !== "string") {
+          parser = location;
+          location = null;
+        }
+        if (parser && typeof parser !== "function")
+          parser = qs2.parse;
+        location = lolcation(location);
+        extracted = extractProtocol(address || "", location);
+        relative = !extracted.protocol && !extracted.slashes;
+        url.slashes = extracted.slashes || relative && location.slashes;
+        url.protocol = extracted.protocol || location.protocol || "";
+        address = extracted.rest;
+        if (extracted.protocol === "file:" && (extracted.slashesCount !== 2 || windowsDriveLetter.test(address)) || !extracted.slashes && (extracted.protocol || extracted.slashesCount < 2 || !isSpecial(url.protocol))) {
+          instructions[3] = [/(.*)/, "pathname"];
+        }
+        for (; i < instructions.length; i++) {
+          instruction = instructions[i];
+          if (typeof instruction === "function") {
+            address = instruction(address, url);
+            continue;
+          }
+          parse = instruction[0];
+          key = instruction[1];
+          if (parse !== parse) {
+            url[key] = address;
+          } else if (typeof parse === "string") {
+            if (~(index = address.indexOf(parse))) {
+              if (typeof instruction[2] === "number") {
+                url[key] = address.slice(0, index);
+                address = address.slice(index + instruction[2]);
+              } else {
+                url[key] = address.slice(index);
+                address = address.slice(0, index);
+              }
+            }
+          } else if (index = parse.exec(address)) {
+            url[key] = index[1];
+            address = address.slice(0, index.index);
+          }
+          url[key] = url[key] || (relative && instruction[3] ? location[key] || "" : "");
+          if (instruction[4])
+            url[key] = url[key].toLowerCase();
+        }
+        if (parser)
+          url.query = parser(url.query);
+        if (relative && location.slashes && url.pathname.charAt(0) !== "/" && (url.pathname !== "" || location.pathname !== "")) {
+          url.pathname = resolve(url.pathname, location.pathname);
+        }
+        if (url.pathname.charAt(0) !== "/" && isSpecial(url.protocol)) {
+          url.pathname = "/" + url.pathname;
+        }
+        if (!required(url.port, url.protocol)) {
+          url.host = url.hostname;
+          url.port = "";
+        }
+        url.username = url.password = "";
+        if (url.auth) {
+          instruction = url.auth.split(":");
+          url.username = instruction[0] || "";
+          url.password = instruction[1] || "";
+        }
+        url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
+        url.href = url.toString();
+      }
+      function set(part, value, fn) {
+        var url = this;
+        switch (part) {
+          case "query":
+            if (typeof value === "string" && value.length) {
+              value = (fn || qs2.parse)(value);
+            }
             url[part] = value;
-          }
-          break;
-        default:
-          url[part] = value;
+            break;
+          case "port":
+            url[part] = value;
+            if (!required(value, url.protocol)) {
+              url.host = url.hostname;
+              url[part] = "";
+            } else if (value) {
+              url.host = url.hostname + ":" + value;
+            }
+            break;
+          case "hostname":
+            url[part] = value;
+            if (url.port)
+              value += ":" + url.port;
+            url.host = value;
+            break;
+          case "host":
+            url[part] = value;
+            if (/:\d+$/.test(value)) {
+              value = value.split(":");
+              url.port = value.pop();
+              url.hostname = value.join(":");
+            } else {
+              url.hostname = value;
+              url.port = "";
+            }
+            break;
+          case "protocol":
+            url.protocol = value.toLowerCase();
+            url.slashes = !fn;
+            break;
+          case "pathname":
+          case "hash":
+            if (value) {
+              var char = part === "pathname" ? "/" : "#";
+              url[part] = value.charAt(0) !== char ? char + value : value;
+            } else {
+              url[part] = value;
+            }
+            break;
+          default:
+            url[part] = value;
+        }
+        for (var i = 0; i < rules.length; i++) {
+          var ins = rules[i];
+          if (ins[4])
+            url[ins[1]] = url[ins[1]].toLowerCase();
+        }
+        url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
+        url.href = url.toString();
+        return url;
       }
-      for (var i = 0; i < rules.length; i++) {
-        var ins = rules[i];
-        if (ins[4])
-          url[ins[1]] = url[ins[1]].toLowerCase();
+      function toString(stringify) {
+        if (!stringify || typeof stringify !== "function")
+          stringify = qs2.stringify;
+        var query, url = this, protocol = url.protocol;
+        if (protocol && protocol.charAt(protocol.length - 1) !== ":")
+          protocol += ":";
+        var result = protocol + (url.slashes || isSpecial(url.protocol) ? "//" : "");
+        if (url.username) {
+          result += url.username;
+          if (url.password)
+            result += ":" + url.password;
+          result += "@";
+        }
+        result += url.host + url.pathname;
+        query = typeof url.query === "object" ? stringify(url.query) : url.query;
+        if (query)
+          result += query.charAt(0) !== "?" ? "?" + query : query;
+        if (url.hash)
+          result += url.hash;
+        return result;
       }
-      url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
-      url.href = url.toString();
-      return url;
+      Url.prototype = { set, toString };
+      Url.extractProtocol = extractProtocol;
+      Url.location = lolcation;
+      Url.trimLeft = trimLeft;
+      Url.qs = qs2;
+      module.exports = Url;
     }
-    function toString(stringify) {
-      if (!stringify || typeof stringify !== "function")
-        stringify = qs2.stringify;
-      var query, url = this, protocol = url.protocol;
-      if (protocol && protocol.charAt(protocol.length - 1) !== ":")
-        protocol += ":";
-      var result = protocol + (url.slashes || isSpecial(url.protocol) ? "//" : "");
-      if (url.username) {
-        result += url.username;
-        if (url.password)
-          result += ":" + url.password;
-        result += "@";
-      }
-      result += url.host + url.pathname;
-      query = typeof url.query === "object" ? stringify(url.query) : url.query;
-      if (query)
-        result += query.charAt(0) !== "?" ? "?" + query : query;
-      if (url.hash)
-        result += url.hash;
-      return result;
-    }
-    Url.prototype = { set, toString };
-    Url.extractProtocol = extractProtocol;
-    Url.location = lolcation;
-    Url.trimLeft = trimLeft;
-    Url.qs = qs2;
-    module2.exports = Url;
-  }
-});
+  });
 
-// runtime/thunk/thunk.ts
-__export(exports, {
-  ensureSwitchUnreachable: () => ensureSwitchUnreachable,
-  findAndExecutePackFunction: () => findAndExecutePackFunction,
-  handleError: () => handleError,
-  handleErrorAsync: () => handleErrorAsync,
-  handleFetcherStatusError: () => handleFetcherStatusError,
-  marshalValue: () => marshalValue,
-  unmarshalValue: () => unmarshalValue
-});
-init_buffer_shim();
+  // runtime/thunk/thunk.ts
+  var thunk_exports = {};
+  __export(thunk_exports, {
+    ensureSwitchUnreachable: () => ensureSwitchUnreachable,
+    findAndExecutePackFunction: () => findAndExecutePackFunction,
+    handleError: () => handleError,
+    handleErrorAsync: () => handleErrorAsync,
+    handleFetcherStatusError: () => handleFetcherStatusError,
+    marshalValue: () => marshalValue,
+    unmarshalValue: () => unmarshalValue
+  });
+  init_buffer_shim();
 
-// types.ts
-init_buffer_shim();
-var PackCategory;
-(function(PackCategory2) {
-  PackCategory2["CRM"] = "CRM";
-  PackCategory2["Calendar"] = "Calendar";
-  PackCategory2["Communication"] = "Communication";
-  PackCategory2["DataStorage"] = "DataStorage";
-  PackCategory2["Design"] = "Design";
-  PackCategory2["Financial"] = "Financial";
-  PackCategory2["Fun"] = "Fun";
-  PackCategory2["Geo"] = "Geo";
-  PackCategory2["IT"] = "IT";
-  PackCategory2["Mathematics"] = "Mathematics";
-  PackCategory2["Organization"] = "Organization";
-  PackCategory2["Recruiting"] = "Recruiting";
-  PackCategory2["Shopping"] = "Shopping";
-  PackCategory2["Social"] = "Social";
-  PackCategory2["Sports"] = "Sports";
-  PackCategory2["Travel"] = "Travel";
-  PackCategory2["Weather"] = "Weather";
-})(PackCategory || (PackCategory = {}));
-var AuthenticationType;
-(function(AuthenticationType2) {
-  AuthenticationType2["None"] = "None";
-  AuthenticationType2["HeaderBearerToken"] = "HeaderBearerToken";
-  AuthenticationType2["CustomHeaderToken"] = "CustomHeaderToken";
-  AuthenticationType2["QueryParamToken"] = "QueryParamToken";
-  AuthenticationType2["MultiQueryParamToken"] = "MultiQueryParamToken";
-  AuthenticationType2["OAuth2"] = "OAuth2";
-  AuthenticationType2["WebBasic"] = "WebBasic";
-  AuthenticationType2["AWSSignature4"] = "AWSSignature4";
-  AuthenticationType2["CodaApiHeaderBearerToken"] = "CodaApiHeaderBearerToken";
-  AuthenticationType2["Various"] = "Various";
-})(AuthenticationType || (AuthenticationType = {}));
-var DefaultConnectionType;
-(function(DefaultConnectionType2) {
-  DefaultConnectionType2[DefaultConnectionType2["SharedDataOnly"] = 1] = "SharedDataOnly";
-  DefaultConnectionType2[DefaultConnectionType2["Shared"] = 2] = "Shared";
-  DefaultConnectionType2[DefaultConnectionType2["ProxyActionsOnly"] = 3] = "ProxyActionsOnly";
-})(DefaultConnectionType || (DefaultConnectionType = {}));
-var PostSetupType;
-(function(PostSetupType2) {
-  PostSetupType2["SetEndpoint"] = "SetEndPoint";
-})(PostSetupType || (PostSetupType = {}));
-var FeatureSet;
-(function(FeatureSet2) {
-  FeatureSet2["Basic"] = "Basic";
-  FeatureSet2["Pro"] = "Pro";
-  FeatureSet2["Team"] = "Team";
-  FeatureSet2["Enterprise"] = "Enterprise";
-})(FeatureSet || (FeatureSet = {}));
-var QuotaLimitType;
-(function(QuotaLimitType2) {
-  QuotaLimitType2["Action"] = "Action";
-  QuotaLimitType2["Getter"] = "Getter";
-  QuotaLimitType2["Sync"] = "Sync";
-  QuotaLimitType2["Metadata"] = "Metadata";
-})(QuotaLimitType || (QuotaLimitType = {}));
-var SyncInterval;
-(function(SyncInterval2) {
-  SyncInterval2["Manual"] = "Manual";
-  SyncInterval2["Daily"] = "Daily";
-  SyncInterval2["Hourly"] = "Hourly";
-  SyncInterval2["EveryTenMinutes"] = "EveryTenMinutes";
-})(SyncInterval || (SyncInterval = {}));
+  // types.ts
+  init_buffer_shim();
+  var PackCategory;
+  (function(PackCategory2) {
+    PackCategory2["CRM"] = "CRM";
+    PackCategory2["Calendar"] = "Calendar";
+    PackCategory2["Communication"] = "Communication";
+    PackCategory2["DataStorage"] = "DataStorage";
+    PackCategory2["Design"] = "Design";
+    PackCategory2["Financial"] = "Financial";
+    PackCategory2["Fun"] = "Fun";
+    PackCategory2["Geo"] = "Geo";
+    PackCategory2["IT"] = "IT";
+    PackCategory2["Mathematics"] = "Mathematics";
+    PackCategory2["Organization"] = "Organization";
+    PackCategory2["Recruiting"] = "Recruiting";
+    PackCategory2["Shopping"] = "Shopping";
+    PackCategory2["Social"] = "Social";
+    PackCategory2["Sports"] = "Sports";
+    PackCategory2["Travel"] = "Travel";
+    PackCategory2["Weather"] = "Weather";
+  })(PackCategory || (PackCategory = {}));
+  var AuthenticationType;
+  (function(AuthenticationType2) {
+    AuthenticationType2["None"] = "None";
+    AuthenticationType2["HeaderBearerToken"] = "HeaderBearerToken";
+    AuthenticationType2["CustomHeaderToken"] = "CustomHeaderToken";
+    AuthenticationType2["QueryParamToken"] = "QueryParamToken";
+    AuthenticationType2["MultiQueryParamToken"] = "MultiQueryParamToken";
+    AuthenticationType2["OAuth2"] = "OAuth2";
+    AuthenticationType2["WebBasic"] = "WebBasic";
+    AuthenticationType2["AWSSignature4"] = "AWSSignature4";
+    AuthenticationType2["CodaApiHeaderBearerToken"] = "CodaApiHeaderBearerToken";
+    AuthenticationType2["Various"] = "Various";
+  })(AuthenticationType || (AuthenticationType = {}));
+  var DefaultConnectionType;
+  (function(DefaultConnectionType2) {
+    DefaultConnectionType2[DefaultConnectionType2["SharedDataOnly"] = 1] = "SharedDataOnly";
+    DefaultConnectionType2[DefaultConnectionType2["Shared"] = 2] = "Shared";
+    DefaultConnectionType2[DefaultConnectionType2["ProxyActionsOnly"] = 3] = "ProxyActionsOnly";
+  })(DefaultConnectionType || (DefaultConnectionType = {}));
+  var PostSetupType;
+  (function(PostSetupType2) {
+    PostSetupType2["SetEndpoint"] = "SetEndPoint";
+  })(PostSetupType || (PostSetupType = {}));
+  var FeatureSet;
+  (function(FeatureSet2) {
+    FeatureSet2["Basic"] = "Basic";
+    FeatureSet2["Pro"] = "Pro";
+    FeatureSet2["Team"] = "Team";
+    FeatureSet2["Enterprise"] = "Enterprise";
+  })(FeatureSet || (FeatureSet = {}));
+  var QuotaLimitType;
+  (function(QuotaLimitType2) {
+    QuotaLimitType2["Action"] = "Action";
+    QuotaLimitType2["Getter"] = "Getter";
+    QuotaLimitType2["Sync"] = "Sync";
+    QuotaLimitType2["Metadata"] = "Metadata";
+  })(QuotaLimitType || (QuotaLimitType = {}));
+  var SyncInterval;
+  (function(SyncInterval2) {
+    SyncInterval2["Manual"] = "Manual";
+    SyncInterval2["Daily"] = "Daily";
+    SyncInterval2["Hourly"] = "Hourly";
+    SyncInterval2["EveryTenMinutes"] = "EveryTenMinutes";
+  })(SyncInterval || (SyncInterval = {}));
 
-// runtime/types.ts
-init_buffer_shim();
-var FormulaType;
-(function(FormulaType2) {
-  FormulaType2["Standard"] = "Standard";
-  FormulaType2["Sync"] = "Sync";
-  FormulaType2["Metadata"] = "Metadata";
-})(FormulaType || (FormulaType = {}));
-var MetadataFormulaType;
-(function(MetadataFormulaType2) {
-  MetadataFormulaType2["GetConnectionName"] = "GetConnectionName";
-  MetadataFormulaType2["GetConnectionUserId"] = "GetConnectionUserId";
-  MetadataFormulaType2["ParameterAutocomplete"] = "ParameterAutocomplete";
-  MetadataFormulaType2["PostSetupSetEndpoint"] = "PostSetupSetEndpoint";
-  MetadataFormulaType2["SyncListDynamicUrls"] = "SyncListDynamicUrls";
-  MetadataFormulaType2["SyncGetDisplayUrl"] = "SyncGetDisplayUrl";
-  MetadataFormulaType2["SyncGetTableName"] = "SyncGetTableName";
-  MetadataFormulaType2["SyncGetSchema"] = "SyncGetSchema";
-})(MetadataFormulaType || (MetadataFormulaType = {}));
+  // runtime/types.ts
+  init_buffer_shim();
+  var FormulaType;
+  (function(FormulaType2) {
+    FormulaType2["Standard"] = "Standard";
+    FormulaType2["Sync"] = "Sync";
+    FormulaType2["Metadata"] = "Metadata";
+  })(FormulaType || (FormulaType = {}));
+  var MetadataFormulaType;
+  (function(MetadataFormulaType2) {
+    MetadataFormulaType2["GetConnectionName"] = "GetConnectionName";
+    MetadataFormulaType2["GetConnectionUserId"] = "GetConnectionUserId";
+    MetadataFormulaType2["ParameterAutocomplete"] = "ParameterAutocomplete";
+    MetadataFormulaType2["PostSetupSetEndpoint"] = "PostSetupSetEndpoint";
+    MetadataFormulaType2["SyncListDynamicUrls"] = "SyncListDynamicUrls";
+    MetadataFormulaType2["SyncGetDisplayUrl"] = "SyncGetDisplayUrl";
+    MetadataFormulaType2["SyncGetTableName"] = "SyncGetTableName";
+    MetadataFormulaType2["SyncGetSchema"] = "SyncGetSchema";
+  })(MetadataFormulaType || (MetadataFormulaType = {}));
 
-// api.ts
-init_buffer_shim();
+  // api.ts
+  init_buffer_shim();
 
-// api_types.ts
-init_buffer_shim();
-var Type;
-(function(Type2) {
-  Type2[Type2["string"] = 0] = "string";
-  Type2[Type2["number"] = 1] = "number";
-  Type2[Type2["object"] = 2] = "object";
-  Type2[Type2["boolean"] = 3] = "boolean";
-  Type2[Type2["date"] = 4] = "date";
-  Type2[Type2["html"] = 5] = "html";
-  Type2[Type2["image"] = 6] = "image";
-})(Type || (Type = {}));
-var ParameterType;
-(function(ParameterType2) {
-  ParameterType2["String"] = "string";
-  ParameterType2["Number"] = "number";
-  ParameterType2["Boolean"] = "boolean";
-  ParameterType2["Date"] = "date";
-  ParameterType2["Html"] = "html";
-  ParameterType2["Image"] = "image";
-  ParameterType2["StringArray"] = "stringArray";
-  ParameterType2["NumberArray"] = "numberArray";
-  ParameterType2["BooleanArray"] = "booleanArray";
-  ParameterType2["DateArray"] = "dateArray";
-  ParameterType2["HtmlArray"] = "htmlArray`";
-  ParameterType2["ImageArray"] = "imageArray";
-})(ParameterType || (ParameterType = {}));
-var ParameterTypeInputMap = {
-  [ParameterType.String]: 0,
-  [ParameterType.Number]: 1,
-  [ParameterType.Boolean]: 3,
-  [ParameterType.Date]: 4,
-  [ParameterType.Html]: 5,
-  [ParameterType.Image]: 6,
-  [ParameterType.StringArray]: { type: "array", items: 0 },
-  [ParameterType.NumberArray]: { type: "array", items: 1 },
-  [ParameterType.BooleanArray]: { type: "array", items: 3 },
-  [ParameterType.DateArray]: { type: "array", items: 4 },
-  [ParameterType.HtmlArray]: { type: "array", items: 5 },
-  [ParameterType.ImageArray]: { type: "array", items: 6 }
-};
-var ConnectionRequirement;
-(function(ConnectionRequirement2) {
-  ConnectionRequirement2["None"] = "none";
-  ConnectionRequirement2["Optional"] = "optional";
-  ConnectionRequirement2["Required"] = "required";
-})(ConnectionRequirement || (ConnectionRequirement = {}));
-var NetworkConnection;
-(function(NetworkConnection2) {
-  NetworkConnection2["None"] = "none";
-  NetworkConnection2["Optional"] = "optional";
-  NetworkConnection2["Required"] = "required";
-})(NetworkConnection || (NetworkConnection = {}));
-var PrecannedDateRange;
-(function(PrecannedDateRange2) {
-  PrecannedDateRange2["Yesterday"] = "yesterday";
-  PrecannedDateRange2["Last7Days"] = "last_7_days";
-  PrecannedDateRange2["Last30Days"] = "last_30_days";
-  PrecannedDateRange2["LastWeek"] = "last_week";
-  PrecannedDateRange2["LastMonth"] = "last_month";
-  PrecannedDateRange2["Last3Months"] = "last_3_months";
-  PrecannedDateRange2["Last6Months"] = "last_6_months";
-  PrecannedDateRange2["LastYear"] = "last_year";
-  PrecannedDateRange2["Today"] = "today";
-  PrecannedDateRange2["ThisWeek"] = "this_week";
-  PrecannedDateRange2["ThisWeekStart"] = "this_week_start";
-  PrecannedDateRange2["ThisMonth"] = "this_month";
-  PrecannedDateRange2["ThisMonthStart"] = "this_month_start";
-  PrecannedDateRange2["ThisYearStart"] = "this_year_start";
-  PrecannedDateRange2["YearToDate"] = "year_to_date";
-  PrecannedDateRange2["ThisYear"] = "this_year";
-  PrecannedDateRange2["Tomorrow"] = "tomorrow";
-  PrecannedDateRange2["Next7Days"] = "next_7_days";
-  PrecannedDateRange2["Next30Days"] = "next_30_days";
-  PrecannedDateRange2["NextWeek"] = "next_week";
-  PrecannedDateRange2["NextMonth"] = "next_month";
-  PrecannedDateRange2["Next3Months"] = "next_3_months";
-  PrecannedDateRange2["Next6Months"] = "next_6_months";
-  PrecannedDateRange2["NextYear"] = "next_year";
-  PrecannedDateRange2["Everything"] = "everything";
-})(PrecannedDateRange || (PrecannedDateRange = {}));
-
-// schema.ts
-init_buffer_shim();
-
-// helpers/ensure.ts
-init_buffer_shim();
-
-// schema.ts
-var import_pascalcase = __toModule(require_pascalcase());
-var ValueType;
-(function(ValueType2) {
-  ValueType2["Boolean"] = "boolean";
-  ValueType2["Number"] = "number";
-  ValueType2["String"] = "string";
-  ValueType2["Array"] = "array";
-  ValueType2["Object"] = "object";
-})(ValueType || (ValueType = {}));
-var ValueHintType;
-(function(ValueHintType2) {
-  ValueHintType2["Date"] = "date";
-  ValueHintType2["Time"] = "time";
-  ValueHintType2["DateTime"] = "datetime";
-  ValueHintType2["Duration"] = "duration";
-  ValueHintType2["Person"] = "person";
-  ValueHintType2["Percent"] = "percent";
-  ValueHintType2["Currency"] = "currency";
-  ValueHintType2["ImageReference"] = "image";
-  ValueHintType2["ImageAttachment"] = "imageAttachment";
-  ValueHintType2["Url"] = "url";
-  ValueHintType2["Markdown"] = "markdown";
-  ValueHintType2["Html"] = "html";
-  ValueHintType2["Embed"] = "embed";
-  ValueHintType2["Reference"] = "reference";
-  ValueHintType2["Attachment"] = "attachment";
-  ValueHintType2["Slider"] = "slider";
-  ValueHintType2["Scale"] = "scale";
-})(ValueHintType || (ValueHintType = {}));
-var StringHintValueTypes = [
-  ValueHintType.Attachment,
-  ValueHintType.Date,
-  ValueHintType.Time,
-  ValueHintType.DateTime,
-  ValueHintType.Duration,
-  ValueHintType.Embed,
-  ValueHintType.Html,
-  ValueHintType.ImageReference,
-  ValueHintType.ImageAttachment,
-  ValueHintType.Markdown,
-  ValueHintType.Url
-];
-var NumberHintValueTypes = [
-  ValueHintType.Date,
-  ValueHintType.Time,
-  ValueHintType.DateTime,
-  ValueHintType.Percent,
-  ValueHintType.Currency,
-  ValueHintType.Slider,
-  ValueHintType.Scale
-];
-var ObjectHintValueTypes = [ValueHintType.Person, ValueHintType.Reference];
-var CurrencyFormat;
-(function(CurrencyFormat2) {
-  CurrencyFormat2["Currency"] = "currency";
-  CurrencyFormat2["Accounting"] = "accounting";
-  CurrencyFormat2["Financial"] = "financial";
-})(CurrencyFormat || (CurrencyFormat = {}));
-var ScaleIconSet;
-(function(ScaleIconSet2) {
-  ScaleIconSet2["Star"] = "star";
-  ScaleIconSet2["Circle"] = "circle";
-  ScaleIconSet2["Fire"] = "fire";
-  ScaleIconSet2["Bug"] = "bug";
-  ScaleIconSet2["Diamond"] = "diamond";
-  ScaleIconSet2["Bell"] = "bell";
-  ScaleIconSet2["ThumbsUp"] = "thumbsup";
-  ScaleIconSet2["Heart"] = "heart";
-  ScaleIconSet2["Chili"] = "chili";
-  ScaleIconSet2["Smiley"] = "smiley";
-  ScaleIconSet2["Lightning"] = "lightning";
-  ScaleIconSet2["Currency"] = "currency";
-  ScaleIconSet2["Coffee"] = "coffee";
-  ScaleIconSet2["Person"] = "person";
-  ScaleIconSet2["Battery"] = "battery";
-  ScaleIconSet2["Cocktail"] = "cocktail";
-  ScaleIconSet2["Cloud"] = "cloud";
-  ScaleIconSet2["Sun"] = "sun";
-  ScaleIconSet2["Checkmark"] = "checkmark";
-  ScaleIconSet2["LightBulb"] = "lightbulb";
-})(ScaleIconSet || (ScaleIconSet = {}));
-var DurationUnit;
-(function(DurationUnit2) {
-  DurationUnit2["Days"] = "days";
-  DurationUnit2["Hours"] = "hours";
-  DurationUnit2["Minutes"] = "minutes";
-  DurationUnit2["Seconds"] = "seconds";
-})(DurationUnit || (DurationUnit = {}));
-var SimpleStringHintValueTypes = [
-  ValueHintType.Attachment,
-  ValueHintType.Embed,
-  ValueHintType.Html,
-  ValueHintType.ImageReference,
-  ValueHintType.ImageAttachment,
-  ValueHintType.Markdown,
-  ValueHintType.Url
-];
-var AttributionNodeType;
-(function(AttributionNodeType2) {
-  AttributionNodeType2[AttributionNodeType2["Text"] = 1] = "Text";
-  AttributionNodeType2[AttributionNodeType2["Link"] = 2] = "Link";
-  AttributionNodeType2[AttributionNodeType2["Image"] = 3] = "Image";
-})(AttributionNodeType || (AttributionNodeType = {}));
-
-// handler_templates.ts
-init_buffer_shim();
-var import_clone = __toModule(require_clone());
-
-// helpers/url.ts
-init_buffer_shim();
-var import_qs = __toModule(require_lib());
-var import_url_parse = __toModule(require_url_parse());
-
-// api.ts
-var StatusCodeError = class extends Error {
-  constructor(statusCode, body, options, response) {
-    super(`${statusCode} - ${JSON.stringify(body)}`);
-    this.name = "StatusCodeError";
-    this.statusCode = statusCode;
-    this.body = body;
-    this.error = body;
-    this.options = options;
-    let responseBody = response == null ? void 0 : response.body;
-    if (typeof responseBody === "object") {
-      responseBody = JSON.stringify(responseBody);
-    }
-    this.response = { ...response, body: responseBody };
-  }
-};
-function isDynamicSyncTable(syncTable) {
-  return "isDynamic" in syncTable;
-}
-
-// runtime/common/helpers.ts
-init_buffer_shim();
-function findFormula(packDef, formulaNameWithNamespace) {
-  const packFormulas = packDef.formulas;
-  if (!packFormulas) {
-    throw new Error(`Pack definition has no formulas.`);
-  }
-  const [namespace, name] = formulaNameWithNamespace.includes("::") ? formulaNameWithNamespace.split("::") : ["", formulaNameWithNamespace];
-  if (namespace) {
-    console.log(`Warning: formula was invoked with a namespace (${formulaNameWithNamespace}), but namespaces are now deprecated.`);
-  }
-  const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
-  if (!formulas || !formulas.length) {
-    throw new Error(`Pack definition has no formulas${namespace != null ? namespace : ` for namespace "${namespace}"`}.`);
-  }
-  for (const formula of formulas) {
-    if (formula.name === name) {
-      return formula;
-    }
-  }
-  throw new Error(`Pack definition has no formula "${name}"${namespace != null ? namespace : ` in namespace "${namespace}"`}.`);
-}
-function findSyncFormula(packDef, syncFormulaName) {
-  if (!packDef.syncTables) {
-    throw new Error(`Pack definition has no sync tables.`);
-  }
-  for (const syncTable of packDef.syncTables) {
-    const syncFormula = syncTable.getter;
-    if (syncTable.name === syncFormulaName) {
-      return syncFormula;
-    }
-  }
-  throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
-}
-
-// runtime/common/marshaling/index.ts
-init_buffer_shim();
-
-// runtime/common/marshaling/marshal_buffer.ts
-init_buffer_shim();
-
-// runtime/common/marshaling/constants.ts
-init_buffer_shim();
-var CodaMarshalerType;
-(function(CodaMarshalerType2) {
-  CodaMarshalerType2["Error"] = "Error";
-  CodaMarshalerType2["Buffer"] = "Buffer";
-  CodaMarshalerType2["Number"] = "Number";
-  CodaMarshalerType2["Date"] = "Date";
-})(CodaMarshalerType || (CodaMarshalerType = {}));
-var MarshalingInjectedKeys;
-(function(MarshalingInjectedKeys2) {
-  MarshalingInjectedKeys2["CodaMarshaler"] = "__coda_marshaler__";
-  MarshalingInjectedKeys2["ErrorClassName"] = "__error_class_name__";
-  MarshalingInjectedKeys2["ErrorClassType"] = "__error_class_type__";
-})(MarshalingInjectedKeys || (MarshalingInjectedKeys = {}));
-
-// runtime/common/marshaling/marshal_buffer.ts
-function marshalBuffer(val) {
-  if (val instanceof Buffer2) {
-    return {
-      data: [...Uint8Array.from(val)],
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Buffer
-    };
-  }
-}
-function unmarshalBuffer(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Buffer) {
-    return;
-  }
-  return Buffer2.from(val.data);
-}
-
-// runtime/common/marshaling/marshal_dates.ts
-init_buffer_shim();
-function marshalDate(val) {
-  if (val instanceof Date) {
-    return {
-      date: val.toJSON(),
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Date
-    };
-  }
-}
-function unmarshalDate(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Date) {
-    return;
-  }
-  return new Date(Date.parse(val.date));
-}
-
-// runtime/common/marshaling/marshal_errors.ts
-init_buffer_shim();
-var ErrorClassType;
-(function(ErrorClassType2) {
-  ErrorClassType2["System"] = "System";
-  ErrorClassType2["Coda"] = "Coda";
-  ErrorClassType2["Other"] = "Other";
-})(ErrorClassType || (ErrorClassType = {}));
-var recognizableSystemErrorClasses = [
-  Error,
-  EvalError,
-  RangeError,
-  ReferenceError,
-  SyntaxError,
-  TypeError,
-  URIError
-];
-var recognizableCodaErrorClasses = [
-  StatusCodeError
-];
-function getErrorClassType(err) {
-  if (recognizableSystemErrorClasses.some((cls) => cls === err.constructor)) {
-    return ErrorClassType.System;
-  }
-  if (recognizableCodaErrorClasses.some((cls) => cls === err.constructor)) {
-    return ErrorClassType.Coda;
-  }
-  return ErrorClassType.Other;
-}
-function marshalError(err) {
-  if (!(err instanceof Error)) {
-    return;
-  }
-  const { name, stack, message, ...args } = err;
-  return {
-    name,
-    stack,
-    message,
-    [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Error,
-    [MarshalingInjectedKeys.ErrorClassName]: err.constructor.name,
-    [MarshalingInjectedKeys.ErrorClassType]: getErrorClassType(err),
-    ...args
+  // api_types.ts
+  init_buffer_shim();
+  var Type;
+  (function(Type2) {
+    Type2[Type2["string"] = 0] = "string";
+    Type2[Type2["number"] = 1] = "number";
+    Type2[Type2["object"] = 2] = "object";
+    Type2[Type2["boolean"] = 3] = "boolean";
+    Type2[Type2["date"] = 4] = "date";
+    Type2[Type2["html"] = 5] = "html";
+    Type2[Type2["image"] = 6] = "image";
+  })(Type || (Type = {}));
+  var ParameterType;
+  (function(ParameterType2) {
+    ParameterType2["String"] = "string";
+    ParameterType2["Number"] = "number";
+    ParameterType2["Boolean"] = "boolean";
+    ParameterType2["Date"] = "date";
+    ParameterType2["Html"] = "html";
+    ParameterType2["Image"] = "image";
+    ParameterType2["StringArray"] = "stringArray";
+    ParameterType2["NumberArray"] = "numberArray";
+    ParameterType2["BooleanArray"] = "booleanArray";
+    ParameterType2["DateArray"] = "dateArray";
+    ParameterType2["HtmlArray"] = "htmlArray`";
+    ParameterType2["ImageArray"] = "imageArray";
+  })(ParameterType || (ParameterType = {}));
+  var ParameterTypeInputMap = {
+    [ParameterType.String]: 0,
+    [ParameterType.Number]: 1,
+    [ParameterType.Boolean]: 3,
+    [ParameterType.Date]: 4,
+    [ParameterType.Html]: 5,
+    [ParameterType.Image]: 6,
+    [ParameterType.StringArray]: { type: "array", items: 0 },
+    [ParameterType.NumberArray]: { type: "array", items: 1 },
+    [ParameterType.BooleanArray]: { type: "array", items: 3 },
+    [ParameterType.DateArray]: { type: "array", items: 4 },
+    [ParameterType.HtmlArray]: { type: "array", items: 5 },
+    [ParameterType.ImageArray]: { type: "array", items: 6 }
   };
-}
-function getErrorClass(errorClassType, name) {
-  let errorClasses;
-  switch (errorClassType) {
-    case ErrorClassType.System:
-      errorClasses = recognizableSystemErrorClasses;
-      break;
-    case ErrorClassType.Coda:
-      errorClasses = recognizableCodaErrorClasses;
-      break;
-    default:
-      errorClasses = [];
-  }
-  return errorClasses.find((cls) => cls.name === name) || Error;
-}
-function unmarshalError(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Error) {
-    return;
-  }
-  const {
-    name,
-    stack,
-    message,
-    [MarshalingInjectedKeys.ErrorClassName]: errorClassName,
-    [MarshalingInjectedKeys.CodaMarshaler]: _,
-    [MarshalingInjectedKeys.ErrorClassType]: errorClassType,
-    ...otherProperties
-  } = val;
-  const ErrorClass = getErrorClass(errorClassType, errorClassName);
-  const error = new ErrorClass();
-  error.message = message;
-  error.stack = stack;
-  error.name = name;
-  for (const key of Object.keys(otherProperties)) {
-    error[key] = otherProperties[key];
-  }
-  return error;
-}
+  var ConnectionRequirement;
+  (function(ConnectionRequirement2) {
+    ConnectionRequirement2["None"] = "none";
+    ConnectionRequirement2["Optional"] = "optional";
+    ConnectionRequirement2["Required"] = "required";
+  })(ConnectionRequirement || (ConnectionRequirement = {}));
+  var NetworkConnection;
+  (function(NetworkConnection2) {
+    NetworkConnection2["None"] = "none";
+    NetworkConnection2["Optional"] = "optional";
+    NetworkConnection2["Required"] = "required";
+  })(NetworkConnection || (NetworkConnection = {}));
+  var PrecannedDateRange;
+  (function(PrecannedDateRange2) {
+    PrecannedDateRange2["Yesterday"] = "yesterday";
+    PrecannedDateRange2["Last7Days"] = "last_7_days";
+    PrecannedDateRange2["Last30Days"] = "last_30_days";
+    PrecannedDateRange2["LastWeek"] = "last_week";
+    PrecannedDateRange2["LastMonth"] = "last_month";
+    PrecannedDateRange2["Last3Months"] = "last_3_months";
+    PrecannedDateRange2["Last6Months"] = "last_6_months";
+    PrecannedDateRange2["LastYear"] = "last_year";
+    PrecannedDateRange2["Today"] = "today";
+    PrecannedDateRange2["ThisWeek"] = "this_week";
+    PrecannedDateRange2["ThisWeekStart"] = "this_week_start";
+    PrecannedDateRange2["ThisMonth"] = "this_month";
+    PrecannedDateRange2["ThisMonthStart"] = "this_month_start";
+    PrecannedDateRange2["ThisYearStart"] = "this_year_start";
+    PrecannedDateRange2["YearToDate"] = "year_to_date";
+    PrecannedDateRange2["ThisYear"] = "this_year";
+    PrecannedDateRange2["Tomorrow"] = "tomorrow";
+    PrecannedDateRange2["Next7Days"] = "next_7_days";
+    PrecannedDateRange2["Next30Days"] = "next_30_days";
+    PrecannedDateRange2["NextWeek"] = "next_week";
+    PrecannedDateRange2["NextMonth"] = "next_month";
+    PrecannedDateRange2["Next3Months"] = "next_3_months";
+    PrecannedDateRange2["Next6Months"] = "next_6_months";
+    PrecannedDateRange2["NextYear"] = "next_year";
+    PrecannedDateRange2["Everything"] = "everything";
+  })(PrecannedDateRange || (PrecannedDateRange = {}));
 
-// runtime/common/marshaling/marshal_numbers.ts
-init_buffer_shim();
-function marshalNumber(val) {
-  if (typeof val === "number" && (isNaN(val) || val === Infinity)) {
-    return {
-      data: val.toString(),
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Number
-    };
-  }
-}
-function unmarshalNumber(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Number) {
-    return;
-  }
-  return Number(val.data);
-}
+  // schema.ts
+  init_buffer_shim();
 
-// runtime/common/marshaling/index.ts
-var HACK_UNDEFINED_JSON_VALUE = "__CODA_UNDEFINED__";
-var MaxTraverseDepth = 100;
-var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
-var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
-function serialize(val) {
-  for (const marshaler of customMarshalers) {
-    const result = marshaler(val);
-    if (result !== void 0) {
-      return result;
+  // helpers/ensure.ts
+  init_buffer_shim();
+
+  // schema.ts
+  var import_pascalcase = __toModule(require_pascalcase());
+  var ValueType;
+  (function(ValueType2) {
+    ValueType2["Boolean"] = "boolean";
+    ValueType2["Number"] = "number";
+    ValueType2["String"] = "string";
+    ValueType2["Array"] = "array";
+    ValueType2["Object"] = "object";
+  })(ValueType || (ValueType = {}));
+  var ValueHintType;
+  (function(ValueHintType2) {
+    ValueHintType2["Date"] = "date";
+    ValueHintType2["Time"] = "time";
+    ValueHintType2["DateTime"] = "datetime";
+    ValueHintType2["Duration"] = "duration";
+    ValueHintType2["Person"] = "person";
+    ValueHintType2["Percent"] = "percent";
+    ValueHintType2["Currency"] = "currency";
+    ValueHintType2["ImageReference"] = "image";
+    ValueHintType2["ImageAttachment"] = "imageAttachment";
+    ValueHintType2["Url"] = "url";
+    ValueHintType2["Markdown"] = "markdown";
+    ValueHintType2["Html"] = "html";
+    ValueHintType2["Embed"] = "embed";
+    ValueHintType2["Reference"] = "reference";
+    ValueHintType2["Attachment"] = "attachment";
+    ValueHintType2["Slider"] = "slider";
+    ValueHintType2["Scale"] = "scale";
+  })(ValueHintType || (ValueHintType = {}));
+  var StringHintValueTypes = [
+    ValueHintType.Attachment,
+    ValueHintType.Date,
+    ValueHintType.Time,
+    ValueHintType.DateTime,
+    ValueHintType.Duration,
+    ValueHintType.Embed,
+    ValueHintType.Html,
+    ValueHintType.ImageReference,
+    ValueHintType.ImageAttachment,
+    ValueHintType.Markdown,
+    ValueHintType.Url
+  ];
+  var NumberHintValueTypes = [
+    ValueHintType.Date,
+    ValueHintType.Time,
+    ValueHintType.DateTime,
+    ValueHintType.Percent,
+    ValueHintType.Currency,
+    ValueHintType.Slider,
+    ValueHintType.Scale
+  ];
+  var ObjectHintValueTypes = [ValueHintType.Person, ValueHintType.Reference];
+  var CurrencyFormat;
+  (function(CurrencyFormat2) {
+    CurrencyFormat2["Currency"] = "currency";
+    CurrencyFormat2["Accounting"] = "accounting";
+    CurrencyFormat2["Financial"] = "financial";
+  })(CurrencyFormat || (CurrencyFormat = {}));
+  var ScaleIconSet;
+  (function(ScaleIconSet2) {
+    ScaleIconSet2["Star"] = "star";
+    ScaleIconSet2["Circle"] = "circle";
+    ScaleIconSet2["Fire"] = "fire";
+    ScaleIconSet2["Bug"] = "bug";
+    ScaleIconSet2["Diamond"] = "diamond";
+    ScaleIconSet2["Bell"] = "bell";
+    ScaleIconSet2["ThumbsUp"] = "thumbsup";
+    ScaleIconSet2["Heart"] = "heart";
+    ScaleIconSet2["Chili"] = "chili";
+    ScaleIconSet2["Smiley"] = "smiley";
+    ScaleIconSet2["Lightning"] = "lightning";
+    ScaleIconSet2["Currency"] = "currency";
+    ScaleIconSet2["Coffee"] = "coffee";
+    ScaleIconSet2["Person"] = "person";
+    ScaleIconSet2["Battery"] = "battery";
+    ScaleIconSet2["Cocktail"] = "cocktail";
+    ScaleIconSet2["Cloud"] = "cloud";
+    ScaleIconSet2["Sun"] = "sun";
+    ScaleIconSet2["Checkmark"] = "checkmark";
+    ScaleIconSet2["LightBulb"] = "lightbulb";
+  })(ScaleIconSet || (ScaleIconSet = {}));
+  var DurationUnit;
+  (function(DurationUnit2) {
+    DurationUnit2["Days"] = "days";
+    DurationUnit2["Hours"] = "hours";
+    DurationUnit2["Minutes"] = "minutes";
+    DurationUnit2["Seconds"] = "seconds";
+  })(DurationUnit || (DurationUnit = {}));
+  var SimpleStringHintValueTypes = [
+    ValueHintType.Attachment,
+    ValueHintType.Embed,
+    ValueHintType.Html,
+    ValueHintType.ImageReference,
+    ValueHintType.ImageAttachment,
+    ValueHintType.Markdown,
+    ValueHintType.Url
+  ];
+  var AttributionNodeType;
+  (function(AttributionNodeType2) {
+    AttributionNodeType2[AttributionNodeType2["Text"] = 1] = "Text";
+    AttributionNodeType2[AttributionNodeType2["Link"] = 2] = "Link";
+    AttributionNodeType2[AttributionNodeType2["Image"] = 3] = "Image";
+  })(AttributionNodeType || (AttributionNodeType = {}));
+
+  // handler_templates.ts
+  init_buffer_shim();
+  var import_clone = __toModule(require_clone());
+
+  // helpers/url.ts
+  init_buffer_shim();
+  var import_qs = __toModule(require_lib());
+  var import_url_parse = __toModule(require_url_parse());
+
+  // api.ts
+  var StatusCodeError = class extends Error {
+    constructor(statusCode, body, options, response) {
+      super(`${statusCode} - ${JSON.stringify(body)}`);
+      this.name = "StatusCodeError";
+      this.statusCode = statusCode;
+      this.body = body;
+      this.error = body;
+      this.options = options;
+      let responseBody = response == null ? void 0 : response.body;
+      if (typeof responseBody === "object") {
+        responseBody = JSON.stringify(responseBody);
+      }
+      this.response = { ...response, body: responseBody };
+    }
+  };
+  function isDynamicSyncTable(syncTable) {
+    return "isDynamic" in syncTable;
+  }
+
+  // runtime/common/helpers.ts
+  init_buffer_shim();
+  function findFormula(packDef, formulaNameWithNamespace) {
+    const packFormulas = packDef.formulas;
+    if (!packFormulas) {
+      throw new Error(`Pack definition has no formulas.`);
+    }
+    const [namespace, name] = formulaNameWithNamespace.includes("::") ? formulaNameWithNamespace.split("::") : ["", formulaNameWithNamespace];
+    if (namespace) {
+      console.log(`Warning: formula was invoked with a namespace (${formulaNameWithNamespace}), but namespaces are now deprecated.`);
+    }
+    const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
+    if (!formulas || !formulas.length) {
+      throw new Error(`Pack definition has no formulas${namespace != null ? namespace : ` for namespace "${namespace}"`}.`);
+    }
+    for (const formula of formulas) {
+      if (formula.name === name) {
+        return formula;
+      }
+    }
+    throw new Error(`Pack definition has no formula "${name}"${namespace != null ? namespace : ` in namespace "${namespace}"`}.`);
+  }
+  function findSyncFormula(packDef, syncFormulaName) {
+    if (!packDef.syncTables) {
+      throw new Error(`Pack definition has no sync tables.`);
+    }
+    for (const syncTable of packDef.syncTables) {
+      const syncFormula = syncTable.getter;
+      if (syncTable.name === syncFormulaName) {
+        return syncFormula;
+      }
+    }
+    throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
+  }
+
+  // runtime/common/marshaling/index.ts
+  init_buffer_shim();
+
+  // runtime/common/marshaling/marshal_buffer.ts
+  init_buffer_shim();
+
+  // runtime/common/marshaling/constants.ts
+  init_buffer_shim();
+  var CodaMarshalerType;
+  (function(CodaMarshalerType2) {
+    CodaMarshalerType2["Error"] = "Error";
+    CodaMarshalerType2["Buffer"] = "Buffer";
+    CodaMarshalerType2["Number"] = "Number";
+    CodaMarshalerType2["Date"] = "Date";
+  })(CodaMarshalerType || (CodaMarshalerType = {}));
+  var MarshalingInjectedKeys;
+  (function(MarshalingInjectedKeys2) {
+    MarshalingInjectedKeys2["CodaMarshaler"] = "__coda_marshaler__";
+    MarshalingInjectedKeys2["ErrorClassName"] = "__error_class_name__";
+    MarshalingInjectedKeys2["ErrorClassType"] = "__error_class_type__";
+  })(MarshalingInjectedKeys || (MarshalingInjectedKeys = {}));
+
+  // runtime/common/marshaling/marshal_buffer.ts
+  function marshalBuffer(val) {
+    if (val instanceof Buffer2) {
+      return {
+        data: [...Uint8Array.from(val)],
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Buffer
+      };
     }
   }
-  return val;
-}
-function deserialize(_, val) {
-  if (val) {
-    for (const unmarshaler of customUnmarshalers) {
-      const result = unmarshaler(val);
+  function unmarshalBuffer(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Buffer) {
+      return;
+    }
+    return Buffer2.from(val.data);
+  }
+
+  // runtime/common/marshaling/marshal_dates.ts
+  init_buffer_shim();
+  function marshalDate(val) {
+    if (val instanceof Date) {
+      return {
+        date: val.toJSON(),
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Date
+      };
+    }
+  }
+  function unmarshalDate(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Date) {
+      return;
+    }
+    return new Date(Date.parse(val.date));
+  }
+
+  // runtime/common/marshaling/marshal_errors.ts
+  init_buffer_shim();
+  var ErrorClassType;
+  (function(ErrorClassType2) {
+    ErrorClassType2["System"] = "System";
+    ErrorClassType2["Coda"] = "Coda";
+    ErrorClassType2["Other"] = "Other";
+  })(ErrorClassType || (ErrorClassType = {}));
+  var recognizableSystemErrorClasses = [
+    Error,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError
+  ];
+  var recognizableCodaErrorClasses = [
+    StatusCodeError
+  ];
+  function getErrorClassType(err) {
+    if (recognizableSystemErrorClasses.some((cls) => cls === err.constructor)) {
+      return ErrorClassType.System;
+    }
+    if (recognizableCodaErrorClasses.some((cls) => cls === err.constructor)) {
+      return ErrorClassType.Coda;
+    }
+    return ErrorClassType.Other;
+  }
+  function marshalError(err) {
+    if (!(err instanceof Error)) {
+      return;
+    }
+    const { name, stack, message, ...args } = err;
+    return {
+      name,
+      stack,
+      message,
+      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Error,
+      [MarshalingInjectedKeys.ErrorClassName]: err.constructor.name,
+      [MarshalingInjectedKeys.ErrorClassType]: getErrorClassType(err),
+      ...args
+    };
+  }
+  function getErrorClass(errorClassType, name) {
+    let errorClasses;
+    switch (errorClassType) {
+      case ErrorClassType.System:
+        errorClasses = recognizableSystemErrorClasses;
+        break;
+      case ErrorClassType.Coda:
+        errorClasses = recognizableCodaErrorClasses;
+        break;
+      default:
+        errorClasses = [];
+    }
+    return errorClasses.find((cls) => cls.name === name) || Error;
+  }
+  function unmarshalError(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Error) {
+      return;
+    }
+    const {
+      name,
+      stack,
+      message,
+      [MarshalingInjectedKeys.ErrorClassName]: errorClassName,
+      [MarshalingInjectedKeys.CodaMarshaler]: _,
+      [MarshalingInjectedKeys.ErrorClassType]: errorClassType,
+      ...otherProperties
+    } = val;
+    const ErrorClass = getErrorClass(errorClassType, errorClassName);
+    const error = new ErrorClass();
+    error.message = message;
+    error.stack = stack;
+    error.name = name;
+    for (const key of Object.keys(otherProperties)) {
+      error[key] = otherProperties[key];
+    }
+    return error;
+  }
+
+  // runtime/common/marshaling/marshal_numbers.ts
+  init_buffer_shim();
+  function marshalNumber(val) {
+    if (typeof val === "number" && (isNaN(val) || val === Infinity)) {
+      return {
+        data: val.toString(),
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Number
+      };
+    }
+  }
+  function unmarshalNumber(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Number) {
+      return;
+    }
+    return Number(val.data);
+  }
+
+  // runtime/common/marshaling/index.ts
+  var HACK_UNDEFINED_JSON_VALUE = "__CODA_UNDEFINED__";
+  var MaxTraverseDepth = 100;
+  var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
+  var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
+  function serialize(val) {
+    for (const marshaler of customMarshalers) {
+      const result = marshaler(val);
       if (result !== void 0) {
         return result;
       }
     }
-  }
-  return val;
-}
-function processValue(val, depth = 0) {
-  if (depth >= MaxTraverseDepth) {
-    throw new Error("marshaling value is too deep or containing circular strcture");
-  }
-  if (val === void 0) {
-    return HACK_UNDEFINED_JSON_VALUE;
-  }
-  if (val === null) {
     return val;
   }
-  if (Array.isArray(val)) {
-    return val.map((item) => processValue(item, depth + 1));
-  }
-  const serializedValue = serialize(val);
-  if (typeof serializedValue === "object") {
-    let objectValue = serializedValue;
-    if ("toJSON" in serializedValue && typeof serializedValue.toJSON === "function") {
-      objectValue = serializedValue.toJSON();
+  function deserialize(_, val) {
+    if (val) {
+      for (const unmarshaler of customUnmarshalers) {
+        const result = unmarshaler(val);
+        if (result !== void 0) {
+          return result;
+        }
+      }
     }
-    const processedValue = {};
-    for (const key of Object.getOwnPropertyNames(objectValue)) {
-      processedValue[key] = processValue(objectValue[key], depth + 1);
-    }
-    return processedValue;
-  }
-  return serializedValue;
-}
-function marshalValue(val) {
-  return JSON.stringify(processValue(val));
-}
-function unmarshalValue(marshaledValue) {
-  if (marshaledValue === void 0) {
-    return marshaledValue;
-  }
-  const parsed = JSON.parse(marshaledValue, deserialize);
-  return reviveUndefinedValues(parsed);
-}
-function wrapError(err) {
-  return new Error(marshalValue(err));
-}
-function unwrapError(err) {
-  try {
-    const unmarshaledValue = unmarshalValue(err.message);
-    if (unmarshaledValue instanceof Error) {
-      return unmarshaledValue;
-    }
-    return err;
-  } catch (_) {
-    return err;
-  }
-}
-function reviveUndefinedValues(val) {
-  if (val === null) {
     return val;
   }
-  if (val === HACK_UNDEFINED_JSON_VALUE) {
-    return void 0;
+  function processValue(val, depth = 0) {
+    if (depth >= MaxTraverseDepth) {
+      throw new Error("marshaling value is too deep or containing circular strcture");
+    }
+    if (val === void 0) {
+      return HACK_UNDEFINED_JSON_VALUE;
+    }
+    if (val === null) {
+      return val;
+    }
+    if (Array.isArray(val)) {
+      return val.map((item) => processValue(item, depth + 1));
+    }
+    const serializedValue = serialize(val);
+    if (typeof serializedValue === "object") {
+      let objectValue = serializedValue;
+      if ("toJSON" in serializedValue && typeof serializedValue.toJSON === "function") {
+        objectValue = serializedValue.toJSON();
+      }
+      const processedValue = {};
+      for (const key of Object.getOwnPropertyNames(objectValue)) {
+        processedValue[key] = processValue(objectValue[key], depth + 1);
+      }
+      return processedValue;
+    }
+    return serializedValue;
   }
-  if (Array.isArray(val)) {
-    return val.map((x) => reviveUndefinedValues(x));
+  function marshalValue(val) {
+    return JSON.stringify(processValue(val));
   }
-  if (typeof val === "object") {
-    for (const key of Object.getOwnPropertyNames(val)) {
-      val[key] = reviveUndefinedValues(val[key]);
+  function unmarshalValue(marshaledValue) {
+    if (marshaledValue === void 0) {
+      return marshaledValue;
+    }
+    const parsed = JSON.parse(marshaledValue, deserialize);
+    return reviveUndefinedValues(parsed);
+  }
+  function wrapError(err) {
+    return new Error(marshalValue(err));
+  }
+  function unwrapError(err) {
+    try {
+      const unmarshaledValue = unmarshalValue(err.message);
+      if (unmarshaledValue instanceof Error) {
+        return unmarshaledValue;
+      }
+      return err;
+    } catch (_) {
+      return err;
     }
   }
-  return val;
-}
+  function reviveUndefinedValues(val) {
+    if (val === null) {
+      return val;
+    }
+    if (val === HACK_UNDEFINED_JSON_VALUE) {
+      return void 0;
+    }
+    if (Array.isArray(val)) {
+      return val.map((x) => reviveUndefinedValues(x));
+    }
+    if (typeof val === "object") {
+      for (const key of Object.getOwnPropertyNames(val)) {
+        val[key] = reviveUndefinedValues(val[key]);
+      }
+    }
+    return val;
+  }
 
-// runtime/thunk/thunk.ts
-async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true) {
-  try {
-    return await doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext);
-  } catch (err) {
-    throw shouldWrapError ? wrapError(err) : err;
+  // runtime/thunk/thunk.ts
+  async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true) {
+    try {
+      return await doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext);
+    } catch (err) {
+      throw shouldWrapError ? wrapError(err) : err;
+    }
   }
-}
-function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext) {
-  const { syncTables, defaultAuthentication } = manifest;
-  switch (formulaSpec.type) {
-    case FormulaType.Standard: {
-      const formula = findFormula(manifest, formulaSpec.formulaName);
-      return formula.execute(params, executionContext);
-    }
-    case FormulaType.Sync: {
-      const formula = findSyncFormula(manifest, formulaSpec.formulaName);
-      return formula.execute(params, executionContext);
-    }
-    case FormulaType.Metadata: {
-      switch (formulaSpec.metadataFormulaType) {
-        case MetadataFormulaType.GetConnectionName:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionName)) {
-            return defaultAuthentication.getConnectionName.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.GetConnectionUserId:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionUserId)) {
-            return defaultAuthentication.getConnectionUserId.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.ParameterAutocomplete:
-          const parentFormula = findParentFormula(manifest, formulaSpec);
-          if (parentFormula) {
-            return parentFormula.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.PostSetupSetEndpoint:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.postSetup)) {
-            const setupStep = defaultAuthentication.postSetup.find((step) => step.type === PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
-            if (setupStep) {
-              return setupStep.getOptionsFormula.execute(params, executionContext);
+  function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext) {
+    const { syncTables, defaultAuthentication } = manifest;
+    switch (formulaSpec.type) {
+      case FormulaType.Standard: {
+        const formula = findFormula(manifest, formulaSpec.formulaName);
+        return formula.execute(params, executionContext);
+      }
+      case FormulaType.Sync: {
+        const formula = findSyncFormula(manifest, formulaSpec.formulaName);
+        return formula.execute(params, executionContext);
+      }
+      case FormulaType.Metadata: {
+        switch (formulaSpec.metadataFormulaType) {
+          case MetadataFormulaType.GetConnectionName:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionName)) {
+              return defaultAuthentication.getConnectionName.execute(params, executionContext);
             }
-          }
-          break;
-        case MetadataFormulaType.SyncListDynamicUrls:
-        case MetadataFormulaType.SyncGetDisplayUrl:
-        case MetadataFormulaType.SyncGetTableName:
-        case MetadataFormulaType.SyncGetSchema:
-          if (syncTables) {
-            const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
-            if (syncTable) {
-              let formula;
-              if (isDynamicSyncTable(syncTable)) {
-                switch (formulaSpec.metadataFormulaType) {
-                  case MetadataFormulaType.SyncListDynamicUrls:
-                    formula = syncTable.listDynamicUrls;
-                    break;
-                  case MetadataFormulaType.SyncGetDisplayUrl:
-                    formula = syncTable.getDisplayUrl;
-                    break;
-                  case MetadataFormulaType.SyncGetTableName:
-                    formula = syncTable.getName;
-                    break;
-                  case MetadataFormulaType.SyncGetSchema:
-                    formula = syncTable.getSchema;
-                    break;
-                  default:
-                    return ensureSwitchUnreachable(formulaSpec);
+            break;
+          case MetadataFormulaType.GetConnectionUserId:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionUserId)) {
+              return defaultAuthentication.getConnectionUserId.execute(params, executionContext);
+            }
+            break;
+          case MetadataFormulaType.ParameterAutocomplete:
+            const parentFormula = findParentFormula(manifest, formulaSpec);
+            if (parentFormula) {
+              return parentFormula.execute(params, executionContext);
+            }
+            break;
+          case MetadataFormulaType.PostSetupSetEndpoint:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.postSetup)) {
+              const setupStep = defaultAuthentication.postSetup.find((step) => step.type === PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
+              if (setupStep) {
+                return setupStep.getOptionsFormula.execute(params, executionContext);
+              }
+            }
+            break;
+          case MetadataFormulaType.SyncListDynamicUrls:
+          case MetadataFormulaType.SyncGetDisplayUrl:
+          case MetadataFormulaType.SyncGetTableName:
+          case MetadataFormulaType.SyncGetSchema:
+            if (syncTables) {
+              const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
+              if (syncTable) {
+                let formula;
+                if (isDynamicSyncTable(syncTable)) {
+                  switch (formulaSpec.metadataFormulaType) {
+                    case MetadataFormulaType.SyncListDynamicUrls:
+                      formula = syncTable.listDynamicUrls;
+                      break;
+                    case MetadataFormulaType.SyncGetDisplayUrl:
+                      formula = syncTable.getDisplayUrl;
+                      break;
+                    case MetadataFormulaType.SyncGetTableName:
+                      formula = syncTable.getName;
+                      break;
+                    case MetadataFormulaType.SyncGetSchema:
+                      formula = syncTable.getSchema;
+                      break;
+                    default:
+                      return ensureSwitchUnreachable(formulaSpec);
+                  }
+                } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
+                  formula = syncTable.getSchema;
                 }
-              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
-                formula = syncTable.getSchema;
-              }
-              if (formula) {
-                return formula.execute(params, executionContext);
+                if (formula) {
+                  return formula.execute(params, executionContext);
+                }
               }
             }
-          }
-          break;
-        default:
-          return ensureSwitchUnreachable(formulaSpec);
+            break;
+          default:
+            return ensureSwitchUnreachable(formulaSpec);
+        }
+        break;
       }
-      break;
+      default:
+        return ensureSwitchUnreachable(formulaSpec);
     }
-    default:
-      return ensureSwitchUnreachable(formulaSpec);
+    throw new Error(`Could not find a formula matching formula spec ${JSON.stringify(formulaSpec)}`);
   }
-  throw new Error(`Could not find a formula matching formula spec ${JSON.stringify(formulaSpec)}`);
-}
-function findParentFormula(manifest, formulaSpec) {
-  const { formulas, syncTables } = manifest;
-  let formula;
-  switch (formulaSpec.parentFormulaType) {
-    case FormulaType.Standard:
-      if (formulas) {
-        const namespacedFormulas = Array.isArray(formulas) ? formulas : Object.values(formulas)[0];
-        formula = namespacedFormulas.find((defn) => defn.name === formulaSpec.parentFormulaName);
-      }
-      break;
-    case FormulaType.Sync:
-      if (syncTables) {
-        const syncTable = syncTables.find((table) => table.getter.name === formulaSpec.parentFormulaName);
-        formula = syncTable == null ? void 0 : syncTable.getter;
-      }
-      break;
-    default:
-      return ensureSwitchUnreachable(formulaSpec.parentFormulaType);
+  function findParentFormula(manifest, formulaSpec) {
+    const { formulas, syncTables } = manifest;
+    let formula;
+    switch (formulaSpec.parentFormulaType) {
+      case FormulaType.Standard:
+        if (formulas) {
+          const namespacedFormulas = Array.isArray(formulas) ? formulas : Object.values(formulas)[0];
+          formula = namespacedFormulas.find((defn) => defn.name === formulaSpec.parentFormulaName);
+        }
+        break;
+      case FormulaType.Sync:
+        if (syncTables) {
+          const syncTable = syncTables.find((table) => table.getter.name === formulaSpec.parentFormulaName);
+          formula = syncTable == null ? void 0 : syncTable.getter;
+        }
+        break;
+      default:
+        return ensureSwitchUnreachable(formulaSpec.parentFormulaType);
+    }
+    if (formula) {
+      const params = formula.parameters.concat(formula.varargParameters || []);
+      const paramDef = params.find((param) => param.name === formulaSpec.parameterName);
+      return paramDef == null ? void 0 : paramDef.autocomplete;
+    }
   }
-  if (formula) {
-    const params = formula.parameters.concat(formula.varargParameters || []);
-    const paramDef = params.find((param) => param.name === formulaSpec.parameterName);
-    return paramDef == null ? void 0 : paramDef.autocomplete;
+  function ensureSwitchUnreachable(value) {
+    throw new Error(`Unreachable code hit with value ${String(value)}`);
   }
-}
-function ensureSwitchUnreachable(value) {
-  throw new Error(`Unreachable code hit with value ${String(value)}`);
-}
-async function handleErrorAsync(func) {
-  try {
-    return await func();
-  } catch (err) {
-    throw unwrapError(err);
+  async function handleErrorAsync(func) {
+    try {
+      return await func();
+    } catch (err) {
+      throw unwrapError(err);
+    }
   }
-}
-function handleError(func) {
-  try {
-    return func();
-  } catch (err) {
-    throw unwrapError(err);
+  function handleError(func) {
+    try {
+      return func();
+    } catch (err) {
+      throw unwrapError(err);
+    }
   }
-}
-function handleFetcherStatusError(fetchResult, fetchRequest) {
-  if (fetchResult.status >= 300) {
-    throw new StatusCodeError(fetchResult.status, fetchResult.body, fetchRequest, {
-      body: fetchResult.body,
-      headers: fetchResult.headers
-    });
+  function handleFetcherStatusError(fetchResult, fetchRequest) {
+    if (fetchResult.status >= 300) {
+      throw new StatusCodeError(fetchResult.status, fetchResult.body, fetchRequest, {
+        body: fetchResult.body,
+        headers: fetchResult.headers
+      });
+    }
   }
-}
+  return thunk_exports;
+})();
 /*!
  * The buffer module from node.js, for the browser.
  *

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -100,19 +100,19 @@ export async function handleUpload({
 
   const metadata = compilePackMetadata(manifest);
   let packVersion = manifest.version;
-  if (!packVersion) {
-    const nextPackVersionInfo = await client.getNextPackVersion(
-      packId,
-      {},
-      {proposedMetadata: JSON.stringify(metadata)},
-    );
-    packVersion = nextPackVersionInfo.nextVersion;
-    print(`Pack version not provided. Generated one for you: version is ${packVersion}`);
-  }
-
-  metadata.version = packVersion;
-
   try {
+    if (!packVersion) {
+      const nextPackVersionInfo = await client.getNextPackVersion(
+        packId,
+        {},
+        {proposedMetadata: JSON.stringify(metadata)},
+      );
+      packVersion = nextPackVersionInfo.nextVersion;
+      print(`Pack version not provided. Generated one for you: version is ${packVersion}`);
+    }
+
+    metadata.version = packVersion;
+
     const bundle = readFile(bundlePath);
     if (!bundle) {
       printAndExit(`Could not find bundle file at path ${bundlePath}`);

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -1,4933 +1,4938 @@
 'use strict';
-var __create = Object.create;
-var __defProp = Object.defineProperty;
-var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
-var __getOwnPropNames = Object.getOwnPropertyNames;
-var __getProtoOf = Object.getPrototypeOf;
-var __hasOwnProp = Object.prototype.hasOwnProperty;
-var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
-var __esm = (fn, res) => function __init() {
-  return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res;
-};
-var __commonJS = (cb, mod) => function __require() {
-  return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
-};
-var __export = (target, all) => {
-  __markAsModule(target);
-  for (var name in all)
-    __defProp(target, name, { get: all[name], enumerable: true });
-};
-var __reExport = (target, module2, desc) => {
-  if (module2 && typeof module2 === "object" || typeof module2 === "function") {
-    for (let key of __getOwnPropNames(module2))
-      if (!__hasOwnProp.call(target, key) && key !== "default")
-        __defProp(target, key, { get: () => module2[key], enumerable: !(desc = __getOwnPropDesc(module2, key)) || desc.enumerable });
-  }
-  return target;
-};
-var __toModule = (module2) => {
-  return __reExport(__markAsModule(__defProp(module2 != null ? __create(__getProtoOf(module2)) : {}, "default", module2 && module2.__esModule && "default" in module2 ? { get: () => module2.default, enumerable: true } : { value: module2, enumerable: true })), module2);
-};
+var module = module || {};
+module.exports = (() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+  var __esm = (fn, res) => function __init() {
+    return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res;
+  };
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __export = (target, all) => {
+    __markAsModule(target);
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __reExport = (target, module, desc) => {
+    if (module && typeof module === "object" || typeof module === "function") {
+      for (let key of __getOwnPropNames(module))
+        if (!__hasOwnProp.call(target, key) && key !== "default")
+          __defProp(target, key, { get: () => module[key], enumerable: !(desc = __getOwnPropDesc(module, key)) || desc.enumerable });
+    }
+    return target;
+  };
+  var __toModule = (module) => {
+    return __reExport(__markAsModule(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", module && module.__esModule && "default" in module ? { get: () => module.default, enumerable: true } : { value: module, enumerable: true })), module);
+  };
 
-// node_modules/base64-js/index.js
-var require_base64_js = __commonJS({
-  "node_modules/base64-js/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    exports.byteLength = byteLength;
-    exports.toByteArray = toByteArray;
-    exports.fromByteArray = fromByteArray;
-    var lookup = [];
-    var revLookup = [];
-    var Arr = typeof Uint8Array !== "undefined" ? Uint8Array : Array;
-    var code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    for (i = 0, len = code.length; i < len; ++i) {
-      lookup[i] = code[i];
-      revLookup[code.charCodeAt(i)] = i;
-    }
-    var i;
-    var len;
-    revLookup["-".charCodeAt(0)] = 62;
-    revLookup["_".charCodeAt(0)] = 63;
-    function getLens(b64) {
-      var len2 = b64.length;
-      if (len2 % 4 > 0) {
-        throw new Error("Invalid string. Length must be a multiple of 4");
+  // node_modules/base64-js/index.js
+  var require_base64_js = __commonJS({
+    "node_modules/base64-js/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      exports.byteLength = byteLength;
+      exports.toByteArray = toByteArray;
+      exports.fromByteArray = fromByteArray;
+      var lookup = [];
+      var revLookup = [];
+      var Arr = typeof Uint8Array !== "undefined" ? Uint8Array : Array;
+      var code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+      for (i = 0, len = code.length; i < len; ++i) {
+        lookup[i] = code[i];
+        revLookup[code.charCodeAt(i)] = i;
       }
-      var validLen = b64.indexOf("=");
-      if (validLen === -1)
-        validLen = len2;
-      var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
-      return [validLen, placeHoldersLen];
-    }
-    function byteLength(b64) {
-      var lens = getLens(b64);
-      var validLen = lens[0];
-      var placeHoldersLen = lens[1];
-      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
-    }
-    function _byteLength(b64, validLen, placeHoldersLen) {
-      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
-    }
-    function toByteArray(b64) {
-      var tmp;
-      var lens = getLens(b64);
-      var validLen = lens[0];
-      var placeHoldersLen = lens[1];
-      var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
-      var curByte = 0;
-      var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
-      var i2;
-      for (i2 = 0; i2 < len2; i2 += 4) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
-        arr[curByte++] = tmp >> 16 & 255;
-        arr[curByte++] = tmp >> 8 & 255;
-        arr[curByte++] = tmp & 255;
-      }
-      if (placeHoldersLen === 2) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
-        arr[curByte++] = tmp & 255;
-      }
-      if (placeHoldersLen === 1) {
-        tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
-        arr[curByte++] = tmp >> 8 & 255;
-        arr[curByte++] = tmp & 255;
-      }
-      return arr;
-    }
-    function tripletToBase64(num) {
-      return lookup[num >> 18 & 63] + lookup[num >> 12 & 63] + lookup[num >> 6 & 63] + lookup[num & 63];
-    }
-    function encodeChunk(uint8, start, end) {
-      var tmp;
-      var output = [];
-      for (var i2 = start; i2 < end; i2 += 3) {
-        tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
-        output.push(tripletToBase64(tmp));
-      }
-      return output.join("");
-    }
-    function fromByteArray(uint8) {
-      var tmp;
-      var len2 = uint8.length;
-      var extraBytes = len2 % 3;
-      var parts = [];
-      var maxChunkLength = 16383;
-      for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
-        parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
-      }
-      if (extraBytes === 1) {
-        tmp = uint8[len2 - 1];
-        parts.push(lookup[tmp >> 2] + lookup[tmp << 4 & 63] + "==");
-      } else if (extraBytes === 2) {
-        tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
-        parts.push(lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + "=");
-      }
-      return parts.join("");
-    }
-  }
-});
-
-// node_modules/ieee754/index.js
-var require_ieee754 = __commonJS({
-  "node_modules/ieee754/index.js"(exports) {
-    init_buffer_shim();
-    exports.read = function(buffer, offset, isLE, mLen, nBytes) {
-      var e, m;
-      var eLen = nBytes * 8 - mLen - 1;
-      var eMax = (1 << eLen) - 1;
-      var eBias = eMax >> 1;
-      var nBits = -7;
-      var i = isLE ? nBytes - 1 : 0;
-      var d = isLE ? -1 : 1;
-      var s = buffer[offset + i];
-      i += d;
-      e = s & (1 << -nBits) - 1;
-      s >>= -nBits;
-      nBits += eLen;
-      for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
-      }
-      m = e & (1 << -nBits) - 1;
-      e >>= -nBits;
-      nBits += mLen;
-      for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
-      }
-      if (e === 0) {
-        e = 1 - eBias;
-      } else if (e === eMax) {
-        return m ? NaN : (s ? -1 : 1) * Infinity;
-      } else {
-        m = m + Math.pow(2, mLen);
-        e = e - eBias;
-      }
-      return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
-    };
-    exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
-      var e, m, c;
-      var eLen = nBytes * 8 - mLen - 1;
-      var eMax = (1 << eLen) - 1;
-      var eBias = eMax >> 1;
-      var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
-      var i = isLE ? 0 : nBytes - 1;
-      var d = isLE ? 1 : -1;
-      var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
-      value = Math.abs(value);
-      if (isNaN(value) || value === Infinity) {
-        m = isNaN(value) ? 1 : 0;
-        e = eMax;
-      } else {
-        e = Math.floor(Math.log(value) / Math.LN2);
-        if (value * (c = Math.pow(2, -e)) < 1) {
-          e--;
-          c *= 2;
+      var i;
+      var len;
+      revLookup["-".charCodeAt(0)] = 62;
+      revLookup["_".charCodeAt(0)] = 63;
+      function getLens(b64) {
+        var len2 = b64.length;
+        if (len2 % 4 > 0) {
+          throw new Error("Invalid string. Length must be a multiple of 4");
         }
-        if (e + eBias >= 1) {
-          value += rt / c;
+        var validLen = b64.indexOf("=");
+        if (validLen === -1)
+          validLen = len2;
+        var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
+        return [validLen, placeHoldersLen];
+      }
+      function byteLength(b64) {
+        var lens = getLens(b64);
+        var validLen = lens[0];
+        var placeHoldersLen = lens[1];
+        return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+      }
+      function _byteLength(b64, validLen, placeHoldersLen) {
+        return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+      }
+      function toByteArray(b64) {
+        var tmp;
+        var lens = getLens(b64);
+        var validLen = lens[0];
+        var placeHoldersLen = lens[1];
+        var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
+        var curByte = 0;
+        var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
+        var i2;
+        for (i2 = 0; i2 < len2; i2 += 4) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
+          arr[curByte++] = tmp >> 16 & 255;
+          arr[curByte++] = tmp >> 8 & 255;
+          arr[curByte++] = tmp & 255;
+        }
+        if (placeHoldersLen === 2) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
+          arr[curByte++] = tmp & 255;
+        }
+        if (placeHoldersLen === 1) {
+          tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
+          arr[curByte++] = tmp >> 8 & 255;
+          arr[curByte++] = tmp & 255;
+        }
+        return arr;
+      }
+      function tripletToBase64(num) {
+        return lookup[num >> 18 & 63] + lookup[num >> 12 & 63] + lookup[num >> 6 & 63] + lookup[num & 63];
+      }
+      function encodeChunk(uint8, start, end) {
+        var tmp;
+        var output = [];
+        for (var i2 = start; i2 < end; i2 += 3) {
+          tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
+          output.push(tripletToBase64(tmp));
+        }
+        return output.join("");
+      }
+      function fromByteArray(uint8) {
+        var tmp;
+        var len2 = uint8.length;
+        var extraBytes = len2 % 3;
+        var parts = [];
+        var maxChunkLength = 16383;
+        for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
+          parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
+        }
+        if (extraBytes === 1) {
+          tmp = uint8[len2 - 1];
+          parts.push(lookup[tmp >> 2] + lookup[tmp << 4 & 63] + "==");
+        } else if (extraBytes === 2) {
+          tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
+          parts.push(lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + "=");
+        }
+        return parts.join("");
+      }
+    }
+  });
+
+  // node_modules/ieee754/index.js
+  var require_ieee754 = __commonJS({
+    "node_modules/ieee754/index.js"(exports) {
+      init_buffer_shim();
+      exports.read = function(buffer, offset, isLE, mLen, nBytes) {
+        var e, m;
+        var eLen = nBytes * 8 - mLen - 1;
+        var eMax = (1 << eLen) - 1;
+        var eBias = eMax >> 1;
+        var nBits = -7;
+        var i = isLE ? nBytes - 1 : 0;
+        var d = isLE ? -1 : 1;
+        var s = buffer[offset + i];
+        i += d;
+        e = s & (1 << -nBits) - 1;
+        s >>= -nBits;
+        nBits += eLen;
+        for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
+        }
+        m = e & (1 << -nBits) - 1;
+        e >>= -nBits;
+        nBits += mLen;
+        for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
+        }
+        if (e === 0) {
+          e = 1 - eBias;
+        } else if (e === eMax) {
+          return m ? NaN : (s ? -1 : 1) * Infinity;
         } else {
-          value += rt * Math.pow(2, 1 - eBias);
+          m = m + Math.pow(2, mLen);
+          e = e - eBias;
         }
-        if (value * c >= 2) {
-          e++;
-          c /= 2;
-        }
-        if (e + eBias >= eMax) {
-          m = 0;
+        return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
+      };
+      exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
+        var e, m, c;
+        var eLen = nBytes * 8 - mLen - 1;
+        var eMax = (1 << eLen) - 1;
+        var eBias = eMax >> 1;
+        var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
+        var i = isLE ? 0 : nBytes - 1;
+        var d = isLE ? 1 : -1;
+        var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
+        value = Math.abs(value);
+        if (isNaN(value) || value === Infinity) {
+          m = isNaN(value) ? 1 : 0;
           e = eMax;
-        } else if (e + eBias >= 1) {
-          m = (value * c - 1) * Math.pow(2, mLen);
-          e = e + eBias;
         } else {
-          m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
-          e = 0;
+          e = Math.floor(Math.log(value) / Math.LN2);
+          if (value * (c = Math.pow(2, -e)) < 1) {
+            e--;
+            c *= 2;
+          }
+          if (e + eBias >= 1) {
+            value += rt / c;
+          } else {
+            value += rt * Math.pow(2, 1 - eBias);
+          }
+          if (value * c >= 2) {
+            e++;
+            c /= 2;
+          }
+          if (e + eBias >= eMax) {
+            m = 0;
+            e = eMax;
+          } else if (e + eBias >= 1) {
+            m = (value * c - 1) * Math.pow(2, mLen);
+            e = e + eBias;
+          } else {
+            m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
+            e = 0;
+          }
         }
-      }
-      for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
-      }
-      e = e << mLen | m;
-      eLen += mLen;
-      for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
-      }
-      buffer[offset + i - d] |= s * 128;
-    };
-  }
-});
+        for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
+        }
+        e = e << mLen | m;
+        eLen += mLen;
+        for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
+        }
+        buffer[offset + i - d] |= s * 128;
+      };
+    }
+  });
 
-// node_modules/buffer/index.js
-var require_buffer = __commonJS({
-  "node_modules/buffer/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    var base64 = require_base64_js();
-    var ieee754 = require_ieee754();
-    var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
-    exports.Buffer = Buffer3;
-    exports.SlowBuffer = SlowBuffer;
-    exports.INSPECT_MAX_BYTES = 50;
-    var K_MAX_LENGTH = 2147483647;
-    exports.kMaxLength = K_MAX_LENGTH;
-    Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
-    if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
-      console.error("This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.");
-    }
-    function typedArraySupport() {
-      try {
-        const arr = new Uint8Array(1);
-        const proto = { foo: function() {
-          return 42;
-        } };
-        Object.setPrototypeOf(proto, Uint8Array.prototype);
-        Object.setPrototypeOf(arr, proto);
-        return arr.foo() === 42;
-      } catch (e) {
-        return false;
+  // node_modules/buffer/index.js
+  var require_buffer = __commonJS({
+    "node_modules/buffer/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      var base64 = require_base64_js();
+      var ieee754 = require_ieee754();
+      var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
+      exports.Buffer = Buffer3;
+      exports.SlowBuffer = SlowBuffer;
+      exports.INSPECT_MAX_BYTES = 50;
+      var K_MAX_LENGTH = 2147483647;
+      exports.kMaxLength = K_MAX_LENGTH;
+      Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
+      if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
+        console.error("This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.");
       }
-    }
-    Object.defineProperty(Buffer3.prototype, "parent", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer3.isBuffer(this))
-          return void 0;
-        return this.buffer;
-      }
-    });
-    Object.defineProperty(Buffer3.prototype, "offset", {
-      enumerable: true,
-      get: function() {
-        if (!Buffer3.isBuffer(this))
-          return void 0;
-        return this.byteOffset;
-      }
-    });
-    function createBuffer(length) {
-      if (length > K_MAX_LENGTH) {
-        throw new RangeError('The value "' + length + '" is invalid for option "size"');
-      }
-      const buf = new Uint8Array(length);
-      Object.setPrototypeOf(buf, Buffer3.prototype);
-      return buf;
-    }
-    function Buffer3(arg, encodingOrOffset, length) {
-      if (typeof arg === "number") {
-        if (typeof encodingOrOffset === "string") {
-          throw new TypeError('The "string" argument must be of type string. Received type number');
+      function typedArraySupport() {
+        try {
+          const arr = new Uint8Array(1);
+          const proto = { foo: function() {
+            return 42;
+          } };
+          Object.setPrototypeOf(proto, Uint8Array.prototype);
+          Object.setPrototypeOf(arr, proto);
+          return arr.foo() === 42;
+        } catch (e) {
+          return false;
         }
-        return allocUnsafe(arg);
       }
-      return from(arg, encodingOrOffset, length);
-    }
-    Buffer3.poolSize = 8192;
-    function from(value, encodingOrOffset, length) {
-      if (typeof value === "string") {
-        return fromString(value, encodingOrOffset);
-      }
-      if (ArrayBuffer.isView(value)) {
-        return fromArrayView(value);
-      }
-      if (value == null) {
-        throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
-      }
-      if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
-        return fromArrayBuffer(value, encodingOrOffset, length);
-      }
-      if (typeof value === "number") {
-        throw new TypeError('The "value" argument must not be of type number. Received type number');
-      }
-      const valueOf = value.valueOf && value.valueOf();
-      if (valueOf != null && valueOf !== value) {
-        return Buffer3.from(valueOf, encodingOrOffset, length);
-      }
-      const b = fromObject(value);
-      if (b)
-        return b;
-      if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
-        return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
-      }
-      throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
-    }
-    Buffer3.from = function(value, encodingOrOffset, length) {
-      return from(value, encodingOrOffset, length);
-    };
-    Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
-    Object.setPrototypeOf(Buffer3, Uint8Array);
-    function assertSize(size) {
-      if (typeof size !== "number") {
-        throw new TypeError('"size" argument must be of type number');
-      } else if (size < 0) {
-        throw new RangeError('The value "' + size + '" is invalid for option "size"');
-      }
-    }
-    function alloc(size, fill, encoding) {
-      assertSize(size);
-      if (size <= 0) {
-        return createBuffer(size);
-      }
-      if (fill !== void 0) {
-        return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
-      }
-      return createBuffer(size);
-    }
-    Buffer3.alloc = function(size, fill, encoding) {
-      return alloc(size, fill, encoding);
-    };
-    function allocUnsafe(size) {
-      assertSize(size);
-      return createBuffer(size < 0 ? 0 : checked(size) | 0);
-    }
-    Buffer3.allocUnsafe = function(size) {
-      return allocUnsafe(size);
-    };
-    Buffer3.allocUnsafeSlow = function(size) {
-      return allocUnsafe(size);
-    };
-    function fromString(string, encoding) {
-      if (typeof encoding !== "string" || encoding === "") {
-        encoding = "utf8";
-      }
-      if (!Buffer3.isEncoding(encoding)) {
-        throw new TypeError("Unknown encoding: " + encoding);
-      }
-      const length = byteLength(string, encoding) | 0;
-      let buf = createBuffer(length);
-      const actual = buf.write(string, encoding);
-      if (actual !== length) {
-        buf = buf.slice(0, actual);
-      }
-      return buf;
-    }
-    function fromArrayLike(array) {
-      const length = array.length < 0 ? 0 : checked(array.length) | 0;
-      const buf = createBuffer(length);
-      for (let i = 0; i < length; i += 1) {
-        buf[i] = array[i] & 255;
-      }
-      return buf;
-    }
-    function fromArrayView(arrayView) {
-      if (isInstance(arrayView, Uint8Array)) {
-        const copy = new Uint8Array(arrayView);
-        return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
-      }
-      return fromArrayLike(arrayView);
-    }
-    function fromArrayBuffer(array, byteOffset, length) {
-      if (byteOffset < 0 || array.byteLength < byteOffset) {
-        throw new RangeError('"offset" is outside of buffer bounds');
-      }
-      if (array.byteLength < byteOffset + (length || 0)) {
-        throw new RangeError('"length" is outside of buffer bounds');
-      }
-      let buf;
-      if (byteOffset === void 0 && length === void 0) {
-        buf = new Uint8Array(array);
-      } else if (length === void 0) {
-        buf = new Uint8Array(array, byteOffset);
-      } else {
-        buf = new Uint8Array(array, byteOffset, length);
-      }
-      Object.setPrototypeOf(buf, Buffer3.prototype);
-      return buf;
-    }
-    function fromObject(obj) {
-      if (Buffer3.isBuffer(obj)) {
-        const len = checked(obj.length) | 0;
-        const buf = createBuffer(len);
-        if (buf.length === 0) {
-          return buf;
+      Object.defineProperty(Buffer3.prototype, "parent", {
+        enumerable: true,
+        get: function() {
+          if (!Buffer3.isBuffer(this))
+            return void 0;
+          return this.buffer;
         }
-        obj.copy(buf, 0, 0, len);
+      });
+      Object.defineProperty(Buffer3.prototype, "offset", {
+        enumerable: true,
+        get: function() {
+          if (!Buffer3.isBuffer(this))
+            return void 0;
+          return this.byteOffset;
+        }
+      });
+      function createBuffer(length) {
+        if (length > K_MAX_LENGTH) {
+          throw new RangeError('The value "' + length + '" is invalid for option "size"');
+        }
+        const buf = new Uint8Array(length);
+        Object.setPrototypeOf(buf, Buffer3.prototype);
         return buf;
       }
-      if (obj.length !== void 0) {
-        if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
-          return createBuffer(0);
-        }
-        return fromArrayLike(obj);
-      }
-      if (obj.type === "Buffer" && Array.isArray(obj.data)) {
-        return fromArrayLike(obj.data);
-      }
-    }
-    function checked(length) {
-      if (length >= K_MAX_LENGTH) {
-        throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
-      }
-      return length | 0;
-    }
-    function SlowBuffer(length) {
-      if (+length != length) {
-        length = 0;
-      }
-      return Buffer3.alloc(+length);
-    }
-    Buffer3.isBuffer = function isBuffer(b) {
-      return b != null && b._isBuffer === true && b !== Buffer3.prototype;
-    };
-    Buffer3.compare = function compare(a, b) {
-      if (isInstance(a, Uint8Array))
-        a = Buffer3.from(a, a.offset, a.byteLength);
-      if (isInstance(b, Uint8Array))
-        b = Buffer3.from(b, b.offset, b.byteLength);
-      if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b)) {
-        throw new TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
-      }
-      if (a === b)
-        return 0;
-      let x = a.length;
-      let y = b.length;
-      for (let i = 0, len = Math.min(x, y); i < len; ++i) {
-        if (a[i] !== b[i]) {
-          x = a[i];
-          y = b[i];
-          break;
-        }
-      }
-      if (x < y)
-        return -1;
-      if (y < x)
-        return 1;
-      return 0;
-    };
-    Buffer3.isEncoding = function isEncoding(encoding) {
-      switch (String(encoding).toLowerCase()) {
-        case "hex":
-        case "utf8":
-        case "utf-8":
-        case "ascii":
-        case "latin1":
-        case "binary":
-        case "base64":
-        case "ucs2":
-        case "ucs-2":
-        case "utf16le":
-        case "utf-16le":
-          return true;
-        default:
-          return false;
-      }
-    };
-    Buffer3.concat = function concat(list, length) {
-      if (!Array.isArray(list)) {
-        throw new TypeError('"list" argument must be an Array of Buffers');
-      }
-      if (list.length === 0) {
-        return Buffer3.alloc(0);
-      }
-      let i;
-      if (length === void 0) {
-        length = 0;
-        for (i = 0; i < list.length; ++i) {
-          length += list[i].length;
-        }
-      }
-      const buffer = Buffer3.allocUnsafe(length);
-      let pos = 0;
-      for (i = 0; i < list.length; ++i) {
-        let buf = list[i];
-        if (isInstance(buf, Uint8Array)) {
-          if (pos + buf.length > buffer.length) {
-            if (!Buffer3.isBuffer(buf))
-              buf = Buffer3.from(buf);
-            buf.copy(buffer, pos);
-          } else {
-            Uint8Array.prototype.set.call(buffer, buf, pos);
+      function Buffer3(arg, encodingOrOffset, length) {
+        if (typeof arg === "number") {
+          if (typeof encodingOrOffset === "string") {
+            throw new TypeError('The "string" argument must be of type string. Received type number');
           }
-        } else if (!Buffer3.isBuffer(buf)) {
-          throw new TypeError('"list" argument must be an Array of Buffers');
-        } else {
-          buf.copy(buffer, pos);
+          return allocUnsafe(arg);
         }
-        pos += buf.length;
+        return from(arg, encodingOrOffset, length);
       }
-      return buffer;
-    };
-    function byteLength(string, encoding) {
-      if (Buffer3.isBuffer(string)) {
-        return string.length;
-      }
-      if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
-        return string.byteLength;
-      }
-      if (typeof string !== "string") {
-        throw new TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
-      }
-      const len = string.length;
-      const mustMatch = arguments.length > 2 && arguments[2] === true;
-      if (!mustMatch && len === 0)
-        return 0;
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return len;
-          case "utf8":
-          case "utf-8":
-            return utf8ToBytes(string).length;
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return len * 2;
-          case "hex":
-            return len >>> 1;
-          case "base64":
-            return base64ToBytes(string).length;
-          default:
-            if (loweredCase) {
-              return mustMatch ? -1 : utf8ToBytes(string).length;
-            }
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
+      Buffer3.poolSize = 8192;
+      function from(value, encodingOrOffset, length) {
+        if (typeof value === "string") {
+          return fromString(value, encodingOrOffset);
         }
-      }
-    }
-    Buffer3.byteLength = byteLength;
-    function slowToString(encoding, start, end) {
-      let loweredCase = false;
-      if (start === void 0 || start < 0) {
-        start = 0;
-      }
-      if (start > this.length) {
-        return "";
-      }
-      if (end === void 0 || end > this.length) {
-        end = this.length;
-      }
-      if (end <= 0) {
-        return "";
-      }
-      end >>>= 0;
-      start >>>= 0;
-      if (end <= start) {
-        return "";
-      }
-      if (!encoding)
-        encoding = "utf8";
-      while (true) {
-        switch (encoding) {
-          case "hex":
-            return hexSlice(this, start, end);
-          case "utf8":
-          case "utf-8":
-            return utf8Slice(this, start, end);
-          case "ascii":
-            return asciiSlice(this, start, end);
-          case "latin1":
-          case "binary":
-            return latin1Slice(this, start, end);
-          case "base64":
-            return base64Slice(this, start, end);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return utf16leSlice(this, start, end);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = (encoding + "").toLowerCase();
-            loweredCase = true;
+        if (ArrayBuffer.isView(value)) {
+          return fromArrayView(value);
         }
-      }
-    }
-    Buffer3.prototype._isBuffer = true;
-    function swap(b, n, m) {
-      const i = b[n];
-      b[n] = b[m];
-      b[m] = i;
-    }
-    Buffer3.prototype.swap16 = function swap16() {
-      const len = this.length;
-      if (len % 2 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 16-bits");
-      }
-      for (let i = 0; i < len; i += 2) {
-        swap(this, i, i + 1);
-      }
-      return this;
-    };
-    Buffer3.prototype.swap32 = function swap32() {
-      const len = this.length;
-      if (len % 4 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 32-bits");
-      }
-      for (let i = 0; i < len; i += 4) {
-        swap(this, i, i + 3);
-        swap(this, i + 1, i + 2);
-      }
-      return this;
-    };
-    Buffer3.prototype.swap64 = function swap64() {
-      const len = this.length;
-      if (len % 8 !== 0) {
-        throw new RangeError("Buffer size must be a multiple of 64-bits");
-      }
-      for (let i = 0; i < len; i += 8) {
-        swap(this, i, i + 7);
-        swap(this, i + 1, i + 6);
-        swap(this, i + 2, i + 5);
-        swap(this, i + 3, i + 4);
-      }
-      return this;
-    };
-    Buffer3.prototype.toString = function toString() {
-      const length = this.length;
-      if (length === 0)
-        return "";
-      if (arguments.length === 0)
-        return utf8Slice(this, 0, length);
-      return slowToString.apply(this, arguments);
-    };
-    Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
-    Buffer3.prototype.equals = function equals(b) {
-      if (!Buffer3.isBuffer(b))
-        throw new TypeError("Argument must be a Buffer");
-      if (this === b)
-        return true;
-      return Buffer3.compare(this, b) === 0;
-    };
-    Buffer3.prototype.inspect = function inspect() {
-      let str = "";
-      const max = exports.INSPECT_MAX_BYTES;
-      str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
-      if (this.length > max)
-        str += " ... ";
-      return "<Buffer " + str + ">";
-    };
-    if (customInspectSymbol) {
-      Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
-    }
-    Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
-      if (isInstance(target, Uint8Array)) {
-        target = Buffer3.from(target, target.offset, target.byteLength);
-      }
-      if (!Buffer3.isBuffer(target)) {
-        throw new TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
-      }
-      if (start === void 0) {
-        start = 0;
-      }
-      if (end === void 0) {
-        end = target ? target.length : 0;
-      }
-      if (thisStart === void 0) {
-        thisStart = 0;
-      }
-      if (thisEnd === void 0) {
-        thisEnd = this.length;
-      }
-      if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
-        throw new RangeError("out of range index");
-      }
-      if (thisStart >= thisEnd && start >= end) {
-        return 0;
-      }
-      if (thisStart >= thisEnd) {
-        return -1;
-      }
-      if (start >= end) {
-        return 1;
-      }
-      start >>>= 0;
-      end >>>= 0;
-      thisStart >>>= 0;
-      thisEnd >>>= 0;
-      if (this === target)
-        return 0;
-      let x = thisEnd - thisStart;
-      let y = end - start;
-      const len = Math.min(x, y);
-      const thisCopy = this.slice(thisStart, thisEnd);
-      const targetCopy = target.slice(start, end);
-      for (let i = 0; i < len; ++i) {
-        if (thisCopy[i] !== targetCopy[i]) {
-          x = thisCopy[i];
-          y = targetCopy[i];
-          break;
+        if (value == null) {
+          throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
         }
-      }
-      if (x < y)
-        return -1;
-      if (y < x)
-        return 1;
-      return 0;
-    };
-    function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
-      if (buffer.length === 0)
-        return -1;
-      if (typeof byteOffset === "string") {
-        encoding = byteOffset;
-        byteOffset = 0;
-      } else if (byteOffset > 2147483647) {
-        byteOffset = 2147483647;
-      } else if (byteOffset < -2147483648) {
-        byteOffset = -2147483648;
-      }
-      byteOffset = +byteOffset;
-      if (numberIsNaN(byteOffset)) {
-        byteOffset = dir ? 0 : buffer.length - 1;
-      }
-      if (byteOffset < 0)
-        byteOffset = buffer.length + byteOffset;
-      if (byteOffset >= buffer.length) {
-        if (dir)
-          return -1;
-        else
-          byteOffset = buffer.length - 1;
-      } else if (byteOffset < 0) {
-        if (dir)
-          byteOffset = 0;
-        else
-          return -1;
-      }
-      if (typeof val === "string") {
-        val = Buffer3.from(val, encoding);
-      }
-      if (Buffer3.isBuffer(val)) {
-        if (val.length === 0) {
-          return -1;
+        if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
+          return fromArrayBuffer(value, encodingOrOffset, length);
         }
-        return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
-      } else if (typeof val === "number") {
-        val = val & 255;
-        if (typeof Uint8Array.prototype.indexOf === "function") {
-          if (dir) {
-            return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
-          } else {
-            return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
-          }
+        if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
+          return fromArrayBuffer(value, encodingOrOffset, length);
         }
-        return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
-      }
-      throw new TypeError("val must be string, number or Buffer");
-    }
-    function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
-      let indexSize = 1;
-      let arrLength = arr.length;
-      let valLength = val.length;
-      if (encoding !== void 0) {
-        encoding = String(encoding).toLowerCase();
-        if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
-          if (arr.length < 2 || val.length < 2) {
-            return -1;
-          }
-          indexSize = 2;
-          arrLength /= 2;
-          valLength /= 2;
-          byteOffset /= 2;
+        if (typeof value === "number") {
+          throw new TypeError('The "value" argument must not be of type number. Received type number');
         }
-      }
-      function read(buf, i2) {
-        if (indexSize === 1) {
-          return buf[i2];
-        } else {
-          return buf.readUInt16BE(i2 * indexSize);
+        const valueOf = value.valueOf && value.valueOf();
+        if (valueOf != null && valueOf !== value) {
+          return Buffer3.from(valueOf, encodingOrOffset, length);
         }
-      }
-      let i;
-      if (dir) {
-        let foundIndex = -1;
-        for (i = byteOffset; i < arrLength; i++) {
-          if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
-            if (foundIndex === -1)
-              foundIndex = i;
-            if (i - foundIndex + 1 === valLength)
-              return foundIndex * indexSize;
-          } else {
-            if (foundIndex !== -1)
-              i -= i - foundIndex;
-            foundIndex = -1;
-          }
+        const b = fromObject(value);
+        if (b)
+          return b;
+        if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
+          return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
         }
-      } else {
-        if (byteOffset + valLength > arrLength)
-          byteOffset = arrLength - valLength;
-        for (i = byteOffset; i >= 0; i--) {
-          let found = true;
-          for (let j = 0; j < valLength; j++) {
-            if (read(arr, i + j) !== read(val, j)) {
-              found = false;
-              break;
-            }
-          }
-          if (found)
-            return i;
-        }
+        throw new TypeError("The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value);
       }
-      return -1;
-    }
-    Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
-      return this.indexOf(val, byteOffset, encoding) !== -1;
-    };
-    Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
-    };
-    Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
-      return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
-    };
-    function hexWrite(buf, string, offset, length) {
-      offset = Number(offset) || 0;
-      const remaining = buf.length - offset;
-      if (!length) {
-        length = remaining;
-      } else {
-        length = Number(length);
-        if (length > remaining) {
-          length = remaining;
-        }
-      }
-      const strLen = string.length;
-      if (length > strLen / 2) {
-        length = strLen / 2;
-      }
-      let i;
-      for (i = 0; i < length; ++i) {
-        const parsed = parseInt(string.substr(i * 2, 2), 16);
-        if (numberIsNaN(parsed))
-          return i;
-        buf[offset + i] = parsed;
-      }
-      return i;
-    }
-    function utf8Write(buf, string, offset, length) {
-      return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    function asciiWrite(buf, string, offset, length) {
-      return blitBuffer(asciiToBytes(string), buf, offset, length);
-    }
-    function base64Write(buf, string, offset, length) {
-      return blitBuffer(base64ToBytes(string), buf, offset, length);
-    }
-    function ucs2Write(buf, string, offset, length) {
-      return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
-    }
-    Buffer3.prototype.write = function write(string, offset, length, encoding) {
-      if (offset === void 0) {
-        encoding = "utf8";
-        length = this.length;
-        offset = 0;
-      } else if (length === void 0 && typeof offset === "string") {
-        encoding = offset;
-        length = this.length;
-        offset = 0;
-      } else if (isFinite(offset)) {
-        offset = offset >>> 0;
-        if (isFinite(length)) {
-          length = length >>> 0;
-          if (encoding === void 0)
-            encoding = "utf8";
-        } else {
-          encoding = length;
-          length = void 0;
-        }
-      } else {
-        throw new Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
-      }
-      const remaining = this.length - offset;
-      if (length === void 0 || length > remaining)
-        length = remaining;
-      if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
-        throw new RangeError("Attempt to write outside buffer bounds");
-      }
-      if (!encoding)
-        encoding = "utf8";
-      let loweredCase = false;
-      for (; ; ) {
-        switch (encoding) {
-          case "hex":
-            return hexWrite(this, string, offset, length);
-          case "utf8":
-          case "utf-8":
-            return utf8Write(this, string, offset, length);
-          case "ascii":
-          case "latin1":
-          case "binary":
-            return asciiWrite(this, string, offset, length);
-          case "base64":
-            return base64Write(this, string, offset, length);
-          case "ucs2":
-          case "ucs-2":
-          case "utf16le":
-          case "utf-16le":
-            return ucs2Write(this, string, offset, length);
-          default:
-            if (loweredCase)
-              throw new TypeError("Unknown encoding: " + encoding);
-            encoding = ("" + encoding).toLowerCase();
-            loweredCase = true;
-        }
-      }
-    };
-    Buffer3.prototype.toJSON = function toJSON() {
-      return {
-        type: "Buffer",
-        data: Array.prototype.slice.call(this._arr || this, 0)
+      Buffer3.from = function(value, encodingOrOffset, length) {
+        return from(value, encodingOrOffset, length);
       };
-    };
-    function base64Slice(buf, start, end) {
-      if (start === 0 && end === buf.length) {
-        return base64.fromByteArray(buf);
-      } else {
-        return base64.fromByteArray(buf.slice(start, end));
-      }
-    }
-    function utf8Slice(buf, start, end) {
-      end = Math.min(buf.length, end);
-      const res = [];
-      let i = start;
-      while (i < end) {
-        const firstByte = buf[i];
-        let codePoint = null;
-        let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
-        if (i + bytesPerSequence <= end) {
-          let secondByte, thirdByte, fourthByte, tempCodePoint;
-          switch (bytesPerSequence) {
-            case 1:
-              if (firstByte < 128) {
-                codePoint = firstByte;
-              }
-              break;
-            case 2:
-              secondByte = buf[i + 1];
-              if ((secondByte & 192) === 128) {
-                tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
-                if (tempCodePoint > 127) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 3:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
-                if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
-                  codePoint = tempCodePoint;
-                }
-              }
-              break;
-            case 4:
-              secondByte = buf[i + 1];
-              thirdByte = buf[i + 2];
-              fourthByte = buf[i + 3];
-              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
-                tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
-                if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
-                  codePoint = tempCodePoint;
-                }
-              }
-          }
+      Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
+      Object.setPrototypeOf(Buffer3, Uint8Array);
+      function assertSize(size) {
+        if (typeof size !== "number") {
+          throw new TypeError('"size" argument must be of type number');
+        } else if (size < 0) {
+          throw new RangeError('The value "' + size + '" is invalid for option "size"');
         }
-        if (codePoint === null) {
-          codePoint = 65533;
-          bytesPerSequence = 1;
-        } else if (codePoint > 65535) {
-          codePoint -= 65536;
-          res.push(codePoint >>> 10 & 1023 | 55296);
-          codePoint = 56320 | codePoint & 1023;
+      }
+      function alloc(size, fill, encoding) {
+        assertSize(size);
+        if (size <= 0) {
+          return createBuffer(size);
         }
-        res.push(codePoint);
-        i += bytesPerSequence;
-      }
-      return decodeCodePointsArray(res);
-    }
-    var MAX_ARGUMENTS_LENGTH = 4096;
-    function decodeCodePointsArray(codePoints) {
-      const len = codePoints.length;
-      if (len <= MAX_ARGUMENTS_LENGTH) {
-        return String.fromCharCode.apply(String, codePoints);
-      }
-      let res = "";
-      let i = 0;
-      while (i < len) {
-        res += String.fromCharCode.apply(String, codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH));
-      }
-      return res;
-    }
-    function asciiSlice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i] & 127);
-      }
-      return ret;
-    }
-    function latin1Slice(buf, start, end) {
-      let ret = "";
-      end = Math.min(buf.length, end);
-      for (let i = start; i < end; ++i) {
-        ret += String.fromCharCode(buf[i]);
-      }
-      return ret;
-    }
-    function hexSlice(buf, start, end) {
-      const len = buf.length;
-      if (!start || start < 0)
-        start = 0;
-      if (!end || end < 0 || end > len)
-        end = len;
-      let out = "";
-      for (let i = start; i < end; ++i) {
-        out += hexSliceLookupTable[buf[i]];
-      }
-      return out;
-    }
-    function utf16leSlice(buf, start, end) {
-      const bytes = buf.slice(start, end);
-      let res = "";
-      for (let i = 0; i < bytes.length - 1; i += 2) {
-        res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
-      }
-      return res;
-    }
-    Buffer3.prototype.slice = function slice(start, end) {
-      const len = this.length;
-      start = ~~start;
-      end = end === void 0 ? len : ~~end;
-      if (start < 0) {
-        start += len;
-        if (start < 0)
-          start = 0;
-      } else if (start > len) {
-        start = len;
-      }
-      if (end < 0) {
-        end += len;
-        if (end < 0)
-          end = 0;
-      } else if (end > len) {
-        end = len;
-      }
-      if (end < start)
-        end = start;
-      const newBuf = this.subarray(start, end);
-      Object.setPrototypeOf(newBuf, Buffer3.prototype);
-      return newBuf;
-    };
-    function checkOffset(offset, ext, length) {
-      if (offset % 1 !== 0 || offset < 0)
-        throw new RangeError("offset is not uint");
-      if (offset + ext > length)
-        throw new RangeError("Trying to access beyond buffer length");
-    }
-    Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      return val;
-    };
-    Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        checkOffset(offset, byteLength2, this.length);
-      }
-      let val = this[offset + --byteLength2];
-      let mul = 1;
-      while (byteLength2 > 0 && (mul *= 256)) {
-        val += this[offset + --byteLength2] * mul;
-      }
-      return val;
-    };
-    Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      return this[offset];
-    };
-    Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] | this[offset + 1] << 8;
-    };
-    Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      return this[offset] << 8 | this[offset + 1];
-    };
-    Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
-    };
-    Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
-    };
-    Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
-      const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
-      return BigInt(lo) + (BigInt(hi) << BigInt(32));
-    });
-    Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
-      return (BigInt(hi) << BigInt(32)) + BigInt(lo);
-    });
-    Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let val = this[offset];
-      let mul = 1;
-      let i = 0;
-      while (++i < byteLength2 && (mul *= 256)) {
-        val += this[offset + i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert)
-        checkOffset(offset, byteLength2, this.length);
-      let i = byteLength2;
-      let mul = 1;
-      let val = this[offset + --i];
-      while (i > 0 && (mul *= 256)) {
-        val += this[offset + --i] * mul;
-      }
-      mul *= 128;
-      if (val >= mul)
-        val -= Math.pow(2, 8 * byteLength2);
-      return val;
-    };
-    Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 1, this.length);
-      if (!(this[offset] & 128))
-        return this[offset];
-      return (255 - this[offset] + 1) * -1;
-    };
-    Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset] | this[offset + 1] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 2, this.length);
-      const val = this[offset + 1] | this[offset] << 8;
-      return val & 32768 ? val | 4294901760 : val;
-    };
-    Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
-    };
-    Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
-    };
-    Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
-      return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
-    });
-    Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
-      offset = offset >>> 0;
-      validateNumber(offset, "offset");
-      const first = this[offset];
-      const last = this[offset + 7];
-      if (first === void 0 || last === void 0) {
-        boundsError(offset, this.length - 8);
-      }
-      const val = (first << 24) + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
-      return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
-    });
-    Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, true, 23, 4);
-    };
-    Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 4, this.length);
-      return ieee754.read(this, offset, false, 23, 4);
-    };
-    Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, true, 52, 8);
-    };
-    Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkOffset(offset, 8, this.length);
-      return ieee754.read(this, offset, false, 52, 8);
-    };
-    function checkInt(buf, value, offset, ext, max, min) {
-      if (!Buffer3.isBuffer(buf))
-        throw new TypeError('"buffer" argument must be a Buffer instance');
-      if (value > max || value < min)
-        throw new RangeError('"value" argument is out of bounds');
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-    }
-    Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let mul = 1;
-      let i = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      byteLength2 = byteLength2 >>> 0;
-      if (!noAssert) {
-        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
-        checkInt(this, value, offset, byteLength2, maxBytes, 0);
-      }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        this[offset + i] = value / mul & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 255, 0);
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 65535, 0);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset + 3] = value >>> 24;
-      this[offset + 2] = value >>> 16;
-      this[offset + 1] = value >>> 8;
-      this[offset] = value & 255;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 4294967295, 0);
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    function wrtBigUInt64LE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      lo = lo >> 8;
-      buf[offset++] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      hi = hi >> 8;
-      buf[offset++] = hi;
-      return offset;
-    }
-    function wrtBigUInt64BE(buf, value, offset, min, max) {
-      checkIntBI(value, min, max, buf, offset, 7);
-      let lo = Number(value & BigInt(4294967295));
-      buf[offset + 7] = lo;
-      lo = lo >> 8;
-      buf[offset + 6] = lo;
-      lo = lo >> 8;
-      buf[offset + 5] = lo;
-      lo = lo >> 8;
-      buf[offset + 4] = lo;
-      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
-      buf[offset + 3] = hi;
-      hi = hi >> 8;
-      buf[offset + 2] = hi;
-      hi = hi >> 8;
-      buf[offset + 1] = hi;
-      hi = hi >> 8;
-      buf[offset] = hi;
-      return offset + 8;
-    }
-    Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
-    });
-    Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
-      }
-      let i = 0;
-      let mul = 1;
-      let sub = 0;
-      this[offset] = value & 255;
-      while (++i < byteLength2 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
-          sub = 1;
+        if (fill !== void 0) {
+          return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
         }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
+        return createBuffer(size);
       }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        const limit = Math.pow(2, 8 * byteLength2 - 1);
-        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      Buffer3.alloc = function(size, fill, encoding) {
+        return alloc(size, fill, encoding);
+      };
+      function allocUnsafe(size) {
+        assertSize(size);
+        return createBuffer(size < 0 ? 0 : checked(size) | 0);
       }
-      let i = byteLength2 - 1;
-      let mul = 1;
-      let sub = 0;
-      this[offset + i] = value & 255;
-      while (--i >= 0 && (mul *= 256)) {
-        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
-          sub = 1;
+      Buffer3.allocUnsafe = function(size) {
+        return allocUnsafe(size);
+      };
+      Buffer3.allocUnsafeSlow = function(size) {
+        return allocUnsafe(size);
+      };
+      function fromString(string, encoding) {
+        if (typeof encoding !== "string" || encoding === "") {
+          encoding = "utf8";
         }
-        this[offset + i] = (value / mul >> 0) - sub & 255;
-      }
-      return offset + byteLength2;
-    };
-    Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 1, 127, -128);
-      if (value < 0)
-        value = 255 + value + 1;
-      this[offset] = value & 255;
-      return offset + 1;
-    };
-    Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 2, 32767, -32768);
-      this[offset] = value >>> 8;
-      this[offset + 1] = value & 255;
-      return offset + 2;
-    };
-    Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      this[offset] = value & 255;
-      this[offset + 1] = value >>> 8;
-      this[offset + 2] = value >>> 16;
-      this[offset + 3] = value >>> 24;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert)
-        checkInt(this, value, offset, 4, 2147483647, -2147483648);
-      if (value < 0)
-        value = 4294967295 + value + 1;
-      this[offset] = value >>> 24;
-      this[offset + 1] = value >>> 16;
-      this[offset + 2] = value >>> 8;
-      this[offset + 3] = value & 255;
-      return offset + 4;
-    };
-    Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
-      return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
-      return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
-    });
-    function checkIEEE754(buf, value, offset, ext, max, min) {
-      if (offset + ext > buf.length)
-        throw new RangeError("Index out of range");
-      if (offset < 0)
-        throw new RangeError("Index out of range");
-    }
-    function writeFloat(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 23, 4);
-      return offset + 4;
-    }
-    Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, true, noAssert);
-    };
-    Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
-      return writeFloat(this, value, offset, false, noAssert);
-    };
-    function writeDouble(buf, value, offset, littleEndian, noAssert) {
-      value = +value;
-      offset = offset >>> 0;
-      if (!noAssert) {
-        checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
-      }
-      ieee754.write(buf, value, offset, littleEndian, 52, 8);
-      return offset + 8;
-    }
-    Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, true, noAssert);
-    };
-    Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
-      return writeDouble(this, value, offset, false, noAssert);
-    };
-    Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
-      if (!Buffer3.isBuffer(target))
-        throw new TypeError("argument should be a Buffer");
-      if (!start)
-        start = 0;
-      if (!end && end !== 0)
-        end = this.length;
-      if (targetStart >= target.length)
-        targetStart = target.length;
-      if (!targetStart)
-        targetStart = 0;
-      if (end > 0 && end < start)
-        end = start;
-      if (end === start)
-        return 0;
-      if (target.length === 0 || this.length === 0)
-        return 0;
-      if (targetStart < 0) {
-        throw new RangeError("targetStart out of bounds");
-      }
-      if (start < 0 || start >= this.length)
-        throw new RangeError("Index out of range");
-      if (end < 0)
-        throw new RangeError("sourceEnd out of bounds");
-      if (end > this.length)
-        end = this.length;
-      if (target.length - targetStart < end - start) {
-        end = target.length - targetStart + start;
-      }
-      const len = end - start;
-      if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
-        this.copyWithin(targetStart, start, end);
-      } else {
-        Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
-      }
-      return len;
-    };
-    Buffer3.prototype.fill = function fill(val, start, end, encoding) {
-      if (typeof val === "string") {
-        if (typeof start === "string") {
-          encoding = start;
-          start = 0;
-          end = this.length;
-        } else if (typeof end === "string") {
-          encoding = end;
-          end = this.length;
-        }
-        if (encoding !== void 0 && typeof encoding !== "string") {
-          throw new TypeError("encoding must be a string");
-        }
-        if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
+        if (!Buffer3.isEncoding(encoding)) {
           throw new TypeError("Unknown encoding: " + encoding);
         }
-        if (val.length === 1) {
-          const code = val.charCodeAt(0);
-          if (encoding === "utf8" && code < 128 || encoding === "latin1") {
-            val = code;
+        const length = byteLength(string, encoding) | 0;
+        let buf = createBuffer(length);
+        const actual = buf.write(string, encoding);
+        if (actual !== length) {
+          buf = buf.slice(0, actual);
+        }
+        return buf;
+      }
+      function fromArrayLike(array) {
+        const length = array.length < 0 ? 0 : checked(array.length) | 0;
+        const buf = createBuffer(length);
+        for (let i = 0; i < length; i += 1) {
+          buf[i] = array[i] & 255;
+        }
+        return buf;
+      }
+      function fromArrayView(arrayView) {
+        if (isInstance(arrayView, Uint8Array)) {
+          const copy = new Uint8Array(arrayView);
+          return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
+        }
+        return fromArrayLike(arrayView);
+      }
+      function fromArrayBuffer(array, byteOffset, length) {
+        if (byteOffset < 0 || array.byteLength < byteOffset) {
+          throw new RangeError('"offset" is outside of buffer bounds');
+        }
+        if (array.byteLength < byteOffset + (length || 0)) {
+          throw new RangeError('"length" is outside of buffer bounds');
+        }
+        let buf;
+        if (byteOffset === void 0 && length === void 0) {
+          buf = new Uint8Array(array);
+        } else if (length === void 0) {
+          buf = new Uint8Array(array, byteOffset);
+        } else {
+          buf = new Uint8Array(array, byteOffset, length);
+        }
+        Object.setPrototypeOf(buf, Buffer3.prototype);
+        return buf;
+      }
+      function fromObject(obj) {
+        if (Buffer3.isBuffer(obj)) {
+          const len = checked(obj.length) | 0;
+          const buf = createBuffer(len);
+          if (buf.length === 0) {
+            return buf;
+          }
+          obj.copy(buf, 0, 0, len);
+          return buf;
+        }
+        if (obj.length !== void 0) {
+          if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
+            return createBuffer(0);
+          }
+          return fromArrayLike(obj);
+        }
+        if (obj.type === "Buffer" && Array.isArray(obj.data)) {
+          return fromArrayLike(obj.data);
+        }
+      }
+      function checked(length) {
+        if (length >= K_MAX_LENGTH) {
+          throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
+        }
+        return length | 0;
+      }
+      function SlowBuffer(length) {
+        if (+length != length) {
+          length = 0;
+        }
+        return Buffer3.alloc(+length);
+      }
+      Buffer3.isBuffer = function isBuffer(b) {
+        return b != null && b._isBuffer === true && b !== Buffer3.prototype;
+      };
+      Buffer3.compare = function compare(a, b) {
+        if (isInstance(a, Uint8Array))
+          a = Buffer3.from(a, a.offset, a.byteLength);
+        if (isInstance(b, Uint8Array))
+          b = Buffer3.from(b, b.offset, b.byteLength);
+        if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b)) {
+          throw new TypeError('The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array');
+        }
+        if (a === b)
+          return 0;
+        let x = a.length;
+        let y = b.length;
+        for (let i = 0, len = Math.min(x, y); i < len; ++i) {
+          if (a[i] !== b[i]) {
+            x = a[i];
+            y = b[i];
+            break;
           }
         }
-      } else if (typeof val === "number") {
-        val = val & 255;
-      } else if (typeof val === "boolean") {
-        val = Number(val);
-      }
-      if (start < 0 || this.length < start || this.length < end) {
-        throw new RangeError("Out of range index");
-      }
-      if (end <= start) {
-        return this;
-      }
-      start = start >>> 0;
-      end = end === void 0 ? this.length : end >>> 0;
-      if (!val)
-        val = 0;
-      let i;
-      if (typeof val === "number") {
-        for (i = start; i < end; ++i) {
-          this[i] = val;
-        }
-      } else {
-        const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
-        const len = bytes.length;
-        if (len === 0) {
-          throw new TypeError('The value "' + val + '" is invalid for argument "value"');
-        }
-        for (i = 0; i < end - start; ++i) {
-          this[i + start] = bytes[i % len];
-        }
-      }
-      return this;
-    };
-    var errors = {};
-    function E(sym, getMessage, Base) {
-      errors[sym] = class NodeError extends Base {
-        constructor() {
-          super();
-          Object.defineProperty(this, "message", {
-            value: getMessage.apply(this, arguments),
-            writable: true,
-            configurable: true
-          });
-          this.name = `${this.name} [${sym}]`;
-          this.stack;
-          delete this.name;
-        }
-        get code() {
-          return sym;
-        }
-        set code(value) {
-          Object.defineProperty(this, "code", {
-            configurable: true,
-            enumerable: true,
-            value,
-            writable: true
-          });
-        }
-        toString() {
-          return `${this.name} [${sym}]: ${this.message}`;
+        if (x < y)
+          return -1;
+        if (y < x)
+          return 1;
+        return 0;
+      };
+      Buffer3.isEncoding = function isEncoding(encoding) {
+        switch (String(encoding).toLowerCase()) {
+          case "hex":
+          case "utf8":
+          case "utf-8":
+          case "ascii":
+          case "latin1":
+          case "binary":
+          case "base64":
+          case "ucs2":
+          case "ucs-2":
+          case "utf16le":
+          case "utf-16le":
+            return true;
+          default:
+            return false;
         }
       };
-    }
-    E("ERR_BUFFER_OUT_OF_BOUNDS", function(name) {
-      if (name) {
-        return `${name} is outside of buffer bounds`;
-      }
-      return "Attempt to access memory outside buffer bounds";
-    }, RangeError);
-    E("ERR_INVALID_ARG_TYPE", function(name, actual) {
-      return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
-    }, TypeError);
-    E("ERR_OUT_OF_RANGE", function(str, range, input) {
-      let msg = `The value of "${str}" is out of range.`;
-      let received = input;
-      if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
-        received = addNumericalSeparator(String(input));
-      } else if (typeof input === "bigint") {
-        received = String(input);
-        if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
-          received = addNumericalSeparator(received);
+      Buffer3.concat = function concat(list, length) {
+        if (!Array.isArray(list)) {
+          throw new TypeError('"list" argument must be an Array of Buffers');
         }
-        received += "n";
-      }
-      msg += ` It must be ${range}. Received ${received}`;
-      return msg;
-    }, RangeError);
-    function addNumericalSeparator(val) {
-      let res = "";
-      let i = val.length;
-      const start = val[0] === "-" ? 1 : 0;
-      for (; i >= start + 4; i -= 3) {
-        res = `_${val.slice(i - 3, i)}${res}`;
-      }
-      return `${val.slice(0, i)}${res}`;
-    }
-    function checkBounds(buf, offset, byteLength2) {
-      validateNumber(offset, "offset");
-      if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
-        boundsError(offset, buf.length - (byteLength2 + 1));
-      }
-    }
-    function checkIntBI(value, min, max, buf, offset, byteLength2) {
-      if (value > max || value < min) {
-        const n = typeof min === "bigint" ? "n" : "";
-        let range;
-        if (byteLength2 > 3) {
-          if (min === 0 || min === BigInt(0)) {
-            range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
+        if (list.length === 0) {
+          return Buffer3.alloc(0);
+        }
+        let i;
+        if (length === void 0) {
+          length = 0;
+          for (i = 0; i < list.length; ++i) {
+            length += list[i].length;
+          }
+        }
+        const buffer = Buffer3.allocUnsafe(length);
+        let pos = 0;
+        for (i = 0; i < list.length; ++i) {
+          let buf = list[i];
+          if (isInstance(buf, Uint8Array)) {
+            if (pos + buf.length > buffer.length) {
+              if (!Buffer3.isBuffer(buf))
+                buf = Buffer3.from(buf);
+              buf.copy(buffer, pos);
+            } else {
+              Uint8Array.prototype.set.call(buffer, buf, pos);
+            }
+          } else if (!Buffer3.isBuffer(buf)) {
+            throw new TypeError('"list" argument must be an Array of Buffers');
           } else {
-            range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
+            buf.copy(buffer, pos);
+          }
+          pos += buf.length;
+        }
+        return buffer;
+      };
+      function byteLength(string, encoding) {
+        if (Buffer3.isBuffer(string)) {
+          return string.length;
+        }
+        if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
+          return string.byteLength;
+        }
+        if (typeof string !== "string") {
+          throw new TypeError('The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string);
+        }
+        const len = string.length;
+        const mustMatch = arguments.length > 2 && arguments[2] === true;
+        if (!mustMatch && len === 0)
+          return 0;
+        let loweredCase = false;
+        for (; ; ) {
+          switch (encoding) {
+            case "ascii":
+            case "latin1":
+            case "binary":
+              return len;
+            case "utf8":
+            case "utf-8":
+              return utf8ToBytes(string).length;
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return len * 2;
+            case "hex":
+              return len >>> 1;
+            case "base64":
+              return base64ToBytes(string).length;
+            default:
+              if (loweredCase) {
+                return mustMatch ? -1 : utf8ToBytes(string).length;
+              }
+              encoding = ("" + encoding).toLowerCase();
+              loweredCase = true;
+          }
+        }
+      }
+      Buffer3.byteLength = byteLength;
+      function slowToString(encoding, start, end) {
+        let loweredCase = false;
+        if (start === void 0 || start < 0) {
+          start = 0;
+        }
+        if (start > this.length) {
+          return "";
+        }
+        if (end === void 0 || end > this.length) {
+          end = this.length;
+        }
+        if (end <= 0) {
+          return "";
+        }
+        end >>>= 0;
+        start >>>= 0;
+        if (end <= start) {
+          return "";
+        }
+        if (!encoding)
+          encoding = "utf8";
+        while (true) {
+          switch (encoding) {
+            case "hex":
+              return hexSlice(this, start, end);
+            case "utf8":
+            case "utf-8":
+              return utf8Slice(this, start, end);
+            case "ascii":
+              return asciiSlice(this, start, end);
+            case "latin1":
+            case "binary":
+              return latin1Slice(this, start, end);
+            case "base64":
+              return base64Slice(this, start, end);
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return utf16leSlice(this, start, end);
+            default:
+              if (loweredCase)
+                throw new TypeError("Unknown encoding: " + encoding);
+              encoding = (encoding + "").toLowerCase();
+              loweredCase = true;
+          }
+        }
+      }
+      Buffer3.prototype._isBuffer = true;
+      function swap(b, n, m) {
+        const i = b[n];
+        b[n] = b[m];
+        b[m] = i;
+      }
+      Buffer3.prototype.swap16 = function swap16() {
+        const len = this.length;
+        if (len % 2 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 16-bits");
+        }
+        for (let i = 0; i < len; i += 2) {
+          swap(this, i, i + 1);
+        }
+        return this;
+      };
+      Buffer3.prototype.swap32 = function swap32() {
+        const len = this.length;
+        if (len % 4 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 32-bits");
+        }
+        for (let i = 0; i < len; i += 4) {
+          swap(this, i, i + 3);
+          swap(this, i + 1, i + 2);
+        }
+        return this;
+      };
+      Buffer3.prototype.swap64 = function swap64() {
+        const len = this.length;
+        if (len % 8 !== 0) {
+          throw new RangeError("Buffer size must be a multiple of 64-bits");
+        }
+        for (let i = 0; i < len; i += 8) {
+          swap(this, i, i + 7);
+          swap(this, i + 1, i + 6);
+          swap(this, i + 2, i + 5);
+          swap(this, i + 3, i + 4);
+        }
+        return this;
+      };
+      Buffer3.prototype.toString = function toString() {
+        const length = this.length;
+        if (length === 0)
+          return "";
+        if (arguments.length === 0)
+          return utf8Slice(this, 0, length);
+        return slowToString.apply(this, arguments);
+      };
+      Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
+      Buffer3.prototype.equals = function equals(b) {
+        if (!Buffer3.isBuffer(b))
+          throw new TypeError("Argument must be a Buffer");
+        if (this === b)
+          return true;
+        return Buffer3.compare(this, b) === 0;
+      };
+      Buffer3.prototype.inspect = function inspect() {
+        let str = "";
+        const max = exports.INSPECT_MAX_BYTES;
+        str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
+        if (this.length > max)
+          str += " ... ";
+        return "<Buffer " + str + ">";
+      };
+      if (customInspectSymbol) {
+        Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
+      }
+      Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
+        if (isInstance(target, Uint8Array)) {
+          target = Buffer3.from(target, target.offset, target.byteLength);
+        }
+        if (!Buffer3.isBuffer(target)) {
+          throw new TypeError('The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target);
+        }
+        if (start === void 0) {
+          start = 0;
+        }
+        if (end === void 0) {
+          end = target ? target.length : 0;
+        }
+        if (thisStart === void 0) {
+          thisStart = 0;
+        }
+        if (thisEnd === void 0) {
+          thisEnd = this.length;
+        }
+        if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+          throw new RangeError("out of range index");
+        }
+        if (thisStart >= thisEnd && start >= end) {
+          return 0;
+        }
+        if (thisStart >= thisEnd) {
+          return -1;
+        }
+        if (start >= end) {
+          return 1;
+        }
+        start >>>= 0;
+        end >>>= 0;
+        thisStart >>>= 0;
+        thisEnd >>>= 0;
+        if (this === target)
+          return 0;
+        let x = thisEnd - thisStart;
+        let y = end - start;
+        const len = Math.min(x, y);
+        const thisCopy = this.slice(thisStart, thisEnd);
+        const targetCopy = target.slice(start, end);
+        for (let i = 0; i < len; ++i) {
+          if (thisCopy[i] !== targetCopy[i]) {
+            x = thisCopy[i];
+            y = targetCopy[i];
+            break;
+          }
+        }
+        if (x < y)
+          return -1;
+        if (y < x)
+          return 1;
+        return 0;
+      };
+      function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
+        if (buffer.length === 0)
+          return -1;
+        if (typeof byteOffset === "string") {
+          encoding = byteOffset;
+          byteOffset = 0;
+        } else if (byteOffset > 2147483647) {
+          byteOffset = 2147483647;
+        } else if (byteOffset < -2147483648) {
+          byteOffset = -2147483648;
+        }
+        byteOffset = +byteOffset;
+        if (numberIsNaN(byteOffset)) {
+          byteOffset = dir ? 0 : buffer.length - 1;
+        }
+        if (byteOffset < 0)
+          byteOffset = buffer.length + byteOffset;
+        if (byteOffset >= buffer.length) {
+          if (dir)
+            return -1;
+          else
+            byteOffset = buffer.length - 1;
+        } else if (byteOffset < 0) {
+          if (dir)
+            byteOffset = 0;
+          else
+            return -1;
+        }
+        if (typeof val === "string") {
+          val = Buffer3.from(val, encoding);
+        }
+        if (Buffer3.isBuffer(val)) {
+          if (val.length === 0) {
+            return -1;
+          }
+          return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
+        } else if (typeof val === "number") {
+          val = val & 255;
+          if (typeof Uint8Array.prototype.indexOf === "function") {
+            if (dir) {
+              return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
+            } else {
+              return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
+            }
+          }
+          return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
+        }
+        throw new TypeError("val must be string, number or Buffer");
+      }
+      function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
+        let indexSize = 1;
+        let arrLength = arr.length;
+        let valLength = val.length;
+        if (encoding !== void 0) {
+          encoding = String(encoding).toLowerCase();
+          if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
+            if (arr.length < 2 || val.length < 2) {
+              return -1;
+            }
+            indexSize = 2;
+            arrLength /= 2;
+            valLength /= 2;
+            byteOffset /= 2;
+          }
+        }
+        function read(buf, i2) {
+          if (indexSize === 1) {
+            return buf[i2];
+          } else {
+            return buf.readUInt16BE(i2 * indexSize);
+          }
+        }
+        let i;
+        if (dir) {
+          let foundIndex = -1;
+          for (i = byteOffset; i < arrLength; i++) {
+            if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+              if (foundIndex === -1)
+                foundIndex = i;
+              if (i - foundIndex + 1 === valLength)
+                return foundIndex * indexSize;
+            } else {
+              if (foundIndex !== -1)
+                i -= i - foundIndex;
+              foundIndex = -1;
+            }
           }
         } else {
-          range = `>= ${min}${n} and <= ${max}${n}`;
-        }
-        throw new errors.ERR_OUT_OF_RANGE("value", range, value);
-      }
-      checkBounds(buf, offset, byteLength2);
-    }
-    function validateNumber(value, name) {
-      if (typeof value !== "number") {
-        throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
-      }
-    }
-    function boundsError(value, length, type) {
-      if (Math.floor(value) !== value) {
-        validateNumber(value, type);
-        throw new errors.ERR_OUT_OF_RANGE(type || "offset", "an integer", value);
-      }
-      if (length < 0) {
-        throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
-      }
-      throw new errors.ERR_OUT_OF_RANGE(type || "offset", `>= ${type ? 1 : 0} and <= ${length}`, value);
-    }
-    var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
-    function base64clean(str) {
-      str = str.split("=")[0];
-      str = str.trim().replace(INVALID_BASE64_RE, "");
-      if (str.length < 2)
-        return "";
-      while (str.length % 4 !== 0) {
-        str = str + "=";
-      }
-      return str;
-    }
-    function utf8ToBytes(string, units) {
-      units = units || Infinity;
-      let codePoint;
-      const length = string.length;
-      let leadSurrogate = null;
-      const bytes = [];
-      for (let i = 0; i < length; ++i) {
-        codePoint = string.charCodeAt(i);
-        if (codePoint > 55295 && codePoint < 57344) {
-          if (!leadSurrogate) {
-            if (codePoint > 56319) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
-            } else if (i + 1 === length) {
-              if ((units -= 3) > -1)
-                bytes.push(239, 191, 189);
-              continue;
+          if (byteOffset + valLength > arrLength)
+            byteOffset = arrLength - valLength;
+          for (i = byteOffset; i >= 0; i--) {
+            let found = true;
+            for (let j = 0; j < valLength; j++) {
+              if (read(arr, i + j) !== read(val, j)) {
+                found = false;
+                break;
+              }
             }
-            leadSurrogate = codePoint;
-            continue;
+            if (found)
+              return i;
           }
-          if (codePoint < 56320) {
-            if ((units -= 3) > -1)
-              bytes.push(239, 191, 189);
-            leadSurrogate = codePoint;
-            continue;
-          }
-          codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
-        } else if (leadSurrogate) {
-          if ((units -= 3) > -1)
-            bytes.push(239, 191, 189);
         }
-        leadSurrogate = null;
-        if (codePoint < 128) {
-          if ((units -= 1) < 0)
-            break;
-          bytes.push(codePoint);
-        } else if (codePoint < 2048) {
-          if ((units -= 2) < 0)
-            break;
-          bytes.push(codePoint >> 6 | 192, codePoint & 63 | 128);
-        } else if (codePoint < 65536) {
-          if ((units -= 3) < 0)
-            break;
-          bytes.push(codePoint >> 12 | 224, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
-        } else if (codePoint < 1114112) {
-          if ((units -= 4) < 0)
-            break;
-          bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+        return -1;
+      }
+      Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
+        return this.indexOf(val, byteOffset, encoding) !== -1;
+      };
+      Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+        return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
+      };
+      Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+        return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
+      };
+      function hexWrite(buf, string, offset, length) {
+        offset = Number(offset) || 0;
+        const remaining = buf.length - offset;
+        if (!length) {
+          length = remaining;
         } else {
-          throw new Error("Invalid code point");
-        }
-      }
-      return bytes;
-    }
-    function asciiToBytes(str) {
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        byteArray.push(str.charCodeAt(i) & 255);
-      }
-      return byteArray;
-    }
-    function utf16leToBytes(str, units) {
-      let c, hi, lo;
-      const byteArray = [];
-      for (let i = 0; i < str.length; ++i) {
-        if ((units -= 2) < 0)
-          break;
-        c = str.charCodeAt(i);
-        hi = c >> 8;
-        lo = c % 256;
-        byteArray.push(lo);
-        byteArray.push(hi);
-      }
-      return byteArray;
-    }
-    function base64ToBytes(str) {
-      return base64.toByteArray(base64clean(str));
-    }
-    function blitBuffer(src, dst, offset, length) {
-      let i;
-      for (i = 0; i < length; ++i) {
-        if (i + offset >= dst.length || i >= src.length)
-          break;
-        dst[i + offset] = src[i];
-      }
-      return i;
-    }
-    function isInstance(obj, type) {
-      return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
-    }
-    function numberIsNaN(obj) {
-      return obj !== obj;
-    }
-    var hexSliceLookupTable = function() {
-      const alphabet = "0123456789abcdef";
-      const table = new Array(256);
-      for (let i = 0; i < 16; ++i) {
-        const i16 = i * 16;
-        for (let j = 0; j < 16; ++j) {
-          table[i16 + j] = alphabet[i] + alphabet[j];
-        }
-      }
-      return table;
-    }();
-    function defineBigIntMethod(fn) {
-      return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
-    }
-    function BufferBigIntNotDefined() {
-      throw new Error("BigInt not supported");
-    }
-  }
-});
-
-// testing/injections/buffer_shim.js
-var Buffer2;
-var init_buffer_shim = __esm({
-  "testing/injections/buffer_shim.js"() {
-    Buffer2 = require_buffer().Buffer;
-  }
-});
-
-// node_modules/pascalcase/index.js
-var require_pascalcase = __commonJS({
-  "node_modules/pascalcase/index.js"(exports, module2) {
-    init_buffer_shim();
-    var titlecase = (input) => input[0].toLocaleUpperCase() + input.slice(1);
-    module2.exports = (value) => {
-      if (value === null || value === void 0)
-        return "";
-      if (typeof value.toString !== "function")
-        return "";
-      let input = value.toString().trim();
-      if (input === "")
-        return "";
-      if (input.length === 1)
-        return input.toLocaleUpperCase();
-      let match = input.match(/[a-zA-Z0-9]+/g);
-      if (match) {
-        return match.map((m) => titlecase(m)).join("");
-      }
-      return input;
-    };
-  }
-});
-
-// node_modules/clone/clone.js
-var require_clone = __commonJS({
-  "node_modules/clone/clone.js"(exports, module2) {
-    init_buffer_shim();
-    var clone2 = function() {
-      "use strict";
-      function _instanceof(obj, type) {
-        return type != null && obj instanceof type;
-      }
-      var nativeMap;
-      try {
-        nativeMap = Map;
-      } catch (_) {
-        nativeMap = function() {
-        };
-      }
-      var nativeSet;
-      try {
-        nativeSet = Set;
-      } catch (_) {
-        nativeSet = function() {
-        };
-      }
-      var nativePromise;
-      try {
-        nativePromise = Promise;
-      } catch (_) {
-        nativePromise = function() {
-        };
-      }
-      function clone3(parent, circular, depth, prototype, includeNonEnumerable) {
-        if (typeof circular === "object") {
-          depth = circular.depth;
-          prototype = circular.prototype;
-          includeNonEnumerable = circular.includeNonEnumerable;
-          circular = circular.circular;
-        }
-        var allParents = [];
-        var allChildren = [];
-        var useBuffer = typeof Buffer2 != "undefined";
-        if (typeof circular == "undefined")
-          circular = true;
-        if (typeof depth == "undefined")
-          depth = Infinity;
-        function _clone(parent2, depth2) {
-          if (parent2 === null)
-            return null;
-          if (depth2 === 0)
-            return parent2;
-          var child;
-          var proto;
-          if (typeof parent2 != "object") {
-            return parent2;
+          length = Number(length);
+          if (length > remaining) {
+            length = remaining;
           }
-          if (_instanceof(parent2, nativeMap)) {
-            child = new nativeMap();
-          } else if (_instanceof(parent2, nativeSet)) {
-            child = new nativeSet();
-          } else if (_instanceof(parent2, nativePromise)) {
-            child = new nativePromise(function(resolve, reject) {
-              parent2.then(function(value) {
-                resolve(_clone(value, depth2 - 1));
-              }, function(err) {
-                reject(_clone(err, depth2 - 1));
-              });
-            });
-          } else if (clone3.__isArray(parent2)) {
-            child = [];
-          } else if (clone3.__isRegExp(parent2)) {
-            child = new RegExp(parent2.source, __getRegExpFlags(parent2));
-            if (parent2.lastIndex)
-              child.lastIndex = parent2.lastIndex;
-          } else if (clone3.__isDate(parent2)) {
-            child = new Date(parent2.getTime());
-          } else if (useBuffer && Buffer2.isBuffer(parent2)) {
-            if (Buffer2.allocUnsafe) {
-              child = Buffer2.allocUnsafe(parent2.length);
-            } else {
-              child = new Buffer2(parent2.length);
-            }
-            parent2.copy(child);
-            return child;
-          } else if (_instanceof(parent2, Error)) {
-            child = Object.create(parent2);
+        }
+        const strLen = string.length;
+        if (length > strLen / 2) {
+          length = strLen / 2;
+        }
+        let i;
+        for (i = 0; i < length; ++i) {
+          const parsed = parseInt(string.substr(i * 2, 2), 16);
+          if (numberIsNaN(parsed))
+            return i;
+          buf[offset + i] = parsed;
+        }
+        return i;
+      }
+      function utf8Write(buf, string, offset, length) {
+        return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
+      }
+      function asciiWrite(buf, string, offset, length) {
+        return blitBuffer(asciiToBytes(string), buf, offset, length);
+      }
+      function base64Write(buf, string, offset, length) {
+        return blitBuffer(base64ToBytes(string), buf, offset, length);
+      }
+      function ucs2Write(buf, string, offset, length) {
+        return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
+      }
+      Buffer3.prototype.write = function write(string, offset, length, encoding) {
+        if (offset === void 0) {
+          encoding = "utf8";
+          length = this.length;
+          offset = 0;
+        } else if (length === void 0 && typeof offset === "string") {
+          encoding = offset;
+          length = this.length;
+          offset = 0;
+        } else if (isFinite(offset)) {
+          offset = offset >>> 0;
+          if (isFinite(length)) {
+            length = length >>> 0;
+            if (encoding === void 0)
+              encoding = "utf8";
           } else {
-            if (typeof prototype == "undefined") {
-              proto = Object.getPrototypeOf(parent2);
-              child = Object.create(proto);
+            encoding = length;
+            length = void 0;
+          }
+        } else {
+          throw new Error("Buffer.write(string, encoding, offset[, length]) is no longer supported");
+        }
+        const remaining = this.length - offset;
+        if (length === void 0 || length > remaining)
+          length = remaining;
+        if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
+          throw new RangeError("Attempt to write outside buffer bounds");
+        }
+        if (!encoding)
+          encoding = "utf8";
+        let loweredCase = false;
+        for (; ; ) {
+          switch (encoding) {
+            case "hex":
+              return hexWrite(this, string, offset, length);
+            case "utf8":
+            case "utf-8":
+              return utf8Write(this, string, offset, length);
+            case "ascii":
+            case "latin1":
+            case "binary":
+              return asciiWrite(this, string, offset, length);
+            case "base64":
+              return base64Write(this, string, offset, length);
+            case "ucs2":
+            case "ucs-2":
+            case "utf16le":
+            case "utf-16le":
+              return ucs2Write(this, string, offset, length);
+            default:
+              if (loweredCase)
+                throw new TypeError("Unknown encoding: " + encoding);
+              encoding = ("" + encoding).toLowerCase();
+              loweredCase = true;
+          }
+        }
+      };
+      Buffer3.prototype.toJSON = function toJSON() {
+        return {
+          type: "Buffer",
+          data: Array.prototype.slice.call(this._arr || this, 0)
+        };
+      };
+      function base64Slice(buf, start, end) {
+        if (start === 0 && end === buf.length) {
+          return base64.fromByteArray(buf);
+        } else {
+          return base64.fromByteArray(buf.slice(start, end));
+        }
+      }
+      function utf8Slice(buf, start, end) {
+        end = Math.min(buf.length, end);
+        const res = [];
+        let i = start;
+        while (i < end) {
+          const firstByte = buf[i];
+          let codePoint = null;
+          let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
+          if (i + bytesPerSequence <= end) {
+            let secondByte, thirdByte, fourthByte, tempCodePoint;
+            switch (bytesPerSequence) {
+              case 1:
+                if (firstByte < 128) {
+                  codePoint = firstByte;
+                }
+                break;
+              case 2:
+                secondByte = buf[i + 1];
+                if ((secondByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
+                  if (tempCodePoint > 127) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+                break;
+              case 3:
+                secondByte = buf[i + 1];
+                thirdByte = buf[i + 2];
+                if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
+                  if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+                break;
+              case 4:
+                secondByte = buf[i + 1];
+                thirdByte = buf[i + 2];
+                fourthByte = buf[i + 3];
+                if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
+                  tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
+                  if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
+                    codePoint = tempCodePoint;
+                  }
+                }
+            }
+          }
+          if (codePoint === null) {
+            codePoint = 65533;
+            bytesPerSequence = 1;
+          } else if (codePoint > 65535) {
+            codePoint -= 65536;
+            res.push(codePoint >>> 10 & 1023 | 55296);
+            codePoint = 56320 | codePoint & 1023;
+          }
+          res.push(codePoint);
+          i += bytesPerSequence;
+        }
+        return decodeCodePointsArray(res);
+      }
+      var MAX_ARGUMENTS_LENGTH = 4096;
+      function decodeCodePointsArray(codePoints) {
+        const len = codePoints.length;
+        if (len <= MAX_ARGUMENTS_LENGTH) {
+          return String.fromCharCode.apply(String, codePoints);
+        }
+        let res = "";
+        let i = 0;
+        while (i < len) {
+          res += String.fromCharCode.apply(String, codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH));
+        }
+        return res;
+      }
+      function asciiSlice(buf, start, end) {
+        let ret = "";
+        end = Math.min(buf.length, end);
+        for (let i = start; i < end; ++i) {
+          ret += String.fromCharCode(buf[i] & 127);
+        }
+        return ret;
+      }
+      function latin1Slice(buf, start, end) {
+        let ret = "";
+        end = Math.min(buf.length, end);
+        for (let i = start; i < end; ++i) {
+          ret += String.fromCharCode(buf[i]);
+        }
+        return ret;
+      }
+      function hexSlice(buf, start, end) {
+        const len = buf.length;
+        if (!start || start < 0)
+          start = 0;
+        if (!end || end < 0 || end > len)
+          end = len;
+        let out = "";
+        for (let i = start; i < end; ++i) {
+          out += hexSliceLookupTable[buf[i]];
+        }
+        return out;
+      }
+      function utf16leSlice(buf, start, end) {
+        const bytes = buf.slice(start, end);
+        let res = "";
+        for (let i = 0; i < bytes.length - 1; i += 2) {
+          res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
+        }
+        return res;
+      }
+      Buffer3.prototype.slice = function slice(start, end) {
+        const len = this.length;
+        start = ~~start;
+        end = end === void 0 ? len : ~~end;
+        if (start < 0) {
+          start += len;
+          if (start < 0)
+            start = 0;
+        } else if (start > len) {
+          start = len;
+        }
+        if (end < 0) {
+          end += len;
+          if (end < 0)
+            end = 0;
+        } else if (end > len) {
+          end = len;
+        }
+        if (end < start)
+          end = start;
+        const newBuf = this.subarray(start, end);
+        Object.setPrototypeOf(newBuf, Buffer3.prototype);
+        return newBuf;
+      };
+      function checkOffset(offset, ext, length) {
+        if (offset % 1 !== 0 || offset < 0)
+          throw new RangeError("offset is not uint");
+        if (offset + ext > length)
+          throw new RangeError("Trying to access beyond buffer length");
+      }
+      Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let val = this[offset];
+        let mul = 1;
+        let i = 0;
+        while (++i < byteLength2 && (mul *= 256)) {
+          val += this[offset + i] * mul;
+        }
+        return val;
+      };
+      Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          checkOffset(offset, byteLength2, this.length);
+        }
+        let val = this[offset + --byteLength2];
+        let mul = 1;
+        while (byteLength2 > 0 && (mul *= 256)) {
+          val += this[offset + --byteLength2] * mul;
+        }
+        return val;
+      };
+      Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 1, this.length);
+        return this[offset];
+      };
+      Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        return this[offset] | this[offset + 1] << 8;
+      };
+      Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        return this[offset] << 8 | this[offset + 1];
+      };
+      Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
+      };
+      Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
+      };
+      Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
+        const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
+        return BigInt(lo) + (BigInt(hi) << BigInt(32));
+      });
+      Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+        const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
+        return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+      });
+      Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let val = this[offset];
+        let mul = 1;
+        let i = 0;
+        while (++i < byteLength2 && (mul *= 256)) {
+          val += this[offset + i] * mul;
+        }
+        mul *= 128;
+        if (val >= mul)
+          val -= Math.pow(2, 8 * byteLength2);
+        return val;
+      };
+      Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert)
+          checkOffset(offset, byteLength2, this.length);
+        let i = byteLength2;
+        let mul = 1;
+        let val = this[offset + --i];
+        while (i > 0 && (mul *= 256)) {
+          val += this[offset + --i] * mul;
+        }
+        mul *= 128;
+        if (val >= mul)
+          val -= Math.pow(2, 8 * byteLength2);
+        return val;
+      };
+      Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 1, this.length);
+        if (!(this[offset] & 128))
+          return this[offset];
+        return (255 - this[offset] + 1) * -1;
+      };
+      Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        const val = this[offset] | this[offset + 1] << 8;
+        return val & 32768 ? val | 4294901760 : val;
+      };
+      Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 2, this.length);
+        const val = this[offset + 1] | this[offset] << 8;
+        return val & 32768 ? val | 4294901760 : val;
+      };
+      Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
+      };
+      Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
+      };
+      Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
+        return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
+      });
+      Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+        offset = offset >>> 0;
+        validateNumber(offset, "offset");
+        const first = this[offset];
+        const last = this[offset + 7];
+        if (first === void 0 || last === void 0) {
+          boundsError(offset, this.length - 8);
+        }
+        const val = (first << 24) + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+        return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
+      });
+      Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return ieee754.read(this, offset, true, 23, 4);
+      };
+      Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 4, this.length);
+        return ieee754.read(this, offset, false, 23, 4);
+      };
+      Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 8, this.length);
+        return ieee754.read(this, offset, true, 52, 8);
+      };
+      Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkOffset(offset, 8, this.length);
+        return ieee754.read(this, offset, false, 52, 8);
+      };
+      function checkInt(buf, value, offset, ext, max, min) {
+        if (!Buffer3.isBuffer(buf))
+          throw new TypeError('"buffer" argument must be a Buffer instance');
+        if (value > max || value < min)
+          throw new RangeError('"value" argument is out of bounds');
+        if (offset + ext > buf.length)
+          throw new RangeError("Index out of range");
+      }
+      Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+          checkInt(this, value, offset, byteLength2, maxBytes, 0);
+        }
+        let mul = 1;
+        let i = 0;
+        this[offset] = value & 255;
+        while (++i < byteLength2 && (mul *= 256)) {
+          this[offset + i] = value / mul & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        byteLength2 = byteLength2 >>> 0;
+        if (!noAssert) {
+          const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+          checkInt(this, value, offset, byteLength2, maxBytes, 0);
+        }
+        let i = byteLength2 - 1;
+        let mul = 1;
+        this[offset + i] = value & 255;
+        while (--i >= 0 && (mul *= 256)) {
+          this[offset + i] = value / mul & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 1, 255, 0);
+        this[offset] = value & 255;
+        return offset + 1;
+      };
+      Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 65535, 0);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 65535, 0);
+        this[offset] = value >>> 8;
+        this[offset + 1] = value & 255;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 4294967295, 0);
+        this[offset + 3] = value >>> 24;
+        this[offset + 2] = value >>> 16;
+        this[offset + 1] = value >>> 8;
+        this[offset] = value & 255;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 4294967295, 0);
+        this[offset] = value >>> 24;
+        this[offset + 1] = value >>> 16;
+        this[offset + 2] = value >>> 8;
+        this[offset + 3] = value & 255;
+        return offset + 4;
+      };
+      function wrtBigUInt64LE(buf, value, offset, min, max) {
+        checkIntBI(value, min, max, buf, offset, 7);
+        let lo = Number(value & BigInt(4294967295));
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        lo = lo >> 8;
+        buf[offset++] = lo;
+        let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        hi = hi >> 8;
+        buf[offset++] = hi;
+        return offset;
+      }
+      function wrtBigUInt64BE(buf, value, offset, min, max) {
+        checkIntBI(value, min, max, buf, offset, 7);
+        let lo = Number(value & BigInt(4294967295));
+        buf[offset + 7] = lo;
+        lo = lo >> 8;
+        buf[offset + 6] = lo;
+        lo = lo >> 8;
+        buf[offset + 5] = lo;
+        lo = lo >> 8;
+        buf[offset + 4] = lo;
+        let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+        buf[offset + 3] = hi;
+        hi = hi >> 8;
+        buf[offset + 2] = hi;
+        hi = hi >> 8;
+        buf[offset + 1] = hi;
+        hi = hi >> 8;
+        buf[offset] = hi;
+        return offset + 8;
+      }
+      Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+        return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+      });
+      Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+        return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+      });
+      Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          const limit = Math.pow(2, 8 * byteLength2 - 1);
+          checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+        }
+        let i = 0;
+        let mul = 1;
+        let sub = 0;
+        this[offset] = value & 255;
+        while (++i < byteLength2 && (mul *= 256)) {
+          if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+            sub = 1;
+          }
+          this[offset + i] = (value / mul >> 0) - sub & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          const limit = Math.pow(2, 8 * byteLength2 - 1);
+          checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+        }
+        let i = byteLength2 - 1;
+        let mul = 1;
+        let sub = 0;
+        this[offset + i] = value & 255;
+        while (--i >= 0 && (mul *= 256)) {
+          if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+            sub = 1;
+          }
+          this[offset + i] = (value / mul >> 0) - sub & 255;
+        }
+        return offset + byteLength2;
+      };
+      Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 1, 127, -128);
+        if (value < 0)
+          value = 255 + value + 1;
+        this[offset] = value & 255;
+        return offset + 1;
+      };
+      Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 32767, -32768);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 2, 32767, -32768);
+        this[offset] = value >>> 8;
+        this[offset + 1] = value & 255;
+        return offset + 2;
+      };
+      Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 2147483647, -2147483648);
+        this[offset] = value & 255;
+        this[offset + 1] = value >>> 8;
+        this[offset + 2] = value >>> 16;
+        this[offset + 3] = value >>> 24;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert)
+          checkInt(this, value, offset, 4, 2147483647, -2147483648);
+        if (value < 0)
+          value = 4294967295 + value + 1;
+        this[offset] = value >>> 24;
+        this[offset + 1] = value >>> 16;
+        this[offset + 2] = value >>> 8;
+        this[offset + 3] = value & 255;
+        return offset + 4;
+      };
+      Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+        return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+      });
+      Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+        return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+      });
+      function checkIEEE754(buf, value, offset, ext, max, min) {
+        if (offset + ext > buf.length)
+          throw new RangeError("Index out of range");
+        if (offset < 0)
+          throw new RangeError("Index out of range");
+      }
+      function writeFloat(buf, value, offset, littleEndian, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
+        }
+        ieee754.write(buf, value, offset, littleEndian, 23, 4);
+        return offset + 4;
+      }
+      Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+        return writeFloat(this, value, offset, true, noAssert);
+      };
+      Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+        return writeFloat(this, value, offset, false, noAssert);
+      };
+      function writeDouble(buf, value, offset, littleEndian, noAssert) {
+        value = +value;
+        offset = offset >>> 0;
+        if (!noAssert) {
+          checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
+        }
+        ieee754.write(buf, value, offset, littleEndian, 52, 8);
+        return offset + 8;
+      }
+      Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+        return writeDouble(this, value, offset, true, noAssert);
+      };
+      Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+        return writeDouble(this, value, offset, false, noAssert);
+      };
+      Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
+        if (!Buffer3.isBuffer(target))
+          throw new TypeError("argument should be a Buffer");
+        if (!start)
+          start = 0;
+        if (!end && end !== 0)
+          end = this.length;
+        if (targetStart >= target.length)
+          targetStart = target.length;
+        if (!targetStart)
+          targetStart = 0;
+        if (end > 0 && end < start)
+          end = start;
+        if (end === start)
+          return 0;
+        if (target.length === 0 || this.length === 0)
+          return 0;
+        if (targetStart < 0) {
+          throw new RangeError("targetStart out of bounds");
+        }
+        if (start < 0 || start >= this.length)
+          throw new RangeError("Index out of range");
+        if (end < 0)
+          throw new RangeError("sourceEnd out of bounds");
+        if (end > this.length)
+          end = this.length;
+        if (target.length - targetStart < end - start) {
+          end = target.length - targetStart + start;
+        }
+        const len = end - start;
+        if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
+          this.copyWithin(targetStart, start, end);
+        } else {
+          Uint8Array.prototype.set.call(target, this.subarray(start, end), targetStart);
+        }
+        return len;
+      };
+      Buffer3.prototype.fill = function fill(val, start, end, encoding) {
+        if (typeof val === "string") {
+          if (typeof start === "string") {
+            encoding = start;
+            start = 0;
+            end = this.length;
+          } else if (typeof end === "string") {
+            encoding = end;
+            end = this.length;
+          }
+          if (encoding !== void 0 && typeof encoding !== "string") {
+            throw new TypeError("encoding must be a string");
+          }
+          if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
+            throw new TypeError("Unknown encoding: " + encoding);
+          }
+          if (val.length === 1) {
+            const code = val.charCodeAt(0);
+            if (encoding === "utf8" && code < 128 || encoding === "latin1") {
+              val = code;
+            }
+          }
+        } else if (typeof val === "number") {
+          val = val & 255;
+        } else if (typeof val === "boolean") {
+          val = Number(val);
+        }
+        if (start < 0 || this.length < start || this.length < end) {
+          throw new RangeError("Out of range index");
+        }
+        if (end <= start) {
+          return this;
+        }
+        start = start >>> 0;
+        end = end === void 0 ? this.length : end >>> 0;
+        if (!val)
+          val = 0;
+        let i;
+        if (typeof val === "number") {
+          for (i = start; i < end; ++i) {
+            this[i] = val;
+          }
+        } else {
+          const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
+          const len = bytes.length;
+          if (len === 0) {
+            throw new TypeError('The value "' + val + '" is invalid for argument "value"');
+          }
+          for (i = 0; i < end - start; ++i) {
+            this[i + start] = bytes[i % len];
+          }
+        }
+        return this;
+      };
+      var errors = {};
+      function E(sym, getMessage, Base) {
+        errors[sym] = class NodeError extends Base {
+          constructor() {
+            super();
+            Object.defineProperty(this, "message", {
+              value: getMessage.apply(this, arguments),
+              writable: true,
+              configurable: true
+            });
+            this.name = `${this.name} [${sym}]`;
+            this.stack;
+            delete this.name;
+          }
+          get code() {
+            return sym;
+          }
+          set code(value) {
+            Object.defineProperty(this, "code", {
+              configurable: true,
+              enumerable: true,
+              value,
+              writable: true
+            });
+          }
+          toString() {
+            return `${this.name} [${sym}]: ${this.message}`;
+          }
+        };
+      }
+      E("ERR_BUFFER_OUT_OF_BOUNDS", function(name) {
+        if (name) {
+          return `${name} is outside of buffer bounds`;
+        }
+        return "Attempt to access memory outside buffer bounds";
+      }, RangeError);
+      E("ERR_INVALID_ARG_TYPE", function(name, actual) {
+        return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
+      }, TypeError);
+      E("ERR_OUT_OF_RANGE", function(str, range, input) {
+        let msg = `The value of "${str}" is out of range.`;
+        let received = input;
+        if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
+          received = addNumericalSeparator(String(input));
+        } else if (typeof input === "bigint") {
+          received = String(input);
+          if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
+            received = addNumericalSeparator(received);
+          }
+          received += "n";
+        }
+        msg += ` It must be ${range}. Received ${received}`;
+        return msg;
+      }, RangeError);
+      function addNumericalSeparator(val) {
+        let res = "";
+        let i = val.length;
+        const start = val[0] === "-" ? 1 : 0;
+        for (; i >= start + 4; i -= 3) {
+          res = `_${val.slice(i - 3, i)}${res}`;
+        }
+        return `${val.slice(0, i)}${res}`;
+      }
+      function checkBounds(buf, offset, byteLength2) {
+        validateNumber(offset, "offset");
+        if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
+          boundsError(offset, buf.length - (byteLength2 + 1));
+        }
+      }
+      function checkIntBI(value, min, max, buf, offset, byteLength2) {
+        if (value > max || value < min) {
+          const n = typeof min === "bigint" ? "n" : "";
+          let range;
+          if (byteLength2 > 3) {
+            if (min === 0 || min === BigInt(0)) {
+              range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
             } else {
-              child = Object.create(prototype);
-              proto = prototype;
+              range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
             }
+          } else {
+            range = `>= ${min}${n} and <= ${max}${n}`;
           }
-          if (circular) {
-            var index = allParents.indexOf(parent2);
-            if (index != -1) {
-              return allChildren[index];
-            }
-            allParents.push(parent2);
-            allChildren.push(child);
-          }
-          if (_instanceof(parent2, nativeMap)) {
-            parent2.forEach(function(value, key) {
-              var keyChild = _clone(key, depth2 - 1);
-              var valueChild = _clone(value, depth2 - 1);
-              child.set(keyChild, valueChild);
-            });
-          }
-          if (_instanceof(parent2, nativeSet)) {
-            parent2.forEach(function(value) {
-              var entryChild = _clone(value, depth2 - 1);
-              child.add(entryChild);
-            });
-          }
-          for (var i in parent2) {
-            var attrs;
-            if (proto) {
-              attrs = Object.getOwnPropertyDescriptor(proto, i);
-            }
-            if (attrs && attrs.set == null) {
-              continue;
-            }
-            child[i] = _clone(parent2[i], depth2 - 1);
-          }
-          if (Object.getOwnPropertySymbols) {
-            var symbols = Object.getOwnPropertySymbols(parent2);
-            for (var i = 0; i < symbols.length; i++) {
-              var symbol = symbols[i];
-              var descriptor = Object.getOwnPropertyDescriptor(parent2, symbol);
-              if (descriptor && !descriptor.enumerable && !includeNonEnumerable) {
+          throw new errors.ERR_OUT_OF_RANGE("value", range, value);
+        }
+        checkBounds(buf, offset, byteLength2);
+      }
+      function validateNumber(value, name) {
+        if (typeof value !== "number") {
+          throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
+        }
+      }
+      function boundsError(value, length, type) {
+        if (Math.floor(value) !== value) {
+          validateNumber(value, type);
+          throw new errors.ERR_OUT_OF_RANGE(type || "offset", "an integer", value);
+        }
+        if (length < 0) {
+          throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
+        }
+        throw new errors.ERR_OUT_OF_RANGE(type || "offset", `>= ${type ? 1 : 0} and <= ${length}`, value);
+      }
+      var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
+      function base64clean(str) {
+        str = str.split("=")[0];
+        str = str.trim().replace(INVALID_BASE64_RE, "");
+        if (str.length < 2)
+          return "";
+        while (str.length % 4 !== 0) {
+          str = str + "=";
+        }
+        return str;
+      }
+      function utf8ToBytes(string, units) {
+        units = units || Infinity;
+        let codePoint;
+        const length = string.length;
+        let leadSurrogate = null;
+        const bytes = [];
+        for (let i = 0; i < length; ++i) {
+          codePoint = string.charCodeAt(i);
+          if (codePoint > 55295 && codePoint < 57344) {
+            if (!leadSurrogate) {
+              if (codePoint > 56319) {
+                if ((units -= 3) > -1)
+                  bytes.push(239, 191, 189);
+                continue;
+              } else if (i + 1 === length) {
+                if ((units -= 3) > -1)
+                  bytes.push(239, 191, 189);
                 continue;
               }
-              child[symbol] = _clone(parent2[symbol], depth2 - 1);
-              if (!descriptor.enumerable) {
-                Object.defineProperty(child, symbol, {
+              leadSurrogate = codePoint;
+              continue;
+            }
+            if (codePoint < 56320) {
+              if ((units -= 3) > -1)
+                bytes.push(239, 191, 189);
+              leadSurrogate = codePoint;
+              continue;
+            }
+            codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
+          } else if (leadSurrogate) {
+            if ((units -= 3) > -1)
+              bytes.push(239, 191, 189);
+          }
+          leadSurrogate = null;
+          if (codePoint < 128) {
+            if ((units -= 1) < 0)
+              break;
+            bytes.push(codePoint);
+          } else if (codePoint < 2048) {
+            if ((units -= 2) < 0)
+              break;
+            bytes.push(codePoint >> 6 | 192, codePoint & 63 | 128);
+          } else if (codePoint < 65536) {
+            if ((units -= 3) < 0)
+              break;
+            bytes.push(codePoint >> 12 | 224, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+          } else if (codePoint < 1114112) {
+            if ((units -= 4) < 0)
+              break;
+            bytes.push(codePoint >> 18 | 240, codePoint >> 12 & 63 | 128, codePoint >> 6 & 63 | 128, codePoint & 63 | 128);
+          } else {
+            throw new Error("Invalid code point");
+          }
+        }
+        return bytes;
+      }
+      function asciiToBytes(str) {
+        const byteArray = [];
+        for (let i = 0; i < str.length; ++i) {
+          byteArray.push(str.charCodeAt(i) & 255);
+        }
+        return byteArray;
+      }
+      function utf16leToBytes(str, units) {
+        let c, hi, lo;
+        const byteArray = [];
+        for (let i = 0; i < str.length; ++i) {
+          if ((units -= 2) < 0)
+            break;
+          c = str.charCodeAt(i);
+          hi = c >> 8;
+          lo = c % 256;
+          byteArray.push(lo);
+          byteArray.push(hi);
+        }
+        return byteArray;
+      }
+      function base64ToBytes(str) {
+        return base64.toByteArray(base64clean(str));
+      }
+      function blitBuffer(src, dst, offset, length) {
+        let i;
+        for (i = 0; i < length; ++i) {
+          if (i + offset >= dst.length || i >= src.length)
+            break;
+          dst[i + offset] = src[i];
+        }
+        return i;
+      }
+      function isInstance(obj, type) {
+        return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
+      }
+      function numberIsNaN(obj) {
+        return obj !== obj;
+      }
+      var hexSliceLookupTable = function() {
+        const alphabet = "0123456789abcdef";
+        const table = new Array(256);
+        for (let i = 0; i < 16; ++i) {
+          const i16 = i * 16;
+          for (let j = 0; j < 16; ++j) {
+            table[i16 + j] = alphabet[i] + alphabet[j];
+          }
+        }
+        return table;
+      }();
+      function defineBigIntMethod(fn) {
+        return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
+      }
+      function BufferBigIntNotDefined() {
+        throw new Error("BigInt not supported");
+      }
+    }
+  });
+
+  // testing/injections/buffer_shim.js
+  var Buffer2;
+  var init_buffer_shim = __esm({
+    "testing/injections/buffer_shim.js"() {
+      Buffer2 = require_buffer().Buffer;
+    }
+  });
+
+  // node_modules/pascalcase/index.js
+  var require_pascalcase = __commonJS({
+    "node_modules/pascalcase/index.js"(exports, module) {
+      init_buffer_shim();
+      var titlecase = (input) => input[0].toLocaleUpperCase() + input.slice(1);
+      module.exports = (value) => {
+        if (value === null || value === void 0)
+          return "";
+        if (typeof value.toString !== "function")
+          return "";
+        let input = value.toString().trim();
+        if (input === "")
+          return "";
+        if (input.length === 1)
+          return input.toLocaleUpperCase();
+        let match = input.match(/[a-zA-Z0-9]+/g);
+        if (match) {
+          return match.map((m) => titlecase(m)).join("");
+        }
+        return input;
+      };
+    }
+  });
+
+  // node_modules/clone/clone.js
+  var require_clone = __commonJS({
+    "node_modules/clone/clone.js"(exports, module) {
+      init_buffer_shim();
+      var clone2 = function() {
+        "use strict";
+        function _instanceof(obj, type) {
+          return type != null && obj instanceof type;
+        }
+        var nativeMap;
+        try {
+          nativeMap = Map;
+        } catch (_) {
+          nativeMap = function() {
+          };
+        }
+        var nativeSet;
+        try {
+          nativeSet = Set;
+        } catch (_) {
+          nativeSet = function() {
+          };
+        }
+        var nativePromise;
+        try {
+          nativePromise = Promise;
+        } catch (_) {
+          nativePromise = function() {
+          };
+        }
+        function clone3(parent, circular, depth, prototype, includeNonEnumerable) {
+          if (typeof circular === "object") {
+            depth = circular.depth;
+            prototype = circular.prototype;
+            includeNonEnumerable = circular.includeNonEnumerable;
+            circular = circular.circular;
+          }
+          var allParents = [];
+          var allChildren = [];
+          var useBuffer = typeof Buffer2 != "undefined";
+          if (typeof circular == "undefined")
+            circular = true;
+          if (typeof depth == "undefined")
+            depth = Infinity;
+          function _clone(parent2, depth2) {
+            if (parent2 === null)
+              return null;
+            if (depth2 === 0)
+              return parent2;
+            var child;
+            var proto;
+            if (typeof parent2 != "object") {
+              return parent2;
+            }
+            if (_instanceof(parent2, nativeMap)) {
+              child = new nativeMap();
+            } else if (_instanceof(parent2, nativeSet)) {
+              child = new nativeSet();
+            } else if (_instanceof(parent2, nativePromise)) {
+              child = new nativePromise(function(resolve, reject) {
+                parent2.then(function(value) {
+                  resolve(_clone(value, depth2 - 1));
+                }, function(err) {
+                  reject(_clone(err, depth2 - 1));
+                });
+              });
+            } else if (clone3.__isArray(parent2)) {
+              child = [];
+            } else if (clone3.__isRegExp(parent2)) {
+              child = new RegExp(parent2.source, __getRegExpFlags(parent2));
+              if (parent2.lastIndex)
+                child.lastIndex = parent2.lastIndex;
+            } else if (clone3.__isDate(parent2)) {
+              child = new Date(parent2.getTime());
+            } else if (useBuffer && Buffer2.isBuffer(parent2)) {
+              if (Buffer2.allocUnsafe) {
+                child = Buffer2.allocUnsafe(parent2.length);
+              } else {
+                child = new Buffer2(parent2.length);
+              }
+              parent2.copy(child);
+              return child;
+            } else if (_instanceof(parent2, Error)) {
+              child = Object.create(parent2);
+            } else {
+              if (typeof prototype == "undefined") {
+                proto = Object.getPrototypeOf(parent2);
+                child = Object.create(proto);
+              } else {
+                child = Object.create(prototype);
+                proto = prototype;
+              }
+            }
+            if (circular) {
+              var index = allParents.indexOf(parent2);
+              if (index != -1) {
+                return allChildren[index];
+              }
+              allParents.push(parent2);
+              allChildren.push(child);
+            }
+            if (_instanceof(parent2, nativeMap)) {
+              parent2.forEach(function(value, key) {
+                var keyChild = _clone(key, depth2 - 1);
+                var valueChild = _clone(value, depth2 - 1);
+                child.set(keyChild, valueChild);
+              });
+            }
+            if (_instanceof(parent2, nativeSet)) {
+              parent2.forEach(function(value) {
+                var entryChild = _clone(value, depth2 - 1);
+                child.add(entryChild);
+              });
+            }
+            for (var i in parent2) {
+              var attrs;
+              if (proto) {
+                attrs = Object.getOwnPropertyDescriptor(proto, i);
+              }
+              if (attrs && attrs.set == null) {
+                continue;
+              }
+              child[i] = _clone(parent2[i], depth2 - 1);
+            }
+            if (Object.getOwnPropertySymbols) {
+              var symbols = Object.getOwnPropertySymbols(parent2);
+              for (var i = 0; i < symbols.length; i++) {
+                var symbol = symbols[i];
+                var descriptor = Object.getOwnPropertyDescriptor(parent2, symbol);
+                if (descriptor && !descriptor.enumerable && !includeNonEnumerable) {
+                  continue;
+                }
+                child[symbol] = _clone(parent2[symbol], depth2 - 1);
+                if (!descriptor.enumerable) {
+                  Object.defineProperty(child, symbol, {
+                    enumerable: false
+                  });
+                }
+              }
+            }
+            if (includeNonEnumerable) {
+              var allPropertyNames = Object.getOwnPropertyNames(parent2);
+              for (var i = 0; i < allPropertyNames.length; i++) {
+                var propertyName = allPropertyNames[i];
+                var descriptor = Object.getOwnPropertyDescriptor(parent2, propertyName);
+                if (descriptor && descriptor.enumerable) {
+                  continue;
+                }
+                child[propertyName] = _clone(parent2[propertyName], depth2 - 1);
+                Object.defineProperty(child, propertyName, {
                   enumerable: false
                 });
               }
             }
+            return child;
           }
-          if (includeNonEnumerable) {
-            var allPropertyNames = Object.getOwnPropertyNames(parent2);
-            for (var i = 0; i < allPropertyNames.length; i++) {
-              var propertyName = allPropertyNames[i];
-              var descriptor = Object.getOwnPropertyDescriptor(parent2, propertyName);
-              if (descriptor && descriptor.enumerable) {
-                continue;
-              }
-              child[propertyName] = _clone(parent2[propertyName], depth2 - 1);
-              Object.defineProperty(child, propertyName, {
-                enumerable: false
-              });
-            }
-          }
-          return child;
+          return _clone(parent, depth);
         }
-        return _clone(parent, depth);
-      }
-      clone3.clonePrototype = function clonePrototype(parent) {
-        if (parent === null)
-          return null;
-        var c = function() {
+        clone3.clonePrototype = function clonePrototype(parent) {
+          if (parent === null)
+            return null;
+          var c = function() {
+          };
+          c.prototype = parent;
+          return new c();
         };
-        c.prototype = parent;
-        return new c();
-      };
-      function __objToStr(o) {
-        return Object.prototype.toString.call(o);
+        function __objToStr(o) {
+          return Object.prototype.toString.call(o);
+        }
+        clone3.__objToStr = __objToStr;
+        function __isDate(o) {
+          return typeof o === "object" && __objToStr(o) === "[object Date]";
+        }
+        clone3.__isDate = __isDate;
+        function __isArray(o) {
+          return typeof o === "object" && __objToStr(o) === "[object Array]";
+        }
+        clone3.__isArray = __isArray;
+        function __isRegExp(o) {
+          return typeof o === "object" && __objToStr(o) === "[object RegExp]";
+        }
+        clone3.__isRegExp = __isRegExp;
+        function __getRegExpFlags(re) {
+          var flags = "";
+          if (re.global)
+            flags += "g";
+          if (re.ignoreCase)
+            flags += "i";
+          if (re.multiline)
+            flags += "m";
+          return flags;
+        }
+        clone3.__getRegExpFlags = __getRegExpFlags;
+        return clone3;
+      }();
+      if (typeof module === "object" && module.exports) {
+        module.exports = clone2;
       }
-      clone3.__objToStr = __objToStr;
-      function __isDate(o) {
-        return typeof o === "object" && __objToStr(o) === "[object Date]";
-      }
-      clone3.__isDate = __isDate;
-      function __isArray(o) {
-        return typeof o === "object" && __objToStr(o) === "[object Array]";
-      }
-      clone3.__isArray = __isArray;
-      function __isRegExp(o) {
-        return typeof o === "object" && __objToStr(o) === "[object RegExp]";
-      }
-      clone3.__isRegExp = __isRegExp;
-      function __getRegExpFlags(re) {
-        var flags = "";
-        if (re.global)
-          flags += "g";
-        if (re.ignoreCase)
-          flags += "i";
-        if (re.multiline)
-          flags += "m";
-        return flags;
-      }
-      clone3.__getRegExpFlags = __getRegExpFlags;
-      return clone3;
-    }();
-    if (typeof module2 === "object" && module2.exports) {
-      module2.exports = clone2;
     }
-  }
-});
+  });
 
-// node_modules/has-symbols/shams.js
-var require_shams = __commonJS({
-  "node_modules/has-symbols/shams.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    module2.exports = function hasSymbols() {
-      if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function") {
-        return false;
-      }
-      if (typeof Symbol.iterator === "symbol") {
-        return true;
-      }
-      var obj = {};
-      var sym = Symbol("test");
-      var symObj = Object(sym);
-      if (typeof sym === "string") {
-        return false;
-      }
-      if (Object.prototype.toString.call(sym) !== "[object Symbol]") {
-        return false;
-      }
-      if (Object.prototype.toString.call(symObj) !== "[object Symbol]") {
-        return false;
-      }
-      var symVal = 42;
-      obj[sym] = symVal;
-      for (sym in obj) {
-        return false;
-      }
-      if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
-        return false;
-      }
-      if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0) {
-        return false;
-      }
-      var syms = Object.getOwnPropertySymbols(obj);
-      if (syms.length !== 1 || syms[0] !== sym) {
-        return false;
-      }
-      if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) {
-        return false;
-      }
-      if (typeof Object.getOwnPropertyDescriptor === "function") {
-        var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
-        if (descriptor.value !== symVal || descriptor.enumerable !== true) {
+  // node_modules/has-symbols/shams.js
+  var require_shams = __commonJS({
+    "node_modules/has-symbols/shams.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      module.exports = function hasSymbols() {
+        if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function") {
           return false;
         }
-      }
-      return true;
-    };
-  }
-});
-
-// node_modules/has-symbols/index.js
-var require_has_symbols = __commonJS({
-  "node_modules/has-symbols/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var origSymbol = typeof Symbol !== "undefined" && Symbol;
-    var hasSymbolSham = require_shams();
-    module2.exports = function hasNativeSymbols() {
-      if (typeof origSymbol !== "function") {
-        return false;
-      }
-      if (typeof Symbol !== "function") {
-        return false;
-      }
-      if (typeof origSymbol("foo") !== "symbol") {
-        return false;
-      }
-      if (typeof Symbol("bar") !== "symbol") {
-        return false;
-      }
-      return hasSymbolSham();
-    };
-  }
-});
-
-// node_modules/function-bind/implementation.js
-var require_implementation = __commonJS({
-  "node_modules/function-bind/implementation.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
-    var slice = Array.prototype.slice;
-    var toStr = Object.prototype.toString;
-    var funcType = "[object Function]";
-    module2.exports = function bind(that) {
-      var target = this;
-      if (typeof target !== "function" || toStr.call(target) !== funcType) {
-        throw new TypeError(ERROR_MESSAGE + target);
-      }
-      var args = slice.call(arguments, 1);
-      var bound;
-      var binder = function() {
-        if (this instanceof bound) {
-          var result = target.apply(this, args.concat(slice.call(arguments)));
-          if (Object(result) === result) {
-            return result;
+        if (typeof Symbol.iterator === "symbol") {
+          return true;
+        }
+        var obj = {};
+        var sym = Symbol("test");
+        var symObj = Object(sym);
+        if (typeof sym === "string") {
+          return false;
+        }
+        if (Object.prototype.toString.call(sym) !== "[object Symbol]") {
+          return false;
+        }
+        if (Object.prototype.toString.call(symObj) !== "[object Symbol]") {
+          return false;
+        }
+        var symVal = 42;
+        obj[sym] = symVal;
+        for (sym in obj) {
+          return false;
+        }
+        if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
+          return false;
+        }
+        if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0) {
+          return false;
+        }
+        var syms = Object.getOwnPropertySymbols(obj);
+        if (syms.length !== 1 || syms[0] !== sym) {
+          return false;
+        }
+        if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) {
+          return false;
+        }
+        if (typeof Object.getOwnPropertyDescriptor === "function") {
+          var descriptor = Object.getOwnPropertyDescriptor(obj, sym);
+          if (descriptor.value !== symVal || descriptor.enumerable !== true) {
+            return false;
           }
-          return this;
-        } else {
-          return target.apply(that, args.concat(slice.call(arguments)));
+        }
+        return true;
+      };
+    }
+  });
+
+  // node_modules/has-symbols/index.js
+  var require_has_symbols = __commonJS({
+    "node_modules/has-symbols/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var origSymbol = typeof Symbol !== "undefined" && Symbol;
+      var hasSymbolSham = require_shams();
+      module.exports = function hasNativeSymbols() {
+        if (typeof origSymbol !== "function") {
+          return false;
+        }
+        if (typeof Symbol !== "function") {
+          return false;
+        }
+        if (typeof origSymbol("foo") !== "symbol") {
+          return false;
+        }
+        if (typeof Symbol("bar") !== "symbol") {
+          return false;
+        }
+        return hasSymbolSham();
+      };
+    }
+  });
+
+  // node_modules/function-bind/implementation.js
+  var require_implementation = __commonJS({
+    "node_modules/function-bind/implementation.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
+      var slice = Array.prototype.slice;
+      var toStr = Object.prototype.toString;
+      var funcType = "[object Function]";
+      module.exports = function bind(that) {
+        var target = this;
+        if (typeof target !== "function" || toStr.call(target) !== funcType) {
+          throw new TypeError(ERROR_MESSAGE + target);
+        }
+        var args = slice.call(arguments, 1);
+        var bound;
+        var binder = function() {
+          if (this instanceof bound) {
+            var result = target.apply(this, args.concat(slice.call(arguments)));
+            if (Object(result) === result) {
+              return result;
+            }
+            return this;
+          } else {
+            return target.apply(that, args.concat(slice.call(arguments)));
+          }
+        };
+        var boundLength = Math.max(0, target.length - args.length);
+        var boundArgs = [];
+        for (var i = 0; i < boundLength; i++) {
+          boundArgs.push("$" + i);
+        }
+        bound = Function("binder", "return function (" + boundArgs.join(",") + "){ return binder.apply(this,arguments); }")(binder);
+        if (target.prototype) {
+          var Empty = function Empty2() {
+          };
+          Empty.prototype = target.prototype;
+          bound.prototype = new Empty();
+          Empty.prototype = null;
+        }
+        return bound;
+      };
+    }
+  });
+
+  // node_modules/function-bind/index.js
+  var require_function_bind = __commonJS({
+    "node_modules/function-bind/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var implementation = require_implementation();
+      module.exports = Function.prototype.bind || implementation;
+    }
+  });
+
+  // node_modules/has/src/index.js
+  var require_src = __commonJS({
+    "node_modules/has/src/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var bind = require_function_bind();
+      module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+    }
+  });
+
+  // node_modules/get-intrinsic/index.js
+  var require_get_intrinsic = __commonJS({
+    "node_modules/get-intrinsic/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var undefined2;
+      var $SyntaxError = SyntaxError;
+      var $Function = Function;
+      var $TypeError = TypeError;
+      var getEvalledConstructor = function(expressionSyntax) {
+        try {
+          return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
+        } catch (e) {
         }
       };
-      var boundLength = Math.max(0, target.length - args.length);
-      var boundArgs = [];
-      for (var i = 0; i < boundLength; i++) {
-        boundArgs.push("$" + i);
-      }
-      bound = Function("binder", "return function (" + boundArgs.join(",") + "){ return binder.apply(this,arguments); }")(binder);
-      if (target.prototype) {
-        var Empty = function Empty2() {
-        };
-        Empty.prototype = target.prototype;
-        bound.prototype = new Empty();
-        Empty.prototype = null;
-      }
-      return bound;
-    };
-  }
-});
-
-// node_modules/function-bind/index.js
-var require_function_bind = __commonJS({
-  "node_modules/function-bind/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var implementation = require_implementation();
-    module2.exports = Function.prototype.bind || implementation;
-  }
-});
-
-// node_modules/has/src/index.js
-var require_src = __commonJS({
-  "node_modules/has/src/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var bind = require_function_bind();
-    module2.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
-  }
-});
-
-// node_modules/get-intrinsic/index.js
-var require_get_intrinsic = __commonJS({
-  "node_modules/get-intrinsic/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var undefined2;
-    var $SyntaxError = SyntaxError;
-    var $Function = Function;
-    var $TypeError = TypeError;
-    var getEvalledConstructor = function(expressionSyntax) {
-      try {
-        return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
-      } catch (e) {
-      }
-    };
-    var $gOPD = Object.getOwnPropertyDescriptor;
-    if ($gOPD) {
-      try {
-        $gOPD({}, "");
-      } catch (e) {
-        $gOPD = null;
-      }
-    }
-    var throwTypeError = function() {
-      throw new $TypeError();
-    };
-    var ThrowTypeError = $gOPD ? function() {
-      try {
-        arguments.callee;
-        return throwTypeError;
-      } catch (calleeThrows) {
+      var $gOPD = Object.getOwnPropertyDescriptor;
+      if ($gOPD) {
         try {
-          return $gOPD(arguments, "callee").get;
-        } catch (gOPDthrows) {
+          $gOPD({}, "");
+        } catch (e) {
+          $gOPD = null;
+        }
+      }
+      var throwTypeError = function() {
+        throw new $TypeError();
+      };
+      var ThrowTypeError = $gOPD ? function() {
+        try {
+          arguments.callee;
           return throwTypeError;
-        }
-      }
-    }() : throwTypeError;
-    var hasSymbols = require_has_symbols()();
-    var getProto = Object.getPrototypeOf || function(x) {
-      return x.__proto__;
-    };
-    var needsEval = {};
-    var TypedArray = typeof Uint8Array === "undefined" ? undefined2 : getProto(Uint8Array);
-    var INTRINSICS = {
-      "%AggregateError%": typeof AggregateError === "undefined" ? undefined2 : AggregateError,
-      "%Array%": Array,
-      "%ArrayBuffer%": typeof ArrayBuffer === "undefined" ? undefined2 : ArrayBuffer,
-      "%ArrayIteratorPrototype%": hasSymbols ? getProto([][Symbol.iterator]()) : undefined2,
-      "%AsyncFromSyncIteratorPrototype%": undefined2,
-      "%AsyncFunction%": needsEval,
-      "%AsyncGenerator%": needsEval,
-      "%AsyncGeneratorFunction%": needsEval,
-      "%AsyncIteratorPrototype%": needsEval,
-      "%Atomics%": typeof Atomics === "undefined" ? undefined2 : Atomics,
-      "%BigInt%": typeof BigInt === "undefined" ? undefined2 : BigInt,
-      "%Boolean%": Boolean,
-      "%DataView%": typeof DataView === "undefined" ? undefined2 : DataView,
-      "%Date%": Date,
-      "%decodeURI%": decodeURI,
-      "%decodeURIComponent%": decodeURIComponent,
-      "%encodeURI%": encodeURI,
-      "%encodeURIComponent%": encodeURIComponent,
-      "%Error%": Error,
-      "%eval%": eval,
-      "%EvalError%": EvalError,
-      "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
-      "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
-      "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
-      "%Function%": $Function,
-      "%GeneratorFunction%": needsEval,
-      "%Int8Array%": typeof Int8Array === "undefined" ? undefined2 : Int8Array,
-      "%Int16Array%": typeof Int16Array === "undefined" ? undefined2 : Int16Array,
-      "%Int32Array%": typeof Int32Array === "undefined" ? undefined2 : Int32Array,
-      "%isFinite%": isFinite,
-      "%isNaN%": isNaN,
-      "%IteratorPrototype%": hasSymbols ? getProto(getProto([][Symbol.iterator]())) : undefined2,
-      "%JSON%": typeof JSON === "object" ? JSON : undefined2,
-      "%Map%": typeof Map === "undefined" ? undefined2 : Map,
-      "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols ? undefined2 : getProto(new Map()[Symbol.iterator]()),
-      "%Math%": Math,
-      "%Number%": Number,
-      "%Object%": Object,
-      "%parseFloat%": parseFloat,
-      "%parseInt%": parseInt,
-      "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
-      "%Proxy%": typeof Proxy === "undefined" ? undefined2 : Proxy,
-      "%RangeError%": RangeError,
-      "%ReferenceError%": ReferenceError,
-      "%Reflect%": typeof Reflect === "undefined" ? undefined2 : Reflect,
-      "%RegExp%": RegExp,
-      "%Set%": typeof Set === "undefined" ? undefined2 : Set,
-      "%SetIteratorPrototype%": typeof Set === "undefined" || !hasSymbols ? undefined2 : getProto(new Set()[Symbol.iterator]()),
-      "%SharedArrayBuffer%": typeof SharedArrayBuffer === "undefined" ? undefined2 : SharedArrayBuffer,
-      "%String%": String,
-      "%StringIteratorPrototype%": hasSymbols ? getProto(""[Symbol.iterator]()) : undefined2,
-      "%Symbol%": hasSymbols ? Symbol : undefined2,
-      "%SyntaxError%": $SyntaxError,
-      "%ThrowTypeError%": ThrowTypeError,
-      "%TypedArray%": TypedArray,
-      "%TypeError%": $TypeError,
-      "%Uint8Array%": typeof Uint8Array === "undefined" ? undefined2 : Uint8Array,
-      "%Uint8ClampedArray%": typeof Uint8ClampedArray === "undefined" ? undefined2 : Uint8ClampedArray,
-      "%Uint16Array%": typeof Uint16Array === "undefined" ? undefined2 : Uint16Array,
-      "%Uint32Array%": typeof Uint32Array === "undefined" ? undefined2 : Uint32Array,
-      "%URIError%": URIError,
-      "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
-      "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
-      "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet
-    };
-    var doEval = function doEval2(name) {
-      var value;
-      if (name === "%AsyncFunction%") {
-        value = getEvalledConstructor("async function () {}");
-      } else if (name === "%GeneratorFunction%") {
-        value = getEvalledConstructor("function* () {}");
-      } else if (name === "%AsyncGeneratorFunction%") {
-        value = getEvalledConstructor("async function* () {}");
-      } else if (name === "%AsyncGenerator%") {
-        var fn = doEval2("%AsyncGeneratorFunction%");
-        if (fn) {
-          value = fn.prototype;
-        }
-      } else if (name === "%AsyncIteratorPrototype%") {
-        var gen = doEval2("%AsyncGenerator%");
-        if (gen) {
-          value = getProto(gen.prototype);
-        }
-      }
-      INTRINSICS[name] = value;
-      return value;
-    };
-    var LEGACY_ALIASES = {
-      "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"],
-      "%ArrayPrototype%": ["Array", "prototype"],
-      "%ArrayProto_entries%": ["Array", "prototype", "entries"],
-      "%ArrayProto_forEach%": ["Array", "prototype", "forEach"],
-      "%ArrayProto_keys%": ["Array", "prototype", "keys"],
-      "%ArrayProto_values%": ["Array", "prototype", "values"],
-      "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"],
-      "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"],
-      "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"],
-      "%BooleanPrototype%": ["Boolean", "prototype"],
-      "%DataViewPrototype%": ["DataView", "prototype"],
-      "%DatePrototype%": ["Date", "prototype"],
-      "%ErrorPrototype%": ["Error", "prototype"],
-      "%EvalErrorPrototype%": ["EvalError", "prototype"],
-      "%Float32ArrayPrototype%": ["Float32Array", "prototype"],
-      "%Float64ArrayPrototype%": ["Float64Array", "prototype"],
-      "%FunctionPrototype%": ["Function", "prototype"],
-      "%Generator%": ["GeneratorFunction", "prototype"],
-      "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"],
-      "%Int8ArrayPrototype%": ["Int8Array", "prototype"],
-      "%Int16ArrayPrototype%": ["Int16Array", "prototype"],
-      "%Int32ArrayPrototype%": ["Int32Array", "prototype"],
-      "%JSONParse%": ["JSON", "parse"],
-      "%JSONStringify%": ["JSON", "stringify"],
-      "%MapPrototype%": ["Map", "prototype"],
-      "%NumberPrototype%": ["Number", "prototype"],
-      "%ObjectPrototype%": ["Object", "prototype"],
-      "%ObjProto_toString%": ["Object", "prototype", "toString"],
-      "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"],
-      "%PromisePrototype%": ["Promise", "prototype"],
-      "%PromiseProto_then%": ["Promise", "prototype", "then"],
-      "%Promise_all%": ["Promise", "all"],
-      "%Promise_reject%": ["Promise", "reject"],
-      "%Promise_resolve%": ["Promise", "resolve"],
-      "%RangeErrorPrototype%": ["RangeError", "prototype"],
-      "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"],
-      "%RegExpPrototype%": ["RegExp", "prototype"],
-      "%SetPrototype%": ["Set", "prototype"],
-      "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"],
-      "%StringPrototype%": ["String", "prototype"],
-      "%SymbolPrototype%": ["Symbol", "prototype"],
-      "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"],
-      "%TypedArrayPrototype%": ["TypedArray", "prototype"],
-      "%TypeErrorPrototype%": ["TypeError", "prototype"],
-      "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"],
-      "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"],
-      "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"],
-      "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"],
-      "%URIErrorPrototype%": ["URIError", "prototype"],
-      "%WeakMapPrototype%": ["WeakMap", "prototype"],
-      "%WeakSetPrototype%": ["WeakSet", "prototype"]
-    };
-    var bind = require_function_bind();
-    var hasOwn = require_src();
-    var $concat = bind.call(Function.call, Array.prototype.concat);
-    var $spliceApply = bind.call(Function.apply, Array.prototype.splice);
-    var $replace = bind.call(Function.call, String.prototype.replace);
-    var $strSlice = bind.call(Function.call, String.prototype.slice);
-    var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
-    var reEscapeChar = /\\(\\)?/g;
-    var stringToPath = function stringToPath2(string) {
-      var first = $strSlice(string, 0, 1);
-      var last = $strSlice(string, -1);
-      if (first === "%" && last !== "%") {
-        throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
-      } else if (last === "%" && first !== "%") {
-        throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
-      }
-      var result = [];
-      $replace(string, rePropName, function(match, number, quote, subString) {
-        result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
-      });
-      return result;
-    };
-    var getBaseIntrinsic = function getBaseIntrinsic2(name, allowMissing) {
-      var intrinsicName = name;
-      var alias;
-      if (hasOwn(LEGACY_ALIASES, intrinsicName)) {
-        alias = LEGACY_ALIASES[intrinsicName];
-        intrinsicName = "%" + alias[0] + "%";
-      }
-      if (hasOwn(INTRINSICS, intrinsicName)) {
-        var value = INTRINSICS[intrinsicName];
-        if (value === needsEval) {
-          value = doEval(intrinsicName);
-        }
-        if (typeof value === "undefined" && !allowMissing) {
-          throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
-        }
-        return {
-          alias,
-          name: intrinsicName,
-          value
-        };
-      }
-      throw new $SyntaxError("intrinsic " + name + " does not exist!");
-    };
-    module2.exports = function GetIntrinsic(name, allowMissing) {
-      if (typeof name !== "string" || name.length === 0) {
-        throw new $TypeError("intrinsic name must be a non-empty string");
-      }
-      if (arguments.length > 1 && typeof allowMissing !== "boolean") {
-        throw new $TypeError('"allowMissing" argument must be a boolean');
-      }
-      var parts = stringToPath(name);
-      var intrinsicBaseName = parts.length > 0 ? parts[0] : "";
-      var intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing);
-      var intrinsicRealName = intrinsic.name;
-      var value = intrinsic.value;
-      var skipFurtherCaching = false;
-      var alias = intrinsic.alias;
-      if (alias) {
-        intrinsicBaseName = alias[0];
-        $spliceApply(parts, $concat([0, 1], alias));
-      }
-      for (var i = 1, isOwn = true; i < parts.length; i += 1) {
-        var part = parts[i];
-        var first = $strSlice(part, 0, 1);
-        var last = $strSlice(part, -1);
-        if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last) {
-          throw new $SyntaxError("property names with quotes must have matching quotes");
-        }
-        if (part === "constructor" || !isOwn) {
-          skipFurtherCaching = true;
-        }
-        intrinsicBaseName += "." + part;
-        intrinsicRealName = "%" + intrinsicBaseName + "%";
-        if (hasOwn(INTRINSICS, intrinsicRealName)) {
-          value = INTRINSICS[intrinsicRealName];
-        } else if (value != null) {
-          if (!(part in value)) {
-            if (!allowMissing) {
-              throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
-            }
-            return void 0;
+        } catch (calleeThrows) {
+          try {
+            return $gOPD(arguments, "callee").get;
+          } catch (gOPDthrows) {
+            return throwTypeError;
           }
-          if ($gOPD && i + 1 >= parts.length) {
-            var desc = $gOPD(value, part);
-            isOwn = !!desc;
-            if (isOwn && "get" in desc && !("originalValue" in desc.get)) {
-              value = desc.get;
+        }
+      }() : throwTypeError;
+      var hasSymbols = require_has_symbols()();
+      var getProto = Object.getPrototypeOf || function(x) {
+        return x.__proto__;
+      };
+      var needsEval = {};
+      var TypedArray = typeof Uint8Array === "undefined" ? undefined2 : getProto(Uint8Array);
+      var INTRINSICS = {
+        "%AggregateError%": typeof AggregateError === "undefined" ? undefined2 : AggregateError,
+        "%Array%": Array,
+        "%ArrayBuffer%": typeof ArrayBuffer === "undefined" ? undefined2 : ArrayBuffer,
+        "%ArrayIteratorPrototype%": hasSymbols ? getProto([][Symbol.iterator]()) : undefined2,
+        "%AsyncFromSyncIteratorPrototype%": undefined2,
+        "%AsyncFunction%": needsEval,
+        "%AsyncGenerator%": needsEval,
+        "%AsyncGeneratorFunction%": needsEval,
+        "%AsyncIteratorPrototype%": needsEval,
+        "%Atomics%": typeof Atomics === "undefined" ? undefined2 : Atomics,
+        "%BigInt%": typeof BigInt === "undefined" ? undefined2 : BigInt,
+        "%Boolean%": Boolean,
+        "%DataView%": typeof DataView === "undefined" ? undefined2 : DataView,
+        "%Date%": Date,
+        "%decodeURI%": decodeURI,
+        "%decodeURIComponent%": decodeURIComponent,
+        "%encodeURI%": encodeURI,
+        "%encodeURIComponent%": encodeURIComponent,
+        "%Error%": Error,
+        "%eval%": eval,
+        "%EvalError%": EvalError,
+        "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
+        "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
+        "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
+        "%Function%": $Function,
+        "%GeneratorFunction%": needsEval,
+        "%Int8Array%": typeof Int8Array === "undefined" ? undefined2 : Int8Array,
+        "%Int16Array%": typeof Int16Array === "undefined" ? undefined2 : Int16Array,
+        "%Int32Array%": typeof Int32Array === "undefined" ? undefined2 : Int32Array,
+        "%isFinite%": isFinite,
+        "%isNaN%": isNaN,
+        "%IteratorPrototype%": hasSymbols ? getProto(getProto([][Symbol.iterator]())) : undefined2,
+        "%JSON%": typeof JSON === "object" ? JSON : undefined2,
+        "%Map%": typeof Map === "undefined" ? undefined2 : Map,
+        "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols ? undefined2 : getProto(new Map()[Symbol.iterator]()),
+        "%Math%": Math,
+        "%Number%": Number,
+        "%Object%": Object,
+        "%parseFloat%": parseFloat,
+        "%parseInt%": parseInt,
+        "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
+        "%Proxy%": typeof Proxy === "undefined" ? undefined2 : Proxy,
+        "%RangeError%": RangeError,
+        "%ReferenceError%": ReferenceError,
+        "%Reflect%": typeof Reflect === "undefined" ? undefined2 : Reflect,
+        "%RegExp%": RegExp,
+        "%Set%": typeof Set === "undefined" ? undefined2 : Set,
+        "%SetIteratorPrototype%": typeof Set === "undefined" || !hasSymbols ? undefined2 : getProto(new Set()[Symbol.iterator]()),
+        "%SharedArrayBuffer%": typeof SharedArrayBuffer === "undefined" ? undefined2 : SharedArrayBuffer,
+        "%String%": String,
+        "%StringIteratorPrototype%": hasSymbols ? getProto(""[Symbol.iterator]()) : undefined2,
+        "%Symbol%": hasSymbols ? Symbol : undefined2,
+        "%SyntaxError%": $SyntaxError,
+        "%ThrowTypeError%": ThrowTypeError,
+        "%TypedArray%": TypedArray,
+        "%TypeError%": $TypeError,
+        "%Uint8Array%": typeof Uint8Array === "undefined" ? undefined2 : Uint8Array,
+        "%Uint8ClampedArray%": typeof Uint8ClampedArray === "undefined" ? undefined2 : Uint8ClampedArray,
+        "%Uint16Array%": typeof Uint16Array === "undefined" ? undefined2 : Uint16Array,
+        "%Uint32Array%": typeof Uint32Array === "undefined" ? undefined2 : Uint32Array,
+        "%URIError%": URIError,
+        "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
+        "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
+        "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet
+      };
+      var doEval = function doEval2(name) {
+        var value;
+        if (name === "%AsyncFunction%") {
+          value = getEvalledConstructor("async function () {}");
+        } else if (name === "%GeneratorFunction%") {
+          value = getEvalledConstructor("function* () {}");
+        } else if (name === "%AsyncGeneratorFunction%") {
+          value = getEvalledConstructor("async function* () {}");
+        } else if (name === "%AsyncGenerator%") {
+          var fn = doEval2("%AsyncGeneratorFunction%");
+          if (fn) {
+            value = fn.prototype;
+          }
+        } else if (name === "%AsyncIteratorPrototype%") {
+          var gen = doEval2("%AsyncGenerator%");
+          if (gen) {
+            value = getProto(gen.prototype);
+          }
+        }
+        INTRINSICS[name] = value;
+        return value;
+      };
+      var LEGACY_ALIASES = {
+        "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"],
+        "%ArrayPrototype%": ["Array", "prototype"],
+        "%ArrayProto_entries%": ["Array", "prototype", "entries"],
+        "%ArrayProto_forEach%": ["Array", "prototype", "forEach"],
+        "%ArrayProto_keys%": ["Array", "prototype", "keys"],
+        "%ArrayProto_values%": ["Array", "prototype", "values"],
+        "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"],
+        "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"],
+        "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"],
+        "%BooleanPrototype%": ["Boolean", "prototype"],
+        "%DataViewPrototype%": ["DataView", "prototype"],
+        "%DatePrototype%": ["Date", "prototype"],
+        "%ErrorPrototype%": ["Error", "prototype"],
+        "%EvalErrorPrototype%": ["EvalError", "prototype"],
+        "%Float32ArrayPrototype%": ["Float32Array", "prototype"],
+        "%Float64ArrayPrototype%": ["Float64Array", "prototype"],
+        "%FunctionPrototype%": ["Function", "prototype"],
+        "%Generator%": ["GeneratorFunction", "prototype"],
+        "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"],
+        "%Int8ArrayPrototype%": ["Int8Array", "prototype"],
+        "%Int16ArrayPrototype%": ["Int16Array", "prototype"],
+        "%Int32ArrayPrototype%": ["Int32Array", "prototype"],
+        "%JSONParse%": ["JSON", "parse"],
+        "%JSONStringify%": ["JSON", "stringify"],
+        "%MapPrototype%": ["Map", "prototype"],
+        "%NumberPrototype%": ["Number", "prototype"],
+        "%ObjectPrototype%": ["Object", "prototype"],
+        "%ObjProto_toString%": ["Object", "prototype", "toString"],
+        "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"],
+        "%PromisePrototype%": ["Promise", "prototype"],
+        "%PromiseProto_then%": ["Promise", "prototype", "then"],
+        "%Promise_all%": ["Promise", "all"],
+        "%Promise_reject%": ["Promise", "reject"],
+        "%Promise_resolve%": ["Promise", "resolve"],
+        "%RangeErrorPrototype%": ["RangeError", "prototype"],
+        "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"],
+        "%RegExpPrototype%": ["RegExp", "prototype"],
+        "%SetPrototype%": ["Set", "prototype"],
+        "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"],
+        "%StringPrototype%": ["String", "prototype"],
+        "%SymbolPrototype%": ["Symbol", "prototype"],
+        "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"],
+        "%TypedArrayPrototype%": ["TypedArray", "prototype"],
+        "%TypeErrorPrototype%": ["TypeError", "prototype"],
+        "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"],
+        "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"],
+        "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"],
+        "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"],
+        "%URIErrorPrototype%": ["URIError", "prototype"],
+        "%WeakMapPrototype%": ["WeakMap", "prototype"],
+        "%WeakSetPrototype%": ["WeakSet", "prototype"]
+      };
+      var bind = require_function_bind();
+      var hasOwn = require_src();
+      var $concat = bind.call(Function.call, Array.prototype.concat);
+      var $spliceApply = bind.call(Function.apply, Array.prototype.splice);
+      var $replace = bind.call(Function.call, String.prototype.replace);
+      var $strSlice = bind.call(Function.call, String.prototype.slice);
+      var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
+      var reEscapeChar = /\\(\\)?/g;
+      var stringToPath = function stringToPath2(string) {
+        var first = $strSlice(string, 0, 1);
+        var last = $strSlice(string, -1);
+        if (first === "%" && last !== "%") {
+          throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
+        } else if (last === "%" && first !== "%") {
+          throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
+        }
+        var result = [];
+        $replace(string, rePropName, function(match, number, quote, subString) {
+          result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
+        });
+        return result;
+      };
+      var getBaseIntrinsic = function getBaseIntrinsic2(name, allowMissing) {
+        var intrinsicName = name;
+        var alias;
+        if (hasOwn(LEGACY_ALIASES, intrinsicName)) {
+          alias = LEGACY_ALIASES[intrinsicName];
+          intrinsicName = "%" + alias[0] + "%";
+        }
+        if (hasOwn(INTRINSICS, intrinsicName)) {
+          var value = INTRINSICS[intrinsicName];
+          if (value === needsEval) {
+            value = doEval(intrinsicName);
+          }
+          if (typeof value === "undefined" && !allowMissing) {
+            throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
+          }
+          return {
+            alias,
+            name: intrinsicName,
+            value
+          };
+        }
+        throw new $SyntaxError("intrinsic " + name + " does not exist!");
+      };
+      module.exports = function GetIntrinsic(name, allowMissing) {
+        if (typeof name !== "string" || name.length === 0) {
+          throw new $TypeError("intrinsic name must be a non-empty string");
+        }
+        if (arguments.length > 1 && typeof allowMissing !== "boolean") {
+          throw new $TypeError('"allowMissing" argument must be a boolean');
+        }
+        var parts = stringToPath(name);
+        var intrinsicBaseName = parts.length > 0 ? parts[0] : "";
+        var intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing);
+        var intrinsicRealName = intrinsic.name;
+        var value = intrinsic.value;
+        var skipFurtherCaching = false;
+        var alias = intrinsic.alias;
+        if (alias) {
+          intrinsicBaseName = alias[0];
+          $spliceApply(parts, $concat([0, 1], alias));
+        }
+        for (var i = 1, isOwn = true; i < parts.length; i += 1) {
+          var part = parts[i];
+          var first = $strSlice(part, 0, 1);
+          var last = $strSlice(part, -1);
+          if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last) {
+            throw new $SyntaxError("property names with quotes must have matching quotes");
+          }
+          if (part === "constructor" || !isOwn) {
+            skipFurtherCaching = true;
+          }
+          intrinsicBaseName += "." + part;
+          intrinsicRealName = "%" + intrinsicBaseName + "%";
+          if (hasOwn(INTRINSICS, intrinsicRealName)) {
+            value = INTRINSICS[intrinsicRealName];
+          } else if (value != null) {
+            if (!(part in value)) {
+              if (!allowMissing) {
+                throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
+              }
+              return void 0;
+            }
+            if ($gOPD && i + 1 >= parts.length) {
+              var desc = $gOPD(value, part);
+              isOwn = !!desc;
+              if (isOwn && "get" in desc && !("originalValue" in desc.get)) {
+                value = desc.get;
+              } else {
+                value = value[part];
+              }
             } else {
+              isOwn = hasOwn(value, part);
               value = value[part];
             }
-          } else {
-            isOwn = hasOwn(value, part);
-            value = value[part];
-          }
-          if (isOwn && !skipFurtherCaching) {
-            INTRINSICS[intrinsicRealName] = value;
+            if (isOwn && !skipFurtherCaching) {
+              INTRINSICS[intrinsicRealName] = value;
+            }
           }
         }
-      }
-      return value;
-    };
-  }
-});
-
-// node_modules/call-bind/index.js
-var require_call_bind = __commonJS({
-  "node_modules/call-bind/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var bind = require_function_bind();
-    var GetIntrinsic = require_get_intrinsic();
-    var $apply = GetIntrinsic("%Function.prototype.apply%");
-    var $call = GetIntrinsic("%Function.prototype.call%");
-    var $reflectApply = GetIntrinsic("%Reflect.apply%", true) || bind.call($call, $apply);
-    var $gOPD = GetIntrinsic("%Object.getOwnPropertyDescriptor%", true);
-    var $defineProperty = GetIntrinsic("%Object.defineProperty%", true);
-    var $max = GetIntrinsic("%Math.max%");
-    if ($defineProperty) {
-      try {
-        $defineProperty({}, "a", { value: 1 });
-      } catch (e) {
-        $defineProperty = null;
-      }
+        return value;
+      };
     }
-    module2.exports = function callBind(originalFunction) {
-      var func = $reflectApply(bind, $call, arguments);
-      if ($gOPD && $defineProperty) {
-        var desc = $gOPD(func, "length");
-        if (desc.configurable) {
-          $defineProperty(func, "length", { value: 1 + $max(0, originalFunction.length - (arguments.length - 1)) });
+  });
+
+  // node_modules/call-bind/index.js
+  var require_call_bind = __commonJS({
+    "node_modules/call-bind/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var bind = require_function_bind();
+      var GetIntrinsic = require_get_intrinsic();
+      var $apply = GetIntrinsic("%Function.prototype.apply%");
+      var $call = GetIntrinsic("%Function.prototype.call%");
+      var $reflectApply = GetIntrinsic("%Reflect.apply%", true) || bind.call($call, $apply);
+      var $gOPD = GetIntrinsic("%Object.getOwnPropertyDescriptor%", true);
+      var $defineProperty = GetIntrinsic("%Object.defineProperty%", true);
+      var $max = GetIntrinsic("%Math.max%");
+      if ($defineProperty) {
+        try {
+          $defineProperty({}, "a", { value: 1 });
+        } catch (e) {
+          $defineProperty = null;
         }
       }
-      return func;
-    };
-    var applyBind = function applyBind2() {
-      return $reflectApply(bind, $apply, arguments);
-    };
-    if ($defineProperty) {
-      $defineProperty(module2.exports, "apply", { value: applyBind });
-    } else {
-      module2.exports.apply = applyBind;
+      module.exports = function callBind(originalFunction) {
+        var func = $reflectApply(bind, $call, arguments);
+        if ($gOPD && $defineProperty) {
+          var desc = $gOPD(func, "length");
+          if (desc.configurable) {
+            $defineProperty(func, "length", { value: 1 + $max(0, originalFunction.length - (arguments.length - 1)) });
+          }
+        }
+        return func;
+      };
+      var applyBind = function applyBind2() {
+        return $reflectApply(bind, $apply, arguments);
+      };
+      if ($defineProperty) {
+        $defineProperty(module.exports, "apply", { value: applyBind });
+      } else {
+        module.exports.apply = applyBind;
+      }
     }
-  }
-});
+  });
 
-// node_modules/call-bind/callBound.js
-var require_callBound = __commonJS({
-  "node_modules/call-bind/callBound.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var callBind = require_call_bind();
-    var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
-    module2.exports = function callBoundIntrinsic(name, allowMissing) {
-      var intrinsic = GetIntrinsic(name, !!allowMissing);
-      if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
-        return callBind(intrinsic);
-      }
-      return intrinsic;
-    };
-  }
-});
+  // node_modules/call-bind/callBound.js
+  var require_callBound = __commonJS({
+    "node_modules/call-bind/callBound.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var GetIntrinsic = require_get_intrinsic();
+      var callBind = require_call_bind();
+      var $indexOf = callBind(GetIntrinsic("String.prototype.indexOf"));
+      module.exports = function callBoundIntrinsic(name, allowMissing) {
+        var intrinsic = GetIntrinsic(name, !!allowMissing);
+        if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
+          return callBind(intrinsic);
+        }
+        return intrinsic;
+      };
+    }
+  });
 
-// (disabled):node_modules/object-inspect/util.inspect
-var require_util = __commonJS({
-  "(disabled):node_modules/object-inspect/util.inspect"() {
-    init_buffer_shim();
-  }
-});
+  // (disabled):node_modules/object-inspect/util.inspect
+  var require_util = __commonJS({
+    "(disabled):node_modules/object-inspect/util.inspect"() {
+      init_buffer_shim();
+    }
+  });
 
-// node_modules/object-inspect/index.js
-var require_object_inspect = __commonJS({
-  "node_modules/object-inspect/index.js"(exports, module2) {
-    init_buffer_shim();
-    var hasMap = typeof Map === "function" && Map.prototype;
-    var mapSizeDescriptor = Object.getOwnPropertyDescriptor && hasMap ? Object.getOwnPropertyDescriptor(Map.prototype, "size") : null;
-    var mapSize = hasMap && mapSizeDescriptor && typeof mapSizeDescriptor.get === "function" ? mapSizeDescriptor.get : null;
-    var mapForEach = hasMap && Map.prototype.forEach;
-    var hasSet = typeof Set === "function" && Set.prototype;
-    var setSizeDescriptor = Object.getOwnPropertyDescriptor && hasSet ? Object.getOwnPropertyDescriptor(Set.prototype, "size") : null;
-    var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === "function" ? setSizeDescriptor.get : null;
-    var setForEach = hasSet && Set.prototype.forEach;
-    var hasWeakMap = typeof WeakMap === "function" && WeakMap.prototype;
-    var weakMapHas = hasWeakMap ? WeakMap.prototype.has : null;
-    var hasWeakSet = typeof WeakSet === "function" && WeakSet.prototype;
-    var weakSetHas = hasWeakSet ? WeakSet.prototype.has : null;
-    var hasWeakRef = typeof WeakRef === "function" && WeakRef.prototype;
-    var weakRefDeref = hasWeakRef ? WeakRef.prototype.deref : null;
-    var booleanValueOf = Boolean.prototype.valueOf;
-    var objectToString = Object.prototype.toString;
-    var functionToString = Function.prototype.toString;
-    var match = String.prototype.match;
-    var bigIntValueOf = typeof BigInt === "function" ? BigInt.prototype.valueOf : null;
-    var gOPS = Object.getOwnPropertySymbols;
-    var symToString = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? Symbol.prototype.toString : null;
-    var hasShammedSymbols = typeof Symbol === "function" && typeof Symbol.iterator === "object";
-    var isEnumerable = Object.prototype.propertyIsEnumerable;
-    var gPO = (typeof Reflect === "function" ? Reflect.getPrototypeOf : Object.getPrototypeOf) || ([].__proto__ === Array.prototype ? function(O) {
-      return O.__proto__;
-    } : null);
-    var inspectCustom = require_util().custom;
-    var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
-    var toStringTag = typeof Symbol === "function" && typeof Symbol.toStringTag !== "undefined" ? Symbol.toStringTag : null;
-    module2.exports = function inspect_(obj, options, depth, seen) {
-      var opts = options || {};
-      if (has(opts, "quoteStyle") && (opts.quoteStyle !== "single" && opts.quoteStyle !== "double")) {
-        throw new TypeError('option "quoteStyle" must be "single" or "double"');
-      }
-      if (has(opts, "maxStringLength") && (typeof opts.maxStringLength === "number" ? opts.maxStringLength < 0 && opts.maxStringLength !== Infinity : opts.maxStringLength !== null)) {
-        throw new TypeError('option "maxStringLength", if provided, must be a positive integer, Infinity, or `null`');
-      }
-      var customInspect = has(opts, "customInspect") ? opts.customInspect : true;
-      if (typeof customInspect !== "boolean") {
-        throw new TypeError('option "customInspect", if provided, must be `true` or `false`');
-      }
-      if (has(opts, "indent") && opts.indent !== null && opts.indent !== "	" && !(parseInt(opts.indent, 10) === opts.indent && opts.indent > 0)) {
-        throw new TypeError('options "indent" must be "\\t", an integer > 0, or `null`');
-      }
-      if (typeof obj === "undefined") {
-        return "undefined";
-      }
-      if (obj === null) {
-        return "null";
-      }
-      if (typeof obj === "boolean") {
-        return obj ? "true" : "false";
-      }
-      if (typeof obj === "string") {
-        return inspectString(obj, opts);
-      }
-      if (typeof obj === "number") {
-        if (obj === 0) {
-          return Infinity / obj > 0 ? "0" : "-0";
+  // node_modules/object-inspect/index.js
+  var require_object_inspect = __commonJS({
+    "node_modules/object-inspect/index.js"(exports, module) {
+      init_buffer_shim();
+      var hasMap = typeof Map === "function" && Map.prototype;
+      var mapSizeDescriptor = Object.getOwnPropertyDescriptor && hasMap ? Object.getOwnPropertyDescriptor(Map.prototype, "size") : null;
+      var mapSize = hasMap && mapSizeDescriptor && typeof mapSizeDescriptor.get === "function" ? mapSizeDescriptor.get : null;
+      var mapForEach = hasMap && Map.prototype.forEach;
+      var hasSet = typeof Set === "function" && Set.prototype;
+      var setSizeDescriptor = Object.getOwnPropertyDescriptor && hasSet ? Object.getOwnPropertyDescriptor(Set.prototype, "size") : null;
+      var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === "function" ? setSizeDescriptor.get : null;
+      var setForEach = hasSet && Set.prototype.forEach;
+      var hasWeakMap = typeof WeakMap === "function" && WeakMap.prototype;
+      var weakMapHas = hasWeakMap ? WeakMap.prototype.has : null;
+      var hasWeakSet = typeof WeakSet === "function" && WeakSet.prototype;
+      var weakSetHas = hasWeakSet ? WeakSet.prototype.has : null;
+      var hasWeakRef = typeof WeakRef === "function" && WeakRef.prototype;
+      var weakRefDeref = hasWeakRef ? WeakRef.prototype.deref : null;
+      var booleanValueOf = Boolean.prototype.valueOf;
+      var objectToString = Object.prototype.toString;
+      var functionToString = Function.prototype.toString;
+      var match = String.prototype.match;
+      var bigIntValueOf = typeof BigInt === "function" ? BigInt.prototype.valueOf : null;
+      var gOPS = Object.getOwnPropertySymbols;
+      var symToString = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? Symbol.prototype.toString : null;
+      var hasShammedSymbols = typeof Symbol === "function" && typeof Symbol.iterator === "object";
+      var isEnumerable = Object.prototype.propertyIsEnumerable;
+      var gPO = (typeof Reflect === "function" ? Reflect.getPrototypeOf : Object.getPrototypeOf) || ([].__proto__ === Array.prototype ? function(O) {
+        return O.__proto__;
+      } : null);
+      var inspectCustom = require_util().custom;
+      var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
+      var toStringTag = typeof Symbol === "function" && typeof Symbol.toStringTag !== "undefined" ? Symbol.toStringTag : null;
+      module.exports = function inspect_(obj, options, depth, seen) {
+        var opts = options || {};
+        if (has(opts, "quoteStyle") && (opts.quoteStyle !== "single" && opts.quoteStyle !== "double")) {
+          throw new TypeError('option "quoteStyle" must be "single" or "double"');
+        }
+        if (has(opts, "maxStringLength") && (typeof opts.maxStringLength === "number" ? opts.maxStringLength < 0 && opts.maxStringLength !== Infinity : opts.maxStringLength !== null)) {
+          throw new TypeError('option "maxStringLength", if provided, must be a positive integer, Infinity, or `null`');
+        }
+        var customInspect = has(opts, "customInspect") ? opts.customInspect : true;
+        if (typeof customInspect !== "boolean") {
+          throw new TypeError('option "customInspect", if provided, must be `true` or `false`');
+        }
+        if (has(opts, "indent") && opts.indent !== null && opts.indent !== "	" && !(parseInt(opts.indent, 10) === opts.indent && opts.indent > 0)) {
+          throw new TypeError('options "indent" must be "\\t", an integer > 0, or `null`');
+        }
+        if (typeof obj === "undefined") {
+          return "undefined";
+        }
+        if (obj === null) {
+          return "null";
+        }
+        if (typeof obj === "boolean") {
+          return obj ? "true" : "false";
+        }
+        if (typeof obj === "string") {
+          return inspectString(obj, opts);
+        }
+        if (typeof obj === "number") {
+          if (obj === 0) {
+            return Infinity / obj > 0 ? "0" : "-0";
+          }
+          return String(obj);
+        }
+        if (typeof obj === "bigint") {
+          return String(obj) + "n";
+        }
+        var maxDepth = typeof opts.depth === "undefined" ? 5 : opts.depth;
+        if (typeof depth === "undefined") {
+          depth = 0;
+        }
+        if (depth >= maxDepth && maxDepth > 0 && typeof obj === "object") {
+          return isArray2(obj) ? "[Array]" : "[Object]";
+        }
+        var indent = getIndent(opts, depth);
+        if (typeof seen === "undefined") {
+          seen = [];
+        } else if (indexOf(seen, obj) >= 0) {
+          return "[Circular]";
+        }
+        function inspect(value, from, noIndent) {
+          if (from) {
+            seen = seen.slice();
+            seen.push(from);
+          }
+          if (noIndent) {
+            var newOpts = {
+              depth: opts.depth
+            };
+            if (has(opts, "quoteStyle")) {
+              newOpts.quoteStyle = opts.quoteStyle;
+            }
+            return inspect_(value, newOpts, depth + 1, seen);
+          }
+          return inspect_(value, opts, depth + 1, seen);
+        }
+        if (typeof obj === "function") {
+          var name = nameOf(obj);
+          var keys = arrObjKeys(obj, inspect);
+          return "[Function" + (name ? ": " + name : " (anonymous)") + "]" + (keys.length > 0 ? " { " + keys.join(", ") + " }" : "");
+        }
+        if (isSymbol(obj)) {
+          var symString = hasShammedSymbols ? String(obj).replace(/^(Symbol\(.*\))_[^)]*$/, "$1") : symToString.call(obj);
+          return typeof obj === "object" && !hasShammedSymbols ? markBoxed(symString) : symString;
+        }
+        if (isElement(obj)) {
+          var s = "<" + String(obj.nodeName).toLowerCase();
+          var attrs = obj.attributes || [];
+          for (var i = 0; i < attrs.length; i++) {
+            s += " " + attrs[i].name + "=" + wrapQuotes(quote(attrs[i].value), "double", opts);
+          }
+          s += ">";
+          if (obj.childNodes && obj.childNodes.length) {
+            s += "...";
+          }
+          s += "</" + String(obj.nodeName).toLowerCase() + ">";
+          return s;
+        }
+        if (isArray2(obj)) {
+          if (obj.length === 0) {
+            return "[]";
+          }
+          var xs = arrObjKeys(obj, inspect);
+          if (indent && !singleLineValues(xs)) {
+            return "[" + indentedJoin(xs, indent) + "]";
+          }
+          return "[ " + xs.join(", ") + " ]";
+        }
+        if (isError(obj)) {
+          var parts = arrObjKeys(obj, inspect);
+          if (parts.length === 0) {
+            return "[" + String(obj) + "]";
+          }
+          return "{ [" + String(obj) + "] " + parts.join(", ") + " }";
+        }
+        if (typeof obj === "object" && customInspect) {
+          if (inspectSymbol && typeof obj[inspectSymbol] === "function") {
+            return obj[inspectSymbol]();
+          } else if (typeof obj.inspect === "function") {
+            return obj.inspect();
+          }
+        }
+        if (isMap(obj)) {
+          var mapParts = [];
+          mapForEach.call(obj, function(value, key) {
+            mapParts.push(inspect(key, obj, true) + " => " + inspect(value, obj));
+          });
+          return collectionOf("Map", mapSize.call(obj), mapParts, indent);
+        }
+        if (isSet(obj)) {
+          var setParts = [];
+          setForEach.call(obj, function(value) {
+            setParts.push(inspect(value, obj));
+          });
+          return collectionOf("Set", setSize.call(obj), setParts, indent);
+        }
+        if (isWeakMap(obj)) {
+          return weakCollectionOf("WeakMap");
+        }
+        if (isWeakSet(obj)) {
+          return weakCollectionOf("WeakSet");
+        }
+        if (isWeakRef(obj)) {
+          return weakCollectionOf("WeakRef");
+        }
+        if (isNumber(obj)) {
+          return markBoxed(inspect(Number(obj)));
+        }
+        if (isBigInt(obj)) {
+          return markBoxed(inspect(bigIntValueOf.call(obj)));
+        }
+        if (isBoolean(obj)) {
+          return markBoxed(booleanValueOf.call(obj));
+        }
+        if (isString(obj)) {
+          return markBoxed(inspect(String(obj)));
+        }
+        if (!isDate(obj) && !isRegExp(obj)) {
+          var ys = arrObjKeys(obj, inspect);
+          var isPlainObject = gPO ? gPO(obj) === Object.prototype : obj instanceof Object || obj.constructor === Object;
+          var protoTag = obj instanceof Object ? "" : "null prototype";
+          var stringTag = !isPlainObject && toStringTag && Object(obj) === obj && toStringTag in obj ? toStr(obj).slice(8, -1) : protoTag ? "Object" : "";
+          var constructorTag = isPlainObject || typeof obj.constructor !== "function" ? "" : obj.constructor.name ? obj.constructor.name + " " : "";
+          var tag = constructorTag + (stringTag || protoTag ? "[" + [].concat(stringTag || [], protoTag || []).join(": ") + "] " : "");
+          if (ys.length === 0) {
+            return tag + "{}";
+          }
+          if (indent) {
+            return tag + "{" + indentedJoin(ys, indent) + "}";
+          }
+          return tag + "{ " + ys.join(", ") + " }";
         }
         return String(obj);
+      };
+      function wrapQuotes(s, defaultStyle, opts) {
+        var quoteChar = (opts.quoteStyle || defaultStyle) === "double" ? '"' : "'";
+        return quoteChar + s + quoteChar;
       }
-      if (typeof obj === "bigint") {
-        return String(obj) + "n";
+      function quote(s) {
+        return String(s).replace(/"/g, "&quot;");
       }
-      var maxDepth = typeof opts.depth === "undefined" ? 5 : opts.depth;
-      if (typeof depth === "undefined") {
-        depth = 0;
+      function isArray2(obj) {
+        return toStr(obj) === "[object Array]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      if (depth >= maxDepth && maxDepth > 0 && typeof obj === "object") {
-        return isArray2(obj) ? "[Array]" : "[Object]";
+      function isDate(obj) {
+        return toStr(obj) === "[object Date]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      var indent = getIndent(opts, depth);
-      if (typeof seen === "undefined") {
-        seen = [];
-      } else if (indexOf(seen, obj) >= 0) {
-        return "[Circular]";
+      function isRegExp(obj) {
+        return toStr(obj) === "[object RegExp]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
       }
-      function inspect(value, from, noIndent) {
-        if (from) {
-          seen = seen.slice();
-          seen.push(from);
+      function isError(obj) {
+        return toStr(obj) === "[object Error]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isString(obj) {
+        return toStr(obj) === "[object String]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isNumber(obj) {
+        return toStr(obj) === "[object Number]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isBoolean(obj) {
+        return toStr(obj) === "[object Boolean]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
+      }
+      function isSymbol(obj) {
+        if (hasShammedSymbols) {
+          return obj && typeof obj === "object" && obj instanceof Symbol;
         }
-        if (noIndent) {
-          var newOpts = {
-            depth: opts.depth
-          };
-          if (has(opts, "quoteStyle")) {
-            newOpts.quoteStyle = opts.quoteStyle;
+        if (typeof obj === "symbol") {
+          return true;
+        }
+        if (!obj || typeof obj !== "object" || !symToString) {
+          return false;
+        }
+        try {
+          symToString.call(obj);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isBigInt(obj) {
+        if (!obj || typeof obj !== "object" || !bigIntValueOf) {
+          return false;
+        }
+        try {
+          bigIntValueOf.call(obj);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      var hasOwn = Object.prototype.hasOwnProperty || function(key) {
+        return key in this;
+      };
+      function has(obj, key) {
+        return hasOwn.call(obj, key);
+      }
+      function toStr(obj) {
+        return objectToString.call(obj);
+      }
+      function nameOf(f) {
+        if (f.name) {
+          return f.name;
+        }
+        var m = match.call(functionToString.call(f), /^function\s*([\w$]+)/);
+        if (m) {
+          return m[1];
+        }
+        return null;
+      }
+      function indexOf(xs, x) {
+        if (xs.indexOf) {
+          return xs.indexOf(x);
+        }
+        for (var i = 0, l = xs.length; i < l; i++) {
+          if (xs[i] === x) {
+            return i;
           }
-          return inspect_(value, newOpts, depth + 1, seen);
         }
-        return inspect_(value, opts, depth + 1, seen);
+        return -1;
       }
-      if (typeof obj === "function") {
-        var name = nameOf(obj);
-        var keys = arrObjKeys(obj, inspect);
-        return "[Function" + (name ? ": " + name : " (anonymous)") + "]" + (keys.length > 0 ? " { " + keys.join(", ") + " }" : "");
-      }
-      if (isSymbol(obj)) {
-        var symString = hasShammedSymbols ? String(obj).replace(/^(Symbol\(.*\))_[^)]*$/, "$1") : symToString.call(obj);
-        return typeof obj === "object" && !hasShammedSymbols ? markBoxed(symString) : symString;
-      }
-      if (isElement(obj)) {
-        var s = "<" + String(obj.nodeName).toLowerCase();
-        var attrs = obj.attributes || [];
-        for (var i = 0; i < attrs.length; i++) {
-          s += " " + attrs[i].name + "=" + wrapQuotes(quote(attrs[i].value), "double", opts);
+      function isMap(x) {
+        if (!mapSize || !x || typeof x !== "object") {
+          return false;
         }
-        s += ">";
-        if (obj.childNodes && obj.childNodes.length) {
-          s += "...";
-        }
-        s += "</" + String(obj.nodeName).toLowerCase() + ">";
-        return s;
-      }
-      if (isArray2(obj)) {
-        if (obj.length === 0) {
-          return "[]";
-        }
-        var xs = arrObjKeys(obj, inspect);
-        if (indent && !singleLineValues(xs)) {
-          return "[" + indentedJoin(xs, indent) + "]";
-        }
-        return "[ " + xs.join(", ") + " ]";
-      }
-      if (isError(obj)) {
-        var parts = arrObjKeys(obj, inspect);
-        if (parts.length === 0) {
-          return "[" + String(obj) + "]";
-        }
-        return "{ [" + String(obj) + "] " + parts.join(", ") + " }";
-      }
-      if (typeof obj === "object" && customInspect) {
-        if (inspectSymbol && typeof obj[inspectSymbol] === "function") {
-          return obj[inspectSymbol]();
-        } else if (typeof obj.inspect === "function") {
-          return obj.inspect();
-        }
-      }
-      if (isMap(obj)) {
-        var mapParts = [];
-        mapForEach.call(obj, function(value, key) {
-          mapParts.push(inspect(key, obj, true) + " => " + inspect(value, obj));
-        });
-        return collectionOf("Map", mapSize.call(obj), mapParts, indent);
-      }
-      if (isSet(obj)) {
-        var setParts = [];
-        setForEach.call(obj, function(value) {
-          setParts.push(inspect(value, obj));
-        });
-        return collectionOf("Set", setSize.call(obj), setParts, indent);
-      }
-      if (isWeakMap(obj)) {
-        return weakCollectionOf("WeakMap");
-      }
-      if (isWeakSet(obj)) {
-        return weakCollectionOf("WeakSet");
-      }
-      if (isWeakRef(obj)) {
-        return weakCollectionOf("WeakRef");
-      }
-      if (isNumber(obj)) {
-        return markBoxed(inspect(Number(obj)));
-      }
-      if (isBigInt(obj)) {
-        return markBoxed(inspect(bigIntValueOf.call(obj)));
-      }
-      if (isBoolean(obj)) {
-        return markBoxed(booleanValueOf.call(obj));
-      }
-      if (isString(obj)) {
-        return markBoxed(inspect(String(obj)));
-      }
-      if (!isDate(obj) && !isRegExp(obj)) {
-        var ys = arrObjKeys(obj, inspect);
-        var isPlainObject = gPO ? gPO(obj) === Object.prototype : obj instanceof Object || obj.constructor === Object;
-        var protoTag = obj instanceof Object ? "" : "null prototype";
-        var stringTag = !isPlainObject && toStringTag && Object(obj) === obj && toStringTag in obj ? toStr(obj).slice(8, -1) : protoTag ? "Object" : "";
-        var constructorTag = isPlainObject || typeof obj.constructor !== "function" ? "" : obj.constructor.name ? obj.constructor.name + " " : "";
-        var tag = constructorTag + (stringTag || protoTag ? "[" + [].concat(stringTag || [], protoTag || []).join(": ") + "] " : "");
-        if (ys.length === 0) {
-          return tag + "{}";
-        }
-        if (indent) {
-          return tag + "{" + indentedJoin(ys, indent) + "}";
-        }
-        return tag + "{ " + ys.join(", ") + " }";
-      }
-      return String(obj);
-    };
-    function wrapQuotes(s, defaultStyle, opts) {
-      var quoteChar = (opts.quoteStyle || defaultStyle) === "double" ? '"' : "'";
-      return quoteChar + s + quoteChar;
-    }
-    function quote(s) {
-      return String(s).replace(/"/g, "&quot;");
-    }
-    function isArray2(obj) {
-      return toStr(obj) === "[object Array]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isDate(obj) {
-      return toStr(obj) === "[object Date]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isRegExp(obj) {
-      return toStr(obj) === "[object RegExp]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isError(obj) {
-      return toStr(obj) === "[object Error]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isString(obj) {
-      return toStr(obj) === "[object String]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isNumber(obj) {
-      return toStr(obj) === "[object Number]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isBoolean(obj) {
-      return toStr(obj) === "[object Boolean]" && (!toStringTag || !(typeof obj === "object" && toStringTag in obj));
-    }
-    function isSymbol(obj) {
-      if (hasShammedSymbols) {
-        return obj && typeof obj === "object" && obj instanceof Symbol;
-      }
-      if (typeof obj === "symbol") {
-        return true;
-      }
-      if (!obj || typeof obj !== "object" || !symToString) {
-        return false;
-      }
-      try {
-        symToString.call(obj);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isBigInt(obj) {
-      if (!obj || typeof obj !== "object" || !bigIntValueOf) {
-        return false;
-      }
-      try {
-        bigIntValueOf.call(obj);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    var hasOwn = Object.prototype.hasOwnProperty || function(key) {
-      return key in this;
-    };
-    function has(obj, key) {
-      return hasOwn.call(obj, key);
-    }
-    function toStr(obj) {
-      return objectToString.call(obj);
-    }
-    function nameOf(f) {
-      if (f.name) {
-        return f.name;
-      }
-      var m = match.call(functionToString.call(f), /^function\s*([\w$]+)/);
-      if (m) {
-        return m[1];
-      }
-      return null;
-    }
-    function indexOf(xs, x) {
-      if (xs.indexOf) {
-        return xs.indexOf(x);
-      }
-      for (var i = 0, l = xs.length; i < l; i++) {
-        if (xs[i] === x) {
-          return i;
-        }
-      }
-      return -1;
-    }
-    function isMap(x) {
-      if (!mapSize || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        mapSize.call(x);
-        try {
-          setSize.call(x);
-        } catch (s) {
-          return true;
-        }
-        return x instanceof Map;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakMap(x) {
-      if (!weakMapHas || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        weakMapHas.call(x, weakMapHas);
-        try {
-          weakSetHas.call(x, weakSetHas);
-        } catch (s) {
-          return true;
-        }
-        return x instanceof WeakMap;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakRef(x) {
-      if (!weakRefDeref || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        weakRefDeref.call(x);
-        return true;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isSet(x) {
-      if (!setSize || !x || typeof x !== "object") {
-        return false;
-      }
-      try {
-        setSize.call(x);
         try {
           mapSize.call(x);
-        } catch (m) {
-          return true;
+          try {
+            setSize.call(x);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof Map;
+        } catch (e) {
         }
-        return x instanceof Set;
-      } catch (e) {
-      }
-      return false;
-    }
-    function isWeakSet(x) {
-      if (!weakSetHas || !x || typeof x !== "object") {
         return false;
       }
-      try {
-        weakSetHas.call(x, weakSetHas);
+      function isWeakMap(x) {
+        if (!weakMapHas || !x || typeof x !== "object") {
+          return false;
+        }
         try {
           weakMapHas.call(x, weakMapHas);
-        } catch (s) {
+          try {
+            weakSetHas.call(x, weakSetHas);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof WeakMap;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isWeakRef(x) {
+        if (!weakRefDeref || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          weakRefDeref.call(x);
+          return true;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isSet(x) {
+        if (!setSize || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          setSize.call(x);
+          try {
+            mapSize.call(x);
+          } catch (m) {
+            return true;
+          }
+          return x instanceof Set;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isWeakSet(x) {
+        if (!weakSetHas || !x || typeof x !== "object") {
+          return false;
+        }
+        try {
+          weakSetHas.call(x, weakSetHas);
+          try {
+            weakMapHas.call(x, weakMapHas);
+          } catch (s) {
+            return true;
+          }
+          return x instanceof WeakSet;
+        } catch (e) {
+        }
+        return false;
+      }
+      function isElement(x) {
+        if (!x || typeof x !== "object") {
+          return false;
+        }
+        if (typeof HTMLElement !== "undefined" && x instanceof HTMLElement) {
           return true;
         }
-        return x instanceof WeakSet;
-      } catch (e) {
+        return typeof x.nodeName === "string" && typeof x.getAttribute === "function";
       }
-      return false;
-    }
-    function isElement(x) {
-      if (!x || typeof x !== "object") {
-        return false;
+      function inspectString(str, opts) {
+        if (str.length > opts.maxStringLength) {
+          var remaining = str.length - opts.maxStringLength;
+          var trailer = "... " + remaining + " more character" + (remaining > 1 ? "s" : "");
+          return inspectString(str.slice(0, opts.maxStringLength), opts) + trailer;
+        }
+        var s = str.replace(/(['\\])/g, "\\$1").replace(/[\x00-\x1f]/g, lowbyte);
+        return wrapQuotes(s, "single", opts);
       }
-      if (typeof HTMLElement !== "undefined" && x instanceof HTMLElement) {
+      function lowbyte(c) {
+        var n = c.charCodeAt(0);
+        var x = {
+          8: "b",
+          9: "t",
+          10: "n",
+          12: "f",
+          13: "r"
+        }[n];
+        if (x) {
+          return "\\" + x;
+        }
+        return "\\x" + (n < 16 ? "0" : "") + n.toString(16).toUpperCase();
+      }
+      function markBoxed(str) {
+        return "Object(" + str + ")";
+      }
+      function weakCollectionOf(type) {
+        return type + " { ? }";
+      }
+      function collectionOf(type, size, entries, indent) {
+        var joinedEntries = indent ? indentedJoin(entries, indent) : entries.join(", ");
+        return type + " (" + size + ") {" + joinedEntries + "}";
+      }
+      function singleLineValues(xs) {
+        for (var i = 0; i < xs.length; i++) {
+          if (indexOf(xs[i], "\n") >= 0) {
+            return false;
+          }
+        }
         return true;
       }
-      return typeof x.nodeName === "string" && typeof x.getAttribute === "function";
-    }
-    function inspectString(str, opts) {
-      if (str.length > opts.maxStringLength) {
-        var remaining = str.length - opts.maxStringLength;
-        var trailer = "... " + remaining + " more character" + (remaining > 1 ? "s" : "");
-        return inspectString(str.slice(0, opts.maxStringLength), opts) + trailer;
-      }
-      var s = str.replace(/(['\\])/g, "\\$1").replace(/[\x00-\x1f]/g, lowbyte);
-      return wrapQuotes(s, "single", opts);
-    }
-    function lowbyte(c) {
-      var n = c.charCodeAt(0);
-      var x = {
-        8: "b",
-        9: "t",
-        10: "n",
-        12: "f",
-        13: "r"
-      }[n];
-      if (x) {
-        return "\\" + x;
-      }
-      return "\\x" + (n < 16 ? "0" : "") + n.toString(16).toUpperCase();
-    }
-    function markBoxed(str) {
-      return "Object(" + str + ")";
-    }
-    function weakCollectionOf(type) {
-      return type + " { ? }";
-    }
-    function collectionOf(type, size, entries, indent) {
-      var joinedEntries = indent ? indentedJoin(entries, indent) : entries.join(", ");
-      return type + " (" + size + ") {" + joinedEntries + "}";
-    }
-    function singleLineValues(xs) {
-      for (var i = 0; i < xs.length; i++) {
-        if (indexOf(xs[i], "\n") >= 0) {
-          return false;
-        }
-      }
-      return true;
-    }
-    function getIndent(opts, depth) {
-      var baseIndent;
-      if (opts.indent === "	") {
-        baseIndent = "	";
-      } else if (typeof opts.indent === "number" && opts.indent > 0) {
-        baseIndent = Array(opts.indent + 1).join(" ");
-      } else {
-        return null;
-      }
-      return {
-        base: baseIndent,
-        prev: Array(depth + 1).join(baseIndent)
-      };
-    }
-    function indentedJoin(xs, indent) {
-      if (xs.length === 0) {
-        return "";
-      }
-      var lineJoiner = "\n" + indent.prev + indent.base;
-      return lineJoiner + xs.join("," + lineJoiner) + "\n" + indent.prev;
-    }
-    function arrObjKeys(obj, inspect) {
-      var isArr = isArray2(obj);
-      var xs = [];
-      if (isArr) {
-        xs.length = obj.length;
-        for (var i = 0; i < obj.length; i++) {
-          xs[i] = has(obj, i) ? inspect(obj[i], obj) : "";
-        }
-      }
-      var syms = typeof gOPS === "function" ? gOPS(obj) : [];
-      var symMap;
-      if (hasShammedSymbols) {
-        symMap = {};
-        for (var k = 0; k < syms.length; k++) {
-          symMap["$" + syms[k]] = syms[k];
-        }
-      }
-      for (var key in obj) {
-        if (!has(obj, key)) {
-          continue;
-        }
-        if (isArr && String(Number(key)) === key && key < obj.length) {
-          continue;
-        }
-        if (hasShammedSymbols && symMap["$" + key] instanceof Symbol) {
-          continue;
-        } else if (/[^\w$]/.test(key)) {
-          xs.push(inspect(key, obj) + ": " + inspect(obj[key], obj));
+      function getIndent(opts, depth) {
+        var baseIndent;
+        if (opts.indent === "	") {
+          baseIndent = "	";
+        } else if (typeof opts.indent === "number" && opts.indent > 0) {
+          baseIndent = Array(opts.indent + 1).join(" ");
         } else {
-          xs.push(key + ": " + inspect(obj[key], obj));
+          return null;
         }
-      }
-      if (typeof gOPS === "function") {
-        for (var j = 0; j < syms.length; j++) {
-          if (isEnumerable.call(obj, syms[j])) {
-            xs.push("[" + inspect(syms[j]) + "]: " + inspect(obj[syms[j]], obj));
-          }
-        }
-      }
-      return xs;
-    }
-  }
-});
-
-// node_modules/side-channel/index.js
-var require_side_channel = __commonJS({
-  "node_modules/side-channel/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var GetIntrinsic = require_get_intrinsic();
-    var callBound = require_callBound();
-    var inspect = require_object_inspect();
-    var $TypeError = GetIntrinsic("%TypeError%");
-    var $WeakMap = GetIntrinsic("%WeakMap%", true);
-    var $Map = GetIntrinsic("%Map%", true);
-    var $weakMapGet = callBound("WeakMap.prototype.get", true);
-    var $weakMapSet = callBound("WeakMap.prototype.set", true);
-    var $weakMapHas = callBound("WeakMap.prototype.has", true);
-    var $mapGet = callBound("Map.prototype.get", true);
-    var $mapSet = callBound("Map.prototype.set", true);
-    var $mapHas = callBound("Map.prototype.has", true);
-    var listGetNode = function(list, key) {
-      for (var prev = list, curr; (curr = prev.next) !== null; prev = curr) {
-        if (curr.key === key) {
-          prev.next = curr.next;
-          curr.next = list.next;
-          list.next = curr;
-          return curr;
-        }
-      }
-    };
-    var listGet = function(objects, key) {
-      var node = listGetNode(objects, key);
-      return node && node.value;
-    };
-    var listSet = function(objects, key, value) {
-      var node = listGetNode(objects, key);
-      if (node) {
-        node.value = value;
-      } else {
-        objects.next = {
-          key,
-          next: objects.next,
-          value
+        return {
+          base: baseIndent,
+          prev: Array(depth + 1).join(baseIndent)
         };
       }
-    };
-    var listHas = function(objects, key) {
-      return !!listGetNode(objects, key);
-    };
-    module2.exports = function getSideChannel() {
-      var $wm;
-      var $m;
-      var $o;
-      var channel = {
-        assert: function(key) {
-          if (!channel.has(key)) {
-            throw new $TypeError("Side channel does not contain " + inspect(key));
+      function indentedJoin(xs, indent) {
+        if (xs.length === 0) {
+          return "";
+        }
+        var lineJoiner = "\n" + indent.prev + indent.base;
+        return lineJoiner + xs.join("," + lineJoiner) + "\n" + indent.prev;
+      }
+      function arrObjKeys(obj, inspect) {
+        var isArr = isArray2(obj);
+        var xs = [];
+        if (isArr) {
+          xs.length = obj.length;
+          for (var i = 0; i < obj.length; i++) {
+            xs[i] = has(obj, i) ? inspect(obj[i], obj) : "";
           }
-        },
-        get: function(key) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if ($wm) {
-              return $weakMapGet($wm, key);
-            }
-          } else if ($Map) {
-            if ($m) {
-              return $mapGet($m, key);
-            }
+        }
+        var syms = typeof gOPS === "function" ? gOPS(obj) : [];
+        var symMap;
+        if (hasShammedSymbols) {
+          symMap = {};
+          for (var k = 0; k < syms.length; k++) {
+            symMap["$" + syms[k]] = syms[k];
+          }
+        }
+        for (var key in obj) {
+          if (!has(obj, key)) {
+            continue;
+          }
+          if (isArr && String(Number(key)) === key && key < obj.length) {
+            continue;
+          }
+          if (hasShammedSymbols && symMap["$" + key] instanceof Symbol) {
+            continue;
+          } else if (/[^\w$]/.test(key)) {
+            xs.push(inspect(key, obj) + ": " + inspect(obj[key], obj));
           } else {
-            if ($o) {
-              return listGet($o, key);
+            xs.push(key + ": " + inspect(obj[key], obj));
+          }
+        }
+        if (typeof gOPS === "function") {
+          for (var j = 0; j < syms.length; j++) {
+            if (isEnumerable.call(obj, syms[j])) {
+              xs.push("[" + inspect(syms[j]) + "]: " + inspect(obj[syms[j]], obj));
             }
           }
-        },
-        has: function(key) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if ($wm) {
-              return $weakMapHas($wm, key);
-            }
-          } else if ($Map) {
-            if ($m) {
-              return $mapHas($m, key);
-            }
-          } else {
-            if ($o) {
-              return listHas($o, key);
-            }
-          }
-          return false;
-        },
-        set: function(key, value) {
-          if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
-            if (!$wm) {
-              $wm = new $WeakMap();
-            }
-            $weakMapSet($wm, key, value);
-          } else if ($Map) {
-            if (!$m) {
-              $m = new $Map();
-            }
-            $mapSet($m, key, value);
-          } else {
-            if (!$o) {
-              $o = { key: {}, next: null };
-            }
-            listSet($o, key, value);
+        }
+        return xs;
+      }
+    }
+  });
+
+  // node_modules/side-channel/index.js
+  var require_side_channel = __commonJS({
+    "node_modules/side-channel/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var GetIntrinsic = require_get_intrinsic();
+      var callBound = require_callBound();
+      var inspect = require_object_inspect();
+      var $TypeError = GetIntrinsic("%TypeError%");
+      var $WeakMap = GetIntrinsic("%WeakMap%", true);
+      var $Map = GetIntrinsic("%Map%", true);
+      var $weakMapGet = callBound("WeakMap.prototype.get", true);
+      var $weakMapSet = callBound("WeakMap.prototype.set", true);
+      var $weakMapHas = callBound("WeakMap.prototype.has", true);
+      var $mapGet = callBound("Map.prototype.get", true);
+      var $mapSet = callBound("Map.prototype.set", true);
+      var $mapHas = callBound("Map.prototype.has", true);
+      var listGetNode = function(list, key) {
+        for (var prev = list, curr; (curr = prev.next) !== null; prev = curr) {
+          if (curr.key === key) {
+            prev.next = curr.next;
+            curr.next = list.next;
+            list.next = curr;
+            return curr;
           }
         }
       };
-      return channel;
-    };
-  }
-});
-
-// node_modules/qs/lib/formats.js
-var require_formats = __commonJS({
-  "node_modules/qs/lib/formats.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var replace = String.prototype.replace;
-    var percentTwenties = /%20/g;
-    var Format = {
-      RFC1738: "RFC1738",
-      RFC3986: "RFC3986"
-    };
-    module2.exports = {
-      "default": Format.RFC3986,
-      formatters: {
-        RFC1738: function(value) {
-          return replace.call(value, percentTwenties, "+");
-        },
-        RFC3986: function(value) {
-          return String(value);
-        }
-      },
-      RFC1738: Format.RFC1738,
-      RFC3986: Format.RFC3986
-    };
-  }
-});
-
-// node_modules/qs/lib/utils.js
-var require_utils = __commonJS({
-  "node_modules/qs/lib/utils.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var formats = require_formats();
-    var has = Object.prototype.hasOwnProperty;
-    var isArray2 = Array.isArray;
-    var hexTable = function() {
-      var array = [];
-      for (var i = 0; i < 256; ++i) {
-        array.push("%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase());
-      }
-      return array;
-    }();
-    var compactQueue = function compactQueue2(queue) {
-      while (queue.length > 1) {
-        var item = queue.pop();
-        var obj = item.obj[item.prop];
-        if (isArray2(obj)) {
-          var compacted = [];
-          for (var j = 0; j < obj.length; ++j) {
-            if (typeof obj[j] !== "undefined") {
-              compacted.push(obj[j]);
-            }
-          }
-          item.obj[item.prop] = compacted;
-        }
-      }
-    };
-    var arrayToObject = function arrayToObject2(source, options) {
-      var obj = options && options.plainObjects ? Object.create(null) : {};
-      for (var i = 0; i < source.length; ++i) {
-        if (typeof source[i] !== "undefined") {
-          obj[i] = source[i];
-        }
-      }
-      return obj;
-    };
-    var merge = function merge2(target, source, options) {
-      if (!source) {
-        return target;
-      }
-      if (typeof source !== "object") {
-        if (isArray2(target)) {
-          target.push(source);
-        } else if (target && typeof target === "object") {
-          if (options && (options.plainObjects || options.allowPrototypes) || !has.call(Object.prototype, source)) {
-            target[source] = true;
-          }
+      var listGet = function(objects, key) {
+        var node = listGetNode(objects, key);
+        return node && node.value;
+      };
+      var listSet = function(objects, key, value) {
+        var node = listGetNode(objects, key);
+        if (node) {
+          node.value = value;
         } else {
-          return [target, source];
+          objects.next = {
+            key,
+            next: objects.next,
+            value
+          };
         }
-        return target;
-      }
-      if (!target || typeof target !== "object") {
-        return [target].concat(source);
-      }
-      var mergeTarget = target;
-      if (isArray2(target) && !isArray2(source)) {
-        mergeTarget = arrayToObject(target, options);
-      }
-      if (isArray2(target) && isArray2(source)) {
-        source.forEach(function(item, i) {
-          if (has.call(target, i)) {
-            var targetItem = target[i];
-            if (targetItem && typeof targetItem === "object" && item && typeof item === "object") {
-              target[i] = merge2(targetItem, item, options);
+      };
+      var listHas = function(objects, key) {
+        return !!listGetNode(objects, key);
+      };
+      module.exports = function getSideChannel() {
+        var $wm;
+        var $m;
+        var $o;
+        var channel = {
+          assert: function(key) {
+            if (!channel.has(key)) {
+              throw new $TypeError("Side channel does not contain " + inspect(key));
+            }
+          },
+          get: function(key) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if ($wm) {
+                return $weakMapGet($wm, key);
+              }
+            } else if ($Map) {
+              if ($m) {
+                return $mapGet($m, key);
+              }
             } else {
-              target.push(item);
+              if ($o) {
+                return listGet($o, key);
+              }
+            }
+          },
+          has: function(key) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if ($wm) {
+                return $weakMapHas($wm, key);
+              }
+            } else if ($Map) {
+              if ($m) {
+                return $mapHas($m, key);
+              }
+            } else {
+              if ($o) {
+                return listHas($o, key);
+              }
+            }
+            return false;
+          },
+          set: function(key, value) {
+            if ($WeakMap && key && (typeof key === "object" || typeof key === "function")) {
+              if (!$wm) {
+                $wm = new $WeakMap();
+              }
+              $weakMapSet($wm, key, value);
+            } else if ($Map) {
+              if (!$m) {
+                $m = new $Map();
+              }
+              $mapSet($m, key, value);
+            } else {
+              if (!$o) {
+                $o = { key: {}, next: null };
+              }
+              listSet($o, key, value);
+            }
+          }
+        };
+        return channel;
+      };
+    }
+  });
+
+  // node_modules/qs/lib/formats.js
+  var require_formats = __commonJS({
+    "node_modules/qs/lib/formats.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var replace = String.prototype.replace;
+      var percentTwenties = /%20/g;
+      var Format = {
+        RFC1738: "RFC1738",
+        RFC3986: "RFC3986"
+      };
+      module.exports = {
+        "default": Format.RFC3986,
+        formatters: {
+          RFC1738: function(value) {
+            return replace.call(value, percentTwenties, "+");
+          },
+          RFC3986: function(value) {
+            return String(value);
+          }
+        },
+        RFC1738: Format.RFC1738,
+        RFC3986: Format.RFC3986
+      };
+    }
+  });
+
+  // node_modules/qs/lib/utils.js
+  var require_utils = __commonJS({
+    "node_modules/qs/lib/utils.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var formats = require_formats();
+      var has = Object.prototype.hasOwnProperty;
+      var isArray2 = Array.isArray;
+      var hexTable = function() {
+        var array = [];
+        for (var i = 0; i < 256; ++i) {
+          array.push("%" + ((i < 16 ? "0" : "") + i.toString(16)).toUpperCase());
+        }
+        return array;
+      }();
+      var compactQueue = function compactQueue2(queue) {
+        while (queue.length > 1) {
+          var item = queue.pop();
+          var obj = item.obj[item.prop];
+          if (isArray2(obj)) {
+            var compacted = [];
+            for (var j = 0; j < obj.length; ++j) {
+              if (typeof obj[j] !== "undefined") {
+                compacted.push(obj[j]);
+              }
+            }
+            item.obj[item.prop] = compacted;
+          }
+        }
+      };
+      var arrayToObject = function arrayToObject2(source, options) {
+        var obj = options && options.plainObjects ? Object.create(null) : {};
+        for (var i = 0; i < source.length; ++i) {
+          if (typeof source[i] !== "undefined") {
+            obj[i] = source[i];
+          }
+        }
+        return obj;
+      };
+      var merge = function merge2(target, source, options) {
+        if (!source) {
+          return target;
+        }
+        if (typeof source !== "object") {
+          if (isArray2(target)) {
+            target.push(source);
+          } else if (target && typeof target === "object") {
+            if (options && (options.plainObjects || options.allowPrototypes) || !has.call(Object.prototype, source)) {
+              target[source] = true;
             }
           } else {
-            target[i] = item;
+            return [target, source];
           }
-        });
-        return target;
-      }
-      return Object.keys(source).reduce(function(acc, key) {
-        var value = source[key];
-        if (has.call(acc, key)) {
-          acc[key] = merge2(acc[key], value, options);
-        } else {
-          acc[key] = value;
+          return target;
         }
-        return acc;
-      }, mergeTarget);
-    };
-    var assign = function assignSingleSource(target, source) {
-      return Object.keys(source).reduce(function(acc, key) {
-        acc[key] = source[key];
-        return acc;
-      }, target);
-    };
-    var decode = function(str, decoder, charset) {
-      var strWithoutPlus = str.replace(/\+/g, " ");
-      if (charset === "iso-8859-1") {
-        return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
-      }
-      try {
-        return decodeURIComponent(strWithoutPlus);
-      } catch (e) {
-        return strWithoutPlus;
-      }
-    };
-    var encode = function encode2(str, defaultEncoder, charset, kind, format) {
-      if (str.length === 0) {
-        return str;
-      }
-      var string = str;
-      if (typeof str === "symbol") {
-        string = Symbol.prototype.toString.call(str);
-      } else if (typeof str !== "string") {
-        string = String(str);
-      }
-      if (charset === "iso-8859-1") {
-        return escape(string).replace(/%u[0-9a-f]{4}/gi, function($0) {
-          return "%26%23" + parseInt($0.slice(2), 16) + "%3B";
-        });
-      }
-      var out = "";
-      for (var i = 0; i < string.length; ++i) {
-        var c = string.charCodeAt(i);
-        if (c === 45 || c === 46 || c === 95 || c === 126 || c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || format === formats.RFC1738 && (c === 40 || c === 41)) {
-          out += string.charAt(i);
-          continue;
+        if (!target || typeof target !== "object") {
+          return [target].concat(source);
         }
-        if (c < 128) {
-          out = out + hexTable[c];
-          continue;
+        var mergeTarget = target;
+        if (isArray2(target) && !isArray2(source)) {
+          mergeTarget = arrayToObject(target, options);
         }
-        if (c < 2048) {
-          out = out + (hexTable[192 | c >> 6] + hexTable[128 | c & 63]);
-          continue;
-        }
-        if (c < 55296 || c >= 57344) {
-          out = out + (hexTable[224 | c >> 12] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63]);
-          continue;
-        }
-        i += 1;
-        c = 65536 + ((c & 1023) << 10 | string.charCodeAt(i) & 1023);
-        out += hexTable[240 | c >> 18] + hexTable[128 | c >> 12 & 63] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63];
-      }
-      return out;
-    };
-    var compact = function compact2(value) {
-      var queue = [{ obj: { o: value }, prop: "o" }];
-      var refs = [];
-      for (var i = 0; i < queue.length; ++i) {
-        var item = queue[i];
-        var obj = item.obj[item.prop];
-        var keys = Object.keys(obj);
-        for (var j = 0; j < keys.length; ++j) {
-          var key = keys[j];
-          var val = obj[key];
-          if (typeof val === "object" && val !== null && refs.indexOf(val) === -1) {
-            queue.push({ obj, prop: key });
-            refs.push(val);
-          }
-        }
-      }
-      compactQueue(queue);
-      return value;
-    };
-    var isRegExp = function isRegExp2(obj) {
-      return Object.prototype.toString.call(obj) === "[object RegExp]";
-    };
-    var isBuffer = function isBuffer2(obj) {
-      if (!obj || typeof obj !== "object") {
-        return false;
-      }
-      return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
-    };
-    var combine = function combine2(a, b) {
-      return [].concat(a, b);
-    };
-    var maybeMap = function maybeMap2(val, fn) {
-      if (isArray2(val)) {
-        var mapped = [];
-        for (var i = 0; i < val.length; i += 1) {
-          mapped.push(fn(val[i]));
-        }
-        return mapped;
-      }
-      return fn(val);
-    };
-    module2.exports = {
-      arrayToObject,
-      assign,
-      combine,
-      compact,
-      decode,
-      encode,
-      isBuffer,
-      isRegExp,
-      maybeMap,
-      merge
-    };
-  }
-});
-
-// node_modules/qs/lib/stringify.js
-var require_stringify = __commonJS({
-  "node_modules/qs/lib/stringify.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var getSideChannel = require_side_channel();
-    var utils = require_utils();
-    var formats = require_formats();
-    var has = Object.prototype.hasOwnProperty;
-    var arrayPrefixGenerators = {
-      brackets: function brackets(prefix) {
-        return prefix + "[]";
-      },
-      comma: "comma",
-      indices: function indices(prefix, key) {
-        return prefix + "[" + key + "]";
-      },
-      repeat: function repeat(prefix) {
-        return prefix;
-      }
-    };
-    var isArray2 = Array.isArray;
-    var push = Array.prototype.push;
-    var pushToArray = function(arr, valueOrArray) {
-      push.apply(arr, isArray2(valueOrArray) ? valueOrArray : [valueOrArray]);
-    };
-    var toISO = Date.prototype.toISOString;
-    var defaultFormat = formats["default"];
-    var defaults = {
-      addQueryPrefix: false,
-      allowDots: false,
-      charset: "utf-8",
-      charsetSentinel: false,
-      delimiter: "&",
-      encode: true,
-      encoder: utils.encode,
-      encodeValuesOnly: false,
-      format: defaultFormat,
-      formatter: formats.formatters[defaultFormat],
-      indices: false,
-      serializeDate: function serializeDate(date) {
-        return toISO.call(date);
-      },
-      skipNulls: false,
-      strictNullHandling: false
-    };
-    var isNonNullishPrimitive = function isNonNullishPrimitive2(v) {
-      return typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "symbol" || typeof v === "bigint";
-    };
-    var stringify = function stringify2(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, sideChannel) {
-      var obj = object;
-      if (sideChannel.has(object)) {
-        throw new RangeError("Cyclic object value");
-      }
-      if (typeof filter === "function") {
-        obj = filter(prefix, obj);
-      } else if (obj instanceof Date) {
-        obj = serializeDate(obj);
-      } else if (generateArrayPrefix === "comma" && isArray2(obj)) {
-        obj = utils.maybeMap(obj, function(value2) {
-          if (value2 instanceof Date) {
-            return serializeDate(value2);
-          }
-          return value2;
-        });
-      }
-      if (obj === null) {
-        if (strictNullHandling) {
-          return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix;
-        }
-        obj = "";
-      }
-      if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
-        if (encoder) {
-          var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, "key", format);
-          return [formatter(keyValue) + "=" + formatter(encoder(obj, defaults.encoder, charset, "value", format))];
-        }
-        return [formatter(prefix) + "=" + formatter(String(obj))];
-      }
-      var values = [];
-      if (typeof obj === "undefined") {
-        return values;
-      }
-      var objKeys;
-      if (generateArrayPrefix === "comma" && isArray2(obj)) {
-        objKeys = [{ value: obj.length > 0 ? obj.join(",") || null : void 0 }];
-      } else if (isArray2(filter)) {
-        objKeys = filter;
-      } else {
-        var keys = Object.keys(obj);
-        objKeys = sort ? keys.sort(sort) : keys;
-      }
-      for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-        var value = typeof key === "object" && key.value !== void 0 ? key.value : obj[key];
-        if (skipNulls && value === null) {
-          continue;
-        }
-        var keyPrefix = isArray2(obj) ? typeof generateArrayPrefix === "function" ? generateArrayPrefix(prefix, key) : prefix : prefix + (allowDots ? "." + key : "[" + key + "]");
-        sideChannel.set(object, true);
-        var valueSideChannel = getSideChannel();
-        pushToArray(values, stringify2(value, keyPrefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, valueSideChannel));
-      }
-      return values;
-    };
-    var normalizeStringifyOptions = function normalizeStringifyOptions2(opts) {
-      if (!opts) {
-        return defaults;
-      }
-      if (opts.encoder !== null && opts.encoder !== void 0 && typeof opts.encoder !== "function") {
-        throw new TypeError("Encoder has to be a function.");
-      }
-      var charset = opts.charset || defaults.charset;
-      if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
-        throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
-      }
-      var format = formats["default"];
-      if (typeof opts.format !== "undefined") {
-        if (!has.call(formats.formatters, opts.format)) {
-          throw new TypeError("Unknown format option provided.");
-        }
-        format = opts.format;
-      }
-      var formatter = formats.formatters[format];
-      var filter = defaults.filter;
-      if (typeof opts.filter === "function" || isArray2(opts.filter)) {
-        filter = opts.filter;
-      }
-      return {
-        addQueryPrefix: typeof opts.addQueryPrefix === "boolean" ? opts.addQueryPrefix : defaults.addQueryPrefix,
-        allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
-        charset,
-        charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
-        delimiter: typeof opts.delimiter === "undefined" ? defaults.delimiter : opts.delimiter,
-        encode: typeof opts.encode === "boolean" ? opts.encode : defaults.encode,
-        encoder: typeof opts.encoder === "function" ? opts.encoder : defaults.encoder,
-        encodeValuesOnly: typeof opts.encodeValuesOnly === "boolean" ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
-        filter,
-        format,
-        formatter,
-        serializeDate: typeof opts.serializeDate === "function" ? opts.serializeDate : defaults.serializeDate,
-        skipNulls: typeof opts.skipNulls === "boolean" ? opts.skipNulls : defaults.skipNulls,
-        sort: typeof opts.sort === "function" ? opts.sort : null,
-        strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
-      };
-    };
-    module2.exports = function(object, opts) {
-      var obj = object;
-      var options = normalizeStringifyOptions(opts);
-      var objKeys;
-      var filter;
-      if (typeof options.filter === "function") {
-        filter = options.filter;
-        obj = filter("", obj);
-      } else if (isArray2(options.filter)) {
-        filter = options.filter;
-        objKeys = filter;
-      }
-      var keys = [];
-      if (typeof obj !== "object" || obj === null) {
-        return "";
-      }
-      var arrayFormat;
-      if (opts && opts.arrayFormat in arrayPrefixGenerators) {
-        arrayFormat = opts.arrayFormat;
-      } else if (opts && "indices" in opts) {
-        arrayFormat = opts.indices ? "indices" : "repeat";
-      } else {
-        arrayFormat = "indices";
-      }
-      var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
-      if (!objKeys) {
-        objKeys = Object.keys(obj);
-      }
-      if (options.sort) {
-        objKeys.sort(options.sort);
-      }
-      var sideChannel = getSideChannel();
-      for (var i = 0; i < objKeys.length; ++i) {
-        var key = objKeys[i];
-        if (options.skipNulls && obj[key] === null) {
-          continue;
-        }
-        pushToArray(keys, stringify(obj[key], key, generateArrayPrefix, options.strictNullHandling, options.skipNulls, options.encode ? options.encoder : null, options.filter, options.sort, options.allowDots, options.serializeDate, options.format, options.formatter, options.encodeValuesOnly, options.charset, sideChannel));
-      }
-      var joined = keys.join(options.delimiter);
-      var prefix = options.addQueryPrefix === true ? "?" : "";
-      if (options.charsetSentinel) {
-        if (options.charset === "iso-8859-1") {
-          prefix += "utf8=%26%2310003%3B&";
-        } else {
-          prefix += "utf8=%E2%9C%93&";
-        }
-      }
-      return joined.length > 0 ? prefix + joined : "";
-    };
-  }
-});
-
-// node_modules/qs/lib/parse.js
-var require_parse = __commonJS({
-  "node_modules/qs/lib/parse.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var utils = require_utils();
-    var has = Object.prototype.hasOwnProperty;
-    var isArray2 = Array.isArray;
-    var defaults = {
-      allowDots: false,
-      allowPrototypes: false,
-      allowSparse: false,
-      arrayLimit: 20,
-      charset: "utf-8",
-      charsetSentinel: false,
-      comma: false,
-      decoder: utils.decode,
-      delimiter: "&",
-      depth: 5,
-      ignoreQueryPrefix: false,
-      interpretNumericEntities: false,
-      parameterLimit: 1e3,
-      parseArrays: true,
-      plainObjects: false,
-      strictNullHandling: false
-    };
-    var interpretNumericEntities = function(str) {
-      return str.replace(/&#(\d+);/g, function($0, numberStr) {
-        return String.fromCharCode(parseInt(numberStr, 10));
-      });
-    };
-    var parseArrayValue = function(val, options) {
-      if (val && typeof val === "string" && options.comma && val.indexOf(",") > -1) {
-        return val.split(",");
-      }
-      return val;
-    };
-    var isoSentinel = "utf8=%26%2310003%3B";
-    var charsetSentinel = "utf8=%E2%9C%93";
-    var parseValues = function parseQueryStringValues(str, options) {
-      var obj = {};
-      var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, "") : str;
-      var limit = options.parameterLimit === Infinity ? void 0 : options.parameterLimit;
-      var parts = cleanStr.split(options.delimiter, limit);
-      var skipIndex = -1;
-      var i;
-      var charset = options.charset;
-      if (options.charsetSentinel) {
-        for (i = 0; i < parts.length; ++i) {
-          if (parts[i].indexOf("utf8=") === 0) {
-            if (parts[i] === charsetSentinel) {
-              charset = "utf-8";
-            } else if (parts[i] === isoSentinel) {
-              charset = "iso-8859-1";
+        if (isArray2(target) && isArray2(source)) {
+          source.forEach(function(item, i) {
+            if (has.call(target, i)) {
+              var targetItem = target[i];
+              if (targetItem && typeof targetItem === "object" && item && typeof item === "object") {
+                target[i] = merge2(targetItem, item, options);
+              } else {
+                target.push(item);
+              }
+            } else {
+              target[i] = item;
             }
-            skipIndex = i;
-            i = parts.length;
+          });
+          return target;
+        }
+        return Object.keys(source).reduce(function(acc, key) {
+          var value = source[key];
+          if (has.call(acc, key)) {
+            acc[key] = merge2(acc[key], value, options);
+          } else {
+            acc[key] = value;
           }
+          return acc;
+        }, mergeTarget);
+      };
+      var assign = function assignSingleSource(target, source) {
+        return Object.keys(source).reduce(function(acc, key) {
+          acc[key] = source[key];
+          return acc;
+        }, target);
+      };
+      var decode = function(str, decoder, charset) {
+        var strWithoutPlus = str.replace(/\+/g, " ");
+        if (charset === "iso-8859-1") {
+          return strWithoutPlus.replace(/%[0-9a-f]{2}/gi, unescape);
         }
-      }
-      for (i = 0; i < parts.length; ++i) {
-        if (i === skipIndex) {
-          continue;
+        try {
+          return decodeURIComponent(strWithoutPlus);
+        } catch (e) {
+          return strWithoutPlus;
         }
-        var part = parts[i];
-        var bracketEqualsPos = part.indexOf("]=");
-        var pos = bracketEqualsPos === -1 ? part.indexOf("=") : bracketEqualsPos + 1;
-        var key, val;
-        if (pos === -1) {
-          key = options.decoder(part, defaults.decoder, charset, "key");
-          val = options.strictNullHandling ? null : "";
-        } else {
-          key = options.decoder(part.slice(0, pos), defaults.decoder, charset, "key");
-          val = utils.maybeMap(parseArrayValue(part.slice(pos + 1), options), function(encodedVal) {
-            return options.decoder(encodedVal, defaults.decoder, charset, "value");
+      };
+      var encode = function encode2(str, defaultEncoder, charset, kind, format) {
+        if (str.length === 0) {
+          return str;
+        }
+        var string = str;
+        if (typeof str === "symbol") {
+          string = Symbol.prototype.toString.call(str);
+        } else if (typeof str !== "string") {
+          string = String(str);
+        }
+        if (charset === "iso-8859-1") {
+          return escape(string).replace(/%u[0-9a-f]{4}/gi, function($0) {
+            return "%26%23" + parseInt($0.slice(2), 16) + "%3B";
           });
         }
-        if (val && options.interpretNumericEntities && charset === "iso-8859-1") {
-          val = interpretNumericEntities(val);
-        }
-        if (part.indexOf("[]=") > -1) {
-          val = isArray2(val) ? [val] : val;
-        }
-        if (has.call(obj, key)) {
-          obj[key] = utils.combine(obj[key], val);
-        } else {
-          obj[key] = val;
-        }
-      }
-      return obj;
-    };
-    var parseObject = function(chain, val, options, valuesParsed) {
-      var leaf = valuesParsed ? val : parseArrayValue(val, options);
-      for (var i = chain.length - 1; i >= 0; --i) {
-        var obj;
-        var root = chain[i];
-        if (root === "[]" && options.parseArrays) {
-          obj = [].concat(leaf);
-        } else {
-          obj = options.plainObjects ? Object.create(null) : {};
-          var cleanRoot = root.charAt(0) === "[" && root.charAt(root.length - 1) === "]" ? root.slice(1, -1) : root;
-          var index = parseInt(cleanRoot, 10);
-          if (!options.parseArrays && cleanRoot === "") {
-            obj = { 0: leaf };
-          } else if (!isNaN(index) && root !== cleanRoot && String(index) === cleanRoot && index >= 0 && (options.parseArrays && index <= options.arrayLimit)) {
-            obj = [];
-            obj[index] = leaf;
-          } else {
-            obj[cleanRoot] = leaf;
-          }
-        }
-        leaf = obj;
-      }
-      return leaf;
-    };
-    var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {
-      if (!givenKey) {
-        return;
-      }
-      var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, "[$1]") : givenKey;
-      var brackets = /(\[[^[\]]*])/;
-      var child = /(\[[^[\]]*])/g;
-      var segment = options.depth > 0 && brackets.exec(key);
-      var parent = segment ? key.slice(0, segment.index) : key;
-      var keys = [];
-      if (parent) {
-        if (!options.plainObjects && has.call(Object.prototype, parent)) {
-          if (!options.allowPrototypes) {
-            return;
-          }
-        }
-        keys.push(parent);
-      }
-      var i = 0;
-      while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
-        i += 1;
-        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
-          if (!options.allowPrototypes) {
-            return;
-          }
-        }
-        keys.push(segment[1]);
-      }
-      if (segment) {
-        keys.push("[" + key.slice(segment.index) + "]");
-      }
-      return parseObject(keys, val, options, valuesParsed);
-    };
-    var normalizeParseOptions = function normalizeParseOptions2(opts) {
-      if (!opts) {
-        return defaults;
-      }
-      if (opts.decoder !== null && opts.decoder !== void 0 && typeof opts.decoder !== "function") {
-        throw new TypeError("Decoder has to be a function.");
-      }
-      if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
-        throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
-      }
-      var charset = typeof opts.charset === "undefined" ? defaults.charset : opts.charset;
-      return {
-        allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
-        allowPrototypes: typeof opts.allowPrototypes === "boolean" ? opts.allowPrototypes : defaults.allowPrototypes,
-        allowSparse: typeof opts.allowSparse === "boolean" ? opts.allowSparse : defaults.allowSparse,
-        arrayLimit: typeof opts.arrayLimit === "number" ? opts.arrayLimit : defaults.arrayLimit,
-        charset,
-        charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
-        comma: typeof opts.comma === "boolean" ? opts.comma : defaults.comma,
-        decoder: typeof opts.decoder === "function" ? opts.decoder : defaults.decoder,
-        delimiter: typeof opts.delimiter === "string" || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
-        depth: typeof opts.depth === "number" || opts.depth === false ? +opts.depth : defaults.depth,
-        ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
-        interpretNumericEntities: typeof opts.interpretNumericEntities === "boolean" ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
-        parameterLimit: typeof opts.parameterLimit === "number" ? opts.parameterLimit : defaults.parameterLimit,
-        parseArrays: opts.parseArrays !== false,
-        plainObjects: typeof opts.plainObjects === "boolean" ? opts.plainObjects : defaults.plainObjects,
-        strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
-      };
-    };
-    module2.exports = function(str, opts) {
-      var options = normalizeParseOptions(opts);
-      if (str === "" || str === null || typeof str === "undefined") {
-        return options.plainObjects ? Object.create(null) : {};
-      }
-      var tempObj = typeof str === "string" ? parseValues(str, options) : str;
-      var obj = options.plainObjects ? Object.create(null) : {};
-      var keys = Object.keys(tempObj);
-      for (var i = 0; i < keys.length; ++i) {
-        var key = keys[i];
-        var newObj = parseKeys(key, tempObj[key], options, typeof str === "string");
-        obj = utils.merge(obj, newObj, options);
-      }
-      if (options.allowSparse === true) {
-        return obj;
-      }
-      return utils.compact(obj);
-    };
-  }
-});
-
-// node_modules/qs/lib/index.js
-var require_lib = __commonJS({
-  "node_modules/qs/lib/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var stringify = require_stringify();
-    var parse = require_parse();
-    var formats = require_formats();
-    module2.exports = {
-      formats,
-      parse,
-      stringify
-    };
-  }
-});
-
-// node_modules/requires-port/index.js
-var require_requires_port = __commonJS({
-  "node_modules/requires-port/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    module2.exports = function required(port, protocol) {
-      protocol = protocol.split(":")[0];
-      port = +port;
-      if (!port)
-        return false;
-      switch (protocol) {
-        case "http":
-        case "ws":
-          return port !== 80;
-        case "https":
-        case "wss":
-          return port !== 443;
-        case "ftp":
-          return port !== 21;
-        case "gopher":
-          return port !== 70;
-        case "file":
-          return false;
-      }
-      return port !== 0;
-    };
-  }
-});
-
-// node_modules/querystringify/index.js
-var require_querystringify = __commonJS({
-  "node_modules/querystringify/index.js"(exports) {
-    init_buffer_shim();
-    "use strict";
-    var has = Object.prototype.hasOwnProperty;
-    var undef;
-    function decode(input) {
-      try {
-        return decodeURIComponent(input.replace(/\+/g, " "));
-      } catch (e) {
-        return null;
-      }
-    }
-    function encode(input) {
-      try {
-        return encodeURIComponent(input);
-      } catch (e) {
-        return null;
-      }
-    }
-    function querystring(query) {
-      var parser = /([^=?#&]+)=?([^&]*)/g, result = {}, part;
-      while (part = parser.exec(query)) {
-        var key = decode(part[1]), value = decode(part[2]);
-        if (key === null || value === null || key in result)
-          continue;
-        result[key] = value;
-      }
-      return result;
-    }
-    function querystringify(obj, prefix) {
-      prefix = prefix || "";
-      var pairs = [], value, key;
-      if (typeof prefix !== "string")
-        prefix = "?";
-      for (key in obj) {
-        if (has.call(obj, key)) {
-          value = obj[key];
-          if (!value && (value === null || value === undef || isNaN(value))) {
-            value = "";
-          }
-          key = encode(key);
-          value = encode(value);
-          if (key === null || value === null)
+        var out = "";
+        for (var i = 0; i < string.length; ++i) {
+          var c = string.charCodeAt(i);
+          if (c === 45 || c === 46 || c === 95 || c === 126 || c >= 48 && c <= 57 || c >= 65 && c <= 90 || c >= 97 && c <= 122 || format === formats.RFC1738 && (c === 40 || c === 41)) {
+            out += string.charAt(i);
             continue;
-          pairs.push(key + "=" + value);
-        }
-      }
-      return pairs.length ? prefix + pairs.join("&") : "";
-    }
-    exports.stringify = querystringify;
-    exports.parse = querystring;
-  }
-});
-
-// node_modules/url-parse/index.js
-var require_url_parse = __commonJS({
-  "node_modules/url-parse/index.js"(exports, module2) {
-    init_buffer_shim();
-    "use strict";
-    var required = require_requires_port();
-    var qs2 = require_querystringify();
-    var slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//;
-    var protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\\/]+)?([\S\s]*)/i;
-    var windowsDriveLetter = /^[a-zA-Z]:/;
-    var whitespace = "[\\x09\\x0A\\x0B\\x0C\\x0D\\x20\\xA0\\u1680\\u180E\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000\\u2028\\u2029\\uFEFF]";
-    var left = new RegExp("^" + whitespace + "+");
-    function trimLeft(str) {
-      return (str ? str : "").toString().replace(left, "");
-    }
-    var rules = [
-      ["#", "hash"],
-      ["?", "query"],
-      function sanitize(address, url) {
-        return isSpecial(url.protocol) ? address.replace(/\\/g, "/") : address;
-      },
-      ["/", "pathname"],
-      ["@", "auth", 1],
-      [NaN, "host", void 0, 1, 1],
-      [/:(\d+)$/, "port", void 0, 1],
-      [NaN, "hostname", void 0, 1, 1]
-    ];
-    var ignore = { hash: 1, query: 1 };
-    function lolcation(loc) {
-      var globalVar;
-      if (typeof window !== "undefined")
-        globalVar = window;
-      else if (typeof global !== "undefined")
-        globalVar = global;
-      else if (typeof self !== "undefined")
-        globalVar = self;
-      else
-        globalVar = {};
-      var location = globalVar.location || {};
-      loc = loc || location;
-      var finaldestination = {}, type = typeof loc, key;
-      if (loc.protocol === "blob:") {
-        finaldestination = new Url(unescape(loc.pathname), {});
-      } else if (type === "string") {
-        finaldestination = new Url(loc, {});
-        for (key in ignore)
-          delete finaldestination[key];
-      } else if (type === "object") {
-        for (key in loc) {
-          if (key in ignore)
+          }
+          if (c < 128) {
+            out = out + hexTable[c];
             continue;
-          finaldestination[key] = loc[key];
+          }
+          if (c < 2048) {
+            out = out + (hexTable[192 | c >> 6] + hexTable[128 | c & 63]);
+            continue;
+          }
+          if (c < 55296 || c >= 57344) {
+            out = out + (hexTable[224 | c >> 12] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63]);
+            continue;
+          }
+          i += 1;
+          c = 65536 + ((c & 1023) << 10 | string.charCodeAt(i) & 1023);
+          out += hexTable[240 | c >> 18] + hexTable[128 | c >> 12 & 63] + hexTable[128 | c >> 6 & 63] + hexTable[128 | c & 63];
         }
-        if (finaldestination.slashes === void 0) {
-          finaldestination.slashes = slashes.test(loc.href);
-        }
-      }
-      return finaldestination;
-    }
-    function isSpecial(scheme) {
-      return scheme === "file:" || scheme === "ftp:" || scheme === "http:" || scheme === "https:" || scheme === "ws:" || scheme === "wss:";
-    }
-    function extractProtocol(address, location) {
-      address = trimLeft(address);
-      location = location || {};
-      var match = protocolre.exec(address);
-      var protocol = match[1] ? match[1].toLowerCase() : "";
-      var forwardSlashes = !!match[2];
-      var otherSlashes = !!match[3];
-      var slashesCount = 0;
-      var rest;
-      if (forwardSlashes) {
-        if (otherSlashes) {
-          rest = match[2] + match[3] + match[4];
-          slashesCount = match[2].length + match[3].length;
-        } else {
-          rest = match[2] + match[4];
-          slashesCount = match[2].length;
-        }
-      } else {
-        if (otherSlashes) {
-          rest = match[3] + match[4];
-          slashesCount = match[3].length;
-        } else {
-          rest = match[4];
-        }
-      }
-      if (protocol === "file:") {
-        if (slashesCount >= 2) {
-          rest = rest.slice(2);
-        }
-      } else if (isSpecial(protocol)) {
-        rest = match[4];
-      } else if (protocol) {
-        if (forwardSlashes) {
-          rest = rest.slice(2);
-        }
-      } else if (slashesCount >= 2 && isSpecial(location.protocol)) {
-        rest = match[4];
-      }
-      return {
-        protocol,
-        slashes: forwardSlashes || isSpecial(protocol),
-        slashesCount,
-        rest
+        return out;
       };
-    }
-    function resolve(relative, base) {
-      if (relative === "")
-        return base;
-      var path = (base || "/").split("/").slice(0, -1).concat(relative.split("/")), i = path.length, last = path[i - 1], unshift = false, up = 0;
-      while (i--) {
-        if (path[i] === ".") {
-          path.splice(i, 1);
-        } else if (path[i] === "..") {
-          path.splice(i, 1);
-          up++;
-        } else if (up) {
-          if (i === 0)
-            unshift = true;
-          path.splice(i, 1);
-          up--;
-        }
-      }
-      if (unshift)
-        path.unshift("");
-      if (last === "." || last === "..")
-        path.push("");
-      return path.join("/");
-    }
-    function Url(address, location, parser) {
-      address = trimLeft(address);
-      if (!(this instanceof Url)) {
-        return new Url(address, location, parser);
-      }
-      var relative, extracted, parse, instruction, index, key, instructions = rules.slice(), type = typeof location, url = this, i = 0;
-      if (type !== "object" && type !== "string") {
-        parser = location;
-        location = null;
-      }
-      if (parser && typeof parser !== "function")
-        parser = qs2.parse;
-      location = lolcation(location);
-      extracted = extractProtocol(address || "", location);
-      relative = !extracted.protocol && !extracted.slashes;
-      url.slashes = extracted.slashes || relative && location.slashes;
-      url.protocol = extracted.protocol || location.protocol || "";
-      address = extracted.rest;
-      if (extracted.protocol === "file:" && (extracted.slashesCount !== 2 || windowsDriveLetter.test(address)) || !extracted.slashes && (extracted.protocol || extracted.slashesCount < 2 || !isSpecial(url.protocol))) {
-        instructions[3] = [/(.*)/, "pathname"];
-      }
-      for (; i < instructions.length; i++) {
-        instruction = instructions[i];
-        if (typeof instruction === "function") {
-          address = instruction(address, url);
-          continue;
-        }
-        parse = instruction[0];
-        key = instruction[1];
-        if (parse !== parse) {
-          url[key] = address;
-        } else if (typeof parse === "string") {
-          if (~(index = address.indexOf(parse))) {
-            if (typeof instruction[2] === "number") {
-              url[key] = address.slice(0, index);
-              address = address.slice(index + instruction[2]);
-            } else {
-              url[key] = address.slice(index);
-              address = address.slice(0, index);
+      var compact = function compact2(value) {
+        var queue = [{ obj: { o: value }, prop: "o" }];
+        var refs = [];
+        for (var i = 0; i < queue.length; ++i) {
+          var item = queue[i];
+          var obj = item.obj[item.prop];
+          var keys = Object.keys(obj);
+          for (var j = 0; j < keys.length; ++j) {
+            var key = keys[j];
+            var val = obj[key];
+            if (typeof val === "object" && val !== null && refs.indexOf(val) === -1) {
+              queue.push({ obj, prop: key });
+              refs.push(val);
             }
           }
-        } else if (index = parse.exec(address)) {
-          url[key] = index[1];
-          address = address.slice(0, index.index);
         }
-        url[key] = url[key] || (relative && instruction[3] ? location[key] || "" : "");
-        if (instruction[4])
-          url[key] = url[key].toLowerCase();
-      }
-      if (parser)
-        url.query = parser(url.query);
-      if (relative && location.slashes && url.pathname.charAt(0) !== "/" && (url.pathname !== "" || location.pathname !== "")) {
-        url.pathname = resolve(url.pathname, location.pathname);
-      }
-      if (url.pathname.charAt(0) !== "/" && isSpecial(url.protocol)) {
-        url.pathname = "/" + url.pathname;
-      }
-      if (!required(url.port, url.protocol)) {
-        url.host = url.hostname;
-        url.port = "";
-      }
-      url.username = url.password = "";
-      if (url.auth) {
-        instruction = url.auth.split(":");
-        url.username = instruction[0] || "";
-        url.password = instruction[1] || "";
-      }
-      url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
-      url.href = url.toString();
+        compactQueue(queue);
+        return value;
+      };
+      var isRegExp = function isRegExp2(obj) {
+        return Object.prototype.toString.call(obj) === "[object RegExp]";
+      };
+      var isBuffer = function isBuffer2(obj) {
+        if (!obj || typeof obj !== "object") {
+          return false;
+        }
+        return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
+      };
+      var combine = function combine2(a, b) {
+        return [].concat(a, b);
+      };
+      var maybeMap = function maybeMap2(val, fn) {
+        if (isArray2(val)) {
+          var mapped = [];
+          for (var i = 0; i < val.length; i += 1) {
+            mapped.push(fn(val[i]));
+          }
+          return mapped;
+        }
+        return fn(val);
+      };
+      module.exports = {
+        arrayToObject,
+        assign,
+        combine,
+        compact,
+        decode,
+        encode,
+        isBuffer,
+        isRegExp,
+        maybeMap,
+        merge
+      };
     }
-    function set(part, value, fn) {
-      var url = this;
-      switch (part) {
-        case "query":
-          if (typeof value === "string" && value.length) {
-            value = (fn || qs2.parse)(value);
+  });
+
+  // node_modules/qs/lib/stringify.js
+  var require_stringify = __commonJS({
+    "node_modules/qs/lib/stringify.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var getSideChannel = require_side_channel();
+      var utils = require_utils();
+      var formats = require_formats();
+      var has = Object.prototype.hasOwnProperty;
+      var arrayPrefixGenerators = {
+        brackets: function brackets(prefix) {
+          return prefix + "[]";
+        },
+        comma: "comma",
+        indices: function indices(prefix, key) {
+          return prefix + "[" + key + "]";
+        },
+        repeat: function repeat(prefix) {
+          return prefix;
+        }
+      };
+      var isArray2 = Array.isArray;
+      var push = Array.prototype.push;
+      var pushToArray = function(arr, valueOrArray) {
+        push.apply(arr, isArray2(valueOrArray) ? valueOrArray : [valueOrArray]);
+      };
+      var toISO = Date.prototype.toISOString;
+      var defaultFormat = formats["default"];
+      var defaults = {
+        addQueryPrefix: false,
+        allowDots: false,
+        charset: "utf-8",
+        charsetSentinel: false,
+        delimiter: "&",
+        encode: true,
+        encoder: utils.encode,
+        encodeValuesOnly: false,
+        format: defaultFormat,
+        formatter: formats.formatters[defaultFormat],
+        indices: false,
+        serializeDate: function serializeDate(date) {
+          return toISO.call(date);
+        },
+        skipNulls: false,
+        strictNullHandling: false
+      };
+      var isNonNullishPrimitive = function isNonNullishPrimitive2(v) {
+        return typeof v === "string" || typeof v === "number" || typeof v === "boolean" || typeof v === "symbol" || typeof v === "bigint";
+      };
+      var stringify = function stringify2(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, sideChannel) {
+        var obj = object;
+        if (sideChannel.has(object)) {
+          throw new RangeError("Cyclic object value");
+        }
+        if (typeof filter === "function") {
+          obj = filter(prefix, obj);
+        } else if (obj instanceof Date) {
+          obj = serializeDate(obj);
+        } else if (generateArrayPrefix === "comma" && isArray2(obj)) {
+          obj = utils.maybeMap(obj, function(value2) {
+            if (value2 instanceof Date) {
+              return serializeDate(value2);
+            }
+            return value2;
+          });
+        }
+        if (obj === null) {
+          if (strictNullHandling) {
+            return encoder && !encodeValuesOnly ? encoder(prefix, defaults.encoder, charset, "key", format) : prefix;
           }
-          url[part] = value;
-          break;
-        case "port":
-          url[part] = value;
-          if (!required(value, url.protocol)) {
-            url.host = url.hostname;
-            url[part] = "";
-          } else if (value) {
-            url.host = url.hostname + ":" + value;
+          obj = "";
+        }
+        if (isNonNullishPrimitive(obj) || utils.isBuffer(obj)) {
+          if (encoder) {
+            var keyValue = encodeValuesOnly ? prefix : encoder(prefix, defaults.encoder, charset, "key", format);
+            return [formatter(keyValue) + "=" + formatter(encoder(obj, defaults.encoder, charset, "value", format))];
           }
-          break;
-        case "hostname":
-          url[part] = value;
-          if (url.port)
-            value += ":" + url.port;
-          url.host = value;
-          break;
-        case "host":
-          url[part] = value;
-          if (/:\d+$/.test(value)) {
-            value = value.split(":");
-            url.port = value.pop();
-            url.hostname = value.join(":");
+          return [formatter(prefix) + "=" + formatter(String(obj))];
+        }
+        var values = [];
+        if (typeof obj === "undefined") {
+          return values;
+        }
+        var objKeys;
+        if (generateArrayPrefix === "comma" && isArray2(obj)) {
+          objKeys = [{ value: obj.length > 0 ? obj.join(",") || null : void 0 }];
+        } else if (isArray2(filter)) {
+          objKeys = filter;
+        } else {
+          var keys = Object.keys(obj);
+          objKeys = sort ? keys.sort(sort) : keys;
+        }
+        for (var i = 0; i < objKeys.length; ++i) {
+          var key = objKeys[i];
+          var value = typeof key === "object" && key.value !== void 0 ? key.value : obj[key];
+          if (skipNulls && value === null) {
+            continue;
+          }
+          var keyPrefix = isArray2(obj) ? typeof generateArrayPrefix === "function" ? generateArrayPrefix(prefix, key) : prefix : prefix + (allowDots ? "." + key : "[" + key + "]");
+          sideChannel.set(object, true);
+          var valueSideChannel = getSideChannel();
+          pushToArray(values, stringify2(value, keyPrefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, format, formatter, encodeValuesOnly, charset, valueSideChannel));
+        }
+        return values;
+      };
+      var normalizeStringifyOptions = function normalizeStringifyOptions2(opts) {
+        if (!opts) {
+          return defaults;
+        }
+        if (opts.encoder !== null && opts.encoder !== void 0 && typeof opts.encoder !== "function") {
+          throw new TypeError("Encoder has to be a function.");
+        }
+        var charset = opts.charset || defaults.charset;
+        if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
+          throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
+        }
+        var format = formats["default"];
+        if (typeof opts.format !== "undefined") {
+          if (!has.call(formats.formatters, opts.format)) {
+            throw new TypeError("Unknown format option provided.");
+          }
+          format = opts.format;
+        }
+        var formatter = formats.formatters[format];
+        var filter = defaults.filter;
+        if (typeof opts.filter === "function" || isArray2(opts.filter)) {
+          filter = opts.filter;
+        }
+        return {
+          addQueryPrefix: typeof opts.addQueryPrefix === "boolean" ? opts.addQueryPrefix : defaults.addQueryPrefix,
+          allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
+          charset,
+          charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
+          delimiter: typeof opts.delimiter === "undefined" ? defaults.delimiter : opts.delimiter,
+          encode: typeof opts.encode === "boolean" ? opts.encode : defaults.encode,
+          encoder: typeof opts.encoder === "function" ? opts.encoder : defaults.encoder,
+          encodeValuesOnly: typeof opts.encodeValuesOnly === "boolean" ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
+          filter,
+          format,
+          formatter,
+          serializeDate: typeof opts.serializeDate === "function" ? opts.serializeDate : defaults.serializeDate,
+          skipNulls: typeof opts.skipNulls === "boolean" ? opts.skipNulls : defaults.skipNulls,
+          sort: typeof opts.sort === "function" ? opts.sort : null,
+          strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
+        };
+      };
+      module.exports = function(object, opts) {
+        var obj = object;
+        var options = normalizeStringifyOptions(opts);
+        var objKeys;
+        var filter;
+        if (typeof options.filter === "function") {
+          filter = options.filter;
+          obj = filter("", obj);
+        } else if (isArray2(options.filter)) {
+          filter = options.filter;
+          objKeys = filter;
+        }
+        var keys = [];
+        if (typeof obj !== "object" || obj === null) {
+          return "";
+        }
+        var arrayFormat;
+        if (opts && opts.arrayFormat in arrayPrefixGenerators) {
+          arrayFormat = opts.arrayFormat;
+        } else if (opts && "indices" in opts) {
+          arrayFormat = opts.indices ? "indices" : "repeat";
+        } else {
+          arrayFormat = "indices";
+        }
+        var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+        if (!objKeys) {
+          objKeys = Object.keys(obj);
+        }
+        if (options.sort) {
+          objKeys.sort(options.sort);
+        }
+        var sideChannel = getSideChannel();
+        for (var i = 0; i < objKeys.length; ++i) {
+          var key = objKeys[i];
+          if (options.skipNulls && obj[key] === null) {
+            continue;
+          }
+          pushToArray(keys, stringify(obj[key], key, generateArrayPrefix, options.strictNullHandling, options.skipNulls, options.encode ? options.encoder : null, options.filter, options.sort, options.allowDots, options.serializeDate, options.format, options.formatter, options.encodeValuesOnly, options.charset, sideChannel));
+        }
+        var joined = keys.join(options.delimiter);
+        var prefix = options.addQueryPrefix === true ? "?" : "";
+        if (options.charsetSentinel) {
+          if (options.charset === "iso-8859-1") {
+            prefix += "utf8=%26%2310003%3B&";
           } else {
-            url.hostname = value;
-            url.port = "";
+            prefix += "utf8=%E2%9C%93&";
           }
-          break;
-        case "protocol":
-          url.protocol = value.toLowerCase();
-          url.slashes = !fn;
-          break;
-        case "pathname":
-        case "hash":
-          if (value) {
-            var char = part === "pathname" ? "/" : "#";
-            url[part] = value.charAt(0) !== char ? char + value : value;
+        }
+        return joined.length > 0 ? prefix + joined : "";
+      };
+    }
+  });
+
+  // node_modules/qs/lib/parse.js
+  var require_parse = __commonJS({
+    "node_modules/qs/lib/parse.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var utils = require_utils();
+      var has = Object.prototype.hasOwnProperty;
+      var isArray2 = Array.isArray;
+      var defaults = {
+        allowDots: false,
+        allowPrototypes: false,
+        allowSparse: false,
+        arrayLimit: 20,
+        charset: "utf-8",
+        charsetSentinel: false,
+        comma: false,
+        decoder: utils.decode,
+        delimiter: "&",
+        depth: 5,
+        ignoreQueryPrefix: false,
+        interpretNumericEntities: false,
+        parameterLimit: 1e3,
+        parseArrays: true,
+        plainObjects: false,
+        strictNullHandling: false
+      };
+      var interpretNumericEntities = function(str) {
+        return str.replace(/&#(\d+);/g, function($0, numberStr) {
+          return String.fromCharCode(parseInt(numberStr, 10));
+        });
+      };
+      var parseArrayValue = function(val, options) {
+        if (val && typeof val === "string" && options.comma && val.indexOf(",") > -1) {
+          return val.split(",");
+        }
+        return val;
+      };
+      var isoSentinel = "utf8=%26%2310003%3B";
+      var charsetSentinel = "utf8=%E2%9C%93";
+      var parseValues = function parseQueryStringValues(str, options) {
+        var obj = {};
+        var cleanStr = options.ignoreQueryPrefix ? str.replace(/^\?/, "") : str;
+        var limit = options.parameterLimit === Infinity ? void 0 : options.parameterLimit;
+        var parts = cleanStr.split(options.delimiter, limit);
+        var skipIndex = -1;
+        var i;
+        var charset = options.charset;
+        if (options.charsetSentinel) {
+          for (i = 0; i < parts.length; ++i) {
+            if (parts[i].indexOf("utf8=") === 0) {
+              if (parts[i] === charsetSentinel) {
+                charset = "utf-8";
+              } else if (parts[i] === isoSentinel) {
+                charset = "iso-8859-1";
+              }
+              skipIndex = i;
+              i = parts.length;
+            }
+          }
+        }
+        for (i = 0; i < parts.length; ++i) {
+          if (i === skipIndex) {
+            continue;
+          }
+          var part = parts[i];
+          var bracketEqualsPos = part.indexOf("]=");
+          var pos = bracketEqualsPos === -1 ? part.indexOf("=") : bracketEqualsPos + 1;
+          var key, val;
+          if (pos === -1) {
+            key = options.decoder(part, defaults.decoder, charset, "key");
+            val = options.strictNullHandling ? null : "";
           } else {
+            key = options.decoder(part.slice(0, pos), defaults.decoder, charset, "key");
+            val = utils.maybeMap(parseArrayValue(part.slice(pos + 1), options), function(encodedVal) {
+              return options.decoder(encodedVal, defaults.decoder, charset, "value");
+            });
+          }
+          if (val && options.interpretNumericEntities && charset === "iso-8859-1") {
+            val = interpretNumericEntities(val);
+          }
+          if (part.indexOf("[]=") > -1) {
+            val = isArray2(val) ? [val] : val;
+          }
+          if (has.call(obj, key)) {
+            obj[key] = utils.combine(obj[key], val);
+          } else {
+            obj[key] = val;
+          }
+        }
+        return obj;
+      };
+      var parseObject = function(chain, val, options, valuesParsed) {
+        var leaf = valuesParsed ? val : parseArrayValue(val, options);
+        for (var i = chain.length - 1; i >= 0; --i) {
+          var obj;
+          var root = chain[i];
+          if (root === "[]" && options.parseArrays) {
+            obj = [].concat(leaf);
+          } else {
+            obj = options.plainObjects ? Object.create(null) : {};
+            var cleanRoot = root.charAt(0) === "[" && root.charAt(root.length - 1) === "]" ? root.slice(1, -1) : root;
+            var index = parseInt(cleanRoot, 10);
+            if (!options.parseArrays && cleanRoot === "") {
+              obj = { 0: leaf };
+            } else if (!isNaN(index) && root !== cleanRoot && String(index) === cleanRoot && index >= 0 && (options.parseArrays && index <= options.arrayLimit)) {
+              obj = [];
+              obj[index] = leaf;
+            } else {
+              obj[cleanRoot] = leaf;
+            }
+          }
+          leaf = obj;
+        }
+        return leaf;
+      };
+      var parseKeys = function parseQueryStringKeys(givenKey, val, options, valuesParsed) {
+        if (!givenKey) {
+          return;
+        }
+        var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, "[$1]") : givenKey;
+        var brackets = /(\[[^[\]]*])/;
+        var child = /(\[[^[\]]*])/g;
+        var segment = options.depth > 0 && brackets.exec(key);
+        var parent = segment ? key.slice(0, segment.index) : key;
+        var keys = [];
+        if (parent) {
+          if (!options.plainObjects && has.call(Object.prototype, parent)) {
+            if (!options.allowPrototypes) {
+              return;
+            }
+          }
+          keys.push(parent);
+        }
+        var i = 0;
+        while (options.depth > 0 && (segment = child.exec(key)) !== null && i < options.depth) {
+          i += 1;
+          if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+            if (!options.allowPrototypes) {
+              return;
+            }
+          }
+          keys.push(segment[1]);
+        }
+        if (segment) {
+          keys.push("[" + key.slice(segment.index) + "]");
+        }
+        return parseObject(keys, val, options, valuesParsed);
+      };
+      var normalizeParseOptions = function normalizeParseOptions2(opts) {
+        if (!opts) {
+          return defaults;
+        }
+        if (opts.decoder !== null && opts.decoder !== void 0 && typeof opts.decoder !== "function") {
+          throw new TypeError("Decoder has to be a function.");
+        }
+        if (typeof opts.charset !== "undefined" && opts.charset !== "utf-8" && opts.charset !== "iso-8859-1") {
+          throw new TypeError("The charset option must be either utf-8, iso-8859-1, or undefined");
+        }
+        var charset = typeof opts.charset === "undefined" ? defaults.charset : opts.charset;
+        return {
+          allowDots: typeof opts.allowDots === "undefined" ? defaults.allowDots : !!opts.allowDots,
+          allowPrototypes: typeof opts.allowPrototypes === "boolean" ? opts.allowPrototypes : defaults.allowPrototypes,
+          allowSparse: typeof opts.allowSparse === "boolean" ? opts.allowSparse : defaults.allowSparse,
+          arrayLimit: typeof opts.arrayLimit === "number" ? opts.arrayLimit : defaults.arrayLimit,
+          charset,
+          charsetSentinel: typeof opts.charsetSentinel === "boolean" ? opts.charsetSentinel : defaults.charsetSentinel,
+          comma: typeof opts.comma === "boolean" ? opts.comma : defaults.comma,
+          decoder: typeof opts.decoder === "function" ? opts.decoder : defaults.decoder,
+          delimiter: typeof opts.delimiter === "string" || utils.isRegExp(opts.delimiter) ? opts.delimiter : defaults.delimiter,
+          depth: typeof opts.depth === "number" || opts.depth === false ? +opts.depth : defaults.depth,
+          ignoreQueryPrefix: opts.ignoreQueryPrefix === true,
+          interpretNumericEntities: typeof opts.interpretNumericEntities === "boolean" ? opts.interpretNumericEntities : defaults.interpretNumericEntities,
+          parameterLimit: typeof opts.parameterLimit === "number" ? opts.parameterLimit : defaults.parameterLimit,
+          parseArrays: opts.parseArrays !== false,
+          plainObjects: typeof opts.plainObjects === "boolean" ? opts.plainObjects : defaults.plainObjects,
+          strictNullHandling: typeof opts.strictNullHandling === "boolean" ? opts.strictNullHandling : defaults.strictNullHandling
+        };
+      };
+      module.exports = function(str, opts) {
+        var options = normalizeParseOptions(opts);
+        if (str === "" || str === null || typeof str === "undefined") {
+          return options.plainObjects ? Object.create(null) : {};
+        }
+        var tempObj = typeof str === "string" ? parseValues(str, options) : str;
+        var obj = options.plainObjects ? Object.create(null) : {};
+        var keys = Object.keys(tempObj);
+        for (var i = 0; i < keys.length; ++i) {
+          var key = keys[i];
+          var newObj = parseKeys(key, tempObj[key], options, typeof str === "string");
+          obj = utils.merge(obj, newObj, options);
+        }
+        if (options.allowSparse === true) {
+          return obj;
+        }
+        return utils.compact(obj);
+      };
+    }
+  });
+
+  // node_modules/qs/lib/index.js
+  var require_lib = __commonJS({
+    "node_modules/qs/lib/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var stringify = require_stringify();
+      var parse = require_parse();
+      var formats = require_formats();
+      module.exports = {
+        formats,
+        parse,
+        stringify
+      };
+    }
+  });
+
+  // node_modules/requires-port/index.js
+  var require_requires_port = __commonJS({
+    "node_modules/requires-port/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      module.exports = function required(port, protocol) {
+        protocol = protocol.split(":")[0];
+        port = +port;
+        if (!port)
+          return false;
+        switch (protocol) {
+          case "http":
+          case "ws":
+            return port !== 80;
+          case "https":
+          case "wss":
+            return port !== 443;
+          case "ftp":
+            return port !== 21;
+          case "gopher":
+            return port !== 70;
+          case "file":
+            return false;
+        }
+        return port !== 0;
+      };
+    }
+  });
+
+  // node_modules/querystringify/index.js
+  var require_querystringify = __commonJS({
+    "node_modules/querystringify/index.js"(exports) {
+      init_buffer_shim();
+      "use strict";
+      var has = Object.prototype.hasOwnProperty;
+      var undef;
+      function decode(input) {
+        try {
+          return decodeURIComponent(input.replace(/\+/g, " "));
+        } catch (e) {
+          return null;
+        }
+      }
+      function encode(input) {
+        try {
+          return encodeURIComponent(input);
+        } catch (e) {
+          return null;
+        }
+      }
+      function querystring(query) {
+        var parser = /([^=?#&]+)=?([^&]*)/g, result = {}, part;
+        while (part = parser.exec(query)) {
+          var key = decode(part[1]), value = decode(part[2]);
+          if (key === null || value === null || key in result)
+            continue;
+          result[key] = value;
+        }
+        return result;
+      }
+      function querystringify(obj, prefix) {
+        prefix = prefix || "";
+        var pairs = [], value, key;
+        if (typeof prefix !== "string")
+          prefix = "?";
+        for (key in obj) {
+          if (has.call(obj, key)) {
+            value = obj[key];
+            if (!value && (value === null || value === undef || isNaN(value))) {
+              value = "";
+            }
+            key = encode(key);
+            value = encode(value);
+            if (key === null || value === null)
+              continue;
+            pairs.push(key + "=" + value);
+          }
+        }
+        return pairs.length ? prefix + pairs.join("&") : "";
+      }
+      exports.stringify = querystringify;
+      exports.parse = querystring;
+    }
+  });
+
+  // node_modules/url-parse/index.js
+  var require_url_parse = __commonJS({
+    "node_modules/url-parse/index.js"(exports, module) {
+      init_buffer_shim();
+      "use strict";
+      var required = require_requires_port();
+      var qs2 = require_querystringify();
+      var slashes = /^[A-Za-z][A-Za-z0-9+-.]*:\/\//;
+      var protocolre = /^([a-z][a-z0-9.+-]*:)?(\/\/)?([\\/]+)?([\S\s]*)/i;
+      var windowsDriveLetter = /^[a-zA-Z]:/;
+      var whitespace = "[\\x09\\x0A\\x0B\\x0C\\x0D\\x20\\xA0\\u1680\\u180E\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200A\\u202F\\u205F\\u3000\\u2028\\u2029\\uFEFF]";
+      var left = new RegExp("^" + whitespace + "+");
+      function trimLeft(str) {
+        return (str ? str : "").toString().replace(left, "");
+      }
+      var rules = [
+        ["#", "hash"],
+        ["?", "query"],
+        function sanitize(address, url) {
+          return isSpecial(url.protocol) ? address.replace(/\\/g, "/") : address;
+        },
+        ["/", "pathname"],
+        ["@", "auth", 1],
+        [NaN, "host", void 0, 1, 1],
+        [/:(\d+)$/, "port", void 0, 1],
+        [NaN, "hostname", void 0, 1, 1]
+      ];
+      var ignore = { hash: 1, query: 1 };
+      function lolcation(loc) {
+        var globalVar;
+        if (typeof window !== "undefined")
+          globalVar = window;
+        else if (typeof global !== "undefined")
+          globalVar = global;
+        else if (typeof self !== "undefined")
+          globalVar = self;
+        else
+          globalVar = {};
+        var location = globalVar.location || {};
+        loc = loc || location;
+        var finaldestination = {}, type = typeof loc, key;
+        if (loc.protocol === "blob:") {
+          finaldestination = new Url(unescape(loc.pathname), {});
+        } else if (type === "string") {
+          finaldestination = new Url(loc, {});
+          for (key in ignore)
+            delete finaldestination[key];
+        } else if (type === "object") {
+          for (key in loc) {
+            if (key in ignore)
+              continue;
+            finaldestination[key] = loc[key];
+          }
+          if (finaldestination.slashes === void 0) {
+            finaldestination.slashes = slashes.test(loc.href);
+          }
+        }
+        return finaldestination;
+      }
+      function isSpecial(scheme) {
+        return scheme === "file:" || scheme === "ftp:" || scheme === "http:" || scheme === "https:" || scheme === "ws:" || scheme === "wss:";
+      }
+      function extractProtocol(address, location) {
+        address = trimLeft(address);
+        location = location || {};
+        var match = protocolre.exec(address);
+        var protocol = match[1] ? match[1].toLowerCase() : "";
+        var forwardSlashes = !!match[2];
+        var otherSlashes = !!match[3];
+        var slashesCount = 0;
+        var rest;
+        if (forwardSlashes) {
+          if (otherSlashes) {
+            rest = match[2] + match[3] + match[4];
+            slashesCount = match[2].length + match[3].length;
+          } else {
+            rest = match[2] + match[4];
+            slashesCount = match[2].length;
+          }
+        } else {
+          if (otherSlashes) {
+            rest = match[3] + match[4];
+            slashesCount = match[3].length;
+          } else {
+            rest = match[4];
+          }
+        }
+        if (protocol === "file:") {
+          if (slashesCount >= 2) {
+            rest = rest.slice(2);
+          }
+        } else if (isSpecial(protocol)) {
+          rest = match[4];
+        } else if (protocol) {
+          if (forwardSlashes) {
+            rest = rest.slice(2);
+          }
+        } else if (slashesCount >= 2 && isSpecial(location.protocol)) {
+          rest = match[4];
+        }
+        return {
+          protocol,
+          slashes: forwardSlashes || isSpecial(protocol),
+          slashesCount,
+          rest
+        };
+      }
+      function resolve(relative, base) {
+        if (relative === "")
+          return base;
+        var path = (base || "/").split("/").slice(0, -1).concat(relative.split("/")), i = path.length, last = path[i - 1], unshift = false, up = 0;
+        while (i--) {
+          if (path[i] === ".") {
+            path.splice(i, 1);
+          } else if (path[i] === "..") {
+            path.splice(i, 1);
+            up++;
+          } else if (up) {
+            if (i === 0)
+              unshift = true;
+            path.splice(i, 1);
+            up--;
+          }
+        }
+        if (unshift)
+          path.unshift("");
+        if (last === "." || last === "..")
+          path.push("");
+        return path.join("/");
+      }
+      function Url(address, location, parser) {
+        address = trimLeft(address);
+        if (!(this instanceof Url)) {
+          return new Url(address, location, parser);
+        }
+        var relative, extracted, parse, instruction, index, key, instructions = rules.slice(), type = typeof location, url = this, i = 0;
+        if (type !== "object" && type !== "string") {
+          parser = location;
+          location = null;
+        }
+        if (parser && typeof parser !== "function")
+          parser = qs2.parse;
+        location = lolcation(location);
+        extracted = extractProtocol(address || "", location);
+        relative = !extracted.protocol && !extracted.slashes;
+        url.slashes = extracted.slashes || relative && location.slashes;
+        url.protocol = extracted.protocol || location.protocol || "";
+        address = extracted.rest;
+        if (extracted.protocol === "file:" && (extracted.slashesCount !== 2 || windowsDriveLetter.test(address)) || !extracted.slashes && (extracted.protocol || extracted.slashesCount < 2 || !isSpecial(url.protocol))) {
+          instructions[3] = [/(.*)/, "pathname"];
+        }
+        for (; i < instructions.length; i++) {
+          instruction = instructions[i];
+          if (typeof instruction === "function") {
+            address = instruction(address, url);
+            continue;
+          }
+          parse = instruction[0];
+          key = instruction[1];
+          if (parse !== parse) {
+            url[key] = address;
+          } else if (typeof parse === "string") {
+            if (~(index = address.indexOf(parse))) {
+              if (typeof instruction[2] === "number") {
+                url[key] = address.slice(0, index);
+                address = address.slice(index + instruction[2]);
+              } else {
+                url[key] = address.slice(index);
+                address = address.slice(0, index);
+              }
+            }
+          } else if (index = parse.exec(address)) {
+            url[key] = index[1];
+            address = address.slice(0, index.index);
+          }
+          url[key] = url[key] || (relative && instruction[3] ? location[key] || "" : "");
+          if (instruction[4])
+            url[key] = url[key].toLowerCase();
+        }
+        if (parser)
+          url.query = parser(url.query);
+        if (relative && location.slashes && url.pathname.charAt(0) !== "/" && (url.pathname !== "" || location.pathname !== "")) {
+          url.pathname = resolve(url.pathname, location.pathname);
+        }
+        if (url.pathname.charAt(0) !== "/" && isSpecial(url.protocol)) {
+          url.pathname = "/" + url.pathname;
+        }
+        if (!required(url.port, url.protocol)) {
+          url.host = url.hostname;
+          url.port = "";
+        }
+        url.username = url.password = "";
+        if (url.auth) {
+          instruction = url.auth.split(":");
+          url.username = instruction[0] || "";
+          url.password = instruction[1] || "";
+        }
+        url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
+        url.href = url.toString();
+      }
+      function set(part, value, fn) {
+        var url = this;
+        switch (part) {
+          case "query":
+            if (typeof value === "string" && value.length) {
+              value = (fn || qs2.parse)(value);
+            }
             url[part] = value;
-          }
-          break;
-        default:
-          url[part] = value;
+            break;
+          case "port":
+            url[part] = value;
+            if (!required(value, url.protocol)) {
+              url.host = url.hostname;
+              url[part] = "";
+            } else if (value) {
+              url.host = url.hostname + ":" + value;
+            }
+            break;
+          case "hostname":
+            url[part] = value;
+            if (url.port)
+              value += ":" + url.port;
+            url.host = value;
+            break;
+          case "host":
+            url[part] = value;
+            if (/:\d+$/.test(value)) {
+              value = value.split(":");
+              url.port = value.pop();
+              url.hostname = value.join(":");
+            } else {
+              url.hostname = value;
+              url.port = "";
+            }
+            break;
+          case "protocol":
+            url.protocol = value.toLowerCase();
+            url.slashes = !fn;
+            break;
+          case "pathname":
+          case "hash":
+            if (value) {
+              var char = part === "pathname" ? "/" : "#";
+              url[part] = value.charAt(0) !== char ? char + value : value;
+            } else {
+              url[part] = value;
+            }
+            break;
+          default:
+            url[part] = value;
+        }
+        for (var i = 0; i < rules.length; i++) {
+          var ins = rules[i];
+          if (ins[4])
+            url[ins[1]] = url[ins[1]].toLowerCase();
+        }
+        url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
+        url.href = url.toString();
+        return url;
       }
-      for (var i = 0; i < rules.length; i++) {
-        var ins = rules[i];
-        if (ins[4])
-          url[ins[1]] = url[ins[1]].toLowerCase();
+      function toString(stringify) {
+        if (!stringify || typeof stringify !== "function")
+          stringify = qs2.stringify;
+        var query, url = this, protocol = url.protocol;
+        if (protocol && protocol.charAt(protocol.length - 1) !== ":")
+          protocol += ":";
+        var result = protocol + (url.slashes || isSpecial(url.protocol) ? "//" : "");
+        if (url.username) {
+          result += url.username;
+          if (url.password)
+            result += ":" + url.password;
+          result += "@";
+        }
+        result += url.host + url.pathname;
+        query = typeof url.query === "object" ? stringify(url.query) : url.query;
+        if (query)
+          result += query.charAt(0) !== "?" ? "?" + query : query;
+        if (url.hash)
+          result += url.hash;
+        return result;
       }
-      url.origin = url.protocol !== "file:" && isSpecial(url.protocol) && url.host ? url.protocol + "//" + url.host : "null";
-      url.href = url.toString();
-      return url;
+      Url.prototype = { set, toString };
+      Url.extractProtocol = extractProtocol;
+      Url.location = lolcation;
+      Url.trimLeft = trimLeft;
+      Url.qs = qs2;
+      module.exports = Url;
     }
-    function toString(stringify) {
-      if (!stringify || typeof stringify !== "function")
-        stringify = qs2.stringify;
-      var query, url = this, protocol = url.protocol;
-      if (protocol && protocol.charAt(protocol.length - 1) !== ":")
-        protocol += ":";
-      var result = protocol + (url.slashes || isSpecial(url.protocol) ? "//" : "");
-      if (url.username) {
-        result += url.username;
-        if (url.password)
-          result += ":" + url.password;
-        result += "@";
-      }
-      result += url.host + url.pathname;
-      query = typeof url.query === "object" ? stringify(url.query) : url.query;
-      if (query)
-        result += query.charAt(0) !== "?" ? "?" + query : query;
-      if (url.hash)
-        result += url.hash;
-      return result;
-    }
-    Url.prototype = { set, toString };
-    Url.extractProtocol = extractProtocol;
-    Url.location = lolcation;
-    Url.trimLeft = trimLeft;
-    Url.qs = qs2;
-    module2.exports = Url;
-  }
-});
+  });
 
-// runtime/thunk/thunk.ts
-__export(exports, {
-  ensureSwitchUnreachable: () => ensureSwitchUnreachable,
-  findAndExecutePackFunction: () => findAndExecutePackFunction,
-  handleError: () => handleError,
-  handleErrorAsync: () => handleErrorAsync,
-  handleFetcherStatusError: () => handleFetcherStatusError,
-  marshalValue: () => marshalValue,
-  unmarshalValue: () => unmarshalValue
-});
-init_buffer_shim();
+  // runtime/thunk/thunk.ts
+  var thunk_exports = {};
+  __export(thunk_exports, {
+    ensureSwitchUnreachable: () => ensureSwitchUnreachable,
+    findAndExecutePackFunction: () => findAndExecutePackFunction,
+    handleError: () => handleError,
+    handleErrorAsync: () => handleErrorAsync,
+    handleFetcherStatusError: () => handleFetcherStatusError,
+    marshalValue: () => marshalValue,
+    unmarshalValue: () => unmarshalValue
+  });
+  init_buffer_shim();
 
-// types.ts
-init_buffer_shim();
-var PackCategory;
-(function(PackCategory2) {
-  PackCategory2["CRM"] = "CRM";
-  PackCategory2["Calendar"] = "Calendar";
-  PackCategory2["Communication"] = "Communication";
-  PackCategory2["DataStorage"] = "DataStorage";
-  PackCategory2["Design"] = "Design";
-  PackCategory2["Financial"] = "Financial";
-  PackCategory2["Fun"] = "Fun";
-  PackCategory2["Geo"] = "Geo";
-  PackCategory2["IT"] = "IT";
-  PackCategory2["Mathematics"] = "Mathematics";
-  PackCategory2["Organization"] = "Organization";
-  PackCategory2["Recruiting"] = "Recruiting";
-  PackCategory2["Shopping"] = "Shopping";
-  PackCategory2["Social"] = "Social";
-  PackCategory2["Sports"] = "Sports";
-  PackCategory2["Travel"] = "Travel";
-  PackCategory2["Weather"] = "Weather";
-})(PackCategory || (PackCategory = {}));
-var AuthenticationType;
-(function(AuthenticationType2) {
-  AuthenticationType2["None"] = "None";
-  AuthenticationType2["HeaderBearerToken"] = "HeaderBearerToken";
-  AuthenticationType2["CustomHeaderToken"] = "CustomHeaderToken";
-  AuthenticationType2["QueryParamToken"] = "QueryParamToken";
-  AuthenticationType2["MultiQueryParamToken"] = "MultiQueryParamToken";
-  AuthenticationType2["OAuth2"] = "OAuth2";
-  AuthenticationType2["WebBasic"] = "WebBasic";
-  AuthenticationType2["AWSSignature4"] = "AWSSignature4";
-  AuthenticationType2["CodaApiHeaderBearerToken"] = "CodaApiHeaderBearerToken";
-  AuthenticationType2["Various"] = "Various";
-})(AuthenticationType || (AuthenticationType = {}));
-var DefaultConnectionType;
-(function(DefaultConnectionType2) {
-  DefaultConnectionType2[DefaultConnectionType2["SharedDataOnly"] = 1] = "SharedDataOnly";
-  DefaultConnectionType2[DefaultConnectionType2["Shared"] = 2] = "Shared";
-  DefaultConnectionType2[DefaultConnectionType2["ProxyActionsOnly"] = 3] = "ProxyActionsOnly";
-})(DefaultConnectionType || (DefaultConnectionType = {}));
-var PostSetupType;
-(function(PostSetupType2) {
-  PostSetupType2["SetEndpoint"] = "SetEndPoint";
-})(PostSetupType || (PostSetupType = {}));
-var FeatureSet;
-(function(FeatureSet2) {
-  FeatureSet2["Basic"] = "Basic";
-  FeatureSet2["Pro"] = "Pro";
-  FeatureSet2["Team"] = "Team";
-  FeatureSet2["Enterprise"] = "Enterprise";
-})(FeatureSet || (FeatureSet = {}));
-var QuotaLimitType;
-(function(QuotaLimitType2) {
-  QuotaLimitType2["Action"] = "Action";
-  QuotaLimitType2["Getter"] = "Getter";
-  QuotaLimitType2["Sync"] = "Sync";
-  QuotaLimitType2["Metadata"] = "Metadata";
-})(QuotaLimitType || (QuotaLimitType = {}));
-var SyncInterval;
-(function(SyncInterval2) {
-  SyncInterval2["Manual"] = "Manual";
-  SyncInterval2["Daily"] = "Daily";
-  SyncInterval2["Hourly"] = "Hourly";
-  SyncInterval2["EveryTenMinutes"] = "EveryTenMinutes";
-})(SyncInterval || (SyncInterval = {}));
+  // types.ts
+  init_buffer_shim();
+  var PackCategory;
+  (function(PackCategory2) {
+    PackCategory2["CRM"] = "CRM";
+    PackCategory2["Calendar"] = "Calendar";
+    PackCategory2["Communication"] = "Communication";
+    PackCategory2["DataStorage"] = "DataStorage";
+    PackCategory2["Design"] = "Design";
+    PackCategory2["Financial"] = "Financial";
+    PackCategory2["Fun"] = "Fun";
+    PackCategory2["Geo"] = "Geo";
+    PackCategory2["IT"] = "IT";
+    PackCategory2["Mathematics"] = "Mathematics";
+    PackCategory2["Organization"] = "Organization";
+    PackCategory2["Recruiting"] = "Recruiting";
+    PackCategory2["Shopping"] = "Shopping";
+    PackCategory2["Social"] = "Social";
+    PackCategory2["Sports"] = "Sports";
+    PackCategory2["Travel"] = "Travel";
+    PackCategory2["Weather"] = "Weather";
+  })(PackCategory || (PackCategory = {}));
+  var AuthenticationType;
+  (function(AuthenticationType2) {
+    AuthenticationType2["None"] = "None";
+    AuthenticationType2["HeaderBearerToken"] = "HeaderBearerToken";
+    AuthenticationType2["CustomHeaderToken"] = "CustomHeaderToken";
+    AuthenticationType2["QueryParamToken"] = "QueryParamToken";
+    AuthenticationType2["MultiQueryParamToken"] = "MultiQueryParamToken";
+    AuthenticationType2["OAuth2"] = "OAuth2";
+    AuthenticationType2["WebBasic"] = "WebBasic";
+    AuthenticationType2["AWSSignature4"] = "AWSSignature4";
+    AuthenticationType2["CodaApiHeaderBearerToken"] = "CodaApiHeaderBearerToken";
+    AuthenticationType2["Various"] = "Various";
+  })(AuthenticationType || (AuthenticationType = {}));
+  var DefaultConnectionType;
+  (function(DefaultConnectionType2) {
+    DefaultConnectionType2[DefaultConnectionType2["SharedDataOnly"] = 1] = "SharedDataOnly";
+    DefaultConnectionType2[DefaultConnectionType2["Shared"] = 2] = "Shared";
+    DefaultConnectionType2[DefaultConnectionType2["ProxyActionsOnly"] = 3] = "ProxyActionsOnly";
+  })(DefaultConnectionType || (DefaultConnectionType = {}));
+  var PostSetupType;
+  (function(PostSetupType2) {
+    PostSetupType2["SetEndpoint"] = "SetEndPoint";
+  })(PostSetupType || (PostSetupType = {}));
+  var FeatureSet;
+  (function(FeatureSet2) {
+    FeatureSet2["Basic"] = "Basic";
+    FeatureSet2["Pro"] = "Pro";
+    FeatureSet2["Team"] = "Team";
+    FeatureSet2["Enterprise"] = "Enterprise";
+  })(FeatureSet || (FeatureSet = {}));
+  var QuotaLimitType;
+  (function(QuotaLimitType2) {
+    QuotaLimitType2["Action"] = "Action";
+    QuotaLimitType2["Getter"] = "Getter";
+    QuotaLimitType2["Sync"] = "Sync";
+    QuotaLimitType2["Metadata"] = "Metadata";
+  })(QuotaLimitType || (QuotaLimitType = {}));
+  var SyncInterval;
+  (function(SyncInterval2) {
+    SyncInterval2["Manual"] = "Manual";
+    SyncInterval2["Daily"] = "Daily";
+    SyncInterval2["Hourly"] = "Hourly";
+    SyncInterval2["EveryTenMinutes"] = "EveryTenMinutes";
+  })(SyncInterval || (SyncInterval = {}));
 
-// runtime/types.ts
-init_buffer_shim();
-var FormulaType;
-(function(FormulaType2) {
-  FormulaType2["Standard"] = "Standard";
-  FormulaType2["Sync"] = "Sync";
-  FormulaType2["Metadata"] = "Metadata";
-})(FormulaType || (FormulaType = {}));
-var MetadataFormulaType;
-(function(MetadataFormulaType2) {
-  MetadataFormulaType2["GetConnectionName"] = "GetConnectionName";
-  MetadataFormulaType2["GetConnectionUserId"] = "GetConnectionUserId";
-  MetadataFormulaType2["ParameterAutocomplete"] = "ParameterAutocomplete";
-  MetadataFormulaType2["PostSetupSetEndpoint"] = "PostSetupSetEndpoint";
-  MetadataFormulaType2["SyncListDynamicUrls"] = "SyncListDynamicUrls";
-  MetadataFormulaType2["SyncGetDisplayUrl"] = "SyncGetDisplayUrl";
-  MetadataFormulaType2["SyncGetTableName"] = "SyncGetTableName";
-  MetadataFormulaType2["SyncGetSchema"] = "SyncGetSchema";
-})(MetadataFormulaType || (MetadataFormulaType = {}));
+  // runtime/types.ts
+  init_buffer_shim();
+  var FormulaType;
+  (function(FormulaType2) {
+    FormulaType2["Standard"] = "Standard";
+    FormulaType2["Sync"] = "Sync";
+    FormulaType2["Metadata"] = "Metadata";
+  })(FormulaType || (FormulaType = {}));
+  var MetadataFormulaType;
+  (function(MetadataFormulaType2) {
+    MetadataFormulaType2["GetConnectionName"] = "GetConnectionName";
+    MetadataFormulaType2["GetConnectionUserId"] = "GetConnectionUserId";
+    MetadataFormulaType2["ParameterAutocomplete"] = "ParameterAutocomplete";
+    MetadataFormulaType2["PostSetupSetEndpoint"] = "PostSetupSetEndpoint";
+    MetadataFormulaType2["SyncListDynamicUrls"] = "SyncListDynamicUrls";
+    MetadataFormulaType2["SyncGetDisplayUrl"] = "SyncGetDisplayUrl";
+    MetadataFormulaType2["SyncGetTableName"] = "SyncGetTableName";
+    MetadataFormulaType2["SyncGetSchema"] = "SyncGetSchema";
+  })(MetadataFormulaType || (MetadataFormulaType = {}));
 
-// api.ts
-init_buffer_shim();
+  // api.ts
+  init_buffer_shim();
 
-// api_types.ts
-init_buffer_shim();
-var Type;
-(function(Type2) {
-  Type2[Type2["string"] = 0] = "string";
-  Type2[Type2["number"] = 1] = "number";
-  Type2[Type2["object"] = 2] = "object";
-  Type2[Type2["boolean"] = 3] = "boolean";
-  Type2[Type2["date"] = 4] = "date";
-  Type2[Type2["html"] = 5] = "html";
-  Type2[Type2["image"] = 6] = "image";
-})(Type || (Type = {}));
-var ParameterType;
-(function(ParameterType2) {
-  ParameterType2["String"] = "string";
-  ParameterType2["Number"] = "number";
-  ParameterType2["Boolean"] = "boolean";
-  ParameterType2["Date"] = "date";
-  ParameterType2["Html"] = "html";
-  ParameterType2["Image"] = "image";
-  ParameterType2["StringArray"] = "stringArray";
-  ParameterType2["NumberArray"] = "numberArray";
-  ParameterType2["BooleanArray"] = "booleanArray";
-  ParameterType2["DateArray"] = "dateArray";
-  ParameterType2["HtmlArray"] = "htmlArray`";
-  ParameterType2["ImageArray"] = "imageArray";
-})(ParameterType || (ParameterType = {}));
-var ParameterTypeInputMap = {
-  [ParameterType.String]: 0,
-  [ParameterType.Number]: 1,
-  [ParameterType.Boolean]: 3,
-  [ParameterType.Date]: 4,
-  [ParameterType.Html]: 5,
-  [ParameterType.Image]: 6,
-  [ParameterType.StringArray]: { type: "array", items: 0 },
-  [ParameterType.NumberArray]: { type: "array", items: 1 },
-  [ParameterType.BooleanArray]: { type: "array", items: 3 },
-  [ParameterType.DateArray]: { type: "array", items: 4 },
-  [ParameterType.HtmlArray]: { type: "array", items: 5 },
-  [ParameterType.ImageArray]: { type: "array", items: 6 }
-};
-var ConnectionRequirement;
-(function(ConnectionRequirement2) {
-  ConnectionRequirement2["None"] = "none";
-  ConnectionRequirement2["Optional"] = "optional";
-  ConnectionRequirement2["Required"] = "required";
-})(ConnectionRequirement || (ConnectionRequirement = {}));
-var NetworkConnection;
-(function(NetworkConnection2) {
-  NetworkConnection2["None"] = "none";
-  NetworkConnection2["Optional"] = "optional";
-  NetworkConnection2["Required"] = "required";
-})(NetworkConnection || (NetworkConnection = {}));
-var PrecannedDateRange;
-(function(PrecannedDateRange2) {
-  PrecannedDateRange2["Yesterday"] = "yesterday";
-  PrecannedDateRange2["Last7Days"] = "last_7_days";
-  PrecannedDateRange2["Last30Days"] = "last_30_days";
-  PrecannedDateRange2["LastWeek"] = "last_week";
-  PrecannedDateRange2["LastMonth"] = "last_month";
-  PrecannedDateRange2["Last3Months"] = "last_3_months";
-  PrecannedDateRange2["Last6Months"] = "last_6_months";
-  PrecannedDateRange2["LastYear"] = "last_year";
-  PrecannedDateRange2["Today"] = "today";
-  PrecannedDateRange2["ThisWeek"] = "this_week";
-  PrecannedDateRange2["ThisWeekStart"] = "this_week_start";
-  PrecannedDateRange2["ThisMonth"] = "this_month";
-  PrecannedDateRange2["ThisMonthStart"] = "this_month_start";
-  PrecannedDateRange2["ThisYearStart"] = "this_year_start";
-  PrecannedDateRange2["YearToDate"] = "year_to_date";
-  PrecannedDateRange2["ThisYear"] = "this_year";
-  PrecannedDateRange2["Tomorrow"] = "tomorrow";
-  PrecannedDateRange2["Next7Days"] = "next_7_days";
-  PrecannedDateRange2["Next30Days"] = "next_30_days";
-  PrecannedDateRange2["NextWeek"] = "next_week";
-  PrecannedDateRange2["NextMonth"] = "next_month";
-  PrecannedDateRange2["Next3Months"] = "next_3_months";
-  PrecannedDateRange2["Next6Months"] = "next_6_months";
-  PrecannedDateRange2["NextYear"] = "next_year";
-  PrecannedDateRange2["Everything"] = "everything";
-})(PrecannedDateRange || (PrecannedDateRange = {}));
-
-// schema.ts
-init_buffer_shim();
-
-// helpers/ensure.ts
-init_buffer_shim();
-
-// schema.ts
-var import_pascalcase = __toModule(require_pascalcase());
-var ValueType;
-(function(ValueType2) {
-  ValueType2["Boolean"] = "boolean";
-  ValueType2["Number"] = "number";
-  ValueType2["String"] = "string";
-  ValueType2["Array"] = "array";
-  ValueType2["Object"] = "object";
-})(ValueType || (ValueType = {}));
-var ValueHintType;
-(function(ValueHintType2) {
-  ValueHintType2["Date"] = "date";
-  ValueHintType2["Time"] = "time";
-  ValueHintType2["DateTime"] = "datetime";
-  ValueHintType2["Duration"] = "duration";
-  ValueHintType2["Person"] = "person";
-  ValueHintType2["Percent"] = "percent";
-  ValueHintType2["Currency"] = "currency";
-  ValueHintType2["ImageReference"] = "image";
-  ValueHintType2["ImageAttachment"] = "imageAttachment";
-  ValueHintType2["Url"] = "url";
-  ValueHintType2["Markdown"] = "markdown";
-  ValueHintType2["Html"] = "html";
-  ValueHintType2["Embed"] = "embed";
-  ValueHintType2["Reference"] = "reference";
-  ValueHintType2["Attachment"] = "attachment";
-  ValueHintType2["Slider"] = "slider";
-  ValueHintType2["Scale"] = "scale";
-})(ValueHintType || (ValueHintType = {}));
-var StringHintValueTypes = [
-  ValueHintType.Attachment,
-  ValueHintType.Date,
-  ValueHintType.Time,
-  ValueHintType.DateTime,
-  ValueHintType.Duration,
-  ValueHintType.Embed,
-  ValueHintType.Html,
-  ValueHintType.ImageReference,
-  ValueHintType.ImageAttachment,
-  ValueHintType.Markdown,
-  ValueHintType.Url
-];
-var NumberHintValueTypes = [
-  ValueHintType.Date,
-  ValueHintType.Time,
-  ValueHintType.DateTime,
-  ValueHintType.Percent,
-  ValueHintType.Currency,
-  ValueHintType.Slider,
-  ValueHintType.Scale
-];
-var ObjectHintValueTypes = [ValueHintType.Person, ValueHintType.Reference];
-var CurrencyFormat;
-(function(CurrencyFormat2) {
-  CurrencyFormat2["Currency"] = "currency";
-  CurrencyFormat2["Accounting"] = "accounting";
-  CurrencyFormat2["Financial"] = "financial";
-})(CurrencyFormat || (CurrencyFormat = {}));
-var ScaleIconSet;
-(function(ScaleIconSet2) {
-  ScaleIconSet2["Star"] = "star";
-  ScaleIconSet2["Circle"] = "circle";
-  ScaleIconSet2["Fire"] = "fire";
-  ScaleIconSet2["Bug"] = "bug";
-  ScaleIconSet2["Diamond"] = "diamond";
-  ScaleIconSet2["Bell"] = "bell";
-  ScaleIconSet2["ThumbsUp"] = "thumbsup";
-  ScaleIconSet2["Heart"] = "heart";
-  ScaleIconSet2["Chili"] = "chili";
-  ScaleIconSet2["Smiley"] = "smiley";
-  ScaleIconSet2["Lightning"] = "lightning";
-  ScaleIconSet2["Currency"] = "currency";
-  ScaleIconSet2["Coffee"] = "coffee";
-  ScaleIconSet2["Person"] = "person";
-  ScaleIconSet2["Battery"] = "battery";
-  ScaleIconSet2["Cocktail"] = "cocktail";
-  ScaleIconSet2["Cloud"] = "cloud";
-  ScaleIconSet2["Sun"] = "sun";
-  ScaleIconSet2["Checkmark"] = "checkmark";
-  ScaleIconSet2["LightBulb"] = "lightbulb";
-})(ScaleIconSet || (ScaleIconSet = {}));
-var DurationUnit;
-(function(DurationUnit2) {
-  DurationUnit2["Days"] = "days";
-  DurationUnit2["Hours"] = "hours";
-  DurationUnit2["Minutes"] = "minutes";
-  DurationUnit2["Seconds"] = "seconds";
-})(DurationUnit || (DurationUnit = {}));
-var SimpleStringHintValueTypes = [
-  ValueHintType.Attachment,
-  ValueHintType.Embed,
-  ValueHintType.Html,
-  ValueHintType.ImageReference,
-  ValueHintType.ImageAttachment,
-  ValueHintType.Markdown,
-  ValueHintType.Url
-];
-var AttributionNodeType;
-(function(AttributionNodeType2) {
-  AttributionNodeType2[AttributionNodeType2["Text"] = 1] = "Text";
-  AttributionNodeType2[AttributionNodeType2["Link"] = 2] = "Link";
-  AttributionNodeType2[AttributionNodeType2["Image"] = 3] = "Image";
-})(AttributionNodeType || (AttributionNodeType = {}));
-
-// handler_templates.ts
-init_buffer_shim();
-var import_clone = __toModule(require_clone());
-
-// helpers/url.ts
-init_buffer_shim();
-var import_qs = __toModule(require_lib());
-var import_url_parse = __toModule(require_url_parse());
-
-// api.ts
-var StatusCodeError = class extends Error {
-  constructor(statusCode, body, options, response) {
-    super(`${statusCode} - ${JSON.stringify(body)}`);
-    this.name = "StatusCodeError";
-    this.statusCode = statusCode;
-    this.body = body;
-    this.error = body;
-    this.options = options;
-    let responseBody = response == null ? void 0 : response.body;
-    if (typeof responseBody === "object") {
-      responseBody = JSON.stringify(responseBody);
-    }
-    this.response = { ...response, body: responseBody };
-  }
-};
-function isDynamicSyncTable(syncTable) {
-  return "isDynamic" in syncTable;
-}
-
-// runtime/common/helpers.ts
-init_buffer_shim();
-function findFormula(packDef, formulaNameWithNamespace) {
-  const packFormulas = packDef.formulas;
-  if (!packFormulas) {
-    throw new Error(`Pack definition has no formulas.`);
-  }
-  const [namespace, name] = formulaNameWithNamespace.includes("::") ? formulaNameWithNamespace.split("::") : ["", formulaNameWithNamespace];
-  if (namespace) {
-    console.log(`Warning: formula was invoked with a namespace (${formulaNameWithNamespace}), but namespaces are now deprecated.`);
-  }
-  const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
-  if (!formulas || !formulas.length) {
-    throw new Error(`Pack definition has no formulas${namespace != null ? namespace : ` for namespace "${namespace}"`}.`);
-  }
-  for (const formula of formulas) {
-    if (formula.name === name) {
-      return formula;
-    }
-  }
-  throw new Error(`Pack definition has no formula "${name}"${namespace != null ? namespace : ` in namespace "${namespace}"`}.`);
-}
-function findSyncFormula(packDef, syncFormulaName) {
-  if (!packDef.syncTables) {
-    throw new Error(`Pack definition has no sync tables.`);
-  }
-  for (const syncTable of packDef.syncTables) {
-    const syncFormula = syncTable.getter;
-    if (syncTable.name === syncFormulaName) {
-      return syncFormula;
-    }
-  }
-  throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
-}
-
-// runtime/common/marshaling/index.ts
-init_buffer_shim();
-
-// runtime/common/marshaling/marshal_buffer.ts
-init_buffer_shim();
-
-// runtime/common/marshaling/constants.ts
-init_buffer_shim();
-var CodaMarshalerType;
-(function(CodaMarshalerType2) {
-  CodaMarshalerType2["Error"] = "Error";
-  CodaMarshalerType2["Buffer"] = "Buffer";
-  CodaMarshalerType2["Number"] = "Number";
-  CodaMarshalerType2["Date"] = "Date";
-})(CodaMarshalerType || (CodaMarshalerType = {}));
-var MarshalingInjectedKeys;
-(function(MarshalingInjectedKeys2) {
-  MarshalingInjectedKeys2["CodaMarshaler"] = "__coda_marshaler__";
-  MarshalingInjectedKeys2["ErrorClassName"] = "__error_class_name__";
-  MarshalingInjectedKeys2["ErrorClassType"] = "__error_class_type__";
-})(MarshalingInjectedKeys || (MarshalingInjectedKeys = {}));
-
-// runtime/common/marshaling/marshal_buffer.ts
-function marshalBuffer(val) {
-  if (val instanceof Buffer2) {
-    return {
-      data: [...Uint8Array.from(val)],
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Buffer
-    };
-  }
-}
-function unmarshalBuffer(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Buffer) {
-    return;
-  }
-  return Buffer2.from(val.data);
-}
-
-// runtime/common/marshaling/marshal_dates.ts
-init_buffer_shim();
-function marshalDate(val) {
-  if (val instanceof Date) {
-    return {
-      date: val.toJSON(),
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Date
-    };
-  }
-}
-function unmarshalDate(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Date) {
-    return;
-  }
-  return new Date(Date.parse(val.date));
-}
-
-// runtime/common/marshaling/marshal_errors.ts
-init_buffer_shim();
-var ErrorClassType;
-(function(ErrorClassType2) {
-  ErrorClassType2["System"] = "System";
-  ErrorClassType2["Coda"] = "Coda";
-  ErrorClassType2["Other"] = "Other";
-})(ErrorClassType || (ErrorClassType = {}));
-var recognizableSystemErrorClasses = [
-  Error,
-  EvalError,
-  RangeError,
-  ReferenceError,
-  SyntaxError,
-  TypeError,
-  URIError
-];
-var recognizableCodaErrorClasses = [
-  StatusCodeError
-];
-function getErrorClassType(err) {
-  if (recognizableSystemErrorClasses.some((cls) => cls === err.constructor)) {
-    return ErrorClassType.System;
-  }
-  if (recognizableCodaErrorClasses.some((cls) => cls === err.constructor)) {
-    return ErrorClassType.Coda;
-  }
-  return ErrorClassType.Other;
-}
-function marshalError(err) {
-  if (!(err instanceof Error)) {
-    return;
-  }
-  const { name, stack, message, ...args } = err;
-  return {
-    name,
-    stack,
-    message,
-    [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Error,
-    [MarshalingInjectedKeys.ErrorClassName]: err.constructor.name,
-    [MarshalingInjectedKeys.ErrorClassType]: getErrorClassType(err),
-    ...args
+  // api_types.ts
+  init_buffer_shim();
+  var Type;
+  (function(Type2) {
+    Type2[Type2["string"] = 0] = "string";
+    Type2[Type2["number"] = 1] = "number";
+    Type2[Type2["object"] = 2] = "object";
+    Type2[Type2["boolean"] = 3] = "boolean";
+    Type2[Type2["date"] = 4] = "date";
+    Type2[Type2["html"] = 5] = "html";
+    Type2[Type2["image"] = 6] = "image";
+  })(Type || (Type = {}));
+  var ParameterType;
+  (function(ParameterType2) {
+    ParameterType2["String"] = "string";
+    ParameterType2["Number"] = "number";
+    ParameterType2["Boolean"] = "boolean";
+    ParameterType2["Date"] = "date";
+    ParameterType2["Html"] = "html";
+    ParameterType2["Image"] = "image";
+    ParameterType2["StringArray"] = "stringArray";
+    ParameterType2["NumberArray"] = "numberArray";
+    ParameterType2["BooleanArray"] = "booleanArray";
+    ParameterType2["DateArray"] = "dateArray";
+    ParameterType2["HtmlArray"] = "htmlArray`";
+    ParameterType2["ImageArray"] = "imageArray";
+  })(ParameterType || (ParameterType = {}));
+  var ParameterTypeInputMap = {
+    [ParameterType.String]: 0,
+    [ParameterType.Number]: 1,
+    [ParameterType.Boolean]: 3,
+    [ParameterType.Date]: 4,
+    [ParameterType.Html]: 5,
+    [ParameterType.Image]: 6,
+    [ParameterType.StringArray]: { type: "array", items: 0 },
+    [ParameterType.NumberArray]: { type: "array", items: 1 },
+    [ParameterType.BooleanArray]: { type: "array", items: 3 },
+    [ParameterType.DateArray]: { type: "array", items: 4 },
+    [ParameterType.HtmlArray]: { type: "array", items: 5 },
+    [ParameterType.ImageArray]: { type: "array", items: 6 }
   };
-}
-function getErrorClass(errorClassType, name) {
-  let errorClasses;
-  switch (errorClassType) {
-    case ErrorClassType.System:
-      errorClasses = recognizableSystemErrorClasses;
-      break;
-    case ErrorClassType.Coda:
-      errorClasses = recognizableCodaErrorClasses;
-      break;
-    default:
-      errorClasses = [];
-  }
-  return errorClasses.find((cls) => cls.name === name) || Error;
-}
-function unmarshalError(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Error) {
-    return;
-  }
-  const {
-    name,
-    stack,
-    message,
-    [MarshalingInjectedKeys.ErrorClassName]: errorClassName,
-    [MarshalingInjectedKeys.CodaMarshaler]: _,
-    [MarshalingInjectedKeys.ErrorClassType]: errorClassType,
-    ...otherProperties
-  } = val;
-  const ErrorClass = getErrorClass(errorClassType, errorClassName);
-  const error = new ErrorClass();
-  error.message = message;
-  error.stack = stack;
-  error.name = name;
-  for (const key of Object.keys(otherProperties)) {
-    error[key] = otherProperties[key];
-  }
-  return error;
-}
+  var ConnectionRequirement;
+  (function(ConnectionRequirement2) {
+    ConnectionRequirement2["None"] = "none";
+    ConnectionRequirement2["Optional"] = "optional";
+    ConnectionRequirement2["Required"] = "required";
+  })(ConnectionRequirement || (ConnectionRequirement = {}));
+  var NetworkConnection;
+  (function(NetworkConnection2) {
+    NetworkConnection2["None"] = "none";
+    NetworkConnection2["Optional"] = "optional";
+    NetworkConnection2["Required"] = "required";
+  })(NetworkConnection || (NetworkConnection = {}));
+  var PrecannedDateRange;
+  (function(PrecannedDateRange2) {
+    PrecannedDateRange2["Yesterday"] = "yesterday";
+    PrecannedDateRange2["Last7Days"] = "last_7_days";
+    PrecannedDateRange2["Last30Days"] = "last_30_days";
+    PrecannedDateRange2["LastWeek"] = "last_week";
+    PrecannedDateRange2["LastMonth"] = "last_month";
+    PrecannedDateRange2["Last3Months"] = "last_3_months";
+    PrecannedDateRange2["Last6Months"] = "last_6_months";
+    PrecannedDateRange2["LastYear"] = "last_year";
+    PrecannedDateRange2["Today"] = "today";
+    PrecannedDateRange2["ThisWeek"] = "this_week";
+    PrecannedDateRange2["ThisWeekStart"] = "this_week_start";
+    PrecannedDateRange2["ThisMonth"] = "this_month";
+    PrecannedDateRange2["ThisMonthStart"] = "this_month_start";
+    PrecannedDateRange2["ThisYearStart"] = "this_year_start";
+    PrecannedDateRange2["YearToDate"] = "year_to_date";
+    PrecannedDateRange2["ThisYear"] = "this_year";
+    PrecannedDateRange2["Tomorrow"] = "tomorrow";
+    PrecannedDateRange2["Next7Days"] = "next_7_days";
+    PrecannedDateRange2["Next30Days"] = "next_30_days";
+    PrecannedDateRange2["NextWeek"] = "next_week";
+    PrecannedDateRange2["NextMonth"] = "next_month";
+    PrecannedDateRange2["Next3Months"] = "next_3_months";
+    PrecannedDateRange2["Next6Months"] = "next_6_months";
+    PrecannedDateRange2["NextYear"] = "next_year";
+    PrecannedDateRange2["Everything"] = "everything";
+  })(PrecannedDateRange || (PrecannedDateRange = {}));
 
-// runtime/common/marshaling/marshal_numbers.ts
-init_buffer_shim();
-function marshalNumber(val) {
-  if (typeof val === "number" && (isNaN(val) || val === Infinity)) {
-    return {
-      data: val.toString(),
-      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Number
-    };
-  }
-}
-function unmarshalNumber(val) {
-  if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Number) {
-    return;
-  }
-  return Number(val.data);
-}
+  // schema.ts
+  init_buffer_shim();
 
-// runtime/common/marshaling/index.ts
-var HACK_UNDEFINED_JSON_VALUE = "__CODA_UNDEFINED__";
-var MaxTraverseDepth = 100;
-var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
-var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
-function serialize(val) {
-  for (const marshaler of customMarshalers) {
-    const result = marshaler(val);
-    if (result !== void 0) {
-      return result;
+  // helpers/ensure.ts
+  init_buffer_shim();
+
+  // schema.ts
+  var import_pascalcase = __toModule(require_pascalcase());
+  var ValueType;
+  (function(ValueType2) {
+    ValueType2["Boolean"] = "boolean";
+    ValueType2["Number"] = "number";
+    ValueType2["String"] = "string";
+    ValueType2["Array"] = "array";
+    ValueType2["Object"] = "object";
+  })(ValueType || (ValueType = {}));
+  var ValueHintType;
+  (function(ValueHintType2) {
+    ValueHintType2["Date"] = "date";
+    ValueHintType2["Time"] = "time";
+    ValueHintType2["DateTime"] = "datetime";
+    ValueHintType2["Duration"] = "duration";
+    ValueHintType2["Person"] = "person";
+    ValueHintType2["Percent"] = "percent";
+    ValueHintType2["Currency"] = "currency";
+    ValueHintType2["ImageReference"] = "image";
+    ValueHintType2["ImageAttachment"] = "imageAttachment";
+    ValueHintType2["Url"] = "url";
+    ValueHintType2["Markdown"] = "markdown";
+    ValueHintType2["Html"] = "html";
+    ValueHintType2["Embed"] = "embed";
+    ValueHintType2["Reference"] = "reference";
+    ValueHintType2["Attachment"] = "attachment";
+    ValueHintType2["Slider"] = "slider";
+    ValueHintType2["Scale"] = "scale";
+  })(ValueHintType || (ValueHintType = {}));
+  var StringHintValueTypes = [
+    ValueHintType.Attachment,
+    ValueHintType.Date,
+    ValueHintType.Time,
+    ValueHintType.DateTime,
+    ValueHintType.Duration,
+    ValueHintType.Embed,
+    ValueHintType.Html,
+    ValueHintType.ImageReference,
+    ValueHintType.ImageAttachment,
+    ValueHintType.Markdown,
+    ValueHintType.Url
+  ];
+  var NumberHintValueTypes = [
+    ValueHintType.Date,
+    ValueHintType.Time,
+    ValueHintType.DateTime,
+    ValueHintType.Percent,
+    ValueHintType.Currency,
+    ValueHintType.Slider,
+    ValueHintType.Scale
+  ];
+  var ObjectHintValueTypes = [ValueHintType.Person, ValueHintType.Reference];
+  var CurrencyFormat;
+  (function(CurrencyFormat2) {
+    CurrencyFormat2["Currency"] = "currency";
+    CurrencyFormat2["Accounting"] = "accounting";
+    CurrencyFormat2["Financial"] = "financial";
+  })(CurrencyFormat || (CurrencyFormat = {}));
+  var ScaleIconSet;
+  (function(ScaleIconSet2) {
+    ScaleIconSet2["Star"] = "star";
+    ScaleIconSet2["Circle"] = "circle";
+    ScaleIconSet2["Fire"] = "fire";
+    ScaleIconSet2["Bug"] = "bug";
+    ScaleIconSet2["Diamond"] = "diamond";
+    ScaleIconSet2["Bell"] = "bell";
+    ScaleIconSet2["ThumbsUp"] = "thumbsup";
+    ScaleIconSet2["Heart"] = "heart";
+    ScaleIconSet2["Chili"] = "chili";
+    ScaleIconSet2["Smiley"] = "smiley";
+    ScaleIconSet2["Lightning"] = "lightning";
+    ScaleIconSet2["Currency"] = "currency";
+    ScaleIconSet2["Coffee"] = "coffee";
+    ScaleIconSet2["Person"] = "person";
+    ScaleIconSet2["Battery"] = "battery";
+    ScaleIconSet2["Cocktail"] = "cocktail";
+    ScaleIconSet2["Cloud"] = "cloud";
+    ScaleIconSet2["Sun"] = "sun";
+    ScaleIconSet2["Checkmark"] = "checkmark";
+    ScaleIconSet2["LightBulb"] = "lightbulb";
+  })(ScaleIconSet || (ScaleIconSet = {}));
+  var DurationUnit;
+  (function(DurationUnit2) {
+    DurationUnit2["Days"] = "days";
+    DurationUnit2["Hours"] = "hours";
+    DurationUnit2["Minutes"] = "minutes";
+    DurationUnit2["Seconds"] = "seconds";
+  })(DurationUnit || (DurationUnit = {}));
+  var SimpleStringHintValueTypes = [
+    ValueHintType.Attachment,
+    ValueHintType.Embed,
+    ValueHintType.Html,
+    ValueHintType.ImageReference,
+    ValueHintType.ImageAttachment,
+    ValueHintType.Markdown,
+    ValueHintType.Url
+  ];
+  var AttributionNodeType;
+  (function(AttributionNodeType2) {
+    AttributionNodeType2[AttributionNodeType2["Text"] = 1] = "Text";
+    AttributionNodeType2[AttributionNodeType2["Link"] = 2] = "Link";
+    AttributionNodeType2[AttributionNodeType2["Image"] = 3] = "Image";
+  })(AttributionNodeType || (AttributionNodeType = {}));
+
+  // handler_templates.ts
+  init_buffer_shim();
+  var import_clone = __toModule(require_clone());
+
+  // helpers/url.ts
+  init_buffer_shim();
+  var import_qs = __toModule(require_lib());
+  var import_url_parse = __toModule(require_url_parse());
+
+  // api.ts
+  var StatusCodeError = class extends Error {
+    constructor(statusCode, body, options, response) {
+      super(`${statusCode} - ${JSON.stringify(body)}`);
+      this.name = "StatusCodeError";
+      this.statusCode = statusCode;
+      this.body = body;
+      this.error = body;
+      this.options = options;
+      let responseBody = response == null ? void 0 : response.body;
+      if (typeof responseBody === "object") {
+        responseBody = JSON.stringify(responseBody);
+      }
+      this.response = { ...response, body: responseBody };
+    }
+  };
+  function isDynamicSyncTable(syncTable) {
+    return "isDynamic" in syncTable;
+  }
+
+  // runtime/common/helpers.ts
+  init_buffer_shim();
+  function findFormula(packDef, formulaNameWithNamespace) {
+    const packFormulas = packDef.formulas;
+    if (!packFormulas) {
+      throw new Error(`Pack definition has no formulas.`);
+    }
+    const [namespace, name] = formulaNameWithNamespace.includes("::") ? formulaNameWithNamespace.split("::") : ["", formulaNameWithNamespace];
+    if (namespace) {
+      console.log(`Warning: formula was invoked with a namespace (${formulaNameWithNamespace}), but namespaces are now deprecated.`);
+    }
+    const formulas = Array.isArray(packFormulas) ? packFormulas : packFormulas[namespace];
+    if (!formulas || !formulas.length) {
+      throw new Error(`Pack definition has no formulas${namespace != null ? namespace : ` for namespace "${namespace}"`}.`);
+    }
+    for (const formula of formulas) {
+      if (formula.name === name) {
+        return formula;
+      }
+    }
+    throw new Error(`Pack definition has no formula "${name}"${namespace != null ? namespace : ` in namespace "${namespace}"`}.`);
+  }
+  function findSyncFormula(packDef, syncFormulaName) {
+    if (!packDef.syncTables) {
+      throw new Error(`Pack definition has no sync tables.`);
+    }
+    for (const syncTable of packDef.syncTables) {
+      const syncFormula = syncTable.getter;
+      if (syncTable.name === syncFormulaName) {
+        return syncFormula;
+      }
+    }
+    throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
+  }
+
+  // runtime/common/marshaling/index.ts
+  init_buffer_shim();
+
+  // runtime/common/marshaling/marshal_buffer.ts
+  init_buffer_shim();
+
+  // runtime/common/marshaling/constants.ts
+  init_buffer_shim();
+  var CodaMarshalerType;
+  (function(CodaMarshalerType2) {
+    CodaMarshalerType2["Error"] = "Error";
+    CodaMarshalerType2["Buffer"] = "Buffer";
+    CodaMarshalerType2["Number"] = "Number";
+    CodaMarshalerType2["Date"] = "Date";
+  })(CodaMarshalerType || (CodaMarshalerType = {}));
+  var MarshalingInjectedKeys;
+  (function(MarshalingInjectedKeys2) {
+    MarshalingInjectedKeys2["CodaMarshaler"] = "__coda_marshaler__";
+    MarshalingInjectedKeys2["ErrorClassName"] = "__error_class_name__";
+    MarshalingInjectedKeys2["ErrorClassType"] = "__error_class_type__";
+  })(MarshalingInjectedKeys || (MarshalingInjectedKeys = {}));
+
+  // runtime/common/marshaling/marshal_buffer.ts
+  function marshalBuffer(val) {
+    if (val instanceof Buffer2) {
+      return {
+        data: [...Uint8Array.from(val)],
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Buffer
+      };
     }
   }
-  return val;
-}
-function deserialize(_, val) {
-  if (val) {
-    for (const unmarshaler of customUnmarshalers) {
-      const result = unmarshaler(val);
+  function unmarshalBuffer(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Buffer) {
+      return;
+    }
+    return Buffer2.from(val.data);
+  }
+
+  // runtime/common/marshaling/marshal_dates.ts
+  init_buffer_shim();
+  function marshalDate(val) {
+    if (val instanceof Date) {
+      return {
+        date: val.toJSON(),
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Date
+      };
+    }
+  }
+  function unmarshalDate(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Date) {
+      return;
+    }
+    return new Date(Date.parse(val.date));
+  }
+
+  // runtime/common/marshaling/marshal_errors.ts
+  init_buffer_shim();
+  var ErrorClassType;
+  (function(ErrorClassType2) {
+    ErrorClassType2["System"] = "System";
+    ErrorClassType2["Coda"] = "Coda";
+    ErrorClassType2["Other"] = "Other";
+  })(ErrorClassType || (ErrorClassType = {}));
+  var recognizableSystemErrorClasses = [
+    Error,
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError
+  ];
+  var recognizableCodaErrorClasses = [
+    StatusCodeError
+  ];
+  function getErrorClassType(err) {
+    if (recognizableSystemErrorClasses.some((cls) => cls === err.constructor)) {
+      return ErrorClassType.System;
+    }
+    if (recognizableCodaErrorClasses.some((cls) => cls === err.constructor)) {
+      return ErrorClassType.Coda;
+    }
+    return ErrorClassType.Other;
+  }
+  function marshalError(err) {
+    if (!(err instanceof Error)) {
+      return;
+    }
+    const { name, stack, message, ...args } = err;
+    return {
+      name,
+      stack,
+      message,
+      [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Error,
+      [MarshalingInjectedKeys.ErrorClassName]: err.constructor.name,
+      [MarshalingInjectedKeys.ErrorClassType]: getErrorClassType(err),
+      ...args
+    };
+  }
+  function getErrorClass(errorClassType, name) {
+    let errorClasses;
+    switch (errorClassType) {
+      case ErrorClassType.System:
+        errorClasses = recognizableSystemErrorClasses;
+        break;
+      case ErrorClassType.Coda:
+        errorClasses = recognizableCodaErrorClasses;
+        break;
+      default:
+        errorClasses = [];
+    }
+    return errorClasses.find((cls) => cls.name === name) || Error;
+  }
+  function unmarshalError(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Error) {
+      return;
+    }
+    const {
+      name,
+      stack,
+      message,
+      [MarshalingInjectedKeys.ErrorClassName]: errorClassName,
+      [MarshalingInjectedKeys.CodaMarshaler]: _,
+      [MarshalingInjectedKeys.ErrorClassType]: errorClassType,
+      ...otherProperties
+    } = val;
+    const ErrorClass = getErrorClass(errorClassType, errorClassName);
+    const error = new ErrorClass();
+    error.message = message;
+    error.stack = stack;
+    error.name = name;
+    for (const key of Object.keys(otherProperties)) {
+      error[key] = otherProperties[key];
+    }
+    return error;
+  }
+
+  // runtime/common/marshaling/marshal_numbers.ts
+  init_buffer_shim();
+  function marshalNumber(val) {
+    if (typeof val === "number" && (isNaN(val) || val === Infinity)) {
+      return {
+        data: val.toString(),
+        [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Number
+      };
+    }
+  }
+  function unmarshalNumber(val) {
+    if (typeof val !== "object" || val[MarshalingInjectedKeys.CodaMarshaler] !== CodaMarshalerType.Number) {
+      return;
+    }
+    return Number(val.data);
+  }
+
+  // runtime/common/marshaling/index.ts
+  var HACK_UNDEFINED_JSON_VALUE = "__CODA_UNDEFINED__";
+  var MaxTraverseDepth = 100;
+  var customMarshalers = [marshalError, marshalBuffer, marshalNumber, marshalDate];
+  var customUnmarshalers = [unmarshalError, unmarshalBuffer, unmarshalNumber, unmarshalDate];
+  function serialize(val) {
+    for (const marshaler of customMarshalers) {
+      const result = marshaler(val);
       if (result !== void 0) {
         return result;
       }
     }
-  }
-  return val;
-}
-function processValue(val, depth = 0) {
-  if (depth >= MaxTraverseDepth) {
-    throw new Error("marshaling value is too deep or containing circular strcture");
-  }
-  if (val === void 0) {
-    return HACK_UNDEFINED_JSON_VALUE;
-  }
-  if (val === null) {
     return val;
   }
-  if (Array.isArray(val)) {
-    return val.map((item) => processValue(item, depth + 1));
-  }
-  const serializedValue = serialize(val);
-  if (typeof serializedValue === "object") {
-    let objectValue = serializedValue;
-    if ("toJSON" in serializedValue && typeof serializedValue.toJSON === "function") {
-      objectValue = serializedValue.toJSON();
+  function deserialize(_, val) {
+    if (val) {
+      for (const unmarshaler of customUnmarshalers) {
+        const result = unmarshaler(val);
+        if (result !== void 0) {
+          return result;
+        }
+      }
     }
-    const processedValue = {};
-    for (const key of Object.getOwnPropertyNames(objectValue)) {
-      processedValue[key] = processValue(objectValue[key], depth + 1);
-    }
-    return processedValue;
-  }
-  return serializedValue;
-}
-function marshalValue(val) {
-  return JSON.stringify(processValue(val));
-}
-function unmarshalValue(marshaledValue) {
-  if (marshaledValue === void 0) {
-    return marshaledValue;
-  }
-  const parsed = JSON.parse(marshaledValue, deserialize);
-  return reviveUndefinedValues(parsed);
-}
-function wrapError(err) {
-  return new Error(marshalValue(err));
-}
-function unwrapError(err) {
-  try {
-    const unmarshaledValue = unmarshalValue(err.message);
-    if (unmarshaledValue instanceof Error) {
-      return unmarshaledValue;
-    }
-    return err;
-  } catch (_) {
-    return err;
-  }
-}
-function reviveUndefinedValues(val) {
-  if (val === null) {
     return val;
   }
-  if (val === HACK_UNDEFINED_JSON_VALUE) {
-    return void 0;
+  function processValue(val, depth = 0) {
+    if (depth >= MaxTraverseDepth) {
+      throw new Error("marshaling value is too deep or containing circular strcture");
+    }
+    if (val === void 0) {
+      return HACK_UNDEFINED_JSON_VALUE;
+    }
+    if (val === null) {
+      return val;
+    }
+    if (Array.isArray(val)) {
+      return val.map((item) => processValue(item, depth + 1));
+    }
+    const serializedValue = serialize(val);
+    if (typeof serializedValue === "object") {
+      let objectValue = serializedValue;
+      if ("toJSON" in serializedValue && typeof serializedValue.toJSON === "function") {
+        objectValue = serializedValue.toJSON();
+      }
+      const processedValue = {};
+      for (const key of Object.getOwnPropertyNames(objectValue)) {
+        processedValue[key] = processValue(objectValue[key], depth + 1);
+      }
+      return processedValue;
+    }
+    return serializedValue;
   }
-  if (Array.isArray(val)) {
-    return val.map((x) => reviveUndefinedValues(x));
+  function marshalValue(val) {
+    return JSON.stringify(processValue(val));
   }
-  if (typeof val === "object") {
-    for (const key of Object.getOwnPropertyNames(val)) {
-      val[key] = reviveUndefinedValues(val[key]);
+  function unmarshalValue(marshaledValue) {
+    if (marshaledValue === void 0) {
+      return marshaledValue;
+    }
+    const parsed = JSON.parse(marshaledValue, deserialize);
+    return reviveUndefinedValues(parsed);
+  }
+  function wrapError(err) {
+    return new Error(marshalValue(err));
+  }
+  function unwrapError(err) {
+    try {
+      const unmarshaledValue = unmarshalValue(err.message);
+      if (unmarshaledValue instanceof Error) {
+        return unmarshaledValue;
+      }
+      return err;
+    } catch (_) {
+      return err;
     }
   }
-  return val;
-}
+  function reviveUndefinedValues(val) {
+    if (val === null) {
+      return val;
+    }
+    if (val === HACK_UNDEFINED_JSON_VALUE) {
+      return void 0;
+    }
+    if (Array.isArray(val)) {
+      return val.map((x) => reviveUndefinedValues(x));
+    }
+    if (typeof val === "object") {
+      for (const key of Object.getOwnPropertyNames(val)) {
+        val[key] = reviveUndefinedValues(val[key]);
+      }
+    }
+    return val;
+  }
 
-// runtime/thunk/thunk.ts
-async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true) {
-  try {
-    return await doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext);
-  } catch (err) {
-    throw shouldWrapError ? wrapError(err) : err;
+  // runtime/thunk/thunk.ts
+  async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true) {
+    try {
+      return await doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext);
+    } catch (err) {
+      throw shouldWrapError ? wrapError(err) : err;
+    }
   }
-}
-function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext) {
-  const { syncTables, defaultAuthentication } = manifest;
-  switch (formulaSpec.type) {
-    case FormulaType.Standard: {
-      const formula = findFormula(manifest, formulaSpec.formulaName);
-      return formula.execute(params, executionContext);
-    }
-    case FormulaType.Sync: {
-      const formula = findSyncFormula(manifest, formulaSpec.formulaName);
-      return formula.execute(params, executionContext);
-    }
-    case FormulaType.Metadata: {
-      switch (formulaSpec.metadataFormulaType) {
-        case MetadataFormulaType.GetConnectionName:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionName)) {
-            return defaultAuthentication.getConnectionName.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.GetConnectionUserId:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionUserId)) {
-            return defaultAuthentication.getConnectionUserId.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.ParameterAutocomplete:
-          const parentFormula = findParentFormula(manifest, formulaSpec);
-          if (parentFormula) {
-            return parentFormula.execute(params, executionContext);
-          }
-          break;
-        case MetadataFormulaType.PostSetupSetEndpoint:
-          if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.postSetup)) {
-            const setupStep = defaultAuthentication.postSetup.find((step) => step.type === PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
-            if (setupStep) {
-              return setupStep.getOptionsFormula.execute(params, executionContext);
+  function doFindAndExecutePackFunction(params, formulaSpec, manifest, executionContext) {
+    const { syncTables, defaultAuthentication } = manifest;
+    switch (formulaSpec.type) {
+      case FormulaType.Standard: {
+        const formula = findFormula(manifest, formulaSpec.formulaName);
+        return formula.execute(params, executionContext);
+      }
+      case FormulaType.Sync: {
+        const formula = findSyncFormula(manifest, formulaSpec.formulaName);
+        return formula.execute(params, executionContext);
+      }
+      case FormulaType.Metadata: {
+        switch (formulaSpec.metadataFormulaType) {
+          case MetadataFormulaType.GetConnectionName:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionName)) {
+              return defaultAuthentication.getConnectionName.execute(params, executionContext);
             }
-          }
-          break;
-        case MetadataFormulaType.SyncListDynamicUrls:
-        case MetadataFormulaType.SyncGetDisplayUrl:
-        case MetadataFormulaType.SyncGetTableName:
-        case MetadataFormulaType.SyncGetSchema:
-          if (syncTables) {
-            const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
-            if (syncTable) {
-              let formula;
-              if (isDynamicSyncTable(syncTable)) {
-                switch (formulaSpec.metadataFormulaType) {
-                  case MetadataFormulaType.SyncListDynamicUrls:
-                    formula = syncTable.listDynamicUrls;
-                    break;
-                  case MetadataFormulaType.SyncGetDisplayUrl:
-                    formula = syncTable.getDisplayUrl;
-                    break;
-                  case MetadataFormulaType.SyncGetTableName:
-                    formula = syncTable.getName;
-                    break;
-                  case MetadataFormulaType.SyncGetSchema:
-                    formula = syncTable.getSchema;
-                    break;
-                  default:
-                    return ensureSwitchUnreachable(formulaSpec);
+            break;
+          case MetadataFormulaType.GetConnectionUserId:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.getConnectionUserId)) {
+              return defaultAuthentication.getConnectionUserId.execute(params, executionContext);
+            }
+            break;
+          case MetadataFormulaType.ParameterAutocomplete:
+            const parentFormula = findParentFormula(manifest, formulaSpec);
+            if (parentFormula) {
+              return parentFormula.execute(params, executionContext);
+            }
+            break;
+          case MetadataFormulaType.PostSetupSetEndpoint:
+            if ((defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.None && (defaultAuthentication == null ? void 0 : defaultAuthentication.type) !== AuthenticationType.Various && (defaultAuthentication == null ? void 0 : defaultAuthentication.postSetup)) {
+              const setupStep = defaultAuthentication.postSetup.find((step) => step.type === PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
+              if (setupStep) {
+                return setupStep.getOptionsFormula.execute(params, executionContext);
+              }
+            }
+            break;
+          case MetadataFormulaType.SyncListDynamicUrls:
+          case MetadataFormulaType.SyncGetDisplayUrl:
+          case MetadataFormulaType.SyncGetTableName:
+          case MetadataFormulaType.SyncGetSchema:
+            if (syncTables) {
+              const syncTable = syncTables.find((table) => table.name === formulaSpec.syncTableName);
+              if (syncTable) {
+                let formula;
+                if (isDynamicSyncTable(syncTable)) {
+                  switch (formulaSpec.metadataFormulaType) {
+                    case MetadataFormulaType.SyncListDynamicUrls:
+                      formula = syncTable.listDynamicUrls;
+                      break;
+                    case MetadataFormulaType.SyncGetDisplayUrl:
+                      formula = syncTable.getDisplayUrl;
+                      break;
+                    case MetadataFormulaType.SyncGetTableName:
+                      formula = syncTable.getName;
+                      break;
+                    case MetadataFormulaType.SyncGetSchema:
+                      formula = syncTable.getSchema;
+                      break;
+                    default:
+                      return ensureSwitchUnreachable(formulaSpec);
+                  }
+                } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
+                  formula = syncTable.getSchema;
                 }
-              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
-                formula = syncTable.getSchema;
-              }
-              if (formula) {
-                return formula.execute(params, executionContext);
+                if (formula) {
+                  return formula.execute(params, executionContext);
+                }
               }
             }
-          }
-          break;
-        default:
-          return ensureSwitchUnreachable(formulaSpec);
+            break;
+          default:
+            return ensureSwitchUnreachable(formulaSpec);
+        }
+        break;
       }
-      break;
+      default:
+        return ensureSwitchUnreachable(formulaSpec);
     }
-    default:
-      return ensureSwitchUnreachable(formulaSpec);
+    throw new Error(`Could not find a formula matching formula spec ${JSON.stringify(formulaSpec)}`);
   }
-  throw new Error(`Could not find a formula matching formula spec ${JSON.stringify(formulaSpec)}`);
-}
-function findParentFormula(manifest, formulaSpec) {
-  const { formulas, syncTables } = manifest;
-  let formula;
-  switch (formulaSpec.parentFormulaType) {
-    case FormulaType.Standard:
-      if (formulas) {
-        const namespacedFormulas = Array.isArray(formulas) ? formulas : Object.values(formulas)[0];
-        formula = namespacedFormulas.find((defn) => defn.name === formulaSpec.parentFormulaName);
-      }
-      break;
-    case FormulaType.Sync:
-      if (syncTables) {
-        const syncTable = syncTables.find((table) => table.getter.name === formulaSpec.parentFormulaName);
-        formula = syncTable == null ? void 0 : syncTable.getter;
-      }
-      break;
-    default:
-      return ensureSwitchUnreachable(formulaSpec.parentFormulaType);
+  function findParentFormula(manifest, formulaSpec) {
+    const { formulas, syncTables } = manifest;
+    let formula;
+    switch (formulaSpec.parentFormulaType) {
+      case FormulaType.Standard:
+        if (formulas) {
+          const namespacedFormulas = Array.isArray(formulas) ? formulas : Object.values(formulas)[0];
+          formula = namespacedFormulas.find((defn) => defn.name === formulaSpec.parentFormulaName);
+        }
+        break;
+      case FormulaType.Sync:
+        if (syncTables) {
+          const syncTable = syncTables.find((table) => table.getter.name === formulaSpec.parentFormulaName);
+          formula = syncTable == null ? void 0 : syncTable.getter;
+        }
+        break;
+      default:
+        return ensureSwitchUnreachable(formulaSpec.parentFormulaType);
+    }
+    if (formula) {
+      const params = formula.parameters.concat(formula.varargParameters || []);
+      const paramDef = params.find((param) => param.name === formulaSpec.parameterName);
+      return paramDef == null ? void 0 : paramDef.autocomplete;
+    }
   }
-  if (formula) {
-    const params = formula.parameters.concat(formula.varargParameters || []);
-    const paramDef = params.find((param) => param.name === formulaSpec.parameterName);
-    return paramDef == null ? void 0 : paramDef.autocomplete;
+  function ensureSwitchUnreachable(value) {
+    throw new Error(`Unreachable code hit with value ${String(value)}`);
   }
-}
-function ensureSwitchUnreachable(value) {
-  throw new Error(`Unreachable code hit with value ${String(value)}`);
-}
-async function handleErrorAsync(func) {
-  try {
-    return await func();
-  } catch (err) {
-    throw unwrapError(err);
+  async function handleErrorAsync(func) {
+    try {
+      return await func();
+    } catch (err) {
+      throw unwrapError(err);
+    }
   }
-}
-function handleError(func) {
-  try {
-    return func();
-  } catch (err) {
-    throw unwrapError(err);
+  function handleError(func) {
+    try {
+      return func();
+    } catch (err) {
+      throw unwrapError(err);
+    }
   }
-}
-function handleFetcherStatusError(fetchResult, fetchRequest) {
-  if (fetchResult.status >= 300) {
-    throw new StatusCodeError(fetchResult.status, fetchResult.body, fetchRequest, {
-      body: fetchResult.body,
-      headers: fetchResult.headers
-    });
+  function handleFetcherStatusError(fetchResult, fetchRequest) {
+    if (fetchResult.status >= 300) {
+      throw new StatusCodeError(fetchResult.status, fetchResult.body, fetchRequest, {
+        body: fetchResult.body,
+        headers: fetchResult.headers
+      });
+    }
   }
-}
+  return thunk_exports;
+})();
 /*!
  * The buffer module from node.js, for the browser.
  *

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -90,13 +90,13 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     }
     const metadata = (0, metadata_1.compilePackMetadata)(manifest);
     let packVersion = manifest.version;
-    if (!packVersion) {
-        const nextPackVersionInfo = await client.getNextPackVersion(packId, {}, { proposedMetadata: JSON.stringify(metadata) });
-        packVersion = nextPackVersionInfo.nextVersion;
-        (0, helpers_5.print)(`Pack version not provided. Generated one for you: version is ${packVersion}`);
-    }
-    metadata.version = packVersion;
     try {
+        if (!packVersion) {
+            const nextPackVersionInfo = await client.getNextPackVersion(packId, {}, { proposedMetadata: JSON.stringify(metadata) });
+            packVersion = nextPackVersionInfo.nextVersion;
+            (0, helpers_5.print)(`Pack version not provided. Generated one for you: version is ${packVersion}`);
+        }
+        metadata.version = packVersion;
         const bundle = (0, helpers_7.readFile)(bundlePath);
         if (!bundle) {
             printAndExit(`Could not find bundle file at path ${bundlePath}`);

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@codahq/packs-sdk",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "license": "MIT",
     "engines": {
         "node": ">=14.17.x"

--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -52,6 +52,6 @@ export declare function injectExecutionContext({ context, fetcher, temporaryBlob
     invocationToken?: string;
     sync?: Sync;
 }): Promise<void>;
-export declare function registerBundle(isolate: Isolate, context: Context, path: string, stubName: string): Promise<void>;
-export declare function registerBundles(isolate: Isolate, context: Context, packBundlePath: string, thunkBundlePath: string): Promise<void>;
+export declare function registerBundle(isolate: Isolate, context: Context, path: string, stubName: string, requiresManualClosure?: boolean): Promise<void>;
+export declare function registerBundles(isolate: Isolate, context: Context, packBundlePath: string, thunkBundlePath: string, requiresManualClosure?: boolean): Promise<void>;
 export declare function getThunkPath(): string;

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -159,7 +159,9 @@ async function registerBundle(isolate, context, path, stubName, requiresManualCl
     const bundle = fs_1.default.readFileSync(path).toString();
     // manual closure will break sourcemap. esp if it's minified.
     const scriptCode = requiresManualClosure
-        ? `(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()`
+        ? // {...exports, ...module.exports} is only necessary when the pack
+            // is bundled with new sdk but runtime is on the old sdk.
+            `(() => { ${stubName} = (() => { ${bundle} \n return {...exports, ...module.exports}; })(); })()`
         : bundle;
     // bundle needs to be converted into a closure to avoid leaking variables to global scope.
     const script = await isolate.compileScript(scriptCode, {

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -103,13 +103,17 @@ function getInjections({ timerStrategy = TimerShimStrategy.None }) {
     const shims = [...getTimerShims(timerStrategy), `${__dirname}/injections/crypto_shim.js`];
     return shims;
 }
-async function buildWithES({ lastBundleFilename, outputBundleFilename, options: buildOptions, }) {
+async function buildWithES({ lastBundleFilename, outputBundleFilename, options: buildOptions, format, }) {
     const options = {
         banner: { js: "'use strict';" },
         bundle: true,
         entryPoints: [lastBundleFilename],
         outfile: outputBundleFilename,
-        format: 'cjs',
+        format,
+        // This is tricky.
+        // - cjs bundles are adding exports to global.exports.
+        // - if iife bundles add exports to global, require() doesn't work. only module.exports works. idk why.
+        globalName: format === 'iife' ? 'module.exports' : undefined,
         platform: 'node',
         inject: getInjections(buildOptions),
         minify: false,
@@ -135,10 +139,20 @@ outputDirectory, manifestPath, minify = true, intermediateOutputDirectory, timer
         timerStrategy,
     };
     const buildChain = [
-        { builder: buildWithES, outputFilename: esbuildBundleFilename },
+        // this bundles the pack and compiles ts to js (need by browserify).
+        // browserify only recognizes cjs format.
+        { builder: options => buildWithES({ ...options, format: 'cjs' }), outputFilename: esbuildBundleFilename },
+        // this browserify node libraries.
         { builder: browserifyBundle, outputFilename: browserifyBundleFilename },
-        // browserify will add additional symbols that need shim injection.
-        { builder: buildWithES, outputFilename: browserifyWithShimBundleFilename },
+        // run esbuild again to inject shim to new symbols added by browserify.
+        //
+        // also change to iife format here to avoid leaking symbols into global in ivm.
+        // - in NodeJS, require(someModule) is executed in a closure where no local symbols will leak.
+        // - in isolated-vm, however everything is evaluated in the global context and all local variables will leak.
+        //
+        // we used to manually create a closure (e.g. `(() => { ${bundle} })()` ) when loading code into isolated-vm
+        // but that breaks sourcemap (esp if it's minified)
+        { builder: options => buildWithES({ ...options, format: 'iife' }), outputFilename: browserifyWithShimBundleFilename },
     ];
     if (minify) {
         buildChain.push({ builder: uglifyBundle, outputFilename: uglifyBundleFilename });

--- a/dist/testing/ivm_helper.js
+++ b/dist/testing/ivm_helper.js
@@ -29,11 +29,11 @@ async function setupIvmContext(bundlePath, executionContext) {
     //
     // TODO(huayang): this is not efficient enough and needs optimization if to be used widely in testing.
     if (fs_1.default.existsSync(CompiledHelperBundlePath)) {
-        await (0, bootstrap_4.registerBundles)(isolate, ivmContext, bundleFullPath, CompiledHelperBundlePath);
+        await (0, bootstrap_4.registerBundles)(isolate, ivmContext, bundleFullPath, CompiledHelperBundlePath, false);
     }
     else if (fs_1.default.existsSync(HelperTsSourceFile)) {
         const bundlePath = await (0, build_1.build)(HelperTsSourceFile);
-        await (0, bootstrap_4.registerBundles)(isolate, ivmContext, bundleFullPath, bundlePath);
+        await (0, bootstrap_4.registerBundles)(isolate, ivmContext, bundleFullPath, bundlePath, false);
     }
     else {
         throw new Error('cannot find the execution helper');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -250,7 +250,9 @@ export async function registerBundle(
 
   // manual closure will break sourcemap. esp if it's minified.
   const scriptCode = requiresManualClosure
-    ? `(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()`
+    ? // {...exports, ...module.exports} is only necessary when the pack
+      // is bundled with new sdk but runtime is on the old sdk.
+      `(() => { ${stubName} = (() => { ${bundle} \n return {...exports, ...module.exports}; })(); })()`
     : bundle;
 
   // bundle needs to be converted into a closure to avoid leaking variables to global scope.

--- a/testing/ivm_helper.ts
+++ b/testing/ivm_helper.ts
@@ -30,10 +30,10 @@ export async function setupIvmContext(bundlePath: string, executionContext: Exec
   //
   // TODO(huayang): this is not efficient enough and needs optimization if to be used widely in testing.
   if (fs.existsSync(CompiledHelperBundlePath)) {
-    await registerBundles(isolate, ivmContext, bundleFullPath, CompiledHelperBundlePath);
+    await registerBundles(isolate, ivmContext, bundleFullPath, CompiledHelperBundlePath, false);
   } else if (fs.existsSync(HelperTsSourceFile)) {
     const bundlePath = await buildBundle(HelperTsSourceFile);
-    await registerBundles(isolate, ivmContext, bundleFullPath, bundlePath);
+    await registerBundles(isolate, ivmContext, bundleFullPath, bundlePath, false);
   } else {
     throw new Error('cannot find the execution helper');
   }


### PR DESCRIPTION
# Context

We used to manually add a closure when throwing a bundle into IVM context. 

```
  const script = await isolate.compileScript(
    `(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()`,
    {
      filename: path,
    },
  );
  await script.run(context);
```

## why manual closure
The reason of doing so is that isolated-vm evaluation has a different behavior from loading / eval / requiring a module in NodeJS. Imagine that we have a simple module like this:

```
-> % cat test.js
'use strict';
function hello() {
  console.log('hello world');
}
module.exports = hello;
```

When the code is `eval` or required in node, no symbol leaks to global. 

```
> require('./test')
[Function: hello]
> global.hello
undefined
> hello
Uncaught ReferenceError: hello is not defined
> module.hello
undefined

> const code = fs.readFileSync('./test.js'); eval(code.toString());
[Function: hello]
> hello
Uncaught ReferenceError: hello is not defined
> global.hello
undefined
> module.hello
undefined
```

This behavior is however different in isolated-vm. if we do 

```
  const script = await isolate.compileScript(testJsBundle, {filename: path});
  await script.run(context);
```

`hello` will leak to `global.hello`. `isolated-vm` does support something like `evalClosure` which will bound local symbols. However  `evalClosure` doesn't allow us specify the filename of the code so that we can't map stack back with source map. (note that [the documentation](https://github.com/laverdet/isolated-vm#contextevalclosureignoredcode-arguments-options) says evalClosure supports scriptOrigin but the code doesn't actually do it. as far as I can tell after looking into the cplus implementation of [isolate_handle.cc](https://github.com/laverdet/isolated-vm/blob/d5b4948250f9c011c3e5a63ea3287ce72bdff2ed/src/module/isolate_handle.cc) used for script and [context_handle.cc](https://github.com/laverdet/isolated-vm/blob/27cb89d3c3c4ef433af22ac8efa38a26f1caabda/src/module/context_handle.cc) used for eval). This limits our option to only `compileScript`.

## why does it break source map.

`(() => { ${stubName} = (() => { ${bundle} \n return exports; })(); })()` isn't compiled with sourcemap. it shifts the offset a few characters away. this is crucial to minified bundles. 

## what's IIFE & CJS

checkout https://betterprogramming.pub/what-are-cjs-amd-umd-esm-system-and-iife-3633a112db62 to see what the difference is between IIFE & CJS

in short, IIFE generates something like 

```
module.exports = (() => { <actual code> })();
```

# What does this PR do

In this PR does 3 things:
- generate thunk bundle and pack bundle in IIFE format (these two bundles are loaded into IVM)
- bump pack-sdk version to 0.7.0 (see below)
- add an option `requiresManualClosure` that allows us to avoid manual closure if the pack bundle is compiled with packs-sdk after 0.7.0. see https://github.com/coda/coda/pull/63913 for the coda repo changes to make this possible. 

# Testing

Assuming that I'll bump this in the coda repo, there are a few things that we need to test.

- [x] legacy pack bundles still run without a problem.
- [x] new pack bundles will run with correct stack trace. 
- [x] new pack bundles will run on old runtime. (this isn't a big deal though)
- [x] test with devapp. (see https://github.com/coda/coda/pull/63913)