### PR TITLE
Fix reference home page

### DIFF
--- a/dist/documentation/typedoc_post_process.js
+++ b/dist/documentation/typedoc_post_process.js
@@ -60,7 +60,7 @@ async function addFrontmatter(file) {
         return;
     }
     const title = match[1];
-    const frontmatter = `---\ntitle: ${title}\n---\n`;
+    const frontmatter = `---\ntitle: "${title}"\n---\n`;
     return fs.promises.writeFile(file, frontmatter + content);
 }
 main().catch(helpers_1.print);

--- a/docs/reference/sdk/README.md
+++ b/docs/reference/sdk/README.md
@@ -1,7 +1,7 @@
 ---
-title: @codahq/packs-sdk
+title: "Pack SDK Reference"
 ---
-# @codahq/packs-sdk
+# Pack SDK Reference
 
 ## Enumerations
 

--- a/docs/reference/sdk/classes/PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/PackDefinitionBuilder.md
@@ -1,5 +1,5 @@
 ---
-title: PackDefinitionBuilder
+title: "PackDefinitionBuilder"
 ---
 # Class: PackDefinitionBuilder
 

--- a/docs/reference/sdk/classes/StatusCodeError.md
+++ b/docs/reference/sdk/classes/StatusCodeError.md
@@ -1,5 +1,5 @@
 ---
-title: StatusCodeError
+title: "StatusCodeError"
 ---
 # Class: StatusCodeError
 

--- a/docs/reference/sdk/classes/UserVisibleError.md
+++ b/docs/reference/sdk/classes/UserVisibleError.md
@@ -1,5 +1,5 @@
 ---
-title: UserVisibleError
+title: "UserVisibleError"
 ---
 # Class: UserVisibleError
 

--- a/docs/reference/sdk/enums/AttributionNodeType.md
+++ b/docs/reference/sdk/enums/AttributionNodeType.md
@@ -1,5 +1,5 @@
 ---
-title: AttributionNodeType
+title: "AttributionNodeType"
 ---
 # Enumeration: AttributionNodeType
 

--- a/docs/reference/sdk/enums/AuthenticationType.md
+++ b/docs/reference/sdk/enums/AuthenticationType.md
@@ -1,5 +1,5 @@
 ---
-title: AuthenticationType
+title: "AuthenticationType"
 ---
 # Enumeration: AuthenticationType
 

--- a/docs/reference/sdk/enums/ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/ConnectionRequirement.md
@@ -1,5 +1,5 @@
 ---
-title: ConnectionRequirement
+title: "ConnectionRequirement"
 ---
 # Enumeration: ConnectionRequirement
 

--- a/docs/reference/sdk/enums/CurrencyFormat.md
+++ b/docs/reference/sdk/enums/CurrencyFormat.md
@@ -1,5 +1,5 @@
 ---
-title: CurrencyFormat
+title: "CurrencyFormat"
 ---
 # Enumeration: CurrencyFormat
 

--- a/docs/reference/sdk/enums/DefaultConnectionType.md
+++ b/docs/reference/sdk/enums/DefaultConnectionType.md
@@ -1,5 +1,5 @@
 ---
-title: DefaultConnectionType
+title: "DefaultConnectionType"
 ---
 # Enumeration: DefaultConnectionType
 

--- a/docs/reference/sdk/enums/DurationUnit.md
+++ b/docs/reference/sdk/enums/DurationUnit.md
@@ -1,5 +1,5 @@
 ---
-title: DurationUnit
+title: "DurationUnit"
 ---
 # Enumeration: DurationUnit
 

--- a/docs/reference/sdk/enums/NetworkConnection.md
+++ b/docs/reference/sdk/enums/NetworkConnection.md
@@ -1,5 +1,5 @@
 ---
-title: NetworkConnection
+title: "NetworkConnection"
 ---
 # Enumeration: NetworkConnection
 

--- a/docs/reference/sdk/enums/ParameterType.md
+++ b/docs/reference/sdk/enums/ParameterType.md
@@ -1,5 +1,5 @@
 ---
-title: ParameterType
+title: "ParameterType"
 ---
 # Enumeration: ParameterType
 

--- a/docs/reference/sdk/enums/PostSetupType.md
+++ b/docs/reference/sdk/enums/PostSetupType.md
@@ -1,5 +1,5 @@
 ---
-title: PostSetupType
+title: "PostSetupType"
 ---
 # Enumeration: PostSetupType
 

--- a/docs/reference/sdk/enums/PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/PrecannedDateRange.md
@@ -1,5 +1,5 @@
 ---
-title: PrecannedDateRange
+title: "PrecannedDateRange"
 ---
 # Enumeration: PrecannedDateRange
 

--- a/docs/reference/sdk/enums/ScaleIconSet.md
+++ b/docs/reference/sdk/enums/ScaleIconSet.md
@@ -1,5 +1,5 @@
 ---
-title: ScaleIconSet
+title: "ScaleIconSet"
 ---
 # Enumeration: ScaleIconSet
 

--- a/docs/reference/sdk/enums/Type.md
+++ b/docs/reference/sdk/enums/Type.md
@@ -1,5 +1,5 @@
 ---
-title: Type
+title: "Type"
 ---
 # Enumeration: Type
 

--- a/docs/reference/sdk/enums/ValueHintType.md
+++ b/docs/reference/sdk/enums/ValueHintType.md
@@ -1,5 +1,5 @@
 ---
-title: ValueHintType
+title: "ValueHintType"
 ---
 # Enumeration: ValueHintType
 

--- a/docs/reference/sdk/enums/ValueType.md
+++ b/docs/reference/sdk/enums/ValueType.md
@@ -1,5 +1,5 @@
 ---
-title: ValueType
+title: "ValueType"
 ---
 # Enumeration: ValueType
 

--- a/docs/reference/sdk/functions/assertCondition.md
+++ b/docs/reference/sdk/functions/assertCondition.md
@@ -1,5 +1,5 @@
 ---
-title: assertCondition
+title: "assertCondition"
 ---
 # Function: assertCondition
 

--- a/docs/reference/sdk/functions/autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/autocompleteSearchObjects.md
@@ -1,5 +1,5 @@
 ---
-title: autocompleteSearchObjects
+title: "autocompleteSearchObjects"
 ---
 # Function: autocompleteSearchObjects
 

--- a/docs/reference/sdk/functions/ensureExists.md
+++ b/docs/reference/sdk/functions/ensureExists.md
@@ -1,5 +1,5 @@
 ---
-title: ensureExists
+title: "ensureExists"
 ---
 # Function: ensureExists
 

--- a/docs/reference/sdk/functions/ensureNonEmptyString.md
+++ b/docs/reference/sdk/functions/ensureNonEmptyString.md
@@ -1,5 +1,5 @@
 ---
-title: ensureNonEmptyString
+title: "ensureNonEmptyString"
 ---
 # Function: ensureNonEmptyString
 

--- a/docs/reference/sdk/functions/ensureUnreachable.md
+++ b/docs/reference/sdk/functions/ensureUnreachable.md
@@ -1,5 +1,5 @@
 ---
-title: ensureUnreachable
+title: "ensureUnreachable"
 ---
 # Function: ensureUnreachable
 

--- a/docs/reference/sdk/functions/generateSchema.md
+++ b/docs/reference/sdk/functions/generateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: generateSchema
+title: "generateSchema"
 ---
 # Function: generateSchema
 

--- a/docs/reference/sdk/functions/getQueryParams.md
+++ b/docs/reference/sdk/functions/getQueryParams.md
@@ -1,5 +1,5 @@
 ---
-title: getQueryParams
+title: "getQueryParams"
 ---
 # Function: getQueryParams
 

--- a/docs/reference/sdk/functions/joinUrl.md
+++ b/docs/reference/sdk/functions/joinUrl.md
@@ -1,5 +1,5 @@
 ---
-title: joinUrl
+title: "joinUrl"
 ---
 # Function: joinUrl
 

--- a/docs/reference/sdk/functions/makeAttributionNode.md
+++ b/docs/reference/sdk/functions/makeAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: makeAttributionNode
+title: "makeAttributionNode"
 ---
 # Function: makeAttributionNode
 

--- a/docs/reference/sdk/functions/makeDynamicSyncTable.md
+++ b/docs/reference/sdk/functions/makeDynamicSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: makeDynamicSyncTable
+title: "makeDynamicSyncTable"
 ---
 # Function: makeDynamicSyncTable
 

--- a/docs/reference/sdk/functions/makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/makeEmptyFormula.md
@@ -1,5 +1,5 @@
 ---
-title: makeEmptyFormula
+title: "makeEmptyFormula"
 ---
 # Function: makeEmptyFormula
 

--- a/docs/reference/sdk/functions/makeFormula.md
+++ b/docs/reference/sdk/functions/makeFormula.md
@@ -1,5 +1,5 @@
 ---
-title: makeFormula
+title: "makeFormula"
 ---
 # Function: makeFormula
 

--- a/docs/reference/sdk/functions/makeMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeMetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: makeMetadataFormula
+title: "makeMetadataFormula"
 ---
 # Function: makeMetadataFormula
 

--- a/docs/reference/sdk/functions/makeObjectSchema.md
+++ b/docs/reference/sdk/functions/makeObjectSchema.md
@@ -1,5 +1,5 @@
 ---
-title: makeObjectSchema
+title: "makeObjectSchema"
 ---
 # Function: makeObjectSchema
 

--- a/docs/reference/sdk/functions/makeParameter.md
+++ b/docs/reference/sdk/functions/makeParameter.md
@@ -1,5 +1,5 @@
 ---
-title: makeParameter
+title: "makeParameter"
 ---
 # Function: makeParameter
 

--- a/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
@@ -1,5 +1,5 @@
 ---
-title: makeReferenceSchemaFromObjectSchema
+title: "makeReferenceSchemaFromObjectSchema"
 ---
 # Function: makeReferenceSchemaFromObjectSchema
 

--- a/docs/reference/sdk/functions/makeSchema.md
+++ b/docs/reference/sdk/functions/makeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: makeSchema
+title: "makeSchema"
 ---
 # Function: makeSchema
 

--- a/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/makeSimpleAutocompleteMetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: makeSimpleAutocompleteMetadataFormula
+title: "makeSimpleAutocompleteMetadataFormula"
 ---
 # Function: makeSimpleAutocompleteMetadataFormula
 

--- a/docs/reference/sdk/functions/makeSyncTable.md
+++ b/docs/reference/sdk/functions/makeSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: makeSyncTable
+title: "makeSyncTable"
 ---
 # Function: makeSyncTable
 

--- a/docs/reference/sdk/functions/makeTranslateObjectFormula.md
+++ b/docs/reference/sdk/functions/makeTranslateObjectFormula.md
@@ -1,5 +1,5 @@
 ---
-title: makeTranslateObjectFormula
+title: "makeTranslateObjectFormula"
 ---
 # Function: makeTranslateObjectFormula
 

--- a/docs/reference/sdk/functions/newPack.md
+++ b/docs/reference/sdk/functions/newPack.md
@@ -1,5 +1,5 @@
 ---
-title: newPack
+title: "newPack"
 ---
 # Function: newPack
 

--- a/docs/reference/sdk/functions/simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/simpleAutocomplete.md
@@ -1,5 +1,5 @@
 ---
-title: simpleAutocomplete
+title: "simpleAutocomplete"
 ---
 # Function: simpleAutocomplete
 

--- a/docs/reference/sdk/functions/withQueryParams.md
+++ b/docs/reference/sdk/functions/withQueryParams.md
@@ -1,5 +1,5 @@
 ---
-title: withQueryParams
+title: "withQueryParams"
 ---
 # Function: withQueryParams
 

--- a/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: AWSAccessKeyAuthentication
+title: "AWSAccessKeyAuthentication"
 ---
 # Interface: AWSAccessKeyAuthentication
 

--- a/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: AWSAssumeRoleAuthentication
+title: "AWSAssumeRoleAuthentication"
 ---
 # Interface: AWSAssumeRoleAuthentication
 

--- a/docs/reference/sdk/interfaces/ArraySchema.md
+++ b/docs/reference/sdk/interfaces/ArraySchema.md
@@ -1,5 +1,5 @@
 ---
-title: ArraySchema
+title: "ArraySchema"
 ---
 # Interface: ArraySchema<T\>
 

--- a/docs/reference/sdk/interfaces/ArrayType.md
+++ b/docs/reference/sdk/interfaces/ArrayType.md
@@ -1,5 +1,5 @@
 ---
-title: ArrayType
+title: "ArrayType"
 ---
 # Interface: ArrayType<T\>
 

--- a/docs/reference/sdk/interfaces/BaseAuthentication.md
+++ b/docs/reference/sdk/interfaces/BaseAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: BaseAuthentication
+title: "BaseAuthentication"
 ---
 # Interface: BaseAuthentication
 

--- a/docs/reference/sdk/interfaces/BaseFormulaDef.md
+++ b/docs/reference/sdk/interfaces/BaseFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: BaseFormulaDef
+title: "BaseFormulaDef"
 ---
 # Interface: BaseFormulaDef<ParamDefsT, ResultT\>
 

--- a/docs/reference/sdk/interfaces/BooleanSchema.md
+++ b/docs/reference/sdk/interfaces/BooleanSchema.md
@@ -1,5 +1,5 @@
 ---
-title: BooleanSchema
+title: "BooleanSchema"
 ---
 # Interface: BooleanSchema
 

--- a/docs/reference/sdk/interfaces/CodaApiBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/CodaApiBearerTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: CodaApiBearerTokenAuthentication
+title: "CodaApiBearerTokenAuthentication"
 ---
 # Interface: CodaApiBearerTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/Continuation.md
+++ b/docs/reference/sdk/interfaces/Continuation.md
@@ -1,5 +1,5 @@
 ---
-title: Continuation
+title: "Continuation"
 ---
 # Interface: Continuation
 

--- a/docs/reference/sdk/interfaces/CurrencySchema.md
+++ b/docs/reference/sdk/interfaces/CurrencySchema.md
@@ -1,5 +1,5 @@
 ---
-title: CurrencySchema
+title: "CurrencySchema"
 ---
 # Interface: CurrencySchema
 

--- a/docs/reference/sdk/interfaces/CustomAuthParameter.md
+++ b/docs/reference/sdk/interfaces/CustomAuthParameter.md
@@ -1,5 +1,5 @@
 ---
-title: CustomAuthParameter
+title: "CustomAuthParameter"
 ---
 # Interface: CustomAuthParameter
 

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: CustomAuthentication
+title: "CustomAuthentication"
 ---
 # Interface: CustomAuthentication
 

--- a/docs/reference/sdk/interfaces/CustomHeaderTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomHeaderTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: CustomHeaderTokenAuthentication
+title: "CustomHeaderTokenAuthentication"
 ---
 # Interface: CustomHeaderTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/DurationSchema.md
+++ b/docs/reference/sdk/interfaces/DurationSchema.md
@@ -1,5 +1,5 @@
 ---
-title: DurationSchema
+title: "DurationSchema"
 ---
 # Interface: DurationSchema
 

--- a/docs/reference/sdk/interfaces/DynamicOptions.md
+++ b/docs/reference/sdk/interfaces/DynamicOptions.md
@@ -1,5 +1,5 @@
 ---
-title: DynamicOptions
+title: "DynamicOptions"
 ---
 # Interface: DynamicOptions
 

--- a/docs/reference/sdk/interfaces/DynamicSyncTableDef.md
+++ b/docs/reference/sdk/interfaces/DynamicSyncTableDef.md
@@ -1,5 +1,5 @@
 ---
-title: DynamicSyncTableDef
+title: "DynamicSyncTableDef"
 ---
 # Interface: DynamicSyncTableDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/DynamicSyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/DynamicSyncTableOptions.md
@@ -1,5 +1,5 @@
 ---
-title: DynamicSyncTableOptions
+title: "DynamicSyncTableOptions"
 ---
 # Interface: DynamicSyncTableOptions<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/EmptyFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: EmptyFormulaDef
+title: "EmptyFormulaDef"
 ---
 # Interface: EmptyFormulaDef<ParamsT\>
 

--- a/docs/reference/sdk/interfaces/ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/ExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: ExecutionContext
+title: "ExecutionContext"
 ---
 # Interface: ExecutionContext
 

--- a/docs/reference/sdk/interfaces/FetchRequest.md
+++ b/docs/reference/sdk/interfaces/FetchRequest.md
@@ -1,5 +1,5 @@
 ---
-title: FetchRequest
+title: "FetchRequest"
 ---
 # Interface: FetchRequest
 

--- a/docs/reference/sdk/interfaces/FetchResponse.md
+++ b/docs/reference/sdk/interfaces/FetchResponse.md
@@ -1,5 +1,5 @@
 ---
-title: FetchResponse
+title: "FetchResponse"
 ---
 # Interface: FetchResponse<T\>
 

--- a/docs/reference/sdk/interfaces/Fetcher.md
+++ b/docs/reference/sdk/interfaces/Fetcher.md
@@ -1,5 +1,5 @@
 ---
-title: Fetcher
+title: "Fetcher"
 ---
 # Interface: Fetcher
 

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -1,5 +1,5 @@
 ---
-title: Format
+title: "Format"
 ---
 # Interface: Format
 

--- a/docs/reference/sdk/interfaces/HeaderBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/HeaderBearerTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: HeaderBearerTokenAuthentication
+title: "HeaderBearerTokenAuthentication"
 ---
 # Interface: HeaderBearerTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/Identity.md
+++ b/docs/reference/sdk/interfaces/Identity.md
@@ -1,5 +1,5 @@
 ---
-title: Identity
+title: "Identity"
 ---
 # Interface: Identity
 

--- a/docs/reference/sdk/interfaces/IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/IdentityDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: IdentityDefinition
+title: "IdentityDefinition"
 ---
 # Interface: IdentityDefinition
 

--- a/docs/reference/sdk/interfaces/ImageAttributionNode.md
+++ b/docs/reference/sdk/interfaces/ImageAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: ImageAttributionNode
+title: "ImageAttributionNode"
 ---
 # Interface: ImageAttributionNode
 

--- a/docs/reference/sdk/interfaces/InvocationLocation.md
+++ b/docs/reference/sdk/interfaces/InvocationLocation.md
@@ -1,5 +1,5 @@
 ---
-title: InvocationLocation
+title: "InvocationLocation"
 ---
 # Interface: InvocationLocation
 

--- a/docs/reference/sdk/interfaces/LinkAttributionNode.md
+++ b/docs/reference/sdk/interfaces/LinkAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: LinkAttributionNode
+title: "LinkAttributionNode"
 ---
 # Interface: LinkAttributionNode
 

--- a/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/MetadataFormulaObjectResultType.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataFormulaObjectResultType
+title: "MetadataFormulaObjectResultType"
 ---
 # Interface: MetadataFormulaObjectResultType
 

--- a/docs/reference/sdk/interfaces/MultiQueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/MultiQueryParamTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: MultiQueryParamTokenAuthentication
+title: "MultiQueryParamTokenAuthentication"
 ---
 # Interface: MultiQueryParamTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/Network.md
+++ b/docs/reference/sdk/interfaces/Network.md
@@ -1,5 +1,5 @@
 ---
-title: Network
+title: "Network"
 ---
 # Interface: Network
 

--- a/docs/reference/sdk/interfaces/NoAuthentication.md
+++ b/docs/reference/sdk/interfaces/NoAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: NoAuthentication
+title: "NoAuthentication"
 ---
 # Interface: NoAuthentication
 

--- a/docs/reference/sdk/interfaces/NumericDateSchema.md
+++ b/docs/reference/sdk/interfaces/NumericDateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: NumericDateSchema
+title: "NumericDateSchema"
 ---
 # Interface: NumericDateSchema
 

--- a/docs/reference/sdk/interfaces/NumericDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/NumericDateTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: NumericDateTimeSchema
+title: "NumericDateTimeSchema"
 ---
 # Interface: NumericDateTimeSchema
 

--- a/docs/reference/sdk/interfaces/NumericSchema.md
+++ b/docs/reference/sdk/interfaces/NumericSchema.md
@@ -1,5 +1,5 @@
 ---
-title: NumericSchema
+title: "NumericSchema"
 ---
 # Interface: NumericSchema
 

--- a/docs/reference/sdk/interfaces/NumericTimeSchema.md
+++ b/docs/reference/sdk/interfaces/NumericTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: NumericTimeSchema
+title: "NumericTimeSchema"
 ---
 # Interface: NumericTimeSchema
 

--- a/docs/reference/sdk/interfaces/OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/OAuth2Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: OAuth2Authentication
+title: "OAuth2Authentication"
 ---
 # Interface: OAuth2Authentication
 

--- a/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/ObjectArrayFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectArrayFormulaDef
+title: "ObjectArrayFormulaDef"
 ---
 # Interface: ObjectArrayFormulaDef<ParamsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/ObjectSchemaDefinition.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectSchemaDefinition
+title: "ObjectSchemaDefinition"
 ---
 # Interface: ObjectSchemaDefinition<K, L\>
 

--- a/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectSchemaProperty
+title: "ObjectSchemaProperty"
 ---
 # Interface: ObjectSchemaProperty
 

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: PackDefinition
+title: "PackDefinition"
 ---
 # Interface: PackDefinition
 

--- a/docs/reference/sdk/interfaces/PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/PackFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: PackFormulaDef
+title: "PackFormulaDef"
 ---
 # Interface: PackFormulaDef<ParamsT, ResultT\>
 

--- a/docs/reference/sdk/interfaces/PackFormulas.md
+++ b/docs/reference/sdk/interfaces/PackFormulas.md
@@ -1,5 +1,5 @@
 ---
-title: PackFormulas
+title: "PackFormulas"
 ---
 # Interface: PackFormulas
 

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: PackVersionDefinition
+title: "PackVersionDefinition"
 ---
 # Interface: PackVersionDefinition
 

--- a/docs/reference/sdk/interfaces/ParamDef.md
+++ b/docs/reference/sdk/interfaces/ParamDef.md
@@ -1,5 +1,5 @@
 ---
-title: ParamDef
+title: "ParamDef"
 ---
 # Interface: ParamDef<T\>
 

--- a/docs/reference/sdk/interfaces/QueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/QueryParamTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: QueryParamTokenAuthentication
+title: "QueryParamTokenAuthentication"
 ---
 # Interface: QueryParamTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/RequestHandlerTemplate.md
@@ -1,5 +1,5 @@
 ---
-title: RequestHandlerTemplate
+title: "RequestHandlerTemplate"
 ---
 # Interface: RequestHandlerTemplate
 

--- a/docs/reference/sdk/interfaces/ResponseHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/ResponseHandlerTemplate.md
@@ -1,5 +1,5 @@
 ---
-title: ResponseHandlerTemplate
+title: "ResponseHandlerTemplate"
 ---
 # Interface: ResponseHandlerTemplate<T\>
 

--- a/docs/reference/sdk/interfaces/ScaleSchema.md
+++ b/docs/reference/sdk/interfaces/ScaleSchema.md
@@ -1,5 +1,5 @@
 ---
-title: ScaleSchema
+title: "ScaleSchema"
 ---
 # Interface: ScaleSchema
 

--- a/docs/reference/sdk/interfaces/SetEndpoint.md
+++ b/docs/reference/sdk/interfaces/SetEndpoint.md
@@ -1,5 +1,5 @@
 ---
-title: SetEndpoint
+title: "SetEndpoint"
 ---
 # Interface: SetEndpoint
 

--- a/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
+++ b/docs/reference/sdk/interfaces/SimpleAutocompleteOption.md
@@ -1,5 +1,5 @@
 ---
-title: SimpleAutocompleteOption
+title: "SimpleAutocompleteOption"
 ---
 # Interface: SimpleAutocompleteOption<T\>
 

--- a/docs/reference/sdk/interfaces/SimpleStringSchema.md
+++ b/docs/reference/sdk/interfaces/SimpleStringSchema.md
@@ -1,5 +1,5 @@
 ---
-title: SimpleStringSchema
+title: "SimpleStringSchema"
 ---
 # Interface: SimpleStringSchema<T\>
 

--- a/docs/reference/sdk/interfaces/SliderSchema.md
+++ b/docs/reference/sdk/interfaces/SliderSchema.md
@@ -1,5 +1,5 @@
 ---
-title: SliderSchema
+title: "SliderSchema"
 ---
 # Interface: SliderSchema
 

--- a/docs/reference/sdk/interfaces/StatusCodeErrorResponse.md
+++ b/docs/reference/sdk/interfaces/StatusCodeErrorResponse.md
@@ -1,5 +1,5 @@
 ---
-title: StatusCodeErrorResponse
+title: "StatusCodeErrorResponse"
 ---
 # Interface: StatusCodeErrorResponse
 

--- a/docs/reference/sdk/interfaces/StringDateSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: StringDateSchema
+title: "StringDateSchema"
 ---
 # Interface: StringDateSchema
 

--- a/docs/reference/sdk/interfaces/StringDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: StringDateTimeSchema
+title: "StringDateTimeSchema"
 ---
 # Interface: StringDateTimeSchema
 

--- a/docs/reference/sdk/interfaces/StringTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: StringTimeSchema
+title: "StringTimeSchema"
 ---
 # Interface: StringTimeSchema
 

--- a/docs/reference/sdk/interfaces/Sync.md
+++ b/docs/reference/sdk/interfaces/Sync.md
@@ -1,5 +1,5 @@
 ---
-title: Sync
+title: "Sync"
 ---
 # Interface: Sync
 

--- a/docs/reference/sdk/interfaces/SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/SyncExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: SyncExecutionContext
+title: "SyncExecutionContext"
 ---
 # Interface: SyncExecutionContext
 

--- a/docs/reference/sdk/interfaces/SyncFormulaDef.md
+++ b/docs/reference/sdk/interfaces/SyncFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: SyncFormulaDef
+title: "SyncFormulaDef"
 ---
 # Interface: SyncFormulaDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/SyncFormulaResult.md
+++ b/docs/reference/sdk/interfaces/SyncFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: SyncFormulaResult
+title: "SyncFormulaResult"
 ---
 # Interface: SyncFormulaResult<K, L, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/SyncTableDef.md
+++ b/docs/reference/sdk/interfaces/SyncTableDef.md
@@ -1,5 +1,5 @@
 ---
-title: SyncTableDef
+title: "SyncTableDef"
 ---
 # Interface: SyncTableDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/SyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/SyncTableOptions.md
@@ -1,5 +1,5 @@
 ---
-title: SyncTableOptions
+title: "SyncTableOptions"
 ---
 # Interface: SyncTableOptions<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/TemporaryBlobStorage.md
@@ -1,5 +1,5 @@
 ---
-title: TemporaryBlobStorage
+title: "TemporaryBlobStorage"
 ---
 # Interface: TemporaryBlobStorage
 

--- a/docs/reference/sdk/interfaces/TextAttributionNode.md
+++ b/docs/reference/sdk/interfaces/TextAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: TextAttributionNode
+title: "TextAttributionNode"
 ---
 # Interface: TextAttributionNode
 

--- a/docs/reference/sdk/interfaces/VariousAuthentication.md
+++ b/docs/reference/sdk/interfaces/VariousAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: VariousAuthentication
+title: "VariousAuthentication"
 ---
 # Interface: VariousAuthentication
 

--- a/docs/reference/sdk/interfaces/WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/WebBasicAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: WebBasicAuthentication
+title: "WebBasicAuthentication"
 ---
 # Interface: WebBasicAuthentication
 

--- a/docs/reference/sdk/types/ArrayFormulaDef.md
+++ b/docs/reference/sdk/types/ArrayFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: ArrayFormulaDef
+title: "ArrayFormulaDef"
 ---
 # Type alias: ArrayFormulaDef<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/AttributionNode.md
+++ b/docs/reference/sdk/types/AttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: AttributionNode
+title: "AttributionNode"
 ---
 # Type alias: AttributionNode
 

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+title: "Authentication"
 ---
 # Type alias: Authentication
 

--- a/docs/reference/sdk/types/BaseFormula.md
+++ b/docs/reference/sdk/types/BaseFormula.md
@@ -1,5 +1,5 @@
 ---
-title: BaseFormula
+title: "BaseFormula"
 ---
 # Type alias: BaseFormula<ParamDefsT, ResultT\>
 

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: BasicPackDefinition
+title: "BasicPackDefinition"
 ---
 # Type alias: BasicPackDefinition
 

--- a/docs/reference/sdk/types/BooleanFormulaDef.md
+++ b/docs/reference/sdk/types/BooleanFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: BooleanFormulaDef
+title: "BooleanFormulaDef"
 ---
 # Type alias: BooleanFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/BooleanPackFormula.md
+++ b/docs/reference/sdk/types/BooleanPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: BooleanPackFormula
+title: "BooleanPackFormula"
 ---
 # Type alias: BooleanPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/DefaultValueType.md
+++ b/docs/reference/sdk/types/DefaultValueType.md
@@ -1,5 +1,5 @@
 ---
-title: DefaultValueType
+title: "DefaultValueType"
 ---
 # Type alias: DefaultValueType<T\>
 

--- a/docs/reference/sdk/types/FetchMethodType.md
+++ b/docs/reference/sdk/types/FetchMethodType.md
@@ -1,5 +1,5 @@
 ---
-title: FetchMethodType
+title: "FetchMethodType"
 ---
 # Type alias: FetchMethodType
 

--- a/docs/reference/sdk/types/Formula.md
+++ b/docs/reference/sdk/types/Formula.md
@@ -1,5 +1,5 @@
 ---
-title: Formula
+title: "Formula"
 ---
 # Type alias: Formula<ParamDefsT, ResultT, SchemaT\>
 

--- a/docs/reference/sdk/types/FormulaDefinition.md
+++ b/docs/reference/sdk/types/FormulaDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: FormulaDefinition
+title: "FormulaDefinition"
 ---
 # Type alias: FormulaDefinition<ParamDefsT, ResultT, SchemaT\>
 

--- a/docs/reference/sdk/types/GenericDynamicSyncTable.md
+++ b/docs/reference/sdk/types/GenericDynamicSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: GenericDynamicSyncTable
+title: "GenericDynamicSyncTable"
 ---
 # Type alias: GenericDynamicSyncTable
 

--- a/docs/reference/sdk/types/GenericSyncFormula.md
+++ b/docs/reference/sdk/types/GenericSyncFormula.md
@@ -1,5 +1,5 @@
 ---
-title: GenericSyncFormula
+title: "GenericSyncFormula"
 ---
 # Type alias: GenericSyncFormula
 

--- a/docs/reference/sdk/types/GenericSyncFormulaResult.md
+++ b/docs/reference/sdk/types/GenericSyncFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: GenericSyncFormulaResult
+title: "GenericSyncFormulaResult"
 ---
 # Type alias: GenericSyncFormulaResult
 

--- a/docs/reference/sdk/types/GenericSyncTable.md
+++ b/docs/reference/sdk/types/GenericSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: GenericSyncTable
+title: "GenericSyncTable"
 ---
 # Type alias: GenericSyncTable
 

--- a/docs/reference/sdk/types/InferrableTypes.md
+++ b/docs/reference/sdk/types/InferrableTypes.md
@@ -1,5 +1,5 @@
 ---
-title: InferrableTypes
+title: "InferrableTypes"
 ---
 # Type alias: InferrableTypes
 

--- a/docs/reference/sdk/types/MetadataContext.md
+++ b/docs/reference/sdk/types/MetadataContext.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataContext
+title: "MetadataContext"
 ---
 # Type alias: MetadataContext
 

--- a/docs/reference/sdk/types/MetadataFormula.md
+++ b/docs/reference/sdk/types/MetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataFormula
+title: "MetadataFormula"
 ---
 # Type alias: MetadataFormula
 

--- a/docs/reference/sdk/types/MetadataFormulaDef.md
+++ b/docs/reference/sdk/types/MetadataFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataFormulaDef
+title: "MetadataFormulaDef"
 ---
 # Type alias: MetadataFormulaDef
 

--- a/docs/reference/sdk/types/MetadataFormulaResultType.md
+++ b/docs/reference/sdk/types/MetadataFormulaResultType.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataFormulaResultType
+title: "MetadataFormulaResultType"
 ---
 # Type alias: MetadataFormulaResultType
 

--- a/docs/reference/sdk/types/MetadataFunction.md
+++ b/docs/reference/sdk/types/MetadataFunction.md
@@ -1,5 +1,5 @@
 ---
-title: MetadataFunction
+title: "MetadataFunction"
 ---
 # Type alias: MetadataFunction
 

--- a/docs/reference/sdk/types/NumberHintTypes.md
+++ b/docs/reference/sdk/types/NumberHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: NumberHintTypes
+title: "NumberHintTypes"
 ---
 # Type alias: NumberHintTypes
 

--- a/docs/reference/sdk/types/NumberSchema.md
+++ b/docs/reference/sdk/types/NumberSchema.md
@@ -1,5 +1,5 @@
 ---
-title: NumberSchema
+title: "NumberSchema"
 ---
 # Type alias: NumberSchema
 

--- a/docs/reference/sdk/types/NumericFormulaDef.md
+++ b/docs/reference/sdk/types/NumericFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: NumericFormulaDef
+title: "NumericFormulaDef"
 ---
 # Type alias: NumericFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/NumericPackFormula.md
+++ b/docs/reference/sdk/types/NumericPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: NumericPackFormula
+title: "NumericPackFormula"
 ---
 # Type alias: NumericPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/ObjectFormulaDef.md
+++ b/docs/reference/sdk/types/ObjectFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectFormulaDef
+title: "ObjectFormulaDef"
 ---
 # Type alias: ObjectFormulaDef<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/ObjectHintTypes.md
+++ b/docs/reference/sdk/types/ObjectHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectHintTypes
+title: "ObjectHintTypes"
 ---
 # Type alias: ObjectHintTypes
 

--- a/docs/reference/sdk/types/ObjectPackFormula.md
+++ b/docs/reference/sdk/types/ObjectPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectPackFormula
+title: "ObjectPackFormula"
 ---
 # Type alias: ObjectPackFormula<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/ObjectSchemaProperties.md
@@ -1,5 +1,5 @@
 ---
-title: ObjectSchemaProperties
+title: "ObjectSchemaProperties"
 ---
 # Type alias: ObjectSchemaProperties<K\>
 

--- a/docs/reference/sdk/types/PackFormulaResult.md
+++ b/docs/reference/sdk/types/PackFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: PackFormulaResult
+title: "PackFormulaResult"
 ---
 # Type alias: PackFormulaResult
 

--- a/docs/reference/sdk/types/PackFormulaValue.md
+++ b/docs/reference/sdk/types/PackFormulaValue.md
@@ -1,5 +1,5 @@
 ---
-title: PackFormulaValue
+title: "PackFormulaValue"
 ---
 # Type alias: PackFormulaValue
 

--- a/docs/reference/sdk/types/PackId.md
+++ b/docs/reference/sdk/types/PackId.md
@@ -1,5 +1,5 @@
 ---
-title: PackId
+title: "PackId"
 ---
 # Type alias: PackId
 

--- a/docs/reference/sdk/types/ParamDefs.md
+++ b/docs/reference/sdk/types/ParamDefs.md
@@ -1,5 +1,5 @@
 ---
-title: ParamDefs
+title: "ParamDefs"
 ---
 # Type alias: ParamDefs
 

--- a/docs/reference/sdk/types/ParamValues.md
+++ b/docs/reference/sdk/types/ParamValues.md
@@ -1,5 +1,5 @@
 ---
-title: ParamValues
+title: "ParamValues"
 ---
 # Type alias: ParamValues<ParamDefsT\>
 

--- a/docs/reference/sdk/types/ParameterOptions.md
+++ b/docs/reference/sdk/types/ParameterOptions.md
@@ -1,5 +1,5 @@
 ---
-title: ParameterOptions
+title: "ParameterOptions"
 ---
 # Type alias: ParameterOptions<T\>
 

--- a/docs/reference/sdk/types/PostSetup.md
+++ b/docs/reference/sdk/types/PostSetup.md
@@ -1,5 +1,5 @@
 ---
-title: PostSetup
+title: "PostSetup"
 ---
 # Type alias: PostSetup
 

--- a/docs/reference/sdk/types/PostSetupDef.md
+++ b/docs/reference/sdk/types/PostSetupDef.md
@@ -1,5 +1,5 @@
 ---
-title: PostSetupDef
+title: "PostSetupDef"
 ---
 # Type alias: PostSetupDef
 

--- a/docs/reference/sdk/types/Schema.md
+++ b/docs/reference/sdk/types/Schema.md
@@ -1,5 +1,5 @@
 ---
-title: Schema
+title: "Schema"
 ---
 # Type alias: Schema
 

--- a/docs/reference/sdk/types/SchemaType.md
+++ b/docs/reference/sdk/types/SchemaType.md
@@ -1,5 +1,5 @@
 ---
-title: SchemaType
+title: "SchemaType"
 ---
 # Type alias: SchemaType<T\>
 

--- a/docs/reference/sdk/types/SetEndpointDef.md
+++ b/docs/reference/sdk/types/SetEndpointDef.md
@@ -1,5 +1,5 @@
 ---
-title: SetEndpointDef
+title: "SetEndpointDef"
 ---
 # Type alias: SetEndpointDef
 

--- a/docs/reference/sdk/types/StringFormulaDef.md
+++ b/docs/reference/sdk/types/StringFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: StringFormulaDef
+title: "StringFormulaDef"
 ---
 # Type alias: StringFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/StringHintTypes.md
+++ b/docs/reference/sdk/types/StringHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: StringHintTypes
+title: "StringHintTypes"
 ---
 # Type alias: StringHintTypes
 

--- a/docs/reference/sdk/types/StringPackFormula.md
+++ b/docs/reference/sdk/types/StringPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: StringPackFormula
+title: "StringPackFormula"
 ---
 # Type alias: StringPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/StringSchema.md
+++ b/docs/reference/sdk/types/StringSchema.md
@@ -1,5 +1,5 @@
 ---
-title: StringSchema
+title: "StringSchema"
 ---
 # Type alias: StringSchema
 

--- a/docs/reference/sdk/types/SyncFormula.md
+++ b/docs/reference/sdk/types/SyncFormula.md
@@ -1,5 +1,5 @@
 ---
-title: SyncFormula
+title: "SyncFormula"
 ---
 # Type alias: SyncFormula<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/SyncTable.md
+++ b/docs/reference/sdk/types/SyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: SyncTable
+title: "SyncTable"
 ---
 # Type alias: SyncTable
 

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: SystemAuthentication
+title: "SystemAuthentication"
 ---
 # Type alias: SystemAuthentication
 

--- a/docs/reference/sdk/types/SystemAuthenticationDef.md
+++ b/docs/reference/sdk/types/SystemAuthenticationDef.md
@@ -1,5 +1,5 @@
 ---
-title: SystemAuthenticationDef
+title: "SystemAuthenticationDef"
 ---
 # Type alias: SystemAuthenticationDef
 

--- a/docs/reference/sdk/types/TypedPackFormula.md
+++ b/docs/reference/sdk/types/TypedPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: TypedPackFormula
+title: "TypedPackFormula"
 ---
 # Type alias: TypedPackFormula
 

--- a/docs/reference/sdk/variables/ValidFetchMethods.md
+++ b/docs/reference/sdk/variables/ValidFetchMethods.md
@@ -1,5 +1,5 @@
 ---
-title: ValidFetchMethods
+title: "ValidFetchMethods"
 ---
 # Variable: ValidFetchMethods
 

--- a/documentation/typedoc_post_process.ts
+++ b/documentation/typedoc_post_process.ts
@@ -40,7 +40,7 @@ async function addFrontmatter(file: string): Promise<void> {
     return;
   }
   const title = match![1];
-  const frontmatter = `---\ntitle: ${title}\n---\n`;
+  const frontmatter = `---\ntitle: "${title}"\n---\n`;
   return fs.promises.writeFile(file, frontmatter + content);
 }
 

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,6 +1,7 @@
 // Typedoc settings.
 // See: https://typedoc.org/guides/options/
 module.exports = {
+  name: "Pack SDK Reference",
   excludeExternals: true,
   excludePrivate: true,
   excludeProtected: true,


### PR DESCRIPTION
Adds quotes around the title frontmatter to fix issue with it rendering incorrectly on the homepage of the ref docs. Also updates the title of that page to be more user friendly.