### PR TITLE
Support a configurable scope delimiter for OAuth2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking Change** The connection requirement for metadata formulas now defaults to optional instead of required. If your pack is using sematic versions, this will likely lead to a major version bump in your next release.
 - An optional "description" field is added to sync table definition, that will be used to display in the UI.
 - You no longer need to use the `--fetch` flag with `coda execute` to use a real fetcher. Set `--no-fetch` to use a mock fetcher (the old default behavior).
+- OAuth2 authentication now supports a `scopeDelimiter` option for non-compliant APIs that use something other than a space to delimit OAuth scopes in authorization URLs.
 
 ### 0.7.3
 

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -58,7 +58,7 @@ if (require.main === module) {
         extraOAuthScopes: {
           alias: 'extra_oauth_scopes',
           string: true,
-          default: '',
+          default: undefined,
           desc:
             `Scopes to request beyond those listed in the manifest, for specific formulas that ` +
             `need extra permissions. Example: --extra_oauth_scopes='first second third'`,

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2801,6 +2801,13 @@ export interface OAuth2Authentication extends BaseAuthentication {
 	 */
 	scopes?: string[];
 	/**
+	 * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+	 *
+	 * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+	 * If the API you are using requires a different delimiter, say a comma, specify it here.
+	 */
+	scopeDelimiter?: string;
+	/**
 	 * A custom prefix to be used when passing the access token in the HTTP Authorization
 	 * header when making requests. Typically this prefix is `Bearer` which is what will be
 	 * used if this value is omitted. However, some services require a different prefix.

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -61,7 +61,7 @@ if (require.main === module) {
             extraOAuthScopes: {
                 alias: 'extra_oauth_scopes',
                 string: true,
-                default: '',
+                default: undefined,
                 desc: `Scopes to request beyond those listed in the manifest, for specific formulas that ` +
                     `need extra permissions. Example: --extra_oauth_scopes='first second third'`,
             },

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -11,15 +11,20 @@ const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }) {
     // TODO: Handle endpointKey.
-    const { authorizationUrl, tokenUrl, additionalParams } = authDef;
+    const { authorizationUrl, tokenUrl, additionalParams, scopeDelimiter } = authDef;
     // Use the manifest's scopes as a default.
     const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+    // ClientOAuth2 doesn't support a scope delimiter, so just hack a fake single pre-delimited scope
+    // if there's a custom delimiter involved.
+    const scopeArray = requestedScopes && scopeDelimiter && scopeDelimiter !== ' '
+        ? [requestedScopes.join(scopeDelimiter)]
+        : requestedScopes;
     const oauth2Client = new client_oauth2_1.default({
         clientId,
         clientSecret,
         authorizationUri: authorizationUrl,
         accessTokenUri: tokenUrl,
-        scopes: requestedScopes,
+        scopes: scopeArray,
         redirectUri: makeRedirectUrl(port),
         query: additionalParams,
     });

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -267,6 +267,7 @@ const defaultAuthenticationValidators = {
         authorizationUrl: z.string(),
         tokenUrl: z.string(),
         scopes: z.array(z.string()).optional(),
+        scopeDelimiter: z.string().optional(),
         tokenPrefix: z.string().optional(),
         additionalParams: z.record(z.any()).optional(),
         endpointKey: z.string().optional(),

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -381,6 +381,13 @@ export interface OAuth2Authentication extends BaseAuthentication {
      */
     scopes?: string[];
     /**
+     * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+     *
+     * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+     * If the API you are using requires a different delimiter, say a comma, specify it here.
+     */
+    scopeDelimiter?: string;
+    /**
      * A custom prefix to be used when passing the access token in the HTTP Authorization
      * header when making requests. Typically this prefix is `Bearer` which is what will be
      * used if this value is omitted. However, some services require a different prefix.

--- a/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
@@ -131,7 +131,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:559](https://github.com/coda/packs-sdk/blob/main/types.ts#L559)
+[types.ts:566](https://github.com/coda/packs-sdk/blob/main/types.ts#L566)
 
 ___
 
@@ -143,4 +143,4 @@ Identifies this as AWSAccessKey authentication.
 
 #### Defined in
 
-[types.ts:557](https://github.com/coda/packs-sdk/blob/main/types.ts#L557)
+[types.ts:564](https://github.com/coda/packs-sdk/blob/main/types.ts#L564)

--- a/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
@@ -133,7 +133,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:572](https://github.com/coda/packs-sdk/blob/main/types.ts#L572)
+[types.ts:579](https://github.com/coda/packs-sdk/blob/main/types.ts#L579)
 
 ___
 
@@ -145,4 +145,4 @@ Identifies this as AWSAssumeRole authentication.
 
 #### Defined in
 
-[types.ts:570](https://github.com/coda/packs-sdk/blob/main/types.ts#L570)
+[types.ts:577](https://github.com/coda/packs-sdk/blob/main/types.ts#L577)

--- a/docs/reference/sdk/interfaces/CustomAuthParameter.md
+++ b/docs/reference/sdk/interfaces/CustomAuthParameter.md
@@ -12,7 +12,7 @@ A description shown to the user indicating what value they should provide for th
 
 #### Defined in
 
-[types.ts:479](https://github.com/coda/packs-sdk/blob/main/types.ts#L479)
+[types.ts:486](https://github.com/coda/packs-sdk/blob/main/types.ts#L486)
 
 ___
 
@@ -24,4 +24,4 @@ The name used to refer to this parameter and to generate the template replacemen
 
 #### Defined in
 
-[types.ts:474](https://github.com/coda/packs-sdk/blob/main/types.ts#L474)
+[types.ts:481](https://github.com/coda/packs-sdk/blob/main/types.ts#L481)

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -151,7 +151,7 @@ replacement inside the constructed network request.
 
 #### Defined in
 
-[types.ts:548](https://github.com/coda/packs-sdk/blob/main/types.ts#L548)
+[types.ts:555](https://github.com/coda/packs-sdk/blob/main/types.ts#L555)
 
 ___
 
@@ -199,4 +199,4 @@ Identifies this as Custom authentication.
 
 #### Defined in
 
-[types.ts:542](https://github.com/coda/packs-sdk/blob/main/types.ts#L542)
+[types.ts:549](https://github.com/coda/packs-sdk/blob/main/types.ts#L549)

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -37,7 +37,7 @@ This must correspond to the name of a regular, public formula defined in this pa
 
 #### Defined in
 
-[types.ts:719](https://github.com/coda/packs-sdk/blob/main/types.ts#L719)
+[types.ts:726](https://github.com/coda/packs-sdk/blob/main/types.ts#L726)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[types.ts:714](https://github.com/coda/packs-sdk/blob/main/types.ts#L714)
+[types.ts:721](https://github.com/coda/packs-sdk/blob/main/types.ts#L721)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[types.ts:721](https://github.com/coda/packs-sdk/blob/main/types.ts#L721)
+[types.ts:728](https://github.com/coda/packs-sdk/blob/main/types.ts#L728)
 
 ___
 
@@ -74,7 +74,7 @@ of values they should put in columns using this format.
 
 #### Defined in
 
-[types.ts:726](https://github.com/coda/packs-sdk/blob/main/types.ts#L726)
+[types.ts:733](https://github.com/coda/packs-sdk/blob/main/types.ts#L733)
 
 ___
 
@@ -87,7 +87,7 @@ is capable of handling. As described in [Format](Format.md), this is a discovery
 
 #### Defined in
 
-[types.ts:731](https://github.com/coda/packs-sdk/blob/main/types.ts#L731)
+[types.ts:738](https://github.com/coda/packs-sdk/blob/main/types.ts#L738)
 
 ___
 
@@ -99,7 +99,7 @@ The name of this column format. This will show to users in the column type choos
 
 #### Defined in
 
-[types.ts:712](https://github.com/coda/packs-sdk/blob/main/types.ts#L712)
+[types.ts:719](https://github.com/coda/packs-sdk/blob/main/types.ts#L719)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[types.ts:735](https://github.com/coda/packs-sdk/blob/main/types.ts#L735)
+[types.ts:742](https://github.com/coda/packs-sdk/blob/main/types.ts#L742)

--- a/docs/reference/sdk/interfaces/OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/OAuth2Authentication.md
@@ -27,7 +27,7 @@ user to the [authorizationUrl](OAuth2Authentication.md#authorizationurl).
 
 #### Defined in
 
-[types.ts:417](https://github.com/coda/packs-sdk/blob/main/types.ts#L417)
+[types.ts:424](https://github.com/coda/packs-sdk/blob/main/types.ts#L424)
 
 ___
 
@@ -97,7 +97,7 @@ as [ExecutionContext.endpoint](ExecutionContext.md#endpoint).
 
 #### Defined in
 
-[types.ts:427](https://github.com/coda/packs-sdk/blob/main/types.ts#L427)
+[types.ts:434](https://github.com/coda/packs-sdk/blob/main/types.ts#L434)
 
 ___
 
@@ -175,6 +175,21 @@ when creating a new account.
 
 ___
 
+### scopeDelimiter
+
+• `Optional` **scopeDelimiter**: `string`
+
+The delimiter to use when joining [scopes](OAuth2Authentication.md#scopes) when generating authorization URLs.
+
+The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+If the API you are using requires a different delimiter, say a comma, specify it here.
+
+#### Defined in
+
+[types.ts:411](https://github.com/coda/packs-sdk/blob/main/types.ts#L411)
+
+___
+
 ### scopes
 
 • `Optional` **scopes**: `string`[]
@@ -202,7 +217,7 @@ When sending authenticated requests, a HTTP header of the form
 
 #### Defined in
 
-[types.ts:412](https://github.com/coda/packs-sdk/blob/main/types.ts#L412)
+[types.ts:419](https://github.com/coda/packs-sdk/blob/main/types.ts#L419)
 
 ___
 
@@ -216,7 +231,7 @@ that should contain the token.
 
 #### Defined in
 
-[types.ts:434](https://github.com/coda/packs-sdk/blob/main/types.ts#L434)
+[types.ts:441](https://github.com/coda/packs-sdk/blob/main/types.ts#L441)
 
 ___
 

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -19,7 +19,7 @@ This should only be used by legacy Coda pack implementations.
 
 #### Defined in
 
-[types.ts:878](https://github.com/coda/packs-sdk/blob/main/types.ts#L878)
+[types.ts:885](https://github.com/coda/packs-sdk/blob/main/types.ts#L885)
 
 ___
 
@@ -35,7 +35,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:823](https://github.com/coda/packs-sdk/blob/main/types.ts#L823)
+[types.ts:830](https://github.com/coda/packs-sdk/blob/main/types.ts#L830)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[types.ts:876](https://github.com/coda/packs-sdk/blob/main/types.ts#L876)
+[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[types.ts:880](https://github.com/coda/packs-sdk/blob/main/types.ts#L880)
+[types.ts:887](https://github.com/coda/packs-sdk/blob/main/types.ts#L887)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[types.ts:881](https://github.com/coda/packs-sdk/blob/main/types.ts#L881)
+[types.ts:888](https://github.com/coda/packs-sdk/blob/main/types.ts#L888)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[types.ts:882](https://github.com/coda/packs-sdk/blob/main/types.ts#L882)
+[types.ts:889](https://github.com/coda/packs-sdk/blob/main/types.ts#L889)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:859](https://github.com/coda/packs-sdk/blob/main/types.ts#L859)
+[types.ts:866](https://github.com/coda/packs-sdk/blob/main/types.ts#L866)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
+[types.ts:852](https://github.com/coda/packs-sdk/blob/main/types.ts#L852)
 
 ___
 
@@ -129,7 +129,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:855](https://github.com/coda/packs-sdk/blob/main/types.ts#L855)
+[types.ts:862](https://github.com/coda/packs-sdk/blob/main/types.ts#L862)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
+[types.ts:880](https://github.com/coda/packs-sdk/blob/main/types.ts#L880)
 
 ___
 
@@ -151,7 +151,7 @@ Whether this is a pack that will be used by Coda internally and not exposed dire
 
 #### Defined in
 
-[types.ts:889](https://github.com/coda/packs-sdk/blob/main/types.ts#L889)
+[types.ts:896](https://github.com/coda/packs-sdk/blob/main/types.ts#L896)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
+[types.ts:886](https://github.com/coda/packs-sdk/blob/main/types.ts#L886)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[types.ts:883](https://github.com/coda/packs-sdk/blob/main/types.ts#L883)
+[types.ts:890](https://github.com/coda/packs-sdk/blob/main/types.ts#L890)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[types.ts:874](https://github.com/coda/packs-sdk/blob/main/types.ts#L874)
+[types.ts:881](https://github.com/coda/packs-sdk/blob/main/types.ts#L881)
 
 ___
 
@@ -203,7 +203,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:838](https://github.com/coda/packs-sdk/blob/main/types.ts#L838)
+[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)
+[types.ts:884](https://github.com/coda/packs-sdk/blob/main/types.ts#L884)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[types.ts:884](https://github.com/coda/packs-sdk/blob/main/types.ts#L884)
+[types.ts:891](https://github.com/coda/packs-sdk/blob/main/types.ts#L891)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[types.ts:885](https://github.com/coda/packs-sdk/blob/main/types.ts#L885)
+[types.ts:892](https://github.com/coda/packs-sdk/blob/main/types.ts#L892)
 
 ___
 
@@ -243,7 +243,7 @@ ___
 
 #### Defined in
 
-[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
+[types.ts:882](https://github.com/coda/packs-sdk/blob/main/types.ts#L882)
 
 ___
 
@@ -259,7 +259,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
 
 ___
 
@@ -276,7 +276,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)
+[types.ts:835](https://github.com/coda/packs-sdk/blob/main/types.ts#L835)
 
 ___
 
@@ -293,4 +293,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:826](https://github.com/coda/packs-sdk/blob/main/types.ts#L826)

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -19,7 +19,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:823](https://github.com/coda/packs-sdk/blob/main/types.ts#L823)
+[types.ts:830](https://github.com/coda/packs-sdk/blob/main/types.ts#L830)
 
 ___
 
@@ -31,7 +31,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:859](https://github.com/coda/packs-sdk/blob/main/types.ts#L859)
+[types.ts:866](https://github.com/coda/packs-sdk/blob/main/types.ts#L866)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
+[types.ts:852](https://github.com/coda/packs-sdk/blob/main/types.ts#L852)
 
 ___
 
@@ -61,7 +61,7 @@ and will be removed shortly.
 
 #### Defined in
 
-[types.ts:855](https://github.com/coda/packs-sdk/blob/main/types.ts#L855)
+[types.ts:862](https://github.com/coda/packs-sdk/blob/main/types.ts#L862)
 
 ___
 
@@ -79,7 +79,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:838](https://github.com/coda/packs-sdk/blob/main/types.ts#L838)
+[types.ts:845](https://github.com/coda/packs-sdk/blob/main/types.ts#L845)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:870](https://github.com/coda/packs-sdk/blob/main/types.ts#L870)
 
 ___
 
@@ -104,7 +104,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)
+[types.ts:835](https://github.com/coda/packs-sdk/blob/main/types.ts#L835)
 
 ___
 
@@ -117,4 +117,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:819](https://github.com/coda/packs-sdk/blob/main/types.ts#L819)
+[types.ts:826](https://github.com/coda/packs-sdk/blob/main/types.ts#L826)

--- a/docs/reference/sdk/interfaces/VariousAuthentication.md
+++ b/docs/reference/sdk/interfaces/VariousAuthentication.md
@@ -12,4 +12,4 @@ Identifies this as Various authentication.
 
 #### Defined in
 
-[types.ts:580](https://github.com/coda/packs-sdk/blob/main/types.ts#L580)
+[types.ts:587](https://github.com/coda/packs-sdk/blob/main/types.ts#L587)

--- a/docs/reference/sdk/interfaces/WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/WebBasicAuthentication.md
@@ -133,7 +133,7 @@ Identifies this as WebBasic authentication.
 
 #### Defined in
 
-[types.ts:445](https://github.com/coda/packs-sdk/blob/main/types.ts#L445)
+[types.ts:452](https://github.com/coda/packs-sdk/blob/main/types.ts#L452)
 
 ___
 
@@ -153,4 +153,4 @@ Configuration for labels to show in the UI when the user sets up a new acount.
 
 #### Defined in
 
-[types.ts:449](https://github.com/coda/packs-sdk/blob/main/types.ts#L449)
+[types.ts:456](https://github.com/coda/packs-sdk/blob/main/types.ts#L456)

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -6,4 +6,4 @@ The union of supported authentication methods.
 
 #### Defined in
 
-[types.ts:586](https://github.com/coda/packs-sdk/blob/main/types.ts#L586)
+[types.ts:593](https://github.com/coda/packs-sdk/blob/main/types.ts#L593)

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -7,4 +7,4 @@ editor where Coda will manage versioning on behalf of the pack author.
 
 #### Defined in
 
-[types.ts:808](https://github.com/coda/packs-sdk/blob/main/types.ts#L808)
+[types.ts:815](https://github.com/coda/packs-sdk/blob/main/types.ts#L815)

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -7,4 +7,4 @@ where the pack author provides credentials used in HTTP requests rather than the
 
 #### Defined in
 
-[types.ts:633](https://github.com/coda/packs-sdk/blob/main/types.ts#L633)
+[types.ts:640](https://github.com/coda/packs-sdk/blob/main/types.ts#L640)

--- a/docs/reference/sdk/types/SystemAuthenticationDef.md
+++ b/docs/reference/sdk/types/SystemAuthenticationDef.md
@@ -9,4 +9,4 @@ an [SystemAuthentication](SystemAuthentication.md) value, which is the value Cod
 
 #### Defined in
 
-[types.ts:649](https://github.com/coda/packs-sdk/blob/main/types.ts#L649)
+[types.ts:656](https://github.com/coda/packs-sdk/blob/main/types.ts#L656)

--- a/testing/oauth_server.ts
+++ b/testing/oauth_server.ts
@@ -30,15 +30,21 @@ export function launchOAuthServerFlow({
   scopes?: string[];
 }) {
   // TODO: Handle endpointKey.
-  const {authorizationUrl, tokenUrl, additionalParams} = authDef;
+  const {authorizationUrl, tokenUrl, additionalParams, scopeDelimiter} = authDef;
   // Use the manifest's scopes as a default.
   const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+  // ClientOAuth2 doesn't support a scope delimiter, so just hack a fake single pre-delimited scope
+  // if there's a custom delimiter involved.
+  const scopeArray =
+    requestedScopes && scopeDelimiter && scopeDelimiter !== ' '
+      ? [requestedScopes.join(scopeDelimiter)]
+      : requestedScopes;
   const oauth2Client = new ClientOAuth2({
     clientId,
     clientSecret,
     authorizationUri: authorizationUrl,
     accessTokenUri: tokenUrl,
-    scopes: requestedScopes,
+    scopes: scopeArray,
     redirectUri: makeRedirectUrl(port),
     query: additionalParams,
   });

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -336,6 +336,7 @@ const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> 
     authorizationUrl: z.string(),
     tokenUrl: z.string(),
     scopes: z.array(z.string()).optional(),
+    scopeDelimiter: z.string().optional(),
     tokenPrefix: z.string().optional(),
     additionalParams: z.record(z.any()).optional(),
     endpointKey: z.string().optional(),

--- a/types.ts
+++ b/types.ts
@@ -403,6 +403,13 @@ export interface OAuth2Authentication extends BaseAuthentication {
    */
   scopes?: string[];
   /**
+   * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+   *
+   * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+   * If the API you are using requires a different delimiter, say a comma, specify it here.
+   */
+  scopeDelimiter?: string;
+  /**
    * A custom prefix to be used when passing the access token in the HTTP Authorization
    * header when making requests. Typically this prefix is `Bearer` which is what will be
    * used if this value is omitted. However, some services require a different prefix.


### PR DESCRIPTION
SDK side of changes to address https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/My-Issues_sud-l#My-issues_tui9H/r19756&modal=true. Sending the `coda` side shortly too.

@ekoleda-codaio what's the best way to test this--is there a Todoist example that would validate that this works out of the box?

PTAL @huayang-codaio @patrick-codaio @ekoleda-codaio @coda/packs 