### PR TITLE
get rid of client-oauth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 local-docs
 site
 .coda-pack.json
+.coda-credentials.json

--- a/dist/testing/constants.d.ts
+++ b/dist/testing/constants.d.ts
@@ -1,0 +1,3 @@
+export declare enum HttpStatusCode {
+    Unauthorized = 401
+}

--- a/dist/testing/constants.js
+++ b/dist/testing/constants.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.HttpStatusCode = void 0;
+var HttpStatusCode;
+(function (HttpStatusCode) {
+    HttpStatusCode[HttpStatusCode["Unauthorized"] = 401] = "Unauthorized";
+})(HttpStatusCode = exports.HttpStatusCode || (exports.HttpStatusCode = {}));

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.newFetcherSyncExecutionContext = exports.newFetcherExecutionContext = exports.requestHelper = exports.AuthenticatingFetcher = void 0;
 const client_sts_1 = require("@aws-sdk/client-sts");
 const types_1 = require("../types");
+const constants_1 = require("./constants");
 const client_sts_2 = require("@aws-sdk/client-sts");
 const sha256_js_1 = require("@aws-crypto/sha256-js");
 const signature_v4_1 = require("@aws-sdk/signature-v4");
@@ -147,7 +148,7 @@ class AuthenticatingFetcher {
         if (!this._authDef || !this._credentials || !this._updateCredentialsCallback) {
             return false;
         }
-        if (requestFailure.statusCode !== 401 || this._authDef.type !== types_1.AuthenticationType.OAuth2) {
+        if (requestFailure.statusCode !== constants_1.HttpStatusCode.Unauthorized || this._authDef.type !== types_1.AuthenticationType.OAuth2) {
             return false;
         }
         const { accessToken, refreshToken } = this._credentials;
@@ -169,21 +170,32 @@ class AuthenticatingFetcher {
             grant_type: 'refresh_token',
             refresh_token: refreshToken,
             client_id: clientId,
-            client_secret: clientSecret,
         };
         const headers = new Headers({
             'Content-Type': 'application/x-www-form-urlencoded',
             accept: 'application/json',
         });
         const formParams = new URLSearchParams();
+        const formParamsWithSecret = new URLSearchParams();
         for (const [key, value] of Object.entries(params)) {
             formParams.append(key, value.toString());
+            formParamsWithSecret.append(key, value.toString());
         }
-        const oauthResponse = await fetch(tokenUrl, {
+        formParamsWithSecret.append('client_secret', clientSecret);
+        let oauthResponse = await fetch(tokenUrl, {
             method: 'POST',
-            body: formParams,
+            body: formParamsWithSecret,
             headers,
         });
+        if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
+            // see testing/oauth_server.ts why we retry with header auth.
+            headers.append('Authorization', `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`);
+            oauthResponse = await fetch(tokenUrl, {
+                method: 'POST',
+                body: formParams,
+                headers,
+            });
+        }
         if (!oauthResponse.ok) {
             new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
         }

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -6,7 +6,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.newFetcherSyncExecutionContext = exports.newFetcherExecutionContext = exports.requestHelper = exports.AuthenticatingFetcher = void 0;
 const client_sts_1 = require("@aws-sdk/client-sts");
 const types_1 = require("../types");
-const client_oauth2_1 = __importDefault(require("client-oauth2"));
 const client_sts_2 = require("@aws-sdk/client-sts");
 const sha256_js_1 = require("@aws-crypto/sha256-js");
 const signature_v4_1 = require("@aws-sdk/signature-v4");
@@ -165,22 +164,35 @@ class AuthenticatingFetcher {
         const { clientId, clientSecret, accessToken, refreshToken, scopes } = this._credentials;
         (0, ensure_1.assertCondition)(accessToken);
         (0, ensure_1.assertCondition)(refreshToken);
-        const { authorizationUrl, tokenUrl, additionalParams } = this._authDef;
-        const oauth2Client = new client_oauth2_1.default({
-            clientId,
-            clientSecret,
-            authorizationUri: authorizationUrl,
-            accessTokenUri: tokenUrl,
-            scopes,
-            query: additionalParams,
+        const { tokenUrl } = this._authDef;
+        const params = {
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: clientId,
+            client_secret: clientSecret,
+        };
+        const headers = new Headers({
+            'Content-Type': 'application/x-www-form-urlencoded',
+            accept: 'application/json',
         });
-        const oauthToken = oauth2Client.createToken(accessToken, refreshToken, {});
-        const refreshedToken = await oauthToken.refresh();
+        const formParams = new URLSearchParams();
+        for (const [key, value] of Object.entries(params)) {
+            formParams.append(key, value.toString());
+        }
+        const oauthResponse = await fetch(tokenUrl, {
+            method: 'POST',
+            body: formParams,
+            headers,
+        });
+        if (!oauthResponse.ok) {
+            new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
+        }
+        const { access_token: newAccessToken, refresh_token: newRefreshToken, ...data } = await oauthResponse.json();
         const newCredentials = {
             ...this._credentials,
-            accessToken: refreshedToken.accessToken,
-            refreshToken: refreshedToken.refreshToken,
-            expires: (0, helpers_1.getExpirationDate)(Number(refreshedToken.data.expires_in)).toString(),
+            accessToken: newAccessToken,
+            refreshToken: newRefreshToken || refreshToken,
+            expires: (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString(),
             scopes,
         };
         this._credentials = newCredentials;

--- a/dist/testing/oauth_server.d.ts
+++ b/dist/testing/oauth_server.d.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch';
 import type { OAuth2Authentication } from '../types';
 interface AfterTokenExchangeParams {
     accessToken: string;

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -4,36 +4,58 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.makeRedirectUrl = exports.launchOAuthServerFlow = void 0;
-const client_oauth2_1 = __importDefault(require("client-oauth2"));
+require("isomorphic-fetch");
 const child_process_1 = require("child_process");
 const express_1 = __importDefault(require("express"));
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const url_1 = require("../helpers/url");
 function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }) {
     // TODO: Handle endpointKey.
     const { authorizationUrl, tokenUrl, additionalParams, scopeDelimiter } = authDef;
     // Use the manifest's scopes as a default.
     const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
-    // ClientOAuth2 doesn't support a scope delimiter, so just hack a fake single pre-delimited scope
-    // if there's a custom delimiter involved.
-    const scopeArray = requestedScopes && scopeDelimiter && scopeDelimiter !== ' '
-        ? [requestedScopes.join(scopeDelimiter)]
-        : requestedScopes;
-    const oauth2Client = new client_oauth2_1.default({
-        clientId,
-        clientSecret,
-        authorizationUri: authorizationUrl,
-        accessTokenUri: tokenUrl,
-        scopes: scopeArray,
-        redirectUri: makeRedirectUrl(port),
-        query: additionalParams,
+    const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
+    const redirectUri = makeRedirectUrl(port);
+    const callback = async (code) => {
+        const params = {
+            grant_type: 'authorization_code',
+            code,
+            client_id: clientId,
+            client_secret: clientSecret,
+            redirect_uri: redirectUri,
+        };
+        const headers = new Headers({
+            'Content-Type': 'application/x-www-form-urlencoded',
+            accept: 'application/json',
+        });
+        const formParams = new URLSearchParams();
+        for (const [key, value] of Object.entries(params)) {
+            formParams.append(key, value.toString());
+        }
+        const oauthResponse = await fetch(tokenUrl, {
+            method: 'POST',
+            body: formParams,
+            headers,
+        });
+        if (!oauthResponse.ok) {
+            new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
+        }
+        const { access_token: accessToken, refresh_token: refreshToken, ...data } = await oauthResponse.json();
+        return { accessToken, refreshToken, data };
+    };
+    const serverContainer = new OAuthServerContainer(callback, afterTokenExchange, port);
+    const authorizationUri = (0, url_1.withQueryParams)(authorizationUrl, {
+        scope,
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        ...(additionalParams || {}),
     });
-    const serverContainer = new OAuthServerContainer(oauth2Client, afterTokenExchange, port);
     const launchCallback = () => {
-        const authUrl = oauth2Client.code.getUri();
         (0, helpers_2.print)(`OAuth server running at http://localhost:${port}.\n` +
-            `Complete the auth flow in your browser. If it does not open automatically, visit ${authUrl}`);
-        (0, child_process_1.exec)(`open "${authUrl}"`);
+            `Complete the auth flow in your browser. If it does not open automatically, visit ${authorizationUri}`);
+        (0, child_process_1.exec)(`open "${authorizationUri}"`);
     };
     serverContainer.start(launchCallback);
 }
@@ -43,20 +65,24 @@ function makeRedirectUrl(port) {
 }
 exports.makeRedirectUrl = makeRedirectUrl;
 class OAuthServerContainer {
-    constructor(oauth2Client, afterTokenExchange, port) {
+    constructor(tokenCallback, afterTokenExchange, port) {
+        this._tokenCallback = tokenCallback;
         this._port = port;
-        this._oauth2Client = oauth2Client;
         this._afterTokenExchange = afterTokenExchange;
     }
     start(launchCallback) {
         const app = (0, express_1.default)();
         app.get('/oauth', async (req, res) => {
-            const tokenData = await this._oauth2Client.code.getToken(req.originalUrl);
-            const { accessToken, refreshToken, data } = tokenData;
-            const expires = data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
-            this._afterTokenExchange({ accessToken, refreshToken, expires });
-            setTimeout(() => this.shutDown(), 10);
-            return res.send('OAuth authentication is complete! You can close this browser tab.');
+            const code = new URL(req.originalUrl, 'http://localhost').searchParams.get('code');
+            setTimeout(() => this.shutDown(), 1000);
+            if (code) {
+                const tokenData = await this._tokenCallback(code);
+                const { accessToken, refreshToken, data } = tokenData;
+                const expires = data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
+                this._afterTokenExchange({ accessToken, refreshToken, expires });
+                return res.send('OAuth authentication is complete! You can close this browser tab.');
+            }
+            return res.send(`Invalid authorization code received: ${code}`);
         });
         this._server = app.listen(this._port, launchCallback);
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/client-sts": "^3.45.0",
     "@aws-sdk/signature-v4": "^3.45.0",
     "browserify": "^17.0.0",
-    "client-oauth2": "^4.3.3",
     "clone": "^2.1.2",
     "es6-promise": "^4.2.8",
     "esbuild": "^0.14.10",

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -16,7 +16,7 @@ pack.setUserAuthentication({
   },
 
   async getConnectionName(context) {
-    const response = await context.fetcher!.fetch({
+    const response = await context.fetcher.fetch({
       method: 'GET',
       url: 'https://www.googleapis.com/oauth2/v2/userinfo',
       headers: {
@@ -33,7 +33,7 @@ pack.addFormula({
   parameters: [],
   resultType: coda.ValueType.String,
   execute: async ([], context) => {
-    const response = await context.fetcher!.fetch({
+    const response = await context.fetcher.fetch({
       method: 'GET',
       url: 'https://www.googleapis.com/oauth2/v2/userinfo',
       headers: {

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -2,6 +2,48 @@ import * as coda from '../..';
 
 export const pack = coda.newPack();
 
+pack.addNetworkDomain('googleapis.com');
+
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.OAuth2,
+  authorizationUrl: 'https://accounts.google.com/o/oauth2/auth',
+  tokenUrl: 'https://accounts.google.com/o/oauth2/token',
+  scopes: ['https://www.googleapis.com/auth/calendar', 'profile', 'email'],
+  additionalParams: {
+    access_type: 'offline',
+    prompt: 'consent select_account',
+    session: false,
+  },
+
+  async getConnectionName(context) {
+    const response = await context.fetcher!.fetch({
+      method: 'GET',
+      url: 'https://www.googleapis.com/oauth2/v2/userinfo',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.body.email;
+  },
+});
+
+pack.addFormula({
+  name: 'GoogleMe',
+  description: 'Me returned by google api',
+  parameters: [],
+  resultType: coda.ValueType.String,
+  execute: async ([], context) => {
+    const response = await context.fetcher!.fetch({
+      method: 'GET',
+      url: 'https://www.googleapis.com/oauth2/v2/userinfo',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.body.email;
+  },
+});
+
 const fakePersonSchema = coda.makeObjectSchema({
   type: coda.ValueType.Object,
   primary: 'name',

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1,0 +1,3 @@
+export enum HttpStatusCode {
+  Unauthorized = 401,
+}

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -4,7 +4,6 @@ import type {Credentials as AWSCredentials} from '@aws-sdk/types';
 import {AssumeRoleCommand} from '@aws-sdk/client-sts';
 import type {Authentication} from '../types';
 import {AuthenticationType} from '../types';
-import ClientOAuth2 from 'client-oauth2';
 import type {Credentials} from './auth_types';
 import type {CustomCredentials} from './auth_types';
 import type {ExecutionContext} from '../api';
@@ -208,22 +207,42 @@ export class AuthenticatingFetcher implements Fetcher {
     const {clientId, clientSecret, accessToken, refreshToken, scopes} = this._credentials as OAuth2Credentials;
     assertCondition(accessToken);
     assertCondition(refreshToken);
-    const {authorizationUrl, tokenUrl, additionalParams} = this._authDef;
-    const oauth2Client = new ClientOAuth2({
-      clientId,
-      clientSecret,
-      authorizationUri: authorizationUrl,
-      accessTokenUri: tokenUrl,
-      scopes,
-      query: additionalParams,
+    const {tokenUrl} = this._authDef;
+
+    const params = {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+    };
+
+    const headers = new Headers({
+      'Content-Type': 'application/x-www-form-urlencoded',
+      accept: 'application/json',
     });
-    const oauthToken = oauth2Client.createToken(accessToken, refreshToken, {});
-    const refreshedToken = await oauthToken.refresh();
+
+    const formParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      formParams.append(key, value.toString());
+    }
+
+    const oauthResponse = await fetch(tokenUrl, {
+      method: 'POST',
+      body: formParams,
+      headers,
+    });
+
+    if (!oauthResponse.ok) {
+      new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
+    }
+
+    const {access_token: newAccessToken, refresh_token: newRefreshToken, ...data} = await oauthResponse.json();
+
     const newCredentials: Credentials = {
       ...this._credentials,
-      accessToken: refreshedToken.accessToken,
-      refreshToken: refreshedToken.refreshToken,
-      expires: getExpirationDate(Number(refreshedToken.data.expires_in)).toString(),
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken || refreshToken,
+      expires: getExpirationDate(Number(data.expires_in)).toString(),
       scopes,
     };
     this._credentials = newCredentials;

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,11 +624,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@servie/events@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@servie/events/-/events-1.0.0.tgz"
-  integrity sha512-sBSO19KzdrJCM3gdx6eIxV8M9Gxfgg6iDQmH5TIAGaUu+X9VDdsINXJOnoiZ1Kx3TrHdH4bt5UVglkjsEGBcvw==
-
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz"
@@ -885,11 +880,6 @@
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
-
-"@types/tough-cookie@^2.3.5":
-  version "2.3.7"
-  resolved "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.7.tgz"
-  integrity sha512-rMQbgMGxnLsdn8e9aPVyuN+zMQLrZ2QW8xlv7eWS1mydfGXN+tsTKffcIzd8rGCcLdmi3xvQw2MDaZI1bBNTaw==
 
 "@types/uglify-js@^3.13.1":
   version "3.13.1"
@@ -1444,11 +1434,6 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-byte-length@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz"
-  integrity sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q==
-
 bytes@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
@@ -1529,14 +1514,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-client-oauth2@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.3.tgz"
-  integrity sha512-k8AvUYJon0vv75ufoVo4nALYb/qwFFicO3I0+39C6xEdflqVtr+f9cy+0ZxAduoVSTfhP5DX2tY2XICAd5hy6Q==
-  dependencies:
-    popsicle "^12.0.5"
-    safe-buffer "^5.2.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -2767,11 +2744,6 @@ insert-module-globals@^7.2.1:
     undeclared-identifiers "^1.1.2"
     xtend "^4.0.0"
 
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
-  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
@@ -3124,14 +3096,7 @@ lunr@^2.3.9:
   resolved "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
-make-error-cause@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/make-error-cause/-/make-error-cause-2.3.0.tgz"
-  integrity sha512-etgt+n4LlOkGSJbBTV9VROHA5R7ekIPS4vfh+bCAoJgRrJWdqJCBbpS3osRJ/HrT7R68MzMiY3L3sDJ/Fd8aBg==
-  dependencies:
-    make-error "^1.3.5"
-
-make-error@^1.1.1, make-error@^1.3.5:
+make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -3569,55 +3534,6 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-popsicle-content-encoding@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz"
-  integrity sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==
-
-popsicle-cookie-jar@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/popsicle-cookie-jar/-/popsicle-cookie-jar-1.0.0.tgz"
-  integrity sha512-vrlOGvNVELko0+J8NpGC5lHWDGrk8LQJq9nwAMIVEVBfN1Lib3BLxAaLRGDTuUnvl45j5N9dT2H85PULz6IjjQ==
-  dependencies:
-    "@types/tough-cookie" "^2.3.5"
-    tough-cookie "^3.0.1"
-
-popsicle-redirects@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.0.tgz"
-  integrity sha512-XCpzVjVk7tty+IJnSdqWevmOr1n8HNDhL86v7mZ6T1JIIf2KGybxUk9mm7ZFOhWMkGB0e8XkacHip7BV8AQWQA==
-
-popsicle-transport-http@^1.0.8:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/popsicle-transport-http/-/popsicle-transport-http-1.1.4.tgz"
-  integrity sha512-HyFa/ZCcObP+H7T5b6d0I6ANBvrMEnjZeglopFhBi1uxEZ95qtX8GZDKU6JSMhf+iiNhxnGPZ/OJ2Q4FnH66LQ==
-  dependencies:
-    make-error-cause "^2.2.0"
-
-popsicle-transport-xhr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz"
-  integrity sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA==
-
-popsicle-user-agent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz"
-  integrity sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==
-
-popsicle@^12.0.5:
-  version "12.1.0"
-  resolved "https://registry.npmjs.org/popsicle/-/popsicle-12.1.0.tgz"
-  integrity sha512-muNC/cIrWhfR6HqqhHazkxjob3eyECBe8uZYSQ/N5vixNAgssacVleerXnE8Are5fspR0a+d2qWaBR1g7RYlmw==
-  dependencies:
-    popsicle-content-encoding "^1.0.0"
-    popsicle-cookie-jar "^1.0.0"
-    popsicle-redirects "^1.1.0"
-    popsicle-transport-http "^1.0.8"
-    popsicle-transport-xhr "^2.0.0"
-    popsicle-user-agent "^1.0.0"
-    servie "^4.3.3"
-    throwback "^4.1.0"
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -3956,15 +3872,6 @@ serve-static@1.14.2:
     parseurl "~1.3.3"
     send "0.17.2"
 
-servie@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/servie/-/servie-4.3.3.tgz"
-  integrity sha512-b0IrY3b1gVMsWvJppCf19g1p3JSnS0hQi6xu4Hi40CIhf0Lx8pQHcvBL+xunShpmOiQzg1NOia812NAWdSaShw==
-  dependencies:
-    "@servie/events" "^1.0.0"
-    byte-length "^1.0.2"
-    ts-expect "^1.1.0"
-
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
@@ -4232,11 +4139,6 @@ through@~2.2.7:
   resolved "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
   integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
 
-throwback@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/throwback/-/throwback-4.1.0.tgz"
-  integrity sha512-dLFe8bU8SeH0xeqeKL7BNo8XoPC/o91nz9/ooeplZPiso+DZukhoyZcSz9TFnUNScm+cA9qjU1m1853M6sPOng==
-
 timers-browserify@^1.0.1:
   version "1.4.2"
   resolved "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
@@ -4264,26 +4166,12 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tough-cookie@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz"
-  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
-  dependencies:
-    ip-regex "^2.1.0"
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz"
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
-
-ts-expect@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/ts-expect/-/ts-expect-1.3.0.tgz"
-  integrity sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ==
 
 ts-loader@^9.2.6:
   version "9.2.6"


### PR DESCRIPTION
according to https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/My-Issues_sud-l#My-issues_tui9H/r20745&modal=true, client-oauth2 doesn't work for some oauth providers since it passes client secret via headers. 

this PR replaces client-oauth2 with direct requests to oauth providers (logic dup'ed from the packs-auth service). 

tested by 
- todoist pack
- fake_v2 pack with google auth. 
- force injecting a refresh and make sure it works. 