### PR TITLE
Remove stray quotes from our custom auth example

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2902,8 +2902,8 @@ export interface CustomAuthParameter {
  * // Suppose you're using an API that requires a secret id in the request URL,
  * // and a different secret value in the request body. You can define a Custom
  * // authentication configuration with two params:
- * // params: [{name: 'secretId', description: 'Secret id'},
- * //          {name: 'secretValue', description: 'Secret value'}])
+ * // params: [{name: "secretId", description: "Secret id"},
+ * //          {name: "secretValue", description: "Secret value"}])
  * // The user or the pack author will be prompted to specify a value for each
  * // of these when setting up an account.
  * // In the `execute` body of your formula, you can specify where those values
@@ -2918,7 +2918,7 @@ export interface CustomAuthParameter {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
- *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
+ *   let secretHeader = "Authorization  {{" + secretValueTemplateName + "}}";
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -2929,7 +2929,7 @@ export interface CustomAuthParameter {
  *     url: urlWithSecret,
  *     body: bodyWithSecret,
  *     headers: {
- *       'X-Custom-Authorization-Header': secretHeader,
+ *       "X-Custom-Authorization-Header": secretHeader,
  *     },
  *   });
  *   // ...

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -482,8 +482,8 @@ export interface CustomAuthParameter {
  * // Suppose you're using an API that requires a secret id in the request URL,
  * // and a different secret value in the request body. You can define a Custom
  * // authentication configuration with two params:
- * // params: [{name: 'secretId', description: 'Secret id'},
- * //          {name: 'secretValue', description: 'Secret value'}])
+ * // params: [{name: "secretId", description: "Secret id"},
+ * //          {name: "secretValue", description: "Secret value"}])
  * // The user or the pack author will be prompted to specify a value for each
  * // of these when setting up an account.
  * // In the `execute` body of your formula, you can specify where those values
@@ -498,7 +498,7 @@ export interface CustomAuthParameter {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
- *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
+ *   let secretHeader = "Authorization  {{" + secretValueTemplateName + "}}";
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -509,7 +509,7 @@ export interface CustomAuthParameter {
  *     url: urlWithSecret,
  *     body: bodyWithSecret,
  *     headers: {
- *       'X-Custom-Authorization-Header': secretHeader,
+ *       "X-Custom-Authorization-Header": secretHeader,
  *     },
  *   });
  *   // ...

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -25,8 +25,8 @@ token is required for security reasons.
 // Suppose you're using an API that requires a secret id in the request URL,
 // and a different secret value in the request body. You can define a Custom
 // authentication configuration with two params:
-// params: [{name: 'secretId', description: 'Secret id'},
-//          {name: 'secretValue', description: 'Secret value'}])
+// params: [{name: "secretId", description: "Secret id"},
+//          {name: "secretValue", description: "Secret value"}])
 // The user or the pack author will be prompted to specify a value for each
 // of these when setting up an account.
 // In the `execute` body of your formula, you can specify where those values
@@ -41,7 +41,7 @@ execute: async function([], context) {
   let secretIdTemplateName = "secretId-" + context.invocationToken;
   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
   let secretValueTemplateName = "secretValue-" + context.invocationToken;
-  let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
+  let secretHeader = "Authorization  {{" + secretValueTemplateName + "}}";
   let bodyWithSecret = JSON.stringify({
     key: "{{" + secretValueTemplateName + "}}",
     otherBodyParam: "foo",
@@ -52,7 +52,7 @@ execute: async function([], context) {
     url: urlWithSecret,
     body: bodyWithSecret,
     headers: {
-      'X-Custom-Authorization-Header': secretHeader,
+      "X-Custom-Authorization-Header": secretHeader,
     },
   });
   // ...

--- a/types.ts
+++ b/types.ts
@@ -509,8 +509,8 @@ export interface CustomAuthParameter {
  * // Suppose you're using an API that requires a secret id in the request URL,
  * // and a different secret value in the request body. You can define a Custom
  * // authentication configuration with two params:
- * // params: [{name: 'secretId', description: 'Secret id'},
- * //          {name: 'secretValue', description: 'Secret value'}])
+ * // params: [{name: "secretId", description: "Secret id"},
+ * //          {name: "secretValue", description: "Secret value"}])
  * // The user or the pack author will be prompted to specify a value for each
  * // of these when setting up an account.
  * // In the `execute` body of your formula, you can specify where those values
@@ -525,7 +525,7 @@ export interface CustomAuthParameter {
  *   let secretIdTemplateName = "secretId-" + context.invocationToken;
  *   let urlWithSecret = "/api/entities/{{" + secretIdTemplateName + "}}"
  *   let secretValueTemplateName = "secretValue-" + context.invocationToken;
- *   let secretHeader = 'Authorization  {{"' + secretValueTemplateName + '"}}';
+ *   let secretHeader = "Authorization  {{" + secretValueTemplateName + "}}";
  *   let bodyWithSecret = JSON.stringify({
  *     key: "{{" + secretValueTemplateName + "}}",
  *     otherBodyParam: "foo",
@@ -536,7 +536,7 @@ export interface CustomAuthParameter {
  *     url: urlWithSecret,
  *     body: bodyWithSecret,
  *     headers: {
- *       'X-Custom-Authorization-Header': secretHeader,
+ *       "X-Custom-Authorization-Header": secretHeader,
  *     },
  *   });
  *   // ...


### PR DESCRIPTION
Fixes https://coda.github.io/packs-sdk/reference/sdk/interfaces/CustomAuthentication/ to match https://coda.github.io/packs-sdk/guides/advanced/authentication/#custom-tokens (which is the correct one). While I'm here, I changed the quotes to double quotes since Eric picked that for our documentation style guide.