### PR TITLE
bump to node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ orbs:
 executors:
   default_build_environment:
     docker:
-      - image: cimg/node:14.17
+      - image: cimg/node:16.13
         auth:
           username: codainternaltools
           password: $DOCKERHUB_PASSWORD

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "license": "MIT",
   "engines": {
-    "node": ">=14.17.x"
+    "node": ">=16.13.x"
   },
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
not sure if there's anything preventing us from bumping to node 16. I've seen tickets on NodeJS 16 so that I feel it's time to bump the build env to node 16. 