### PR TITLE
inject patches in `coda init`

### DIFF
--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -1,14 +1,15 @@
 import type {Authentication} from '../types';
 import type {BasicPackDefinition} from '../types';
 import {Client} from '../helpers/external-api/coda';
+import type {SpawnSyncOptionsWithBufferEncoding} from 'child_process';
 import path from 'path';
 import {print} from '../testing/helpers';
 import {spawnSync} from 'child_process';
 
-export function spawnProcess(command: string) {
+export function spawnProcess(command: string, {stdio = 'inherit'}: SpawnSyncOptionsWithBufferEncoding = {}) {
   return spawnSync(command, {
     shell: true,
-    stdio: 'inherit',
+    stdio,
   });
 }
 

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -8,13 +8,18 @@ const GitIgnore = `.coda.json
 .coda-credentials.json
 `;
 
+function updateMoldSourceMap() {
+  // unfortuanately Windows has no grep.
+  const packageFileName = 'node_modules/mold-source-map/package.json';
+  const lines = fs.readFileSync(packageFileName).toString().split('\n');
+  const validLines = lines.filter(line => !line.includes('"main":'));
+  fs.writeFileSync(packageFileName, validLines.join('\n'));
+}
+
 function addPatches() {
   spawnProcess(`npm set-script postinstall "npx patch-package"`);
 
-  spawnProcess(
-    `grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json.new`,
-  );
-  spawnProcess(`mv node_modules/mold-source-map/package.json.new node_modules/mold-source-map/package.json`);
+  updateMoldSourceMap();
 
   spawnProcess(`npx patch-package --exclude 'nothing' mold-source-map`);
 }

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -39,7 +39,7 @@ export async function handleInit() {
     .join(' ');
   spawnProcess(`npm install --save-dev ${devDependencyPackages}`);
 
-  // https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/Bugs_sucBW#Bugs_tuq-W/r20768&modal=true
+  // developers may run in NodeJs 16 where some packages need to be patched to avoid warnings.
   addPatches();
 
   fs.copySync(`${PacksExamplesDirectory}/examples/template`, process.cwd());

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -23,7 +23,8 @@ export async function handleInit() {
   // stdout looks like `8.1.2\n`.
   const npmVersion = parseInt(spawnProcess('npm -v', {stdio: 'pipe'}).stdout.toString().trim().split('.', 1)[0], 10);
   if (npmVersion < 7) {
-    throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
+    // need npm 7 to support "npm set-script"
+    throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install -g npm@7"`);
   }
 
   let isPacksExamplesInstalled: boolean;

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -20,7 +20,8 @@ function addPatches() {
 }
 
 export async function handleInit() {
-  const npmVersion = parseInt(spawnProcess('npm -v').stdout.toString().trim().split('.', 1)[0], 10);
+  // stdout looks like `8.1.2\n`.
+  const npmVersion = parseInt(spawnProcess('npm -v', {stdio: 'pipe'}).stdout.toString().trim().split('.', 1)[0], 10);
   if (npmVersion < 7) {
     throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
   }

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -20,6 +20,11 @@ function addPatches() {
 }
 
 export async function handleInit() {
+  const npmVersion = parseInt(spawnProcess('npm -v').stdout.toString().trim().split('.', 1)[0], 10);
+  if (npmVersion < 7) {
+    throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
+  }
+
   let isPacksExamplesInstalled: boolean;
   try {
     const listNpmPackages = spawnProcess('npm list @codahq/packs-examples');

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -11,10 +11,11 @@ const GitIgnore = `.coda.json
 function addPatches() {
   spawnProcess(`npm set-script postinstall "npx patch-package"`);
 
-  fs.mkdirpSync('patches');
-  fs.copySync(`${PacksExamplesDirectory}/patches`, path.join(process.cwd(), 'patches'));
+  spawnProcess(
+    `grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json`,
+  );
 
-  spawnProcess(`npm run-script postinstall`);
+  spawnProcess(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 
 export async function handleInit() {

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -12,8 +12,9 @@ function addPatches() {
   spawnProcess(`npm set-script postinstall "npx patch-package"`);
 
   spawnProcess(
-    `grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json`,
+    `grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json.new`,
   );
+  spawnProcess(`mv node_modules/mold-source-map/package.json.new node_modules/mold-source-map/package.json`);
 
   spawnProcess(`npx patch-package --exclude 'nothing' mold-source-map`);
 }

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -8,6 +8,15 @@ const GitIgnore = `.coda.json
 .coda-credentials.json
 `;
 
+function addPatches() {
+  spawnProcess(`npm set-script postinstall "npx patch-package"`);
+
+  fs.mkdirpSync('patches');
+  fs.copySync(`${PacksExamplesDirectory}/patches`, path.join(process.cwd(), 'patches'));
+
+  spawnProcess(`npm run-script postinstall`);
+}
+
 export async function handleInit() {
   let isPacksExamplesInstalled: boolean;
   try {
@@ -29,6 +38,9 @@ export async function handleInit() {
     .map(dependency => `${dependency}@${devDependencies[dependency]}`)
     .join(' ');
   spawnProcess(`npm install --save-dev ${devDependencyPackages}`);
+
+  // https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/Bugs_sucBW#Bugs_tuq-W/r20768&modal=true
+  addPatches();
 
   fs.copySync(`${PacksExamplesDirectory}/examples/template`, process.cwd());
   // npm removes .gitignore files when installing a package, so we can't simply put the .gitignore

--- a/dist/cli/helpers.d.ts
+++ b/dist/cli/helpers.d.ts
@@ -2,7 +2,8 @@
 import type { Authentication } from '../types';
 import type { BasicPackDefinition } from '../types';
 import { Client } from '../helpers/external-api/coda';
-export declare function spawnProcess(command: string): import("child_process").SpawnSyncReturns<Buffer>;
+import type { SpawnSyncOptionsWithBufferEncoding } from 'child_process';
+export declare function spawnProcess(command: string, { stdio }?: SpawnSyncOptionsWithBufferEncoding): import("child_process").SpawnSyncReturns<Buffer>;
 export declare function createCodaClient(apiToken: string, protocolAndHost?: string): Client;
 export declare function formatEndpoint(endpoint: string): string;
 export declare function isTestCommand(): boolean;

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -27,10 +27,10 @@ const coda_1 = require("../helpers/external-api/coda");
 const path_1 = __importDefault(require("path"));
 const helpers_1 = require("../testing/helpers");
 const child_process_1 = require("child_process");
-function spawnProcess(command) {
+function spawnProcess(command, { stdio = 'inherit' } = {}) {
     return (0, child_process_1.spawnSync)(command, {
         shell: true,
-        stdio: 'inherit',
+        stdio,
     });
 }
 exports.spawnProcess = spawnProcess;

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -37,7 +37,7 @@ async function handleInit() {
         .map(dependency => `${dependency}@${devDependencies[dependency]}`)
         .join(' ');
     (0, helpers_1.spawnProcess)(`npm install --save-dev ${devDependencyPackages}`);
-    // https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/Bugs_sucBW#Bugs_tuq-W/r20768&modal=true
+    // developers may run in NodeJs 16 where some packages need to be patched to avoid warnings.
     addPatches();
     fs_extra_1.default.copySync(`${PacksExamplesDirectory}/examples/template`, process.cwd());
     // npm removes .gitignore files when installing a package, so we can't simply put the .gitignore

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -11,10 +11,16 @@ const PacksExamplesDirectory = 'node_modules/@codahq/packs-examples';
 const GitIgnore = `.coda.json
 .coda-credentials.json
 `;
+function updateMoldSourceMap() {
+    // unfortuanately Windows has no grep.
+    const packageFileName = 'node_modules/mold-source-map/package.json';
+    const lines = fs_extra_1.default.readFileSync(packageFileName).toString().split('\n');
+    const validLines = lines.filter(line => !line.includes('"main":'));
+    fs_extra_1.default.writeFileSync(packageFileName, validLines.join('\n'));
+}
 function addPatches() {
     (0, helpers_1.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
-    (0, helpers_1.spawnProcess)(`grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json.new`);
-    (0, helpers_1.spawnProcess)(`mv node_modules/mold-source-map/package.json.new node_modules/mold-source-map/package.json`);
+    updateMoldSourceMap();
     (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 async function handleInit() {

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -13,7 +13,8 @@ const GitIgnore = `.coda.json
 `;
 function addPatches() {
     (0, helpers_1.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
-    (0, helpers_1.spawnProcess)(`grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json`);
+    (0, helpers_1.spawnProcess)(`grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json.new`);
+    (0, helpers_1.spawnProcess)(`mv node_modules/mold-source-map/package.json.new node_modules/mold-source-map/package.json`);
     (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 async function handleInit() {

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -13,9 +13,8 @@ const GitIgnore = `.coda.json
 `;
 function addPatches() {
     (0, helpers_1.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
-    fs_extra_1.default.mkdirpSync('patches');
-    fs_extra_1.default.copySync(`${PacksExamplesDirectory}/patches`, path_1.default.join(process.cwd(), 'patches'));
-    (0, helpers_1.spawnProcess)(`npm run-script postinstall`);
+    (0, helpers_1.spawnProcess)(`grep -v '"main":' node_modules/mold-source-map/package.json > node_modules/mold-source-map/package.json`);
+    (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 async function handleInit() {
     let isPacksExamplesInstalled;

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -11,6 +11,12 @@ const PacksExamplesDirectory = 'node_modules/@codahq/packs-examples';
 const GitIgnore = `.coda.json
 .coda-credentials.json
 `;
+function addPatches() {
+    (0, helpers_1.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
+    fs_extra_1.default.mkdirpSync('patches');
+    fs_extra_1.default.copySync(`${PacksExamplesDirectory}/patches`, path_1.default.join(process.cwd(), 'patches'));
+    (0, helpers_1.spawnProcess)(`npm run-script postinstall`);
+}
 async function handleInit() {
     let isPacksExamplesInstalled;
     try {
@@ -31,6 +37,8 @@ async function handleInit() {
         .map(dependency => `${dependency}@${devDependencies[dependency]}`)
         .join(' ');
     (0, helpers_1.spawnProcess)(`npm install --save-dev ${devDependencyPackages}`);
+    // https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/Bugs_sucBW#Bugs_tuq-W/r20768&modal=true
+    addPatches();
     fs_extra_1.default.copySync(`${PacksExamplesDirectory}/examples/template`, process.cwd());
     // npm removes .gitignore files when installing a package, so we can't simply put the .gitignore
     // in the template example alongside the other files. So we just create it explicitly

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -21,7 +21,8 @@ async function handleInit() {
     // stdout looks like `8.1.2\n`.
     const npmVersion = parseInt((0, helpers_1.spawnProcess)('npm -v', { stdio: 'pipe' }).stdout.toString().trim().split('.', 1)[0], 10);
     if (npmVersion < 7) {
-        throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
+        // need npm 7 to support "npm set-script"
+        throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install -g npm@7"`);
     }
     let isPacksExamplesInstalled;
     try {

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -18,7 +18,8 @@ function addPatches() {
     (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 async function handleInit() {
-    const npmVersion = parseInt((0, helpers_1.spawnProcess)('npm -v').stdout.toString().trim().split('.', 1)[0], 10);
+    // stdout looks like `8.1.2\n`.
+    const npmVersion = parseInt((0, helpers_1.spawnProcess)('npm -v', { stdio: 'pipe' }).stdout.toString().trim().split('.', 1)[0], 10);
     if (npmVersion < 7) {
         throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
     }

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -18,6 +18,10 @@ function addPatches() {
     (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 async function handleInit() {
+    const npmVersion = parseInt((0, helpers_1.spawnProcess)('npm -v').stdout.toString().trim().split('.', 1)[0], 10);
+    if (npmVersion < 7) {
+        throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install npm@7"`);
+    }
     let isPacksExamplesInstalled;
     try {
         const listNpmPackages = (0, helpers_1.spawnProcess)('npm list @codahq/packs-examples');

--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -33,15 +33,14 @@ The instructions below assume some familiarity with the terminal / command promp
 
 1. Install the Pack SDK.
 
-    ```sh
-    # We suggest to use NodeJS 16+
+    ```sh    
     npm init
     npm install @codahq/packs-sdk
     ```
 
     The Pack SDK includes both the `coda` CLI as well as the libraries and type definitions needed to build Packs.
 
-1. Create the file structure for your Pack.
+2. Create the file structure for your Pack.
 
     ```sh
     npx coda init

--- a/docs/get-started/cli.md
+++ b/docs/get-started/cli.md
@@ -34,6 +34,8 @@ The instructions below assume some familiarity with the terminal / command promp
 1. Install the Pack SDK.
 
     ```sh
+    # We suggest to use NodeJS 16+
+    npm init
     npm install @codahq/packs-sdk
     ```
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "https://github.com/coda/packs-sdk"
   },
+  "scripts": {
+    "postinstall": "npx patch-package"
+  },
   "dependencies": {
     "@aws-crypto/sha256-js": "^2.0.1",
     "@aws-sdk/client-sts": "^3.45.0",

--- a/patches/mold-source-map+0.4.0.patch
+++ b/patches/mold-source-map+0.4.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/mold-source-map/package.json b/node_modules/mold-source-map/package.json
+index 6ae458d..97230a0 100644
+--- a/node_modules/mold-source-map/package.json
++++ b/node_modules/mold-source-map/package.json
+@@ -2,7 +2,6 @@
+   "name": "mold-source-map",
+   "version": "0.4.0",
+   "description": "Mold a source map that is almost perfect for you into one that is.",
+-  "main": "mold-source-map.js",
+   "scripts": {
+     "test": "tap test/*.js"
+   },


### PR DESCRIPTION
This PR allows `coda init` to patch `mold-source-map` using the one from packs-example (https://github.com/coda/packs-examples/pull/94). This avoids deprecation warnings from this zombie package. 