### PR TITLE
Add CustomAuth digest transform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ publish-docs-gh-pages:
 
 .PHONY: test
 test:
-	TS_NODE_TRANSPILE_ONLY=1 ${ROOTDIR}/node_modules/.bin/mocha test/*_test.ts
+	TS_NODE_TRANSPILE_ONLY=1 ${ROOTDIR}/node_modules/.bin/mocha --reporter spec test/*_test.ts
 
 .PHONY: test-file
 test-file:

--- a/docs/reference/sdk/README.md
+++ b/docs/reference/sdk/README.md
@@ -35,6 +35,7 @@
 - [CodaApiBearerTokenAuthentication](interfaces/CodaApiBearerTokenAuthentication.md)
 - [Continuation](interfaces/Continuation.md)
 - [CurrencySchema](interfaces/CurrencySchema.md)
+- [CustomAuthHeaderDigestTransform](interfaces/CustomAuthHeaderDigestTransform.md)
 - [CustomAuthParameter](interfaces/CustomAuthParameter.md)
 - [CustomAuthentication](interfaces/CustomAuthentication.md)
 - [CustomHeaderTokenAuthentication](interfaces/CustomHeaderTokenAuthentication.md)

--- a/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
@@ -131,7 +131,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:559](https://github.com/coda/packs-sdk/blob/main/types.ts#L559)
+[types.ts:579](https://github.com/coda/packs-sdk/blob/main/types.ts#L579)
 
 ___
 
@@ -143,4 +143,4 @@ Identifies this as AWSAccessKey authentication.
 
 #### Defined in
 
-[types.ts:557](https://github.com/coda/packs-sdk/blob/main/types.ts#L557)
+[types.ts:577](https://github.com/coda/packs-sdk/blob/main/types.ts#L577)

--- a/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
@@ -133,7 +133,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:572](https://github.com/coda/packs-sdk/blob/main/types.ts#L572)
+[types.ts:592](https://github.com/coda/packs-sdk/blob/main/types.ts#L592)
 
 ___
 
@@ -145,4 +145,4 @@ Identifies this as AWSAssumeRole authentication.
 
 #### Defined in
 
-[types.ts:570](https://github.com/coda/packs-sdk/blob/main/types.ts#L570)
+[types.ts:590](https://github.com/coda/packs-sdk/blob/main/types.ts#L590)

--- a/docs/reference/sdk/interfaces/CustomAuthHeaderDigestTransform.md
+++ b/docs/reference/sdk/interfaces/CustomAuthHeaderDigestTransform.md
@@ -1,0 +1,27 @@
+# Interface: CustomAuthHeaderDigestTransform
+
+An optional header hext digest transform for the [CustomAuthentication](CustomAuthentication.md) authentication type.
+
+## Properties
+
+### algorithm
+
+• **algorithm**: ``"md5"`` \| ``"sha1"`` \| ``"sha256"`` \| ``"sha512"``
+
+The hash digest algorithm to apply to the header value.
+
+#### Defined in
+
+[types.ts:493](https://github.com/coda/packs-sdk/blob/main/types.ts#L493)
+
+___
+
+### header
+
+• **header**: `string`
+
+The header on which the hex digest should be applied.
+
+#### Defined in
+
+[types.ts:489](https://github.com/coda/packs-sdk/blob/main/types.ts#L489)

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -83,6 +83,20 @@ See https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs#h_4
 
 ___
 
+### digestTransform
+
+• `Optional` **digestTransform**: [`CustomAuthHeaderDigestTransform`](CustomAuthHeaderDigestTransform.md)
+
+An optional header hex digest transform that will be performed once template replacement is complete.
+The header [CustomAuthHeaderDigestTransform.header](CustomAuthHeaderDigestTransform.md#header) will be transformed using the specified hex
+digest [CustomAuthHeaderDigestTransform.algorithm](CustomAuthHeaderDigestTransform.md#algorithm).
+
+#### Defined in
+
+[types.ts:568](https://github.com/coda/packs-sdk/blob/main/types.ts#L568)
+
+___
+
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`
@@ -151,7 +165,7 @@ replacement inside the constructed network request.
 
 #### Defined in
 
-[types.ts:548](https://github.com/coda/packs-sdk/blob/main/types.ts#L548)
+[types.ts:562](https://github.com/coda/packs-sdk/blob/main/types.ts#L562)
 
 ___
 
@@ -199,4 +213,4 @@ Identifies this as Custom authentication.
 
 #### Defined in
 
-[types.ts:542](https://github.com/coda/packs-sdk/blob/main/types.ts#L542)
+[types.ts:556](https://github.com/coda/packs-sdk/blob/main/types.ts#L556)

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -37,7 +37,7 @@ This must correspond to the name of a regular, public formula defined in this pa
 
 #### Defined in
 
-[types.ts:719](https://github.com/coda/packs-sdk/blob/main/types.ts#L719)
+[types.ts:739](https://github.com/coda/packs-sdk/blob/main/types.ts#L739)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[types.ts:714](https://github.com/coda/packs-sdk/blob/main/types.ts#L714)
+[types.ts:734](https://github.com/coda/packs-sdk/blob/main/types.ts#L734)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[types.ts:721](https://github.com/coda/packs-sdk/blob/main/types.ts#L721)
+[types.ts:741](https://github.com/coda/packs-sdk/blob/main/types.ts#L741)
 
 ___
 
@@ -74,7 +74,7 @@ of values they should put in columns using this format.
 
 #### Defined in
 
-[types.ts:726](https://github.com/coda/packs-sdk/blob/main/types.ts#L726)
+[types.ts:746](https://github.com/coda/packs-sdk/blob/main/types.ts#L746)
 
 ___
 
@@ -87,7 +87,7 @@ is capable of handling. As described in [Format](Format.md), this is a discovery
 
 #### Defined in
 
-[types.ts:731](https://github.com/coda/packs-sdk/blob/main/types.ts#L731)
+[types.ts:751](https://github.com/coda/packs-sdk/blob/main/types.ts#L751)
 
 ___
 
@@ -99,7 +99,7 @@ The name of this column format. This will show to users in the column type choos
 
 #### Defined in
 
-[types.ts:712](https://github.com/coda/packs-sdk/blob/main/types.ts#L712)
+[types.ts:732](https://github.com/coda/packs-sdk/blob/main/types.ts#L732)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[types.ts:735](https://github.com/coda/packs-sdk/blob/main/types.ts#L735)
+[types.ts:755](https://github.com/coda/packs-sdk/blob/main/types.ts#L755)

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -19,7 +19,7 @@ This should only be used by legacy Coda pack implementations.
 
 #### Defined in
 
-[types.ts:878](https://github.com/coda/packs-sdk/blob/main/types.ts#L878)
+[types.ts:898](https://github.com/coda/packs-sdk/blob/main/types.ts#L898)
 
 ___
 
@@ -35,7 +35,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:823](https://github.com/coda/packs-sdk/blob/main/types.ts#L823)
+[types.ts:843](https://github.com/coda/packs-sdk/blob/main/types.ts#L843)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[types.ts:876](https://github.com/coda/packs-sdk/blob/main/types.ts#L876)
+[types.ts:896](https://github.com/coda/packs-sdk/blob/main/types.ts#L896)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[types.ts:880](https://github.com/coda/packs-sdk/blob/main/types.ts#L880)
+[types.ts:900](https://github.com/coda/packs-sdk/blob/main/types.ts#L900)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[types.ts:881](https://github.com/coda/packs-sdk/blob/main/types.ts#L881)
+[types.ts:901](https://github.com/coda/packs-sdk/blob/main/types.ts#L901)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[types.ts:882](https://github.com/coda/packs-sdk/blob/main/types.ts#L882)
+[types.ts:902](https://github.com/coda/packs-sdk/blob/main/types.ts#L902)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:859](https://github.com/coda/packs-sdk/blob/main/types.ts#L859)
+[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
+[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
 
 ___
 
@@ -129,7 +129,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:855](https://github.com/coda/packs-sdk/blob/main/types.ts#L855)
+[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
+[types.ts:893](https://github.com/coda/packs-sdk/blob/main/types.ts#L893)
 
 ___
 
@@ -151,7 +151,7 @@ Whether this is a pack that will be used by Coda internally and not exposed dire
 
 #### Defined in
 
-[types.ts:889](https://github.com/coda/packs-sdk/blob/main/types.ts#L889)
+[types.ts:909](https://github.com/coda/packs-sdk/blob/main/types.ts#L909)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
+[types.ts:899](https://github.com/coda/packs-sdk/blob/main/types.ts#L899)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
+[types.ts:903](https://github.com/coda/packs-sdk/blob/main/types.ts#L903)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[types.ts:874](https://github.com/coda/packs-sdk/blob/main/types.ts#L874)
+[types.ts:894](https://github.com/coda/packs-sdk/blob/main/types.ts#L894)
 
 ___
 
@@ -203,7 +203,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:838](https://github.com/coda/packs-sdk/blob/main/types.ts#L838)
+[types.ts:858](https://github.com/coda/packs-sdk/blob/main/types.ts#L858)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)
+[types.ts:897](https://github.com/coda/packs-sdk/blob/main/types.ts#L897)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[types.ts:884](https://github.com/coda/packs-sdk/blob/main/types.ts#L884)
+[types.ts:904](https://github.com/coda/packs-sdk/blob/main/types.ts#L904)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[types.ts:885](https://github.com/coda/packs-sdk/blob/main/types.ts#L885)
+[types.ts:905](https://github.com/coda/packs-sdk/blob/main/types.ts#L905)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
+[types.ts:895](https://github.com/coda/packs-sdk/blob/main/types.ts#L895)
 
 ___
 
@@ -259,7 +259,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
 
 ___
 
@@ -276,7 +276,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)
+[types.ts:848](https://github.com/coda/packs-sdk/blob/main/types.ts#L848)
 
 ___
 
@@ -293,4 +293,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -19,7 +19,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:823](https://github.com/coda/packs-sdk/blob/main/types.ts#L823)
+[types.ts:843](https://github.com/coda/packs-sdk/blob/main/types.ts#L843)
 
 ___
 
@@ -31,7 +31,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:859](https://github.com/coda/packs-sdk/blob/main/types.ts#L859)
+[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
+[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
 
 ___
 
@@ -61,7 +61,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:855](https://github.com/coda/packs-sdk/blob/main/types.ts#L855)
+[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
 
 ___
 
@@ -79,7 +79,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:838](https://github.com/coda/packs-sdk/blob/main/types.ts#L838)
+[types.ts:858](https://github.com/coda/packs-sdk/blob/main/types.ts#L858)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
 
 ___
 
@@ -104,7 +104,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)
+[types.ts:848](https://github.com/coda/packs-sdk/blob/main/types.ts#L848)
 
 ___
 
@@ -117,4 +117,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)

--- a/docs/reference/sdk/interfaces/VariousAuthentication.md
+++ b/docs/reference/sdk/interfaces/VariousAuthentication.md
@@ -12,4 +12,4 @@ Identifies this as Various authentication.
 
 #### Defined in
 
-[types.ts:580](https://github.com/coda/packs-sdk/blob/main/types.ts#L580)
+[types.ts:600](https://github.com/coda/packs-sdk/blob/main/types.ts#L600)

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -6,4 +6,4 @@ The union of supported authentication methods.
 
 #### Defined in
 
-[types.ts:586](https://github.com/coda/packs-sdk/blob/main/types.ts#L586)
+[types.ts:606](https://github.com/coda/packs-sdk/blob/main/types.ts#L606)

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -7,4 +7,4 @@ editor where Coda will manage versioning on behalf of the pack author.
 
 #### Defined in
 
-[types.ts:808](https://github.com/coda/packs-sdk/blob/main/types.ts#L808)
+[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -7,4 +7,4 @@ where the pack author provides credentials used in HTTP requests rather than the
 
 #### Defined in
 
-[types.ts:633](https://github.com/coda/packs-sdk/blob/main/types.ts#L633)
+[types.ts:653](https://github.com/coda/packs-sdk/blob/main/types.ts#L653)

--- a/docs/reference/sdk/types/SystemAuthenticationDef.md
+++ b/docs/reference/sdk/types/SystemAuthenticationDef.md
@@ -9,4 +9,4 @@ an [SystemAuthentication](SystemAuthentication.md) value, which is the value Cod
 
 #### Defined in
 
-[types.ts:649](https://github.com/coda/packs-sdk/blob/main/types.ts#L649)
+[types.ts:669](https://github.com/coda/packs-sdk/blob/main/types.ts#L669)

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export type {AWSAccessKeyAuthentication} from './types';
 export type {AWSAssumeRoleAuthentication} from './types';
 export type {BaseAuthentication} from './types';
 export type {CodaApiBearerTokenAuthentication} from './types';
+export type {CustomAuthHeaderDigestTransform} from './types';
 export type {CustomAuthParameter} from './types';
 export type {CustomAuthentication} from './types';
 export type {CustomHeaderTokenAuthentication} from './types';

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -377,6 +377,10 @@ const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> 
         },
         {message: 'Duplicated parameter names in the mutli-query-token authentication config'},
       ),
+    digestTransform: zodCompleteStrictObject<CustomAuthentication['digestTransform']>({
+      algorithm: z.string(),
+      header: z.string(),
+    }).optional(),
     ...baseAuthenticationValidators,
   }),
   [AuthenticationType.Various]: zodCompleteStrictObject<VariousAuthentication>({

--- a/types.ts
+++ b/types.ts
@@ -480,6 +480,20 @@ export interface CustomAuthParameter {
 }
 
 /**
+* An optional header hext digest transform for the {@link CustomAuthentication} authentication type.
+*/
+export interface CustomAuthHeaderDigestTransform {
+  /**
+   * The header on which the hex digest should be applied.
+   */
+  header: string;
+  /**
+   * The hash digest algorithm to apply to the header value.
+   */
+   algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512'
+} 
+
+/**
  * Authenticate for custom, non-standard API authentication schemes by inserting one or more arbitrary secret values
  * into the request (the body, URL, headers, or form data) using template replacement.
  *
@@ -546,6 +560,12 @@ export interface CustomAuthentication extends BaseAuthentication {
    * replacement inside the constructed network request.
    */
   params: CustomAuthParameter[];
+  /**
+   * An optional header hex digest transform that will be performed once template replacement is complete. 
+   * The header {@link CustomAuthHeaderDigestTransform.header} will be transformed using the specified hex
+   * digest {@link CustomAuthHeaderDigestTransform.algorithm}.
+   */
+  digestTransform?: CustomAuthHeaderDigestTransform
 }
 
 /**


### PR DESCRIPTION
I'm building a Pack that uses a form of custom digest auth.   It requires sending a header which is a hex digest hash of `<session-id>:<secret-key>:<secret-token>`.   Given secrets aren't accessible to the Pack invocation code, this requires extending the current `CustomAuth` schema with an optional hex digest transform that is applied after substitution.

Example:
```ts
const customAuthWithDigest = {
  type: AuthenticationType.Custom,
  params: [
     {name: 'secretValue', description: 'Description for param1'},
     {name: 'secretToken', description: 'Description for param2'},
  ],
  digestTransform: {
    algorithm: 'sha1',
    header: 'X-Some-Header',
  }
};
```

You'd then add a header:
```ts
{
  'X-Some-Header': `session-key:{{secretValue-${context.invocationToken}}}:{{secretToken-${context.invocationToken}}}`
}
```

After auth token substitution this becomes:
```ts
{
  'X-Some-Header': `session-key:secret-value:secret-token`
}
```

We'd then hash this using the requested digest algorithm (in this example `sha1`) to return:
```ts
{
  'X-Some-Header': '2c74b0b90597a5cf66b38f1d93b6cf19c379e750'
}
```
