### PR TITLE
Relax continuation typing to support a nested hash

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -212,7 +212,7 @@ export interface DynamicSyncTableDef<
  * ```
  */
 export interface Continuation {
-  [key: string]: string | number;
+  [key: string]: string | number | {[key: string]: string | number};
 }
 
 /**

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -156,7 +156,9 @@ export interface DynamicSyncTableDef<K extends string, L extends string, ParamDe
  * ```
  */
 export interface Continuation {
-    [key: string]: string | number;
+    [key: string]: string | number | {
+        [key: string]: string | number;
+    };
 }
 /**
  * Type definition for the formula that implements a sync table.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1694,7 +1694,9 @@ export interface DynamicSyncTableDef<K extends string, L extends string, ParamDe
  * ```
  */
 export interface Continuation {
-	[key: string]: string | number;
+	[key: string]: string | number | {
+		[key: string]: string | number;
+	};
 }
 /**
  * Type definition for the formula that implements a sync table.

--- a/docs/reference/sdk/interfaces/Continuation.md
+++ b/docs/reference/sdk/interfaces/Continuation.md
@@ -24,4 +24,4 @@ Examples:
 
 ## Indexable
 
-▪ [key: `string`]: `string` \| `number`
+▪ [key: `string`]: `string` \| `number` \| { [key: string]: `string` \| `number`;  }


### PR DESCRIPTION
Relax continuation typing to support a nested hash.

See https://codaproject.slack.com/archives/C02ERJRBA21/p1638833332320300 for context.
