### PR TITLE
Stub out pages for migration

### DIFF
--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -10,7 +10,7 @@ Although it takes a little longer to get started, building Packs on your local m
 - You can use your own version control system, such as [GitHub](https://github.com).
 - You can use popular JavaScript libraries[^1], such as those in [NPM](https://www.npmjs.com/).
 
-[^1]: Not all libraries available on NPM are compatible with the Packs SDK. See the [Using libraries](../guides/advanced/libraries.md) guide for more information.
+[^1]: Not all libraries available on NPM are compatible with the Pack SDK. See the [Using libraries](../guides/advanced/libraries.md) guide for more information.
 
 Local development is enabled through the `coda` command line tool (CLI). Keep reading to learn how to install the CLI and use it to build a Pack.
 
@@ -31,13 +31,13 @@ The instructions below assume some familiarity with the terminal / command promp
     cd my-pack
     ```
 
-1. Install the Packs SDK.
+1. Install the Pack SDK.
 
     ```sh
     npm install @codahq/packs-sdk
     ```
 
-    The Packs SDK includes both the `coda` CLI as well as the libraries and type definitions needed to build Packs.
+    The Pack SDK includes both the `coda` CLI as well as the libraries and type definitions needed to build Packs.
 
 1. Create the file structure for your Pack.
 

--- a/docs/guides/advanced/authentication.md
+++ b/docs/guides/advanced/authentication.md
@@ -1,3 +1,10 @@
-# Authentication
+---
+title: Authentication
+---
 
-TODO
+# Authenticating with other services
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on how to configure authentication.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_lutgF

--- a/docs/guides/advanced/cli.md
+++ b/docs/guides/advanced/cli.md
@@ -1,0 +1,10 @@
+---
+title: Using the CLI
+---
+
+# Using the command line interface
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on how to use the Packs CLI.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/CLI_suDES#_luZPZ

--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -2,7 +2,7 @@
 title: Schemas
 ---
 
-# Structuring data with Schemas
+# Structuring data with schemas
 
 <!-- TODO: Migrate the content to this repo. -->
 [See here][doc] for more information on how to define schemas.

--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -1,0 +1,10 @@
+---
+title: Schemas
+---
+
+# Structuring data with Schemas
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on how to define schemas.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_lupyh

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -1,0 +1,10 @@
+---
+title: Data types
+---
+
+# Return data with meaningful types
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on how to type hints.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_luSAo

--- a/docs/guides/blocks/sync-tables.md
+++ b/docs/guides/blocks/sync-tables.md
@@ -1,0 +1,10 @@
+---
+title: Sync tables
+---
+
+# Add custom sync tables
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on how to build sync tables.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_luz8Y

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,12 @@
+---
+title: Troubleshooting
+---
+
+# How to troubleshoot your code
+
+## Logging
+
+<!-- TODO: Migrate the content to this repo. -->
+[See here][doc] for more information on logging.
+
+[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_lujrM

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,12 @@ hide:
   - toc
 ---
 
-# Welcome
+# Learn how to build your own Pack
 
-Check out the [SDK reference](/packs-sdk/reference/sdk).
+The Coda Pack SDK provides the components and tools you can use to build your own Packs.
+
+[Get Started][get_started]{ .md-button .md-button--primary }
+
+
+[get_started]: get-started/web
+[beta]: https://coda.io/packsbeta

--- a/documentation/theme/main.html
+++ b/documentation/theme/main.html
@@ -6,6 +6,6 @@
 {% endblock %}
 
 {% block announce %}
-  The Packs SDK is currently only available to a limited set of partners.
-  If you are interested in becoming a partner, contact us at <a href="mailto:partners@coda.io">partners@coda.io</a>.
+  The Pack SDK is currently in a limited beta.
+  <a href="https://coda.io/packsbeta">Click here</a> to learn more and apply.
 {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # MkDocs options.
 # See: https://www.mkdocs.org/user-guide/configuration/
-site_name: Coda Packs SDK
+site_name: Coda Pack SDK
 # TODO(spencer): Update with new url
 site_url: !ENV [MK_DOCS_SITE_URL, "https://coda.io/developers/temp-developer-docs/packs/latest/"]
 repo_url: https://github.com/coda/packs-sdk


### PR DESCRIPTION
To help shift the center of mass from the Coda doc to mkdocs, stub out some pages with links back to the Coda doc and TODOs to migrate the content. Also changed the term from "Packs SDK" to "Pack SDK" in a number of places to match branding decision.

Staged: https://coda-packs-sdk.readthedocs-hosted.com/en/ek-merge/