### PR TITLE
Don't trigger a validation error for missing network domains if the auth config requires an endpoint url.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -884,15 +884,15 @@ const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSc
     });
 })
     .refine(data => {
-    var _a, _b;
+    var _a, _b, _c;
     const usesAuthentication = (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) ||
         data.systemConnectionAuthentication;
-    if (!usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length)) {
+    if (!usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length) || ((_b = data.defaultAuthentication) === null || _b === void 0 ? void 0 : _b.requiresEndpointUrl)) {
         return true;
     }
     // Various is an internal authentication type that's only applicable to whitelisted Pack Ids.
     // Skipping validation here to let it exempt from network domains.
-    if (((_b = data.defaultAuthentication) === null || _b === void 0 ? void 0 : _b.type) === types_1.AuthenticationType.Various) {
+    if (((_c = data.defaultAuthentication) === null || _c === void 0 ? void 0 : _c.type) === types_1.AuthenticationType.Various) {
         return true;
     }
     return false;

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1781,8 +1781,20 @@ describe('Pack metadata Validation', () => {
 
     it('various auth type exempt from networkDomains requirement', async () => {
       const metadata = createFakePackVersionMetadata({
+        networkDomains: [],
         defaultAuthentication: {
           type: AuthenticationType.Various,
+        },
+      });
+      await validateJson(metadata);
+    });
+
+    it('requiresEndpointUrl exempt from networkDomains requirement', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: [],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+          requiresEndpointUrl: true,
         },
       });
       await validateJson(metadata);

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1050,7 +1050,7 @@ const legacyPackMetadataSchema = validateFormulas(
       const usesAuthentication =
         (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) ||
         data.systemConnectionAuthentication;
-      if (!usesAuthentication || data.networkDomains?.length) {
+      if (!usesAuthentication || data.networkDomains?.length || data.defaultAuthentication?.requiresEndpointUrl) {
         return true;
       }
 


### PR DESCRIPTION
Just cleaning up some SDK-side validation that prevented this. The real meat of the change is on the `coda`, sending that now.

This is to support use cases like a Wordpress pack, where the domain is arbitrary and the user has to specify it as the endpoint domain, but the pack doesn't need to make requests to any other domain other than the endpoint. Seems like we don't need them to ask for approval in that case, and in fact, our currently approval mechanism is just to allow any network domain, which is worse from a security perspective.

PTAL @huayang-codaio @patrick-codaio @ekoleda-codaio @coda/packs 