### PR TITLE
remove hidden option of the pack parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - An optional "description" field is added to sync table definition, that will be used to display in the UI.
 - You no longer need to use the `--fetch` flag with `coda execute` to use a real fetcher. Set `--no-fetch` to use a mock fetcher (the old default behavior).
 - OAuth2 authentication now supports a `scopeDelimiter` option for non-compliant APIs that use something other than a space to delimit OAuth scopes in authorization URLs.
+- Deprecated `hidden` field is now fully removed on formula parameter.
 
 ### 0.7.3
 

--- a/api_types.ts
+++ b/api_types.ts
@@ -214,8 +214,6 @@ export interface ParamDef<T extends UnionType> {
    * All optional parameters must come after all non-optional parameters.
    */
   optional?: boolean;
-  /** @hidden */
-  hidden?: boolean; // TODO: remove? Seems unused.
   /**
    * A {@link MetadataFormula} that returns valid values for this parameter, optionally matching a search
    * query. This can be useful both if there are a fixed number of valid values for the parameter,

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -150,8 +150,6 @@ export interface ParamDef<T extends UnionType> {
      * All optional parameters must come after all non-optional parameters.
      */
     optional?: boolean;
-    /** @hidden */
-    hidden?: boolean;
     /**
      * A {@link MetadataFormula} that returns valid values for this parameter, optionally matching a search
      * query. This can be useful both if there are a fixed number of valid values for the parameter,

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1001,8 +1001,6 @@ export interface ParamDef<T extends UnionType> {
 	 * All optional parameters must come after all non-optional parameters.
 	 */
 	optional?: boolean;
-	/** @hidden */
-	hidden?: boolean;
 	/**
 	 * A {@link MetadataFormula} that returns valid values for this parameter, optionally matching a search
 	 * query. This can be useful both if there are a fixed number of valid values for the parameter,

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -345,7 +345,6 @@ const paramDefValidator = zodCompleteObject({
     }),
     description: z.string(),
     optional: z.boolean().optional(),
-    hidden: z.boolean().optional(),
     autocomplete: z.unknown(),
     defaultValue: z.unknown(),
 });

--- a/docs/reference/sdk/enums/ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/ConnectionRequirement.md
@@ -16,7 +16,7 @@ Indicates this building block does not make use of an account.
 
 #### Defined in
 
-[api_types.ts:351](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L351)
+[api_types.ts:349](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L349)
 
 ___
 
@@ -31,7 +31,7 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:358](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L358)
+[api_types.ts:356](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L356)
 
 ___
 
@@ -46,4 +46,4 @@ to specify an account to use.
 
 #### Defined in
 
-[api_types.ts:365](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L365)
+[api_types.ts:363](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L363)

--- a/docs/reference/sdk/enums/NetworkConnection.md
+++ b/docs/reference/sdk/enums/NetworkConnection.md
@@ -13,7 +13,7 @@ title: NetworkConnection
 
 #### Defined in
 
-[api_types.ts:370](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L370)
+[api_types.ts:368](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L368)
 
 ___
 
@@ -23,7 +23,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:371](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L371)
+[api_types.ts:369](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L369)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:372](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L372)
+[api_types.ts:370](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L370)

--- a/docs/reference/sdk/enums/PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/PrecannedDateRange.md
@@ -29,7 +29,7 @@ and ending in the distant future (e.g. 12/31/3999). Exact dates are subject to c
 
 #### Defined in
 
-[api_types.ts:684](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L684)
+[api_types.ts:682](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L682)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:653](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L653)
+[api_types.ts:651](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L651)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:656](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L656)
+[api_types.ts:654](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L654)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:657](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L657)
+[api_types.ts:655](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L655)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:652](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L652)
+[api_types.ts:650](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L650)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:655](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L655)
+[api_types.ts:653](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L653)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:654](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L654)
+[api_types.ts:652](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L652)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:658](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L658)
+[api_types.ts:656](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L656)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:673](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L673)
+[api_types.ts:671](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L671)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:676](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L676)
+[api_types.ts:674](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L674)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:677](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L677)
+[api_types.ts:675](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L675)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:672](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L672)
+[api_types.ts:670](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L670)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:675](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L675)
+[api_types.ts:673](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L673)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:674](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L674)
+[api_types.ts:672](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L672)
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:678](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L678)
+[api_types.ts:676](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L676)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:664](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L664)
+[api_types.ts:662](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L662)
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:665](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L665)
+[api_types.ts:663](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L663)
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:662](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L662)
+[api_types.ts:660](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L660)
 
 ___
 
@@ -209,7 +209,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:663](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L663)
+[api_types.ts:661](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L661)
 
 ___
 
@@ -219,7 +219,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:668](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L668)
+[api_types.ts:666](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L666)
 
 ___
 
@@ -229,7 +229,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:666](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L666)
+[api_types.ts:664](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L664)
 
 ___
 
@@ -239,7 +239,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:661](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L661)
+[api_types.ts:659](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L659)
 
 ___
 
@@ -249,7 +249,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:671](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L671)
+[api_types.ts:669](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L669)
 
 ___
 
@@ -259,7 +259,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:667](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L667)
+[api_types.ts:665](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L665)
 
 ___
 
@@ -269,4 +269,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:651](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L651)
+[api_types.ts:649](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L649)

--- a/docs/reference/sdk/interfaces/BaseFormulaDef.md
+++ b/docs/reference/sdk/interfaces/BaseFormulaDef.md
@@ -32,7 +32,7 @@ How long formulas running with the same values should cache their results for.
 
 #### Defined in
 
-[api_types.ts:318](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L318)
+[api_types.ts:316](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L316)
 
 ___
 
@@ -48,7 +48,7 @@ Does this formula require a connection (aka an account)?
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -64,7 +64,7 @@ A brief description of what the formula does.
 
 #### Defined in
 
-[api_types.ts:284](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L284)
+[api_types.ts:282](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282)
 
 ___
 
@@ -80,7 +80,7 @@ Sample inputs and outputs demonstrating usage of this formula.
 
 #### Defined in
 
-[api_types.ts:299](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L299)
+[api_types.ts:297](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L297)
 
 ___
 
@@ -101,7 +101,7 @@ so an end user must have both sets of permissions.
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -118,7 +118,7 @@ Actions are presented as buttons in the Coda UI.
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:303](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303)
 
 ___
 
@@ -135,7 +135,7 @@ The formula can still be invoked by manually typing its full name.
 
 #### Defined in
 
-[api_types.ts:324](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324)
+[api_types.ts:322](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L322)
 
 ___
 
@@ -152,7 +152,7 @@ Not for use by packs that are not authored by Coda.
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -168,7 +168,7 @@ The name of the formula, used to invoke it.
 
 #### Defined in
 
-[api_types.ts:279](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L279)
+[api_types.ts:277](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:313](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L313)
+[api_types.ts:311](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311)
 
 ___
 
@@ -200,7 +200,7 @@ The parameter inputs to the formula, if any.
 
 #### Defined in
 
-[api_types.ts:289](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289)
+[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
 
 ___
 
@@ -217,7 +217,7 @@ numbers of inputs.
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)
 
 ## Methods
 

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -36,7 +36,7 @@ Omit.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:318](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L318)
+[api_types.ts:316](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L316)
 
 ___
 
@@ -52,7 +52,7 @@ Omit.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -68,7 +68,7 @@ Omit.description
 
 #### Defined in
 
-[api_types.ts:284](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L284)
+[api_types.ts:282](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282)
 
 ___
 
@@ -84,7 +84,7 @@ Omit.examples
 
 #### Defined in
 
-[api_types.ts:299](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L299)
+[api_types.ts:297](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L297)
 
 ___
 
@@ -105,7 +105,7 @@ Omit.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -122,7 +122,7 @@ Omit.isAction
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:303](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303)
 
 ___
 
@@ -139,7 +139,7 @@ Omit.isExperimental
 
 #### Defined in
 
-[api_types.ts:324](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324)
+[api_types.ts:322](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L322)
 
 ___
 
@@ -156,7 +156,7 @@ Omit.isSystem
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -172,7 +172,7 @@ Omit.name
 
 #### Defined in
 
-[api_types.ts:279](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L279)
+[api_types.ts:277](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277)
 
 ___
 
@@ -188,7 +188,7 @@ Omit.network
 
 #### Defined in
 
-[api_types.ts:313](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L313)
+[api_types.ts:311](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311)
 
 ___
 
@@ -204,7 +204,7 @@ Omit.parameters
 
 #### Defined in
 
-[api_types.ts:289](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289)
+[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
 
 ___
 
@@ -233,4 +233,4 @@ Omit.varargParameters
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)

--- a/docs/reference/sdk/interfaces/ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/ExecutionContext.md
@@ -27,7 +27,7 @@ to construct URLs to use with the fetcher. Alternatively, you can use relative U
 
 #### Defined in
 
-[api_types.ts:597](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L597)
+[api_types.ts:595](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L595)
 
 ___
 
@@ -39,7 +39,7 @@ The [Fetcher](Fetcher.md) used for making HTTP requests.
 
 #### Defined in
 
-[api_types.ts:584](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L584)
+[api_types.ts:582](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L582)
 
 ___
 
@@ -52,7 +52,7 @@ This is mostly for Coda internal use and we do not recommend relying on it.
 
 #### Defined in
 
-[api_types.ts:602](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L602)
+[api_types.ts:600](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L600)
 
 ___
 
@@ -67,7 +67,7 @@ replaced by the fetcher in secure way.
 
 #### Defined in
 
-[api_types.ts:613](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L613)
+[api_types.ts:611](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L611)
 
 ___
 
@@ -79,7 +79,7 @@ Information about state of the current sync. Only populated if this is a sync ta
 
 #### Defined in
 
-[api_types.ts:617](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L617)
+[api_types.ts:615](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L615)
 
 ___
 
@@ -92,7 +92,7 @@ or are too large to return inline. See [TemporaryBlobStorage](TemporaryBlobStora
 
 #### Defined in
 
-[api_types.ts:589](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L589)
+[api_types.ts:587](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L587)
 
 ___
 
@@ -104,4 +104,4 @@ The timezone of the doc from which this formula was invoked.
 
 #### Defined in
 
-[api_types.ts:606](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L606)
+[api_types.ts:604](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L604)

--- a/docs/reference/sdk/interfaces/FetchRequest.md
+++ b/docs/reference/sdk/interfaces/FetchRequest.md
@@ -19,7 +19,7 @@ If you are sending a JSON payload, make sure to call `JSON.stringify()` on the o
 
 #### Defined in
 
-[api_types.ts:407](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L407)
+[api_types.ts:405](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L405)
 
 ___
 
@@ -36,7 +36,7 @@ set this value to `0`.
 
 #### Defined in
 
-[api_types.ts:424](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L424)
+[api_types.ts:422](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L422)
 
 ___
 
@@ -50,7 +50,7 @@ wish to make an unauthenticated supporting request as part of a formula implemen
 
 #### Defined in
 
-[api_types.ts:437](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L437)
+[api_types.ts:435](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L435)
 
 ___
 
@@ -66,7 +66,7 @@ Key-value form fields, if submitting to an endpoint expecting a URL-encoded form
 
 #### Defined in
 
-[api_types.ts:411](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L411)
+[api_types.ts:409](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L409)
 
 ___
 
@@ -82,7 +82,7 @@ HTTP headers. You should NOT include authentication headers, as Coda will add th
 
 #### Defined in
 
-[api_types.ts:415](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L415)
+[api_types.ts:413](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L413)
 
 ___
 
@@ -97,7 +97,7 @@ will be a NodeJS Buffer.
 
 #### Defined in
 
-[api_types.ts:431](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L431)
+[api_types.ts:429](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L429)
 
 ___
 
@@ -109,7 +109,7 @@ The HTTP method/verb (e.g. GET or POST).
 
 #### Defined in
 
-[api_types.ts:394](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L394)
+[api_types.ts:392](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L392)
 
 ___
 
@@ -124,4 +124,4 @@ apply the user's endpoint automatically.
 
 #### Defined in
 
-[api_types.ts:401](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L401)
+[api_types.ts:399](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L399)

--- a/docs/reference/sdk/interfaces/FetchResponse.md
+++ b/docs/reference/sdk/interfaces/FetchResponse.md
@@ -31,7 +31,7 @@ to disable any parsing. Note however that this will result in the body being a N
 
 #### Defined in
 
-[api_types.ts:459](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L459)
+[api_types.ts:457](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L457)
 
 ___
 
@@ -47,7 +47,7 @@ HTTP response headers. The contents of many headers will be redacted for securit
 
 #### Defined in
 
-[api_types.ts:463](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L463)
+[api_types.ts:461](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L461)
 
 ___
 
@@ -59,4 +59,4 @@ The HTTP status code, e.g. `200`.
 
 #### Defined in
 
-[api_types.ts:447](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L447)
+[api_types.ts:445](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L445)

--- a/docs/reference/sdk/interfaces/Fetcher.md
+++ b/docs/reference/sdk/interfaces/Fetcher.md
@@ -39,4 +39,4 @@ deal with authentication in any way, Coda will handle that entirely on your beha
 
 #### Defined in
 
-[api_types.ts:481](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L481)
+[api_types.ts:479](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L479)

--- a/docs/reference/sdk/interfaces/InvocationLocation.md
+++ b/docs/reference/sdk/interfaces/InvocationLocation.md
@@ -15,7 +15,7 @@ Information about the Coda environment and doc this formula was invoked from, fo
 
 #### Defined in
 
-[api_types.ts:572](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L572)
+[api_types.ts:570](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L570)
 
 ___
 
@@ -27,4 +27,4 @@ The base URL of the Coda environment executing this formula. Only for Coda inter
 
 #### Defined in
 
-[api_types.ts:568](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L568)
+[api_types.ts:566](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L566)

--- a/docs/reference/sdk/interfaces/Network.md
+++ b/docs/reference/sdk/interfaces/Network.md
@@ -13,7 +13,7 @@ title: Network
 
 #### Defined in
 
-[api_types.ts:379](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L379)
+[api_types.ts:377](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L377)
 
 ___
 
@@ -23,7 +23,7 @@ ___
 
 #### Defined in
 
-[api_types.ts:377](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L377)
+[api_types.ts:375](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L375)
 
 ___
 
@@ -33,4 +33,4 @@ ___
 
 #### Defined in
 
-[api_types.ts:378](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L378)
+[api_types.ts:376](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L376)

--- a/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
@@ -38,7 +38,7 @@ Omit.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:318](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L318)
+[api_types.ts:316](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L316)
 
 ___
 
@@ -54,7 +54,7 @@ Omit.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -70,7 +70,7 @@ Omit.description
 
 #### Defined in
 
-[api_types.ts:284](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L284)
+[api_types.ts:282](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282)
 
 ___
 
@@ -86,7 +86,7 @@ Omit.examples
 
 #### Defined in
 
-[api_types.ts:299](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L299)
+[api_types.ts:297](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L297)
 
 ___
 
@@ -107,7 +107,7 @@ Omit.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -124,7 +124,7 @@ Omit.isAction
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:303](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303)
 
 ___
 
@@ -141,7 +141,7 @@ Omit.isExperimental
 
 #### Defined in
 
-[api_types.ts:324](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324)
+[api_types.ts:322](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L322)
 
 ___
 
@@ -158,7 +158,7 @@ Omit.isSystem
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -174,7 +174,7 @@ Omit.name
 
 #### Defined in
 
-[api_types.ts:279](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L279)
+[api_types.ts:277](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277)
 
 ___
 
@@ -190,7 +190,7 @@ Omit.network
 
 #### Defined in
 
-[api_types.ts:313](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L313)
+[api_types.ts:311](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311)
 
 ___
 
@@ -206,7 +206,7 @@ Omit.parameters
 
 #### Defined in
 
-[api_types.ts:289](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289)
+[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
 
 ___
 
@@ -247,4 +247,4 @@ Omit.varargParameters
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -34,7 +34,7 @@ CommonPackFormulaDef.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:318](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L318)
+[api_types.ts:316](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L316)
 
 ___
 
@@ -50,7 +50,7 @@ CommonPackFormulaDef.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -66,7 +66,7 @@ CommonPackFormulaDef.description
 
 #### Defined in
 
-[api_types.ts:284](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L284)
+[api_types.ts:282](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282)
 
 ___
 
@@ -82,7 +82,7 @@ CommonPackFormulaDef.examples
 
 #### Defined in
 
-[api_types.ts:299](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L299)
+[api_types.ts:297](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L297)
 
 ___
 
@@ -103,7 +103,7 @@ CommonPackFormulaDef.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -120,7 +120,7 @@ CommonPackFormulaDef.isAction
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:303](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303)
 
 ___
 
@@ -137,7 +137,7 @@ CommonPackFormulaDef.isExperimental
 
 #### Defined in
 
-[api_types.ts:324](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324)
+[api_types.ts:322](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L322)
 
 ___
 
@@ -154,7 +154,7 @@ CommonPackFormulaDef.isSystem
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -170,7 +170,7 @@ CommonPackFormulaDef.name
 
 #### Defined in
 
-[api_types.ts:279](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L279)
+[api_types.ts:277](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277)
 
 ___
 
@@ -186,7 +186,7 @@ CommonPackFormulaDef.network
 
 #### Defined in
 
-[api_types.ts:313](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L313)
+[api_types.ts:311](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311)
 
 ___
 
@@ -202,7 +202,7 @@ CommonPackFormulaDef.parameters
 
 #### Defined in
 
-[api_types.ts:289](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289)
+[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
 
 ___
 
@@ -219,7 +219,7 @@ CommonPackFormulaDef.varargParameters
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)
 
 ## Methods
 

--- a/docs/reference/sdk/interfaces/ParamDef.md
+++ b/docs/reference/sdk/interfaces/ParamDef.md
@@ -28,7 +28,7 @@ If you have a hardcoded list of valid values, you would only need to use
 
 #### Defined in
 
-[api_types.ts:231](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L231)
+[api_types.ts:229](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L229)
 
 ___
 
@@ -40,7 +40,7 @@ The default value to be used for this parameter if it is not specified by the us
 
 #### Defined in
 
-[api_types.ts:235](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L235)
+[api_types.ts:233](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L233)
 
 ___
 

--- a/docs/reference/sdk/interfaces/Sync.md
+++ b/docs/reference/sdk/interfaces/Sync.md
@@ -17,7 +17,7 @@ value returned in the `continuation` property of result of the prior sync.
 
 #### Defined in
 
-[api_types.ts:539](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L539)
+[api_types.ts:537](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L537)
 
 ___
 
@@ -30,7 +30,7 @@ The dynamic URL is likely necessary for determining which API resources to fetch
 
 #### Defined in
 
-[api_types.ts:550](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L550)
+[api_types.ts:548](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L548)
 
 ___
 
@@ -44,4 +44,4 @@ the response for a dynamic sync table's `execute` function.
 
 #### Defined in
 
-[api_types.ts:545](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L545)
+[api_types.ts:543](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L543)

--- a/docs/reference/sdk/interfaces/SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/SyncExecutionContext.md
@@ -30,7 +30,7 @@ to construct URLs to use with the fetcher. Alternatively, you can use relative U
 
 #### Defined in
 
-[api_types.ts:597](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L597)
+[api_types.ts:595](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L595)
 
 ___
 
@@ -46,7 +46,7 @@ The [Fetcher](Fetcher.md) used for making HTTP requests.
 
 #### Defined in
 
-[api_types.ts:584](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L584)
+[api_types.ts:582](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L582)
 
 ___
 
@@ -63,7 +63,7 @@ This is mostly for Coda internal use and we do not recommend relying on it.
 
 #### Defined in
 
-[api_types.ts:602](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L602)
+[api_types.ts:600](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L600)
 
 ___
 
@@ -82,7 +82,7 @@ replaced by the fetcher in secure way.
 
 #### Defined in
 
-[api_types.ts:613](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L613)
+[api_types.ts:611](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L611)
 
 ___
 
@@ -98,7 +98,7 @@ Information about state of the current sync.
 
 #### Defined in
 
-[api_types.ts:628](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L628)
+[api_types.ts:626](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L626)
 
 ___
 
@@ -115,7 +115,7 @@ or are too large to return inline. See [TemporaryBlobStorage](TemporaryBlobStora
 
 #### Defined in
 
-[api_types.ts:589](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L589)
+[api_types.ts:587](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L587)
 
 ___
 
@@ -131,4 +131,4 @@ The timezone of the doc from which this formula was invoked.
 
 #### Defined in
 
-[api_types.ts:606](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L606)
+[api_types.ts:604](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L604)

--- a/docs/reference/sdk/interfaces/SyncFormulaDef.md
+++ b/docs/reference/sdk/interfaces/SyncFormulaDef.md
@@ -34,7 +34,7 @@ CommonPackFormulaDef.cacheTtlSecs
 
 #### Defined in
 
-[api_types.ts:318](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L318)
+[api_types.ts:316](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L316)
 
 ___
 
@@ -50,7 +50,7 @@ CommonPackFormulaDef.connectionRequirement
 
 #### Defined in
 
-[api_types.ts:310](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L310)
+[api_types.ts:308](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L308)
 
 ___
 
@@ -66,7 +66,7 @@ CommonPackFormulaDef.description
 
 #### Defined in
 
-[api_types.ts:284](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L284)
+[api_types.ts:282](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L282)
 
 ___
 
@@ -82,7 +82,7 @@ CommonPackFormulaDef.examples
 
 #### Defined in
 
-[api_types.ts:299](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L299)
+[api_types.ts:297](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L297)
 
 ___
 
@@ -103,7 +103,7 @@ CommonPackFormulaDef.extraOAuthScopes
 
 #### Defined in
 
-[api_types.ts:340](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L340)
+[api_types.ts:338](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L338)
 
 ___
 
@@ -120,7 +120,7 @@ CommonPackFormulaDef.isAction
 
 #### Defined in
 
-[api_types.ts:305](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L305)
+[api_types.ts:303](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L303)
 
 ___
 
@@ -137,7 +137,7 @@ CommonPackFormulaDef.isExperimental
 
 #### Defined in
 
-[api_types.ts:324](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L324)
+[api_types.ts:322](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L322)
 
 ___
 
@@ -154,7 +154,7 @@ CommonPackFormulaDef.isSystem
 
 #### Defined in
 
-[api_types.ts:330](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L330)
+[api_types.ts:328](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L328)
 
 ___
 
@@ -170,7 +170,7 @@ CommonPackFormulaDef.name
 
 #### Defined in
 
-[api_types.ts:279](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L279)
+[api_types.ts:277](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L277)
 
 ___
 
@@ -186,7 +186,7 @@ CommonPackFormulaDef.network
 
 #### Defined in
 
-[api_types.ts:313](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L313)
+[api_types.ts:311](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L311)
 
 ___
 
@@ -202,7 +202,7 @@ CommonPackFormulaDef.parameters
 
 #### Defined in
 
-[api_types.ts:289](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L289)
+[api_types.ts:287](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L287)
 
 ___
 
@@ -219,7 +219,7 @@ CommonPackFormulaDef.varargParameters
 
 #### Defined in
 
-[api_types.ts:294](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L294)
+[api_types.ts:292](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L292)
 
 ## Methods
 

--- a/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
@@ -55,7 +55,7 @@ Coda reserves the right to ignore long expirations.
 
 #### Defined in
 
-[api_types.ts:527](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L527)
+[api_types.ts:525](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L525)
 
 ___
 
@@ -84,4 +84,4 @@ Coda reserves the right to ignore long expirations.
 
 #### Defined in
 
-[api_types.ts:519](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L519)
+[api_types.ts:517](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L517)

--- a/docs/reference/sdk/types/DefaultValueType.md
+++ b/docs/reference/sdk/types/DefaultValueType.md
@@ -15,4 +15,4 @@ The type of values that are allowable to be used as a [defaultValue](../interfac
 
 #### Defined in
 
-[api_types.ts:268](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L268)
+[api_types.ts:266](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L266)

--- a/docs/reference/sdk/types/FetchMethodType.md
+++ b/docs/reference/sdk/types/FetchMethodType.md
@@ -9,4 +9,4 @@ The type of the HTTP methods (verbs) supported by the fetcher.
 
 #### Defined in
 
-[api_types.ts:385](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L385)
+[api_types.ts:383](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383)

--- a/docs/reference/sdk/types/ParamDefs.md
+++ b/docs/reference/sdk/types/ParamDefs.md
@@ -9,4 +9,4 @@ The type for the complete set of parameter definitions for a fomrula.
 
 #### Defined in
 
-[api_types.ts:244](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L244)
+[api_types.ts:242](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L242)

--- a/docs/reference/sdk/types/ParamValues.md
+++ b/docs/reference/sdk/types/ParamValues.md
@@ -16,4 +16,4 @@ the parameter defintion for that formula.
 
 #### Defined in
 
-[api_types.ts:261](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L261)
+[api_types.ts:259](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L259)

--- a/docs/reference/sdk/variables/ValidFetchMethods.md
+++ b/docs/reference/sdk/variables/ValidFetchMethods.md
@@ -9,4 +9,4 @@ The HTTP methods (verbs) supported by the fetcher.
 
 #### Defined in
 
-[api_types.ts:383](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L383)
+[api_types.ts:381](https://github.com/coda/packs-sdk/blob/main/api_types.ts#L381)

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -428,7 +428,6 @@ const paramDefValidator = zodCompleteObject<ParamDef<any>>({
     ),
   description: z.string(),
   optional: z.boolean().optional(),
-  hidden: z.boolean().optional(),
   autocomplete: z.unknown(),
   defaultValue: z.unknown(),
 });


### PR DESCRIPTION
https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/My-Issues_sud-l#My-issues_tui9H/r20767&modal=true

A few sanity checks before removing this field:
- packs repo doesn't use this field. 
- the field isn't actually loaded into `coda/modules/common/packs/formula.ts:generateFormulaDefinitions`, which means that it's being used on client at this moment. 
- after trying load the hidden option into client (as in `generateFormulaDefinitions`), here are a few observations:
  - hidden parameters will be hidden from the structured builder (e.g. a button). This behavior seems useless for third-party packs. It's currently only being used by https://github.com/coda/coda/blob/main/modules/common/packs/formula.ts#L147 as far as I can tell. This usage is directly related to packs. 
  - it breaks the browser on regular formulas if a parameter is hidden. hidden parameters still show up and can be updated. snapshot workflow is able to pick up a hidden parameter but browser just seems to stuck there forever. 
 
So, my conclusion is that the removal of hidden field is safe and won't be a regression. 