### PR TITLE
Add documentation for RequestHandlerTemplate and ResponseHandlerTemplate.

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1454,7 +1454,7 @@ export declare enum PrecannedDateRange {
  *         return value.toLowerCase();
  *       },
  *     },
- *     queryParams: ["id", "format"],
+ *     queryParams: ["format"],
  *   },
  * });
  * ```

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1432,26 +1432,140 @@ export declare enum PrecannedDateRange {
 	 */
 	Everything = "everything"
 }
-export declare type ParamMapper<T> = (val: T) => T;
+/**
+ * Configuration for how to construct an HTTP request for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ *
+ * @example
+ * ```
+ * coda.makeTranslateObjectFormula({
+ *   name: "FetchWidget",
+ *   description: "Fetches a widget.",
+ *   parameters: [
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "id"}),
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "outputFormat"}),
+ *   ],
+ *   request: {
+ *     method: "GET",
+ *     url: "https://example.com/api/widgets/{id}",
+ *     nameMapping: {outputFormat: "format"},
+ *     transforms: {
+ *       format: function(value) {
+ *         return value.toLowerCase();
+ *       },
+ *     },
+ *     queryParams: ["id", "format"],
+ *   },
+ * });
+ * ```
+ *
+ * If the user calls this formula as `FetchWidget("abc123", "JSON")`, this will make a `GET` request to
+ * `https://example.com/api/widgets/abc123?format=json`.
+ */
 export interface RequestHandlerTemplate {
+	/**
+	 * The URL to fetch.
+	 *
+	 * The path of the URL can include strong formatting directives that can be replaced with
+	 * formula parameters, e.g. "https://example.com/api/{name}".
+	 */
 	url: string;
+	/**
+	 * The HTTP method (verb) to use, e.g. "GET".
+	 *
+	 * If making a POST request or any request that uses a body payload, the body is
+	 * assumed to be JSON.
+	 */
 	method: FetchMethodType;
+	/** Any HTTP headers to include in the request. */
 	headers?: {
 		[header: string]: string;
 	};
+	/**
+	 * An optional mapping from the name of a formula parameter to the name of a URL parameter
+	 * or template substitution variable in the body or URL path.
+	 *
+	 * Fetcher requests are constructed by inserting the user's parameter values into the URL
+	 * or body. You may use the formula parameter names to in your insertion templates or
+	 * as URL parameter names, but you may also use this mapping to rename the formula
+	 * parameters, if you wish to refer to them differently in your implementation
+	 * than how you present them to users.
+	 */
 	nameMapping?: {
 		[functionParamName: string]: string;
 	};
+	/**
+	 * Optional transformations to apply to formula parameters. By default formula parameters
+	 * are passed through as-is to wherever you indicate in the fetcher request. However, if
+	 * you wish to tweak their values before constructing the request, you can apply transformations here.
+	 * The key is the name of the field, which is either the name of the formula parameter, or
+	 * the mapped name for that parameter if you specified a {@link nameMapping}.
+	 * The value is a JavaScript function that takes a user-provided parameter value and returns the value
+	 * that should be used in the request.
+	 */
 	transforms?: {
-		[name: string]: ParamMapper<any>;
+		[name: string]: (val: any) => any;
 	};
+	/**
+	 * The names of parameters that should be included in the request URL.
+	 *
+	 * That is, if some of the formula parameters should go into the URL and others should go into the body,
+	 * specify the subset of parameters here that should go into the URL. If all of the formula parameters
+	 * should become URL parameters, list all of the parameter names here.
+	 *
+	 * These are the mapped names if you are using {@link nameMapping}.
+	 */
 	queryParams?: string[];
+	/**
+	 * A base JavaScript object to be used as the body payload. Any parameters named in {@link bodyParams}
+	 * will be merged into this object, and the resulting object will be stringified and sent as the body.
+	 */
 	bodyTemplate?: object;
+	/**
+	 * The names of parameters that should be included in the request body, if applicable.
+	 *
+	 * That is, if some of the formula parameters should go into the URL and others should go into the body,
+	 * specify the subset of parameters here that should go into the body. If all of the formula parameters
+	 * should go into the body, list all of the parameter names here.
+	 *
+	 * These are the mapped names if you are using {@link nameMapping}.
+	 */
 	bodyParams?: string[];
 }
+/**
+ * Configuration for how to handle the response for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ */
 export interface ResponseHandlerTemplate<T extends Schema> {
+	/** The schema of the objects being returned. */
 	schema?: T;
+	/**
+	 * The key in the response body that indicates the objects of interest.
+	 *
+	 * Sometimes the response body is itself an array of objects, allowing you
+	 * to return the body as-is, but more commonly, the response body is
+	 * an object where one of its properties is the array of objects of interest,
+	 * with other properties containing metadata about the response.
+	 *
+	 * This allows you to specify a response property name to "project" out
+	 * the relevant part of the response body.
+	 *
+	 * For example, suppose the response body looks like:
+	 * ```
+	 * {
+	 *   items: [{name: "Alice"}, {name: "Bob"}],
+	 *   nextPageUrl: "/users?page=2",
+	 * }
+	 * ```
+	 *
+	 * You would set `projectKey: "items"` and the generated formula implementation
+	 * will return `response.body.items`.
+	 */
 	projectKey?: string;
+	/**
+	 * If specified, will catch HTTP errors and call this function with the error,
+	 * instead of letting them throw and the formula failing.
+	 */
 	onError?(error: Error): any;
 }
 /**

--- a/dist/handler_templates.d.ts
+++ b/dist/handler_templates.d.ts
@@ -5,29 +5,142 @@ import type { PackFormulaValue } from './api_types';
 import type { ParamDefs } from './api_types';
 import type { Schema } from './schema';
 import type { SchemaType } from './schema';
-declare type ParamMapper<T> = (val: T) => T;
+/**
+ * Configuration for how to construct an HTTP request for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ *
+ * @example
+ * ```
+ * coda.makeTranslateObjectFormula({
+ *   name: "FetchWidget",
+ *   description: "Fetches a widget.",
+ *   parameters: [
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "id"}),
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "outputFormat"}),
+ *   ],
+ *   request: {
+ *     method: "GET",
+ *     url: "https://example.com/api/widgets/{id}",
+ *     nameMapping: {outputFormat: "format"},
+ *     transforms: {
+ *       format: function(value) {
+ *         return value.toLowerCase();
+ *       },
+ *     },
+ *     queryParams: ["id", "format"],
+ *   },
+ * });
+ * ```
+ *
+ * If the user calls this formula as `FetchWidget("abc123", "JSON")`, this will make a `GET` request to
+ * `https://example.com/api/widgets/abc123?format=json`.
+ */
 export interface RequestHandlerTemplate {
+    /**
+     * The URL to fetch.
+     *
+     * The path of the URL can include strong formatting directives that can be replaced with
+     * formula parameters, e.g. "https://example.com/api/{name}".
+     */
     url: string;
+    /**
+     * The HTTP method (verb) to use, e.g. "GET".
+     *
+     * If making a POST request or any request that uses a body payload, the body is
+     * assumed to be JSON.
+     */
     method: FetchMethodType;
+    /** Any HTTP headers to include in the request. */
     headers?: {
         [header: string]: string;
     };
+    /**
+     * An optional mapping from the name of a formula parameter to the name of a URL parameter
+     * or template substitution variable in the body or URL path.
+     *
+     * Fetcher requests are constructed by inserting the user's parameter values into the URL
+     * or body. You may use the formula parameter names to in your insertion templates or
+     * as URL parameter names, but you may also use this mapping to rename the formula
+     * parameters, if you wish to refer to them differently in your implementation
+     * than how you present them to users.
+     */
     nameMapping?: {
         [functionParamName: string]: string;
     };
+    /**
+     * Optional transformations to apply to formula parameters. By default formula parameters
+     * are passed through as-is to wherever you indicate in the fetcher request. However, if
+     * you wish to tweak their values before constructing the request, you can apply transformations here.
+     * The key is the name of the field, which is either the name of the formula parameter, or
+     * the mapped name for that parameter if you specified a {@link nameMapping}.
+     * The value is a JavaScript function that takes a user-provided parameter value and returns the value
+     * that should be used in the request.
+     */
     transforms?: {
-        [name: string]: ParamMapper<any>;
+        [name: string]: (val: any) => any;
     };
+    /**
+     * The names of parameters that should be included in the request URL.
+     *
+     * That is, if some of the formula parameters should go into the URL and others should go into the body,
+     * specify the subset of parameters here that should go into the URL. If all of the formula parameters
+     * should become URL parameters, list all of the parameter names here.
+     *
+     * These are the mapped names if you are using {@link nameMapping}.
+     */
     queryParams?: string[];
+    /**
+     * A base JavaScript object to be used as the body payload. Any parameters named in {@link bodyParams}
+     * will be merged into this object, and the resulting object will be stringified and sent as the body.
+     */
     bodyTemplate?: object;
+    /**
+     * The names of parameters that should be included in the request body, if applicable.
+     *
+     * That is, if some of the formula parameters should go into the URL and others should go into the body,
+     * specify the subset of parameters here that should go into the body. If all of the formula parameters
+     * should go into the body, list all of the parameter names here.
+     *
+     * These are the mapped names if you are using {@link nameMapping}.
+     */
     bodyParams?: string[];
 }
+/**
+ * Configuration for how to handle the response for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ */
 export interface ResponseHandlerTemplate<T extends Schema> {
+    /** The schema of the objects being returned. */
     schema?: T;
+    /**
+     * The key in the response body that indicates the objects of interest.
+     *
+     * Sometimes the response body is itself an array of objects, allowing you
+     * to return the body as-is, but more commonly, the response body is
+     * an object where one of its properties is the array of objects of interest,
+     * with other properties containing metadata about the response.
+     *
+     * This allows you to specify a response property name to "project" out
+     * the relevant part of the response body.
+     *
+     * For example, suppose the response body looks like:
+     * ```
+     * {
+     *   items: [{name: "Alice"}, {name: "Bob"}],
+     *   nextPageUrl: "/users?page=2",
+     * }
+     * ```
+     *
+     * You would set `projectKey: "items"` and the generated formula implementation
+     * will return `response.body.items`.
+     */
     projectKey?: string;
+    /**
+     * If specified, will catch HTTP errors and call this function with the error,
+     * instead of letting them throw and the formula failing.
+     */
     onError?(error: Error): any;
 }
 export declare function generateRequestHandler<ParamDefsT extends ParamDefs>(request: RequestHandlerTemplate, parameters: ParamDefsT): (params: PackFormulaValue[]) => FetchRequest;
 export declare function transformBody(body: any, schema: Schema): any;
 export declare function generateObjectResponseHandler<T extends Schema>(response: ResponseHandlerTemplate<T>): (response: FetchResponse, runtimeSchema?: T) => SchemaType<T>;
-export {};

--- a/dist/handler_templates.d.ts
+++ b/dist/handler_templates.d.ts
@@ -27,7 +27,7 @@ import type { SchemaType } from './schema';
  *         return value.toLowerCase();
  *       },
  *     },
- *     queryParams: ["id", "format"],
+ *     queryParams: ["format"],
  *   },
  * });
  * ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -167,3 +167,5 @@ export type { InferrableTypes } from './schema';
 export type { NumberHintTypes } from './schema';
 export type { ObjectHintTypes } from './schema';
 export type { StringHintTypes } from './schema';
+export type { RequestHandlerTemplate } from './handler_templates';
+export type { ResponseHandlerTemplate } from './handler_templates';

--- a/docs/reference/sdk/README.md
+++ b/docs/reference/sdk/README.md
@@ -70,6 +70,8 @@
 - [PackVersionDefinition](interfaces/PackVersionDefinition.md)
 - [ParamDef](interfaces/ParamDef.md)
 - [QueryParamTokenAuthentication](interfaces/QueryParamTokenAuthentication.md)
+- [RequestHandlerTemplate](interfaces/RequestHandlerTemplate.md)
+- [ResponseHandlerTemplate](interfaces/ResponseHandlerTemplate.md)
 - [ScaleSchema](interfaces/ScaleSchema.md)
 - [SetEndpoint](interfaces/SetEndpoint.md)
 - [SimpleAutocompleteOption](interfaces/SimpleAutocompleteOption.md)

--- a/docs/reference/sdk/functions/makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/makeEmptyFormula.md
@@ -2,7 +2,7 @@
 
 ▸ **makeEmptyFormula**<`ParamDefsT`\>(`definition`): { `cacheTtlSecs?`: `number` ; `connectionRequirement?`: [`ConnectionRequirement`](../enums/ConnectionRequirement.md) ; `description`: `string` ; `examples?`: { `params`: [`PackFormulaValue`](../types/PackFormulaValue.md)[] ; `result`: [`PackFormulaResult`](../types/PackFormulaResult.md)  }[] ; `extraOAuthScopes?`: `string`[] ; `isAction?`: `boolean` ; `isExperimental?`: `boolean` ; `isSystem?`: `boolean` ; `name`: `string` ; `network?`: [`Network`](../interfaces/Network.md) ; `parameters`: `ParamDefsT` ; `varargParameters?`: [`ParamDefs`](../types/ParamDefs.md)  } & { `execute`: (`params`: [`ParamValues`](../types/ParamValues.md)<`ParamDefsT`\>, `context`: [`ExecutionContext`](../interfaces/ExecutionContext.md)) => `Promise`<`string`\> ; `resultType`: [`string`](../enums/Type.md#string)  }
 
-Creates the definition of an "empty" formula, that is, a formula that uses a {@link RequestHandlerTemplate}
+Creates the definition of an "empty" formula, that is, a formula that uses a [RequestHandlerTemplate](../interfaces/RequestHandlerTemplate.md)
 to define an implementation for the formula rather than implementing an actual `execute` function
 in JavaScript.
 

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -1,6 +1,6 @@
 # Interface: EmptyFormulaDef<ParamsT\>
 
-Inputs to define an "empty" formula, that is, a formula that uses a {@link RequestHandlerTemplate}
+Inputs to define an "empty" formula, that is, a formula that uses a [RequestHandlerTemplate](RequestHandlerTemplate.md)
 to define an implementation for the formula rather than implementing an actual `execute` function
 in JavaScript. An empty formula returns a string. To return a list of objects, see
 [ObjectArrayFormulaDef](ObjectArrayFormulaDef.md).
@@ -207,7 +207,7 @@ ___
 
 ### request
 
-• **request**: `RequestHandlerTemplate`
+• **request**: [`RequestHandlerTemplate`](RequestHandlerTemplate.md)
 
 A definition of the request and any parameter transformations to make in order to implement this formula.
 

--- a/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
@@ -2,8 +2,8 @@
 
 Inputs to declaratively define a formula that returns a list of objects.
 That is, a formula that doesn't require code, which like an [EmptyFormulaDef](EmptyFormulaDef.md) uses
-a {@link RequestHandlerTemplate} to describe the request to be made, but also includes a
-{@link ResponseHandlerTemplate} to describe the schema of the returned objects.
+a [RequestHandlerTemplate](RequestHandlerTemplate.md) to describe the request to be made, but also includes a
+[ResponseHandlerTemplate](ResponseHandlerTemplate.md) to describe the schema of the returned objects.
 These take the place of implementing a JavaScript `execute` function.
 
 This type is generally not used directly, but describes the inputs to [makeTranslateObjectFormula](../functions/makeTranslateObjectFormula.md).
@@ -209,7 +209,7 @@ ___
 
 ### request
 
-• **request**: `RequestHandlerTemplate`
+• **request**: [`RequestHandlerTemplate`](RequestHandlerTemplate.md)
 
 A definition of the request and any parameter transformations to make in order to implement this formula.
 
@@ -221,7 +221,7 @@ ___
 
 ### response
 
-• **response**: `ResponseHandlerTemplate`<`SchemaT`\>
+• **response**: [`ResponseHandlerTemplate`](ResponseHandlerTemplate.md)<`SchemaT`\>
 
 A definition of the schema for the object list returned by this function.
 

--- a/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
@@ -21,7 +21,7 @@ coda.makeTranslateObjectFormula({
         return value.toLowerCase();
       },
     },
-    queryParams: ["id", "format"],
+    queryParams: ["format"],
   },
 });
 ```

--- a/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
@@ -1,0 +1,170 @@
+# Interface: RequestHandlerTemplate
+
+Configuration for how to construct an HTTP request for a code-free formula definition
+created using [makeTranslateObjectFormula](../functions/makeTranslateObjectFormula.md).
+
+**`example`**
+```
+coda.makeTranslateObjectFormula({
+  name: "FetchWidget",
+  description: "Fetches a widget.",
+  parameters: [
+    coda.makeParameter({type: coda.ParameterType.String, name: "id"}),
+    coda.makeParameter({type: coda.ParameterType.String, name: "outputFormat"}),
+  ],
+  request: {
+    method: "GET",
+    url: "https://example.com/api/widgets/{id}",
+    nameMapping: {outputFormat: "format"},
+    transforms: {
+      format: function(value) {
+        return value.toLowerCase();
+      },
+    },
+    queryParams: ["id", "format"],
+  },
+});
+```
+
+If the user calls this formula as `FetchWidget("abc123", "JSON")`, this will make a `GET` request to
+`https://example.com/api/widgets/abc123?format=json`.
+
+## Properties
+
+### bodyParams
+
+• `Optional` **bodyParams**: `string`[]
+
+The names of parameters that should be included in the request body, if applicable.
+
+That is, if some of the formula parameters should go into the URL and others should go into the body,
+specify the subset of parameters here that should go into the body. If all of the formula parameters
+should go into the body, list all of the parameter names here.
+
+These are the mapped names if you are using [nameMapping](RequestHandlerTemplate.md#namemapping).
+
+#### Defined in
+
+[handler_templates.ts:108](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L108)
+
+___
+
+### bodyTemplate
+
+• `Optional` **bodyTemplate**: `object`
+
+A base JavaScript object to be used as the body payload. Any parameters named in [bodyParams](RequestHandlerTemplate.md#bodyparams)
+will be merged into this object, and the resulting object will be stringified and sent as the body.
+
+#### Defined in
+
+[handler_templates.ts:98](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L98)
+
+___
+
+### headers
+
+• `Optional` **headers**: `Object`
+
+Any HTTP headers to include in the request.
+
+#### Index signature
+
+▪ [header: `string`]: `string`
+
+#### Defined in
+
+[handler_templates.ts:62](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L62)
+
+___
+
+### method
+
+• **method**: ``"GET"`` \| ``"PATCH"`` \| ``"POST"`` \| ``"PUT"`` \| ``"DELETE"``
+
+The HTTP method (verb) to use, e.g. "GET".
+
+If making a POST request or any request that uses a body payload, the body is
+assumed to be JSON.
+
+#### Defined in
+
+[handler_templates.ts:60](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L60)
+
+___
+
+### nameMapping
+
+• `Optional` **nameMapping**: `Object`
+
+An optional mapping from the name of a formula parameter to the name of a URL parameter
+or template substitution variable in the body or URL path.
+
+Fetcher requests are constructed by inserting the user's parameter values into the URL
+or body. You may use the formula parameter names to in your insertion templates or
+as URL parameter names, but you may also use this mapping to rename the formula
+parameters, if you wish to refer to them differently in your implementation
+than how you present them to users.
+
+#### Index signature
+
+▪ [functionParamName: `string`]: `string`
+
+#### Defined in
+
+[handler_templates.ts:73](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L73)
+
+___
+
+### queryParams
+
+• `Optional` **queryParams**: `string`[]
+
+The names of parameters that should be included in the request URL.
+
+That is, if some of the formula parameters should go into the URL and others should go into the body,
+specify the subset of parameters here that should go into the URL. If all of the formula parameters
+should become URL parameters, list all of the parameter names here.
+
+These are the mapped names if you are using [nameMapping](RequestHandlerTemplate.md#namemapping).
+
+#### Defined in
+
+[handler_templates.ts:93](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L93)
+
+___
+
+### transforms
+
+• `Optional` **transforms**: `Object`
+
+Optional transformations to apply to formula parameters. By default formula parameters
+are passed through as-is to wherever you indicate in the fetcher request. However, if
+you wish to tweak their values before constructing the request, you can apply transformations here.
+The key is the name of the field, which is either the name of the formula parameter, or
+the mapped name for that parameter if you specified a [nameMapping](RequestHandlerTemplate.md#namemapping).
+The value is a JavaScript function that takes a user-provided parameter value and returns the value
+that should be used in the request.
+
+#### Index signature
+
+▪ [name: `string`]: (`val`: `any`) => `any`
+
+#### Defined in
+
+[handler_templates.ts:83](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L83)
+
+___
+
+### url
+
+• **url**: `string`
+
+The URL to fetch.
+
+The path of the URL can include strong formatting directives that can be replaced with
+formula parameters, e.g. "https://example.com/api/{name}".
+
+#### Defined in
+
+[handler_templates.ts:53](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L53)

--- a/docs/reference/sdk/interfaces/ResponseHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/ResponseHandlerTemplate.md
@@ -1,0 +1,76 @@
+# Interface: ResponseHandlerTemplate<T\>
+
+Configuration for how to handle the response for a code-free formula definition
+created using [makeTranslateObjectFormula](../functions/makeTranslateObjectFormula.md).
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`Schema`](../types/Schema.md) |
+
+## Properties
+
+### projectKey
+
+• `Optional` **projectKey**: `string`
+
+The key in the response body that indicates the objects of interest.
+
+Sometimes the response body is itself an array of objects, allowing you
+to return the body as-is, but more commonly, the response body is
+an object where one of its properties is the array of objects of interest,
+with other properties containing metadata about the response.
+
+This allows you to specify a response property name to "project" out
+the relevant part of the response body.
+
+For example, suppose the response body looks like:
+```
+{
+  items: [{name: "Alice"}, {name: "Bob"}],
+  nextPageUrl: "/users?page=2",
+}
+```
+
+You would set `projectKey: "items"` and the generated formula implementation
+will return `response.body.items`.
+
+#### Defined in
+
+[handler_templates.ts:140](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L140)
+
+___
+
+### schema
+
+• `Optional` **schema**: `T`
+
+The schema of the objects being returned.
+
+#### Defined in
+
+[handler_templates.ts:117](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L117)
+
+## Methods
+
+### onError
+
+▸ `Optional` **onError**(`error`): `any`
+
+If specified, will catch HTTP errors and call this function with the error,
+instead of letting them throw and the formula failing.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `error` | `Error` |
+
+#### Returns
+
+`any`
+
+#### Defined in
+
+[handler_templates.ts:145](https://github.com/coda/packs-sdk/blob/main/handler_templates.ts#L145)

--- a/handler_templates.ts
+++ b/handler_templates.ts
@@ -35,7 +35,7 @@ import {withQueryParams} from './helpers/url';
  *         return value.toLowerCase();
  *       },
  *     },
- *     queryParams: ["id", "format"],
+ *     queryParams: ["format"],
  *   },
  * });
  * ```

--- a/handler_templates.ts
+++ b/handler_templates.ts
@@ -13,22 +13,135 @@ import {isArray} from './schema';
 import {isObject} from './schema';
 import {withQueryParams} from './helpers/url';
 
-type ParamMapper<T> = (val: T) => T;
-
+/**
+ * Configuration for how to construct an HTTP request for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ *
+ * @example
+ * ```
+ * coda.makeTranslateObjectFormula({
+ *   name: "FetchWidget",
+ *   description: "Fetches a widget.",
+ *   parameters: [
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "id"}),
+ *     coda.makeParameter({type: coda.ParameterType.String, name: "outputFormat"}),
+ *   ],
+ *   request: {
+ *     method: "GET",
+ *     url: "https://example.com/api/widgets/{id}",
+ *     nameMapping: {outputFormat: "format"},
+ *     transforms: {
+ *       format: function(value) {
+ *         return value.toLowerCase();
+ *       },
+ *     },
+ *     queryParams: ["id", "format"],
+ *   },
+ * });
+ * ```
+ *
+ * If the user calls this formula as `FetchWidget("abc123", "JSON")`, this will make a `GET` request to
+ * `https://example.com/api/widgets/abc123?format=json`.
+ */
 export interface RequestHandlerTemplate {
+  /**
+   * The URL to fetch.
+   *
+   * The path of the URL can include strong formatting directives that can be replaced with
+   * formula parameters, e.g. "https://example.com/api/{name}".
+   */
   url: string;
+  /**
+   * The HTTP method (verb) to use, e.g. "GET".
+   *
+   * If making a POST request or any request that uses a body payload, the body is
+   * assumed to be JSON.
+   */
   method: FetchMethodType;
+  /** Any HTTP headers to include in the request. */
   headers?: {[header: string]: string};
+  /**
+   * An optional mapping from the name of a formula parameter to the name of a URL parameter
+   * or template substitution variable in the body or URL path.
+   *
+   * Fetcher requests are constructed by inserting the user's parameter values into the URL
+   * or body. You may use the formula parameter names to in your insertion templates or
+   * as URL parameter names, but you may also use this mapping to rename the formula
+   * parameters, if you wish to refer to them differently in your implementation
+   * than how you present them to users.
+   */
   nameMapping?: {[functionParamName: string]: string};
-  transforms?: {[name: string]: ParamMapper<any>};
+  /**
+   * Optional transformations to apply to formula parameters. By default formula parameters
+   * are passed through as-is to wherever you indicate in the fetcher request. However, if
+   * you wish to tweak their values before constructing the request, you can apply transformations here.
+   * The key is the name of the field, which is either the name of the formula parameter, or
+   * the mapped name for that parameter if you specified a {@link nameMapping}.
+   * The value is a JavaScript function that takes a user-provided parameter value and returns the value
+   * that should be used in the request.
+   */
+  transforms?: {[name: string]: (val: any) => any};
+  /**
+   * The names of parameters that should be included in the request URL.
+   *
+   * That is, if some of the formula parameters should go into the URL and others should go into the body,
+   * specify the subset of parameters here that should go into the URL. If all of the formula parameters
+   * should become URL parameters, list all of the parameter names here.
+   *
+   * These are the mapped names if you are using {@link nameMapping}.
+   */
   queryParams?: string[];
+  /**
+   * A base JavaScript object to be used as the body payload. Any parameters named in {@link bodyParams}
+   * will be merged into this object, and the resulting object will be stringified and sent as the body.
+   */
   bodyTemplate?: object;
+  /**
+   * The names of parameters that should be included in the request body, if applicable.
+   *
+   * That is, if some of the formula parameters should go into the URL and others should go into the body,
+   * specify the subset of parameters here that should go into the body. If all of the formula parameters
+   * should go into the body, list all of the parameter names here.
+   *
+   * These are the mapped names if you are using {@link nameMapping}.
+   */
   bodyParams?: string[];
 }
 
+/**
+ * Configuration for how to handle the response for a code-free formula definition
+ * created using {@link makeTranslateObjectFormula}.
+ */
 export interface ResponseHandlerTemplate<T extends Schema> {
+  /** The schema of the objects being returned. */
   schema?: T;
+  /**
+   * The key in the response body that indicates the objects of interest.
+   *
+   * Sometimes the response body is itself an array of objects, allowing you
+   * to return the body as-is, but more commonly, the response body is
+   * an object where one of its properties is the array of objects of interest,
+   * with other properties containing metadata about the response.
+   *
+   * This allows you to specify a response property name to "project" out
+   * the relevant part of the response body.
+   *
+   * For example, suppose the response body looks like:
+   * ```
+   * {
+   *   items: [{name: "Alice"}, {name: "Bob"}],
+   *   nextPageUrl: "/users?page=2",
+   * }
+   * ```
+   *
+   * You would set `projectKey: "items"` and the generated formula implementation
+   * will return `response.body.items`.
+   */
   projectKey?: string;
+  /**
+   * If specified, will catch HTTP errors and call this function with the error,
+   * instead of letting them throw and the formula failing.
+   */
   onError?(error: Error): any;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -194,3 +194,6 @@ export type {InferrableTypes} from './schema';
 export type {NumberHintTypes} from './schema';
 export type {ObjectHintTypes} from './schema';
 export type {StringHintTypes} from './schema';
+
+export type {RequestHandlerTemplate} from './handler_templates';
+export type {ResponseHandlerTemplate} from './handler_templates';

--- a/typedoc.js
+++ b/typedoc.js
@@ -15,10 +15,6 @@ module.exports = {
   allReflectionsHaveOwnDocument: true,
 
   intentionallyNotExported: [
-    // TODO(jonathan): Export and document these.
-    'RequestHandlerTemplate',
-    'ResponseHandlerTemplate',
-
     // Internal intermediate or helper types that we probably don't care to export or document.
     '$Values',
     'AsAuthDef',


### PR DESCRIPTION
This the very last part of the SDK that I think needs reference documentation.

This is a bit of a dumpster fire of a feature though, in terms of its understandibility, consistency, and completeness. I'm also complete fine saying that we hide this and say it's unsupported until we decide to invest in it more.

These allow you to define formulas for common fetcher tasks without writing code. It looks like it was part of the original packs code from about 3 years ago and I haven't personally worked with it before, I had to teach myself how this seems to work while writing this. We appear to use it for some early packs like Figma and GitHub.

The aspiration to allow people to write packs declaratively is reasonable and it's long been a goal of Coda to let people write packs who don't know how to code, but since we're code-based for now it would be reasonable to say that this current legacy offering isn't worth putting out there yet.

PTAL @ekoleda-codaio @coda/packs 