### PR TITLE
make format string[] in ExternalPackFormat

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -82,7 +82,7 @@ export type ExternalPackAuthenticationType = AuthenticationType;
 export type ExternalPackFormulas = PackFormulasMetadata | PackFormulaMetadata[];
 export type ExternalObjectPackFormula = ObjectPackFormulaMetadata;
 export type ExternalPackFormula = PackFormulaMetadata;
-export type ExternalPackFormat = Format;
+export type ExternalPackFormat = Omit<Format, 'matchers'> & {matchers?: string[]};
 export type ExternalPackFormatMetadata = PackFormatMetadata;
 export type ExternalSyncTable = PackSyncTable;
 

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2950,7 +2950,9 @@ export declare type ExternalPackAuthenticationType = AuthenticationType;
 export declare type ExternalPackFormulas = PackFormulasMetadata | PackFormulaMetadata[];
 export declare type ExternalObjectPackFormula = ObjectPackFormulaMetadata;
 export declare type ExternalPackFormula = PackFormulaMetadata;
-export declare type ExternalPackFormat = Format;
+export declare type ExternalPackFormat = Omit<Format, "matchers"> & {
+	matchers?: string[];
+};
 export declare type ExternalPackFormatMetadata = PackFormatMetadata;
 export declare type ExternalSyncTable = PackSyncTable;
 export declare type BasePackVersionMetadata = Omit<PackVersionMetadata, "defaultAuthentication" | "systemConnectionAuthentication" | "formulas" | "formats" | "syncTables">;

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -45,7 +45,9 @@ export declare type ExternalPackAuthenticationType = AuthenticationType;
 export declare type ExternalPackFormulas = PackFormulasMetadata | PackFormulaMetadata[];
 export declare type ExternalObjectPackFormula = ObjectPackFormulaMetadata;
 export declare type ExternalPackFormula = PackFormulaMetadata;
-export declare type ExternalPackFormat = Format;
+export declare type ExternalPackFormat = Omit<Format, 'matchers'> & {
+    matchers?: string[];
+};
 export declare type ExternalPackFormatMetadata = PackFormatMetadata;
 export declare type ExternalSyncTable = PackSyncTable;
 declare type BasePackVersionMetadata = Omit<PackVersionMetadata, 'defaultAuthentication' | 'systemConnectionAuthentication' | 'formulas' | 'formats' | 'syncTables'>;

--- a/docs/reference/sdk/interfaces/ExternalPackVersionMetadata.md
+++ b/docs/reference/sdk/interfaces/ExternalPackVersionMetadata.md
@@ -34,7 +34,7 @@ ___
 
 ### formats
 
-• `Optional` **formats**: [`Format`](Format.md)[]
+• `Optional` **formats**: [`ExternalPackFormat`](../types/ExternalPackFormat.md)[]
 
 #### Defined in
 

--- a/docs/reference/sdk/types/ExternalPackFormat.md
+++ b/docs/reference/sdk/types/ExternalPackFormat.md
@@ -1,6 +1,6 @@
 # Type alias: ExternalPackFormat
 
-Ƭ **ExternalPackFormat**: [`Format`](../interfaces/Format.md)
+Ƭ **ExternalPackFormat**: `Omit`<[`Format`](../interfaces/Format.md), ``"matchers"``\> & { `matchers?`: `string`[]  }
 
 #### Defined in
 

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -22,3 +22,10 @@ pack.addFormula({
     return 'Hello ' + name + '!';
   },
 });
+
+pack.addColumnFormat({
+  name: 'test',
+  formulaName: 'Throw',
+  formulaNamespace: 'deprecated',
+  matchers: [/https:\/\/testregex/],
+});


### PR DESCRIPTION
`External` types are stringified and uploaded to s3. can't have regex type in it. 