### PR TITLE
Use a comma to end the parameter snippets

### DIFF
--- a/docs/embedded-snippets/snippets/parameter/array/boolean_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/boolean_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.BooleanArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.BooleanArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/array/date_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/date_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.DateArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.DateArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/array/html_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/html_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.HtmlArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.HtmlArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/array/image_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/image_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.ImageArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.ImageArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/array/number_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/number_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.NumberArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.NumberArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/array/string_array_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/array/string_array_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.StringArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.StringArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/boolean_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/boolean_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.Boolean,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.Boolean,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/date_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/date_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.Date,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.Date,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/html_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/html_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.Html,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.Html,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/image_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/image_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.Image,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.Image,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/number_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/number_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.Number,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.Number,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/snippets/parameter/string_parameter.html
+++ b/docs/embedded-snippets/snippets/parameter/string_parameter.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});",
+          value: "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/samples/topic/parameter.md
+++ b/docs/samples/topic/parameter.md
@@ -17,7 +17,7 @@ coda.makeParameter({
   type: coda.ParameterType.String,
   name: "<User-visible name of parameter>",
   description: "<Help text for the parameter>",
-});
+}),
 ```
 ## No parameters
 A formula without any parameters. This sample returns the name of the current day of the week.

--- a/documentation/.eslintrc.js
+++ b/documentation/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': [
           'error',
           {
-            varsIgnorePattern: 'response|datasourceUrl|MySchema|snippet|data',
+            varsIgnorePattern: 'response|datasourceUrl|MySchema|snippet|data|parameters',
             argsIgnorePattern: 'context|param|parameters',
           },
         ],

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -172,7 +172,7 @@
       {
         "name": "Template",
         "content": "The basic structure of a parameter. This sample is for a string parameter.",
-        "code": "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+        "code": "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
       },
       {
         "name": "No parameters",

--- a/documentation/generated/snippets.json
+++ b/documentation/generated/snippets.json
@@ -88,7 +88,7 @@
       "StringParameter"
     ],
     "content": "Creates a string parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.String,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -97,7 +97,7 @@
       "BooleanParameter"
     ],
     "content": "Creates a boolean parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.Boolean,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.Boolean,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -106,7 +106,7 @@
       "DateParameter"
     ],
     "content": "Creates a date parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.Date,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.Date,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -115,7 +115,7 @@
       "HtmlParameter"
     ],
     "content": "Creates a html parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.Html,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.Html,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -124,7 +124,7 @@
       "ImageParameter"
     ],
     "content": "Creates a image parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.Image,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.Image,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -133,7 +133,7 @@
       "NumberParameter"
     ],
     "content": "Creates a number parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.Number,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.Number,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -142,7 +142,7 @@
       "StringArrayParameter"
     ],
     "content": "Creates a string array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.StringArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.StringArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -151,7 +151,7 @@
       "BooleanArrayParameter"
     ],
     "content": "Creates a boolean array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.BooleanArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.BooleanArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -160,7 +160,7 @@
       "DateArrayParameter"
     ],
     "content": "Creates a date array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.DateArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.DateArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -169,7 +169,7 @@
       "HtmlArrayParameter"
     ],
     "content": "Creates a html array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.HtmlArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.HtmlArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -178,7 +178,7 @@
       "ImageArrayParameter"
     ],
     "content": "Creates a image array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.ImageArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.ImageArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [
@@ -187,7 +187,7 @@
       "NumberArrayParameter"
     ],
     "content": "Creates a number array parameter.",
-    "code": "coda.makeParameter({\n  type: coda.ParameterType.NumberArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n});"
+    "code": "coda.makeParameter({\n  type: coda.ParameterType.NumberArray,\n  name: \"<User-visible name of parameter>\",\n  description: \"<Help text for the parameter>\",\n}),"
   },
   {
     "triggerTokens": [

--- a/documentation/snippets/parameter/array/boolean_array_parameter.ts
+++ b/documentation/snippets/parameter/array/boolean_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.BooleanArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.BooleanArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/array/date_array_parameter.ts
+++ b/documentation/snippets/parameter/array/date_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.DateArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.DateArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/array/html_array_parameter.ts
+++ b/documentation/snippets/parameter/array/html_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.HtmlArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.HtmlArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/array/image_array_parameter.ts
+++ b/documentation/snippets/parameter/array/image_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.ImageArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.ImageArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/array/number_array_parameter.ts
+++ b/documentation/snippets/parameter/array/number_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.NumberArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.NumberArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/array/string_array_parameter.ts
+++ b/documentation/snippets/parameter/array/string_array_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "../../../../index";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.StringArray,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.StringArray,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/boolean_parameter.ts
+++ b/documentation/snippets/parameter/boolean_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.Boolean,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.Boolean,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/date_parameter.ts
+++ b/documentation/snippets/parameter/date_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.Date,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.Date,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/html_parameter.ts
+++ b/documentation/snippets/parameter/html_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.Html,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.Html,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/image_parameter.ts
+++ b/documentation/snippets/parameter/image_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.Image,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.Image,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/number_parameter.ts
+++ b/documentation/snippets/parameter/number_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.Number,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.Number,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];

--- a/documentation/snippets/parameter/string_parameter.ts
+++ b/documentation/snippets/parameter/string_parameter.ts
@@ -1,9 +1,11 @@
 import * as coda from "@codahq/packs-sdk";
 
-// BEGIN
-
-coda.makeParameter({
-  type: coda.ParameterType.String,
-  name: "<User-visible name of parameter>",
-  description: "<Help text for the parameter>",
-});
+let parameters = [
+  // BEGIN
+  coda.makeParameter({
+    type: coda.ParameterType.String,
+    name: "<User-visible name of parameter>",
+    description: "<Help text for the parameter>",
+  }),
+  // END
+];


### PR DESCRIPTION
This makes them easier to use within parameter arrays, where they are most likely to be used. Raised by @punit-codaio during a recent end-to-end review.