### PR TITLE
fix ambiguous execute return type

### DIFF
--- a/builder.ts
+++ b/builder.ts
@@ -128,7 +128,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * ```
    */
   addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(
-    definition: FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>,
+    definition: {resultType: ResultT} & FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>,
   ): this {
     const formula = makeFormula<ParamDefsT, ResultT, SchemaT>({
       ...definition,

--- a/dist/builder.d.ts
+++ b/dist/builder.d.ts
@@ -92,7 +92,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * });
      * ```
      */
-    addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(definition: FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>): this;
+    addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(definition: {
+        resultType: ResultT;
+    } & FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>): this;
     /**
      * Adds a sync table definition to this pack.
      *

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2781,7 +2781,9 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * });
 	 * ```
 	 */
-	addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(definition: FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>): this;
+	addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(definition: {
+		resultType: ResultT;
+	} & FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>): this;
 	/**
 	 * Adds a sync table definition to this pack.
 	 *

--- a/docs/reference/sdk/classes/PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/PackDefinitionBuilder.md
@@ -271,7 +271,7 @@ pack.addFormula({
 
 | Name | Type |
 | :------ | :------ |
-| `definition` | `FormulaDefinitionV2`<`ParamDefsT`, `ResultT`, `SchemaT`\> |
+| `definition` | { `resultType`: `ResultT`  } & `FormulaDefinitionV2`<`ParamDefsT`, `ResultT`, `SchemaT`\> |
 
 #### Returns
 

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -2,9 +2,35 @@ import * as coda from '../..';
 
 export const pack = coda.newPack();
 
+const fakePersonSchema = coda.makeObjectSchema({
+  type: coda.ValueType.Object,
+  primary: 'name',
+  id: 'name',
+  properties: {
+    name: {type: coda.ValueType.String, required: true},
+  },
+});
+
 function doThrow() {
   throw new Error('test');
 }
+
+pack.addFormula({
+  name: 'Person',
+  description: 'A formula that returns an object',
+  parameters: [
+    coda.makeParameter({
+      type: coda.ParameterType.String,
+      name: 'name',
+      description: 'the name of the pereson',
+    }),
+  ],
+  resultType: coda.ValueType.Object,
+  schema: fakePersonSchema,
+  execute: async ([name]) => {
+    return {name};
+  },
+});
 
 pack.addFormula({
   name: 'Throw',


### PR DESCRIPTION
Very interesting bug: when `execute` returns a bad object type on an object formula, TS will complain about returning object on boolean, instead of pointing out that the returned object doesn't match the schema.

The reason is that 

addFormula is defined as 

```
  addFormula<ParamDefsT extends ParamDefs, ResultT extends FormulaResultValueType, SchemaT extends Schema>(
    definition: FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>,
  ): this {
```

where `FormulaDefinitionV2<ParamDefsT, ResultT, SchemaT>` is defined as 

```
export type FormulaDefinitionV2<
  ParamDefsT extends ParamDefs,
  ResultT extends FormulaResultValueType,
  SchemaT extends Schema,
> = ResultT extends ValueType.String
  ? StringFormulaDefV2<ParamDefsT>
  : ResultT extends ValueType.Number
  ? NumericFormulaDefV2<ParamDefsT>
  : ResultT extends ValueType.Boolean
  ? BooleanFormulaDefV2<ParamDefsT>
  : ResultT extends ValueType.Array
  ? ArrayFormulaDefV2<ParamDefsT, SchemaT>
  : ObjectFormulaDefV2<ParamDefsT, SchemaT>;
```

When execute returns a mismatch object, TS detects a conflict that the object type is `resultType: ValueType.Object` but the result type doesn't match `ObjectFormulaDefV2<ParamDefsT, SchemaT>`. In which case, TS can't automatically infer the ResultT by the `FormulaDefinitionV2` definition and falls back to a `BooleanFormulaDefV2` for some reason (that I don't know). 

The fix is to update `addFormula` to make TS able to infer `ResultT` from this level, instead of going into the ambiguous `FormulaDefinitionV2`. 

Before:

![image](https://user-images.githubusercontent.com/70549840/141534502-0f1d0b00-ce1d-42f3-b1ff-809c37535b0f.png)


After:

![image](https://user-images.githubusercontent.com/70549840/141534546-81500e26-5506-4453-9026-0d15cb98efdc.png)
