### PR TITLE
let password fallback to empty space (to be consistent with coda repo)

### DIFF
--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -198,7 +198,7 @@ class AuthenticatingFetcher {
         const url = this._applyAndValidateEndpoint(rawUrl);
         switch (this._authDef.type) {
             case types_1.AuthenticationType.WebBasic: {
-                const { username, password } = this._credentials;
+                const { username, password = '' } = this._credentials;
                 const encodedAuth = Buffer.from(`${username}:${password}`).toString('base64');
                 let bodyWithTemplateSubstitutions = body;
                 if (bodyWithTemplateSubstitutions) {

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -784,7 +784,7 @@ describe('Auth', () => {
         sinon.assert.calledOnceWithExactly(mockMakeRequest, {
           body: undefined,
           form: undefined,
-          headers: {Authorization: 'Basic c29tZS11c2VybmFtZTp1bmRlZmluZWQ=', 'User-Agent': 'Coda-Test-Server-Fetcher'},
+          headers: {Authorization: 'Basic c29tZS11c2VybmFtZTo=', 'User-Agent': 'Coda-Test-Server-Fetcher'},
           method: 'GET',
           url: 'https://example.com',
           isBinaryResponse: undefined,

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -252,7 +252,7 @@ export class AuthenticatingFetcher implements Fetcher {
 
     switch (this._authDef.type) {
       case AuthenticationType.WebBasic: {
-        const {username, password} = this._credentials as WebBasicCredentials;
+        const {username, password = ''} = this._credentials as WebBasicCredentials;
         const encodedAuth = Buffer.from(`${username}:${password}`).toString('base64');
 
         let bodyWithTemplateSubstitutions = body;


### PR DESCRIPTION
https://codaproject.slack.com/archives/C02ERJRBA21/p1640727998430700

otherwise password is set to undefined and thus we have `<password>:undefined` in the header. 

```
> var a = {x: 1, y: undefined}
undefined
> a
{ x: 1, y: undefined }
> var {x, y} = a
undefined
> y
undefined
```