### PR TITLE
making format formulaNamespace optional

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2781,7 +2781,7 @@ export interface Format {
 	 */
 	name: string;
 	/** @deprecated Namespaces are being removed from the product. */
-	formulaNamespace: string;
+	formulaNamespace?: string;
 	/**
 	 * The name of the formula to invoke for values in columns using this format.
 	 * This must correspond to the name of a regular, public formula defined in this pack.

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -662,7 +662,7 @@ const formulaMetadataSchema = z
 });
 const formatMetadataSchema = zodCompleteObject({
     name: z.string(),
-    formulaNamespace: z.string(),
+    formulaNamespace: z.string().optional(),
     formulaName: z.string(),
     hasNoConnection: z.boolean().optional(),
     instructions: z.string().optional(),

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -608,7 +608,7 @@ export interface Format {
      */
     name: string;
     /** @deprecated Namespaces are being removed from the product. */
-    formulaNamespace: string;
+    formulaNamespace?: string;
     /**
      * The name of the formula to invoke for values in columns using this format.
      * This must correspond to the name of a regular, public formula defined in this pack.

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -43,7 +43,7 @@ ___
 
 ### formulaNamespace
 
-• **formulaNamespace**: `string`
+• `Optional` **formulaNamespace**: `string`
 
 **`deprecated`** Namespaces are being removed from the product.
 

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -800,7 +800,7 @@ const formulaMetadataSchema = z
 
 const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
   name: z.string(),
-  formulaNamespace: z.string(), // Will be removed once we deprecate namespace objects.
+  formulaNamespace: z.string().optional(), // Will be removed once we deprecate namespace objects.
   formulaName: z.string(),
   hasNoConnection: z.boolean().optional(),
   instructions: z.string().optional(),

--- a/types.ts
+++ b/types.ts
@@ -691,7 +691,7 @@ export interface Format {
    */
   name: string;
   /** @deprecated Namespaces are being removed from the product. */
-  formulaNamespace: string;
+  formulaNamespace?: string;
   /**
    * The name of the formula to invoke for values in columns using this format.
    * This must correspond to the name of a regular, public formula defined in this pack.


### PR DESCRIPTION
This will make format easier to use before we are able to get rid of `formulaNamespace` completely. 

after:

![image](https://user-images.githubusercontent.com/70549840/142532577-f03cbae6-8b4a-4250-971c-c8ff9e1ff122.png)
