### PR TITLE
Update documentation on type formatting

### DIFF
--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -15,15 +15,26 @@ The core, underlying type of a value is referred to as its value type. The enume
 
 For a formula the value type is specified in the `resultType` property, and for schemas it's specified in the `type` property. The type specified must match the type of the value returned by your code.
 
-```ts
-pack.addFormula({
-  // ...
-  resultType: coda.ValueType.String,
-  execute: async function ([], context) {
-    return "This is a string";
-  },
-});
-```
+=== "Formula"
+
+    ```ts
+    pack.addFormula({
+      // ...
+      resultType: coda.ValueType.String,
+      execute: async function ([], context) {
+        return "This is a string";
+      },
+    });
+    ```
+
+=== "Schema"
+
+    ```ts
+    const MySchema = coda.makeSchema({
+      type: coda.ValueType.String,
+      // ...
+    });
+    ```
 
 [View all types][ValueType]{ .md-button }
 
@@ -218,17 +229,35 @@ The columns of a Coda table are strongly typed, and the data types in the Pack S
 
 ## Formatting options
 
-When used in a sync table, some value types and value hints support additional formatting options. For example, `Number` types support a [`precision`][precision] property that controls how many decimal places to show.
+Some value types and hints support additional formatting options. For example, `Number` types support a [`precision`][precision] option that controls how many decimal places to show, and `Currency` supports a `currencyCode` option that determine the currency symbol to show. These options are set in a schema, and for a formula result this may meaning adding a `schema` property to the formula definition.
 
-```ts
-const DoorSchema = coda.makeObjectSchema({
-  properties: {
-    heightInMeters: {type: coda.ValueType.Number, precision: 3},
-    // ...
-  },
-  // ...
-});
-```
+=== "Formula"
+
+    ```ts
+    pack.addFormula({
+      name: "GetPrice",
+      // ...
+      resultType: coda.ValueType.Number,
+      schema: {
+        type: coda.ValueType.Number,
+        codaType: coda.ValueHintType.Currency,
+        currencyCode: "EUR",
+        precision: 2,
+      },
+      // ...
+    });
+    ```
+
+=== "Schema"
+
+    ```ts
+    const PriceSchema = coda.makeSchema({
+      type: coda.ValueType.Number,
+      codaType: coda.ValueHintType.Currency,
+      currencyCode: "EUR",
+      precision: 2,
+    });
+    ```
 
 The full set of formatting options for a given value type and hint can be found in the corresponding schema definition.
 
@@ -247,8 +276,6 @@ The full set of formatting options for a given value type and hint can be found 
 | `String` or `Number` | `DateTime` | [`StringDateTimeSchema`][StringDateTimeSchema]   |
 | `String`             | `Duration` | [`DurationSchema`][DurationSchema]               |
 
-!!! warning
-    Formatting options currently only work correctly within a sync table column. When used outside of a sync table, or when viewed within a chip, the formatting is ignored.
 
 
 [samples]: ../../samples/topic/data-type.md

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -229,7 +229,7 @@ The columns of a Coda table are strongly typed, and the data types in the Pack S
 
 ## Formatting options
 
-Some value types and hints support additional formatting options. For example, `Number` types support a [`precision`][precision] option that controls how many decimal places to show, and `Currency` supports a `currencyCode` option that determine the currency symbol to show. These options are set in a schema, and for a formula result this may meaning adding a `schema` property to the formula definition.
+Some value types and hints support additional formatting options. For example, `Number` types support a [`precision`][precision] option that controls how many decimal places to show, and `Currency` supports a [`currencyCode`][currencyCode] option that determine the currency symbol to show. These options are set in a schema, and for a formula result this may meaning adding a `schema` property to the formula definition.
 
 === "Formula"
 
@@ -310,7 +310,8 @@ The full set of formatting options for a given value type and hint can be found 
 [embed_force]: https://help.coda.io/en/articles/1211364-embedding-content-in-your-doc#using-the-force-parameter
 [column_formats]: https://help.coda.io/en/articles/1235680-overview-of-column-formats
 [actions]: ../blocks/actions.md
-[precision]: ../../reference/sdk/interfaces/NumericSchema.md/#precision
+[precision]: ../../reference/sdk/interfaces/NumericSchema.md#precision
+[currencyCode]: ../../reference/sdk/interfaces/CurrencySchema.md#currencycode
 [NumericSchema]: ../../reference/sdk/interfaces/NumericSchema.md
 [CurrencySchema]: ../../reference/sdk/interfaces/CurrencySchema.md
 [SliderSchema]: ../../reference/sdk/interfaces/SliderSchema.md


### PR DESCRIPTION
Remove the warning about them not working outside of sync tables, and improve some of the examples.