### PR TITLE
Make typing strict for object property schemas

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -394,25 +394,25 @@ const basePropertyValidators = {
     fromKey: z.string().optional(),
     required: z.boolean().optional(),
 };
-const booleanPropertySchema = zodCompleteObject({
+const booleanPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Boolean),
     ...basePropertyValidators,
 });
-const numericPropertySchema = zodCompleteObject({
+const numericPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Percent).optional(),
     precision: z.number().optional(),
     useThousandsSeparator: z.boolean().optional(),
     ...basePropertyValidators,
 });
-const scalePropertySchema = zodCompleteObject({
+const scalePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Scale),
     maximum: z.number().optional(),
     icon: z.nativeEnum(schema_5.ScaleIconSet).optional(),
     ...basePropertyValidators,
 });
-const sliderPropertySchema = zodCompleteObject({
+const sliderPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Slider),
     maximum: z.number().optional(),
@@ -420,7 +420,7 @@ const sliderPropertySchema = zodCompleteObject({
     step: z.number().optional(),
     ...basePropertyValidators,
 });
-const currencyPropertySchema = zodCompleteObject({
+const currencyPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Currency),
     precision: z.number().optional(),
@@ -428,19 +428,19 @@ const currencyPropertySchema = zodCompleteObject({
     format: z.nativeEnum(schema_2.CurrencyFormat).optional(),
     ...basePropertyValidators,
 });
-const numericDatePropertySchema = zodCompleteObject({
+const numericDatePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Date),
     format: z.string().optional(),
     ...basePropertyValidators,
 });
-const numericTimePropertySchema = zodCompleteObject({
+const numericTimePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.Time),
     format: z.string().optional(),
     ...basePropertyValidators,
 });
-const numericDateTimePropertySchema = zodCompleteObject({
+const numericDateTimePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.Number),
     codaType: zodDiscriminant(schema_7.ValueHintType.DateTime),
     dateFormat: z.string().optional(),
@@ -461,31 +461,31 @@ const numericPackFormulaSchema = zodCompleteObject({
     resultType: zodDiscriminant(api_types_3.Type.number),
     schema: numberPropertySchema.optional(),
 });
-const simpleStringPropertySchema = zodCompleteObject({
+const simpleStringPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.String),
     codaType: z.enum([...schema_6.SimpleStringHintValueTypes]).optional(),
     ...basePropertyValidators,
 });
-const stringDatePropertySchema = zodCompleteObject({
+const stringDatePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.String),
     codaType: zodDiscriminant(schema_7.ValueHintType.Date),
     format: z.string().optional(),
     ...basePropertyValidators,
 });
-const stringTimePropertySchema = zodCompleteObject({
+const stringTimePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.String),
     codaType: zodDiscriminant(schema_7.ValueHintType.Time),
     format: z.string().optional(),
     ...basePropertyValidators,
 });
-const stringDateTimePropertySchema = zodCompleteObject({
+const stringDateTimePropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.String),
     codaType: zodDiscriminant(schema_7.ValueHintType.DateTime),
     dateFormat: z.string().optional(),
     timeFormat: z.string().optional(),
     ...basePropertyValidators,
 });
-const durationPropertySchema = zodCompleteObject({
+const durationPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_8.ValueType.String),
     codaType: zodDiscriminant(schema_7.ValueHintType.Duration),
     precision: z.number().optional(),

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1269,6 +1269,27 @@ describe('Pack metadata Validation', () => {
         ]);
       });
 
+      it('unknown key in properties', async () => {
+        const metadata = metadataForFormulaWithObjectSchema({
+          type: ValueType.Object,
+          primary: 'primary',
+          properties: {
+            primary: {type: ValueType.Number, required: true, foo: true} as any,
+          },
+        });
+        const err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: "Unrecognized key(s) in object: 'foo'",
+            path: 'formulas[0].schema.properties.Primary',
+          },
+          {
+            message: 'Could not find any valid schema for this value.',
+            path: 'formulas[0].schema.properties.Primary',
+          },
+        ]);
+      });
+
       it('featured field not among properties', async () => {
         const metadata = metadataForFormulaWithObjectSchema({
           type: ValueType.Object,

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -484,12 +484,12 @@ const basePropertyValidators = {
   required: z.boolean().optional(),
 };
 
-const booleanPropertySchema = zodCompleteObject<BooleanSchema & ObjectSchemaProperty>({
+const booleanPropertySchema = zodCompleteStrictObject<BooleanSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Boolean),
   ...basePropertyValidators,
 });
 
-const numericPropertySchema = zodCompleteObject<NumericSchema & ObjectSchemaProperty>({
+const numericPropertySchema = zodCompleteStrictObject<NumericSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Percent).optional(),
   precision: z.number().optional(),
@@ -497,7 +497,7 @@ const numericPropertySchema = zodCompleteObject<NumericSchema & ObjectSchemaProp
   ...basePropertyValidators,
 });
 
-const scalePropertySchema = zodCompleteObject<ScaleSchema & ObjectSchemaProperty>({
+const scalePropertySchema = zodCompleteStrictObject<ScaleSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Scale),
   maximum: z.number().optional(),
@@ -505,7 +505,7 @@ const scalePropertySchema = zodCompleteObject<ScaleSchema & ObjectSchemaProperty
   ...basePropertyValidators,
 });
 
-const sliderPropertySchema = zodCompleteObject<SliderSchema & ObjectSchemaProperty>({
+const sliderPropertySchema = zodCompleteStrictObject<SliderSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Slider),
   maximum: z.number().optional(),
@@ -514,7 +514,7 @@ const sliderPropertySchema = zodCompleteObject<SliderSchema & ObjectSchemaProper
   ...basePropertyValidators,
 });
 
-const currencyPropertySchema = zodCompleteObject<CurrencySchema & ObjectSchemaProperty>({
+const currencyPropertySchema = zodCompleteStrictObject<CurrencySchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Currency),
   precision: z.number().optional(),
@@ -523,21 +523,21 @@ const currencyPropertySchema = zodCompleteObject<CurrencySchema & ObjectSchemaPr
   ...basePropertyValidators,
 });
 
-const numericDatePropertySchema = zodCompleteObject<NumericDateSchema & ObjectSchemaProperty>({
+const numericDatePropertySchema = zodCompleteStrictObject<NumericDateSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Date),
   format: z.string().optional(),
   ...basePropertyValidators,
 });
 
-const numericTimePropertySchema = zodCompleteObject<NumericTimeSchema & ObjectSchemaProperty>({
+const numericTimePropertySchema = zodCompleteStrictObject<NumericTimeSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Time),
   format: z.string().optional(),
   ...basePropertyValidators,
 });
 
-const numericDateTimePropertySchema = zodCompleteObject<NumericDateTimeSchema & ObjectSchemaProperty>({
+const numericDateTimePropertySchema = zodCompleteStrictObject<NumericDateTimeSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.DateTime),
   dateFormat: z.string().optional(),
@@ -561,27 +561,27 @@ const numericPackFormulaSchema = zodCompleteObject<Omit<NumericPackFormula<any>,
   schema: numberPropertySchema.optional(),
 });
 
-const simpleStringPropertySchema = zodCompleteObject<SimpleStringSchema & ObjectSchemaProperty>({
+const simpleStringPropertySchema = zodCompleteStrictObject<SimpleStringSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.String),
   codaType: z.enum([...SimpleStringHintValueTypes]).optional(),
   ...basePropertyValidators,
 });
 
-const stringDatePropertySchema = zodCompleteObject<StringDateSchema & ObjectSchemaProperty>({
+const stringDatePropertySchema = zodCompleteStrictObject<StringDateSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.String),
   codaType: zodDiscriminant(ValueHintType.Date),
   format: z.string().optional(),
   ...basePropertyValidators,
 });
 
-const stringTimePropertySchema = zodCompleteObject<StringTimeSchema & ObjectSchemaProperty>({
+const stringTimePropertySchema = zodCompleteStrictObject<StringTimeSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.String),
   codaType: zodDiscriminant(ValueHintType.Time),
   format: z.string().optional(),
   ...basePropertyValidators,
 });
 
-const stringDateTimePropertySchema = zodCompleteObject<StringDateTimeSchema & ObjectSchemaProperty>({
+const stringDateTimePropertySchema = zodCompleteStrictObject<StringDateTimeSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.String),
   codaType: zodDiscriminant(ValueHintType.DateTime),
   dateFormat: z.string().optional(),
@@ -589,7 +589,7 @@ const stringDateTimePropertySchema = zodCompleteObject<StringDateTimeSchema & Ob
   ...basePropertyValidators,
 });
 
-const durationPropertySchema = zodCompleteObject<DurationSchema & ObjectSchemaProperty>({
+const durationPropertySchema = zodCompleteStrictObject<DurationSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.String),
   codaType: zodDiscriminant(ValueHintType.Duration),
   precision: z.number().optional(),


### PR DESCRIPTION
@ekoleda-codaio pointed out that providing a schema with garbage keys like:
```const MySchema = coda.makeObjectSchema({
  type: coda.ValueType.Object,
  properties: {
    thing: {type: coda.ValueType.Number, foo: true},
  },
  id: "thing", // Which property above is a unique ID.
  primary: "thing", // Which property above to display by default.
});
```

caused our diff checker to choke. I think the right thing is to allow the diff checker to ignore these unknown keys and to have the upload validation tester complain when it gets such a key. 

Ideally I think most, if not all of our Zod stuff should be `strictObject`, but I don't know if this breaks tests/error messages, so I'll send out these kinds of updates in smaller, more digestible PRs.