### PR TITLE
add changelog for custom auth type

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2629,8 +2629,8 @@ export interface CustomAuthParameter {
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
- *
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
+ *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -2639,7 +2639,10 @@ export interface CustomAuthParameter {
  *   let response = await context.fetcher.fetch({
  *     method: "GET",
  *     url: urlWithSecret,
- *     body: bodyWithSecret
+ *     body: bodyWithSecret,
+ *     headers: {
+ *       'X-Custom-Authorization-Header': secretHeader,
+ *     },
  *   });
  *   // ...
  * }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -482,8 +482,8 @@ export interface CustomAuthParameter {
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
- *
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
+ *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -492,7 +492,10 @@ export interface CustomAuthParameter {
  *   let response = await context.fetcher.fetch({
  *     method: "GET",
  *     url: urlWithSecret,
- *     body: bodyWithSecret
+ *     body: bodyWithSecret,
+ *     headers: {
+ *       'X-Custom-Authorization-Header': secretHeader,
+ *     },
  *   });
  *   // ...
  * }

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -37,8 +37,8 @@ token is required for security reasons.
 execute: async function([], context) {
   let secretIdTemplateName = "secretId-" + context.invocationToken;
   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
-
   let secretValueTemplateName = "secretValue-" + context.invocationToken;
+  let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
   let bodyWithSecret = JSON.stringify({
     key: "{{" + secretValueTemplateName + "}}",
     otherBodyParam: "foo",
@@ -47,7 +47,10 @@ execute: async function([], context) {
   let response = await context.fetcher.fetch({
     method: "GET",
     url: urlWithSecret,
-    body: bodyWithSecret
+    body: bodyWithSecret,
+    headers: {
+      'X-Custom-Authorization-Header': secretHeader,
+    },
   });
   // ...
 }
@@ -148,7 +151,7 @@ replacement inside the constructed network request.
 
 #### Defined in
 
-[types.ts:535](https://github.com/coda/packs-sdk/blob/main/types.ts#L535)
+[types.ts:538](https://github.com/coda/packs-sdk/blob/main/types.ts#L538)
 
 ___
 
@@ -196,4 +199,4 @@ Identifies this as Custom authentication.
 
 #### Defined in
 
-[types.ts:529](https://github.com/coda/packs-sdk/blob/main/types.ts#L529)
+[types.ts:532](https://github.com/coda/packs-sdk/blob/main/types.ts#L532)

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -37,7 +37,7 @@ This must correspond to the name of a regular, public formula defined in this pa
 
 #### Defined in
 
-[types.ts:710](https://github.com/coda/packs-sdk/blob/main/types.ts#L710)
+[types.ts:713](https://github.com/coda/packs-sdk/blob/main/types.ts#L713)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[types.ts:705](https://github.com/coda/packs-sdk/blob/main/types.ts#L705)
+[types.ts:708](https://github.com/coda/packs-sdk/blob/main/types.ts#L708)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[types.ts:712](https://github.com/coda/packs-sdk/blob/main/types.ts#L712)
+[types.ts:715](https://github.com/coda/packs-sdk/blob/main/types.ts#L715)
 
 ___
 
@@ -74,7 +74,7 @@ of values they should put in columns using this format.
 
 #### Defined in
 
-[types.ts:717](https://github.com/coda/packs-sdk/blob/main/types.ts#L717)
+[types.ts:720](https://github.com/coda/packs-sdk/blob/main/types.ts#L720)
 
 ___
 
@@ -87,7 +87,7 @@ is capable of handling. As described in [Format](Format.md), this is a discovery
 
 #### Defined in
 
-[types.ts:722](https://github.com/coda/packs-sdk/blob/main/types.ts#L722)
+[types.ts:725](https://github.com/coda/packs-sdk/blob/main/types.ts#L725)
 
 ___
 
@@ -99,7 +99,7 @@ The name of this column format. This will show to users in the column type choos
 
 #### Defined in
 
-[types.ts:703](https://github.com/coda/packs-sdk/blob/main/types.ts#L703)
+[types.ts:706](https://github.com/coda/packs-sdk/blob/main/types.ts#L706)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[types.ts:726](https://github.com/coda/packs-sdk/blob/main/types.ts#L726)
+[types.ts:729](https://github.com/coda/packs-sdk/blob/main/types.ts#L729)

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -19,7 +19,7 @@ This should only be used by legacy Coda pack implementations.
 
 #### Defined in
 
-[types.ts:869](https://github.com/coda/packs-sdk/blob/main/types.ts#L869)
+[types.ts:872](https://github.com/coda/packs-sdk/blob/main/types.ts#L872)
 
 ___
 
@@ -35,7 +35,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:814](https://github.com/coda/packs-sdk/blob/main/types.ts#L814)
+[types.ts:817](https://github.com/coda/packs-sdk/blob/main/types.ts#L817)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[types.ts:867](https://github.com/coda/packs-sdk/blob/main/types.ts#L867)
+[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[types.ts:871](https://github.com/coda/packs-sdk/blob/main/types.ts#L871)
+[types.ts:874](https://github.com/coda/packs-sdk/blob/main/types.ts#L874)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[types.ts:872](https://github.com/coda/packs-sdk/blob/main/types.ts#L872)
+[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
+[types.ts:876](https://github.com/coda/packs-sdk/blob/main/types.ts#L876)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:850](https://github.com/coda/packs-sdk/blob/main/types.ts#L850)
+[types.ts:853](https://github.com/coda/packs-sdk/blob/main/types.ts#L853)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)
 
 ___
 
@@ -129,7 +129,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
+[types.ts:849](https://github.com/coda/packs-sdk/blob/main/types.ts#L849)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[types.ts:864](https://github.com/coda/packs-sdk/blob/main/types.ts#L864)
+[types.ts:867](https://github.com/coda/packs-sdk/blob/main/types.ts#L867)
 
 ___
 
@@ -151,7 +151,7 @@ Whether this is a pack that will be used by Coda internally and not exposed dire
 
 #### Defined in
 
-[types.ts:880](https://github.com/coda/packs-sdk/blob/main/types.ts#L880)
+[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
+[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[types.ts:874](https://github.com/coda/packs-sdk/blob/main/types.ts#L874)
+[types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
+[types.ts:868](https://github.com/coda/packs-sdk/blob/main/types.ts#L868)
 
 ___
 
@@ -203,7 +203,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:829](https://github.com/coda/packs-sdk/blob/main/types.ts#L829)
+[types.ts:832](https://github.com/coda/packs-sdk/blob/main/types.ts#L832)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[types.ts:868](https://github.com/coda/packs-sdk/blob/main/types.ts#L868)
+[types.ts:871](https://github.com/coda/packs-sdk/blob/main/types.ts#L871)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
+[types.ts:878](https://github.com/coda/packs-sdk/blob/main/types.ts#L878)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[types.ts:876](https://github.com/coda/packs-sdk/blob/main/types.ts#L876)
+[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[types.ts:866](https://github.com/coda/packs-sdk/blob/main/types.ts#L866)
+[types.ts:869](https://github.com/coda/packs-sdk/blob/main/types.ts#L869)
 
 ___
 
@@ -259,7 +259,7 @@ Definitions of this pack's sync tables. See {@link SyncTable}.
 
 #### Defined in
 
-[types.ts:854](https://github.com/coda/packs-sdk/blob/main/types.ts#L854)
+[types.ts:857](https://github.com/coda/packs-sdk/blob/main/types.ts#L857)
 
 ___
 
@@ -276,7 +276,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:822](https://github.com/coda/packs-sdk/blob/main/types.ts#L822)
 
 ___
 
@@ -293,4 +293,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:810](https://github.com/coda/packs-sdk/blob/main/types.ts#L810)
+[types.ts:813](https://github.com/coda/packs-sdk/blob/main/types.ts#L813)

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -19,7 +19,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:814](https://github.com/coda/packs-sdk/blob/main/types.ts#L814)
+[types.ts:817](https://github.com/coda/packs-sdk/blob/main/types.ts#L817)
 
 ___
 
@@ -31,7 +31,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:850](https://github.com/coda/packs-sdk/blob/main/types.ts#L850)
+[types.ts:853](https://github.com/coda/packs-sdk/blob/main/types.ts#L853)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.ts:836](https://github.com/coda/packs-sdk/blob/main/types.ts#L836)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)
 
 ___
 
@@ -61,7 +61,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
+[types.ts:849](https://github.com/coda/packs-sdk/blob/main/types.ts#L849)
 
 ___
 
@@ -79,7 +79,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:829](https://github.com/coda/packs-sdk/blob/main/types.ts#L829)
+[types.ts:832](https://github.com/coda/packs-sdk/blob/main/types.ts#L832)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's sync tables. See {@link SyncTable}.
 
 #### Defined in
 
-[types.ts:854](https://github.com/coda/packs-sdk/blob/main/types.ts#L854)
+[types.ts:857](https://github.com/coda/packs-sdk/blob/main/types.ts#L857)
 
 ___
 
@@ -104,7 +104,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:822](https://github.com/coda/packs-sdk/blob/main/types.ts#L822)
 
 ___
 
@@ -117,4 +117,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:810](https://github.com/coda/packs-sdk/blob/main/types.ts#L810)
+[types.ts:813](https://github.com/coda/packs-sdk/blob/main/types.ts#L813)

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -6,4 +6,4 @@ The union of supported authentication methods.
 
 #### Defined in
 
-[types.ts:579](https://github.com/coda/packs-sdk/blob/main/types.ts#L579)
+[types.ts:582](https://github.com/coda/packs-sdk/blob/main/types.ts#L582)

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -7,4 +7,4 @@ editor where Coda will manage versioning on behalf of the pack author.
 
 #### Defined in
 
-[types.ts:799](https://github.com/coda/packs-sdk/blob/main/types.ts#L799)
+[types.ts:802](https://github.com/coda/packs-sdk/blob/main/types.ts#L802)

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -7,4 +7,4 @@ where the pack author provides credentials used in HTTP requests rather than the
 
 #### Defined in
 
-[types.ts:624](https://github.com/coda/packs-sdk/blob/main/types.ts#L624)
+[types.ts:627](https://github.com/coda/packs-sdk/blob/main/types.ts#L627)

--- a/types.ts
+++ b/types.ts
@@ -507,8 +507,8 @@ export interface CustomAuthParameter {
  * execute: async function([], context) {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
- *
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
+ *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -517,7 +517,10 @@ export interface CustomAuthParameter {
  *   let response = await context.fetcher.fetch({
  *     method: "GET",
  *     url: urlWithSecret,
- *     body: bodyWithSecret
+ *     body: bodyWithSecret,
+ *     headers: {
+ *       'X-Custom-Authorization-Header': secretHeader,
+ *     },
  *   });
  *   // ...
  * }


### PR DESCRIPTION
Adding in the change log for `AuthenticationType.Custom`. will publish a new NPM version after this goes in

@coda/packs @jonathan-codaio @ekoleda-codaio 