### PR TITLE
Migrate logging content to MkDocs

### DIFF
--- a/docs/guides/advanced/authentication.md
+++ b/docs/guides/advanced/authentication.md
@@ -504,7 +504,6 @@ The step's `getOptionsFormula` works like [dynamic autocomplete][autocomplete_dy
 [sample_automatic_endpoint]: ../../samples/topic/authentication.md#automatic-endpoint
 [sample_selected_endpoint]: ../../samples/topic/authentication.md#selected-endpoint
 
-[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_lutgF
 [hc_account_sharing]: https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs
 [account_settings]: https://coda.io/account
 [AuthenticationType]: ../../reference/sdk/enums/AuthenticationType.md

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -6,10 +6,27 @@ title: Troubleshooting
 
 ## Logging
 
-<!-- TODO: Migrate the content to this repo. -->
-[See here][doc] for more information on logging.
+You can log messages using the standard JavaScript logging method, `console.log()`.
 
-[doc]: https://coda.io/d/Pack-Studio-Beta_dUBjm8jbi39/Building-with-the-SDK_suP0J#_lujrM
+```ts
+let response = context.fetcher.fetch({
+  method: "GET",
+  url: "https://api.example.com/items"
+});
+let items = response.body.items;
+console.log("Retrieved %s items.", items.length);
+```
+
+When executing a Pack locally these logs will be written to the console, and when run in a doc they will be visible in the Pack maker tools. This can be useful for debugging during development as well as in production.
+
+The Packs runtime only includes a subset of the [full `console` methods][mdn_console], specifically:
+
+- `console.debug()`
+- `console.error()`
+- `console.info()`
+- `console.log()`
+- `console.trace()`
+- `console.warn()`
 
 ## Common errors
 
@@ -18,4 +35,5 @@ title: Troubleshooting
 This error indicates that the domain you provided in an `addNetworkDomain()` call doesn't resolved to an accessible IP address. This could be due to a typo in the domain name. However there are some cases where a service assigns IP addresses to subdomains (`foo.example.com`) but not the root domain you are trying to add (`example.com`). If that is the case, either add the subdomain or [contact support][support] to have the root domain manually added to your Pack.
 
 
+[mdn_console]: https://developer.mozilla.org/en-US/docs/Web/API/console
 [support]: ../support.md


### PR DESCRIPTION
This was the last reference to the Packs Beta doc in the documentation. Not a 1:1 port, so feel free to comment on the content.