### PR TITLE
Fix CustomAuthentication typedoc

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2612,17 +2612,22 @@ export interface CustomAuthParameter {
  *
  * @example
  * ```
+ * {% raw %}
  * // Suppose you're using an API that requires a secret id in the request URL,
- * // and a different secret value in the request body. You can define a Custom authentication
- * // configuration with two params:
+ * // and a different secret value in the request body. You can define a Custom
+ * // authentication configuration with two params:
  * // params: [{name: 'secretId', description: 'Secret id'},
  * //          {name: 'secretValue', description: 'Secret value'}])
- * // The user or the pack author will be prompted to specify a value for each of these when setting up an account.
- * // In the `execute` body of your formula, you can specify where those values are inserted in the request using
- * // the template replacement syntax shown above.
+ * // The user or the pack author will be prompted to specify a value for each
+ * // of these when setting up an account.
+ * // In the `execute` body of your formula, you can specify where those values
+ * // are inserted in the request using the template replacement syntax shown
+ * // above.
  * //
- * // A real-world example of an API that would require this is the Plaid API (https://plaid.com/docs/api/products/#auth)
- * // See the use of `secret`, `client_id`, and `access_token` parameters in the body.
+ * // A real-world example of an API that would require this is the Plaid API
+ * // (https://plaid.com/docs/api/products/#auth).
+ * // See the use of `secret`, `client_id`, and `access_token` parameters in the
+ * // body.
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
@@ -2633,9 +2638,14 @@ export interface CustomAuthParameter {
  *     otherBodyParam: "foo",
  *   });
  *
- *   let response = await context.fetcher.fetch({method: "GET", url: urlWithSecret, body: bodyWithSecret});
- *   ...
+ *   let response = await context.fetcher.fetch({
+ *     method: "GET",
+ *     url: urlWithSecret,
+ *     body: bodyWithSecret
+ *   });
+ *   // ...
  * }
+ * {% endraw %}
  * ```
  */
 export interface CustomAuthentication extends BaseAuthentication {

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -463,17 +463,22 @@ export interface CustomAuthParameter {
  *
  * @example
  * ```
+ * {% raw %}
  * // Suppose you're using an API that requires a secret id in the request URL,
- * // and a different secret value in the request body. You can define a Custom authentication
- * // configuration with two params:
+ * // and a different secret value in the request body. You can define a Custom
+ * // authentication configuration with two params:
  * // params: [{name: 'secretId', description: 'Secret id'},
  * //          {name: 'secretValue', description: 'Secret value'}])
- * // The user or the pack author will be prompted to specify a value for each of these when setting up an account.
- * // In the `execute` body of your formula, you can specify where those values are inserted in the request using
- * // the template replacement syntax shown above.
+ * // The user or the pack author will be prompted to specify a value for each
+ * // of these when setting up an account.
+ * // In the `execute` body of your formula, you can specify where those values
+ * // are inserted in the request using the template replacement syntax shown
+ * // above.
  * //
- * // A real-world example of an API that would require this is the Plaid API (https://plaid.com/docs/api/products/#auth)
- * // See the use of `secret`, `client_id`, and `access_token` parameters in the body.
+ * // A real-world example of an API that would require this is the Plaid API
+ * // (https://plaid.com/docs/api/products/#auth).
+ * // See the use of `secret`, `client_id`, and `access_token` parameters in the
+ * // body.
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
@@ -484,9 +489,14 @@ export interface CustomAuthParameter {
  *     otherBodyParam: "foo",
  *   });
  *
- *   let response = await context.fetcher.fetch({method: "GET", url: urlWithSecret, body: bodyWithSecret});
- *   ...
+ *   let response = await context.fetcher.fetch({
+ *     method: "GET",
+ *     url: urlWithSecret,
+ *     body: bodyWithSecret
+ *   });
+ *   // ...
  * }
+ * {% endraw %}
  * ```
  */
 export interface CustomAuthentication extends BaseAuthentication {

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -18,17 +18,22 @@ token is required for security reasons.
 
 **`example`**
 ```
+{% raw %}
 // Suppose you're using an API that requires a secret id in the request URL,
-// and a different secret value in the request body. You can define a Custom authentication
-// configuration with two params:
+// and a different secret value in the request body. You can define a Custom
+// authentication configuration with two params:
 // params: [{name: 'secretId', description: 'Secret id'},
 //          {name: 'secretValue', description: 'Secret value'}])
-// The user or the pack author will be prompted to specify a value for each of these when setting up an account.
-// In the `execute` body of your formula, you can specify where those values are inserted in the request using
-// the template replacement syntax shown above.
+// The user or the pack author will be prompted to specify a value for each
+// of these when setting up an account.
+// In the `execute` body of your formula, you can specify where those values
+// are inserted in the request using the template replacement syntax shown
+// above.
 //
-// A real-world example of an API that would require this is the Plaid API (https://plaid.com/docs/api/products/#auth)
-// See the use of `secret`, `client_id`, and `access_token` parameters in the body.
+// A real-world example of an API that would require this is the Plaid API
+// (https://plaid.com/docs/api/products/#auth).
+// See the use of `secret`, `client_id`, and `access_token` parameters in the
+// body.
 execute: async function([], context) {
   let secretIdTemplateName = "secretId-" + context.invocationToken;
   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
@@ -39,9 +44,14 @@ execute: async function([], context) {
     otherBodyParam: "foo",
   });
 
-  let response = await context.fetcher.fetch({method: "GET", url: urlWithSecret, body: bodyWithSecret});
-  ...
+  let response = await context.fetcher.fetch({
+    method: "GET",
+    url: urlWithSecret,
+    body: bodyWithSecret
+  });
+  // ...
 }
+{% endraw %}
 ```
 
 ## Hierarchy
@@ -138,7 +148,7 @@ replacement inside the constructed network request.
 
 #### Defined in
 
-[types.ts:525](https://github.com/coda/packs-sdk/blob/main/types.ts#L525)
+[types.ts:535](https://github.com/coda/packs-sdk/blob/main/types.ts#L535)
 
 ___
 
@@ -186,4 +196,4 @@ Identifies this as Custom authentication.
 
 #### Defined in
 
-[types.ts:519](https://github.com/coda/packs-sdk/blob/main/types.ts#L519)
+[types.ts:529](https://github.com/coda/packs-sdk/blob/main/types.ts#L529)

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -37,7 +37,7 @@ This must correspond to the name of a regular, public formula defined in this pa
 
 #### Defined in
 
-[types.ts:700](https://github.com/coda/packs-sdk/blob/main/types.ts#L700)
+[types.ts:710](https://github.com/coda/packs-sdk/blob/main/types.ts#L710)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[types.ts:695](https://github.com/coda/packs-sdk/blob/main/types.ts#L695)
+[types.ts:705](https://github.com/coda/packs-sdk/blob/main/types.ts#L705)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[types.ts:702](https://github.com/coda/packs-sdk/blob/main/types.ts#L702)
+[types.ts:712](https://github.com/coda/packs-sdk/blob/main/types.ts#L712)
 
 ___
 
@@ -74,7 +74,7 @@ of values they should put in columns using this format.
 
 #### Defined in
 
-[types.ts:707](https://github.com/coda/packs-sdk/blob/main/types.ts#L707)
+[types.ts:717](https://github.com/coda/packs-sdk/blob/main/types.ts#L717)
 
 ___
 
@@ -87,7 +87,7 @@ is capable of handling. As described in [Format](Format.md), this is a discovery
 
 #### Defined in
 
-[types.ts:712](https://github.com/coda/packs-sdk/blob/main/types.ts#L712)
+[types.ts:722](https://github.com/coda/packs-sdk/blob/main/types.ts#L722)
 
 ___
 
@@ -99,7 +99,7 @@ The name of this column format. This will show to users in the column type choos
 
 #### Defined in
 
-[types.ts:693](https://github.com/coda/packs-sdk/blob/main/types.ts#L693)
+[types.ts:703](https://github.com/coda/packs-sdk/blob/main/types.ts#L703)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[types.ts:716](https://github.com/coda/packs-sdk/blob/main/types.ts#L716)
+[types.ts:726](https://github.com/coda/packs-sdk/blob/main/types.ts#L726)

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -19,7 +19,7 @@ This should only be used by legacy Coda pack implementations.
 
 #### Defined in
 
-[types.ts:859](https://github.com/coda/packs-sdk/blob/main/types.ts#L859)
+[types.ts:869](https://github.com/coda/packs-sdk/blob/main/types.ts#L869)
 
 ___
 
@@ -35,7 +35,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:804](https://github.com/coda/packs-sdk/blob/main/types.ts#L804)
+[types.ts:814](https://github.com/coda/packs-sdk/blob/main/types.ts#L814)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[types.ts:857](https://github.com/coda/packs-sdk/blob/main/types.ts#L857)
+[types.ts:867](https://github.com/coda/packs-sdk/blob/main/types.ts#L867)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[types.ts:861](https://github.com/coda/packs-sdk/blob/main/types.ts#L861)
+[types.ts:871](https://github.com/coda/packs-sdk/blob/main/types.ts#L871)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[types.ts:862](https://github.com/coda/packs-sdk/blob/main/types.ts#L862)
+[types.ts:872](https://github.com/coda/packs-sdk/blob/main/types.ts#L872)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:840](https://github.com/coda/packs-sdk/blob/main/types.ts#L840)
+[types.ts:850](https://github.com/coda/packs-sdk/blob/main/types.ts#L850)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[types.ts:826](https://github.com/coda/packs-sdk/blob/main/types.ts#L826)
+[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
 
 ___
 
@@ -129,7 +129,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
+[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[types.ts:854](https://github.com/coda/packs-sdk/blob/main/types.ts#L854)
+[types.ts:864](https://github.com/coda/packs-sdk/blob/main/types.ts#L864)
 
 ___
 
@@ -151,7 +151,7 @@ Whether this is a pack that will be used by Coda internally and not exposed dire
 
 #### Defined in
 
-[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
+[types.ts:880](https://github.com/coda/packs-sdk/blob/main/types.ts#L880)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[types.ts:860](https://github.com/coda/packs-sdk/blob/main/types.ts#L860)
+[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[types.ts:864](https://github.com/coda/packs-sdk/blob/main/types.ts#L864)
+[types.ts:874](https://github.com/coda/packs-sdk/blob/main/types.ts#L874)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[types.ts:855](https://github.com/coda/packs-sdk/blob/main/types.ts#L855)
+[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
 
 ___
 
@@ -203,7 +203,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:829](https://github.com/coda/packs-sdk/blob/main/types.ts#L829)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[types.ts:858](https://github.com/coda/packs-sdk/blob/main/types.ts#L858)
+[types.ts:868](https://github.com/coda/packs-sdk/blob/main/types.ts#L868)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
+[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[types.ts:866](https://github.com/coda/packs-sdk/blob/main/types.ts#L866)
+[types.ts:876](https://github.com/coda/packs-sdk/blob/main/types.ts#L876)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[types.ts:856](https://github.com/coda/packs-sdk/blob/main/types.ts#L856)
+[types.ts:866](https://github.com/coda/packs-sdk/blob/main/types.ts#L866)
 
 ___
 
@@ -259,7 +259,7 @@ Definitions of this pack's sync tables. See {@link SyncTable}.
 
 #### Defined in
 
-[types.ts:844](https://github.com/coda/packs-sdk/blob/main/types.ts#L844)
+[types.ts:854](https://github.com/coda/packs-sdk/blob/main/types.ts#L854)
 
 ___
 
@@ -276,7 +276,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:809](https://github.com/coda/packs-sdk/blob/main/types.ts#L809)
+[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
 
 ___
 
@@ -293,4 +293,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:800](https://github.com/coda/packs-sdk/blob/main/types.ts#L800)
+[types.ts:810](https://github.com/coda/packs-sdk/blob/main/types.ts#L810)

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -19,7 +19,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:804](https://github.com/coda/packs-sdk/blob/main/types.ts#L804)
+[types.ts:814](https://github.com/coda/packs-sdk/blob/main/types.ts#L814)
 
 ___
 
@@ -31,7 +31,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:840](https://github.com/coda/packs-sdk/blob/main/types.ts#L840)
+[types.ts:850](https://github.com/coda/packs-sdk/blob/main/types.ts#L850)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.ts:826](https://github.com/coda/packs-sdk/blob/main/types.ts#L826)
+[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
 
 ___
 
@@ -61,7 +61,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
+[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
 
 ___
 
@@ -79,7 +79,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:829](https://github.com/coda/packs-sdk/blob/main/types.ts#L829)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's sync tables. See {@link SyncTable}.
 
 #### Defined in
 
-[types.ts:844](https://github.com/coda/packs-sdk/blob/main/types.ts#L844)
+[types.ts:854](https://github.com/coda/packs-sdk/blob/main/types.ts#L854)
 
 ___
 
@@ -104,7 +104,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:809](https://github.com/coda/packs-sdk/blob/main/types.ts#L809)
+[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
 
 ___
 
@@ -117,4 +117,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:800](https://github.com/coda/packs-sdk/blob/main/types.ts#L800)
+[types.ts:810](https://github.com/coda/packs-sdk/blob/main/types.ts#L810)

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -6,4 +6,4 @@ The union of supported authentication methods.
 
 #### Defined in
 
-[types.ts:569](https://github.com/coda/packs-sdk/blob/main/types.ts#L569)
+[types.ts:579](https://github.com/coda/packs-sdk/blob/main/types.ts#L579)

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -7,4 +7,4 @@ editor where Coda will manage versioning on behalf of the pack author.
 
 #### Defined in
 
-[types.ts:789](https://github.com/coda/packs-sdk/blob/main/types.ts#L789)
+[types.ts:799](https://github.com/coda/packs-sdk/blob/main/types.ts#L799)

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -7,4 +7,4 @@ where the pack author provides credentials used in HTTP requests rather than the
 
 #### Defined in
 
-[types.ts:614](https://github.com/coda/packs-sdk/blob/main/types.ts#L614)
+[types.ts:624](https://github.com/coda/packs-sdk/blob/main/types.ts#L624)

--- a/types.ts
+++ b/types.ts
@@ -488,17 +488,22 @@ export interface CustomAuthParameter {
  *
  * @example
  * ```
+ * {% raw %}
  * // Suppose you're using an API that requires a secret id in the request URL,
- * // and a different secret value in the request body. You can define a Custom authentication
- * // configuration with two params:
+ * // and a different secret value in the request body. You can define a Custom
+ * // authentication configuration with two params:
  * // params: [{name: 'secretId', description: 'Secret id'},
  * //          {name: 'secretValue', description: 'Secret value'}])
- * // The user or the pack author will be prompted to specify a value for each of these when setting up an account.
- * // In the `execute` body of your formula, you can specify where those values are inserted in the request using
- * // the template replacement syntax shown above.
+ * // The user or the pack author will be prompted to specify a value for each
+ * // of these when setting up an account.
+ * // In the `execute` body of your formula, you can specify where those values
+ * // are inserted in the request using the template replacement syntax shown
+ * // above.
  * //
- * // A real-world example of an API that would require this is the Plaid API (https://plaid.com/docs/api/products/#auth)
- * // See the use of `secret`, `client_id`, and `access_token` parameters in the body.
+ * // A real-world example of an API that would require this is the Plaid API
+ * // (https://plaid.com/docs/api/products/#auth).
+ * // See the use of `secret`, `client_id`, and `access_token` parameters in the
+ * // body.
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
@@ -509,9 +514,14 @@ export interface CustomAuthParameter {
  *     otherBodyParam: "foo",
  *   });
  *
- *   let response = await context.fetcher.fetch({method: "GET", url: urlWithSecret, body: bodyWithSecret});
- *   ...
+ *   let response = await context.fetcher.fetch({
+ *     method: "GET",
+ *     url: urlWithSecret,
+ *     body: bodyWithSecret
+ *   });
+ *   // ...
  * }
+ * {% endraw %}
  * ```
  */
 export interface CustomAuthentication extends BaseAuthentication {


### PR DESCRIPTION
Without the `{% raw %}` directives the surrounding `{{`'s were getting lost. I also reformatted the code to be max 80 chars, so it fits better on the web page.

Staged: https://coda-packs-sdk--1557.com.readthedocs.build/en/1557/reference/sdk/interfaces/CustomAuthentication/