### PR TITLE
Add a unittest that enforces that all entities reachable by TypeDoc have documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,8 @@ typedoc:
 		exit 1; \
 	fi
 	# Most options loaded from typedoc.js.
+	# If you changes this, also update the similar command in typedoc_coverage_test.ts.
 	${ROOTDIR}/node_modules/.bin/typedoc index.ts --options typedoc.js --out ${ROOTDIR}/docs/reference/sdk
-
-.PHONY: typedoc-progress
-typedoc-progress:
-	${ROOTDIR}/node_modules/.bin/ts-node scripts/tsdoc_progress.ts
 
 .PHONY: docs
 docs: typedoc generated-documentation


### PR DESCRIPTION
PTAL @ekoleda-codaio @coda/packs 