### PR TITLE
Tag all Pack version uploads from CLI as PackSource.Cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.0
 
 - **Breaking Change** The connection requirement for metadata formulas now defaults to optional instead of required. If your pack is using sematic versions, this will likely lead to a major version bump in your next release.
+- **Breaking Change** Updated `coda upload` to use new parameters to tag the source of Pack version uploads as coming from the CLI.
 - An optional "description" field is added to sync table definition, that will be used to display in the UI.
 - You no longer need to use the `--fetch` flag with `coda execute` to use a real fetcher. Set `--no-fetch` to use a mock fetcher (the old default behavior).
 - OAuth2 authentication now supports a `scopeDelimiter` option for non-compliant APIs that use something other than a space to delimit OAuth scopes in authorization URLs.

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -2,6 +2,7 @@ import type {Arguments} from 'yargs';
 import type {Logger} from '../api_types';
 import type {PackUpload} from '../compiled_types';
 import type {PackVersionDefinition} from '..';
+import {PublicApiPackSource} from '../helpers/external-api/v1';
 import type {PublicApiPackVersionUploadInfo} from '../helpers/external-api/v1';
 import type {TimerShimStrategy} from '../testing/compile';
 import {compilePackBundle} from '../testing/compile';
@@ -154,7 +155,7 @@ export async function handleUpload({
 
     logger.info('Validating upload...');
     try {
-      await client.packVersionUploadComplete(packId, packVersion, {}, {notes});
+      await client.packVersionUploadComplete(packId, packVersion, {}, {notes, source: PublicApiPackSource.Cli});
     } catch (err: any) {
       if (isResponseError(err)) {
         printAndExit(`Error while finalizing pack version: ${await formatResponseError(err)}`);

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -23,6 +23,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleUpload = void 0;
+const v1_1 = require("../helpers/external-api/v1");
 const compile_1 = require("../testing/compile");
 const metadata_1 = require("../helpers/metadata");
 const crypto_1 = require("../helpers/crypto");
@@ -131,7 +132,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         await uploadPack(uploadUrl, uploadPayload, headers);
         logger.info('Validating upload...');
         try {
-            await client.packVersionUploadComplete(packId, packVersion, {}, { notes });
+            await client.packVersionUploadComplete(packId, packVersion, {}, { notes, source: v1_1.PublicApiPackSource.Cli });
         }
         catch (err) {
             if ((0, coda_1.isResponseError)(err)) {

--- a/dist/helpers/external-api/coda.d.ts
+++ b/dist/helpers/external-api/coda.d.ts
@@ -3,7 +3,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: 3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d
+ * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
  */
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
@@ -57,7 +57,9 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiTableList>;
-    getTable(docId: string, tableIdOrName: string, params?: {}): Promise<types.PublicApiTable>;
+    getTable(docId: string, tableIdOrName: string, params?: {
+        useUpdatedTableLayouts?: boolean;
+    }): Promise<types.PublicApiTable>;
     listColumns(docId: string, tableIdOrName: string, params?: {
         visibleOnly?: boolean;
         limit?: number;
@@ -177,14 +179,25 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackListingList>;
-    getPackListing(packId: number, params?: {}): Promise<types.PublicApiPackListingDetail>;
+    getPackListing(packId: number, params?: {
+        workspaceId?: string;
+    }): Promise<types.PublicApiPackListingDetail>;
     listPackLogs(packId: number, docId: string, params?: {
         logTypes?: string;
         beforeTimestamp?: string;
         afterTimestamp?: string;
         order?: string;
         q?: string;
+        requestIds?: string;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackLogsList>;
+    listGroupedPackLogs(packId: number, docId: string, params?: {
+        beforeTimestamp?: string;
+        afterTimestamp?: string;
+        order?: string;
+        q?: string;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiGroupedPackLogsList>;
 }

--- a/dist/helpers/external-api/coda.js
+++ b/dist/helpers/external-api/coda.js
@@ -5,7 +5,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: 3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d
+ * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Client = exports.isResponseError = exports.ResponseError = void 0;
@@ -543,6 +543,14 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/logs`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listGroupedPackLogs(packId, docId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/groupedLogs`, pageToken ? { pageToken } : rest);
         return this._makeRequest('GET', codaUrl);
     }
 }

--- a/dist/helpers/external-api/v1.d.ts
+++ b/dist/helpers/external-api/v1.d.ts
@@ -1,8 +1,8 @@
 /**
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
-export declare const OpenApiSpecHash = "3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d";
-export declare const OpenApiSpecVersion = "1.2.1";
+export declare const OpenApiSpecHash = "e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c";
+export declare const OpenApiSpecVersion = "1.2.3";
 /**
  * A constant identifying the type of the resource.
  */
@@ -527,6 +527,8 @@ export declare enum PublicApiLayout {
     BubbleChart = "bubbleChart",
     Calendar = "calendar",
     Card = "card",
+    Detail = "detail",
+    Form = "form",
     GanttChart = "ganttChart",
     LineChart = "lineChart",
     MasterDetail = "masterDetail",
@@ -956,6 +958,7 @@ export declare enum PublicApiColumnFormatType {
     Select = "select",
     PackObject = "packObject",
     Reaction = "reaction",
+    Canvas = "canvas",
     Other = "other"
 }
 /**
@@ -1535,6 +1538,10 @@ export interface PublicApiPublishingCategory {
      * The name of the category.
      */
     categoryName: string;
+    /**
+     * The URL identifier of the category.
+     */
+    categorySlug: string;
 }
 /**
  * Info about the maker
@@ -2236,6 +2243,10 @@ export interface PublicApiPackReleaseList {
     nextPageToken?: PublicApiNextPageToken;
     nextPageLink?: PublicApiNextPageLink & string;
 }
+export declare enum PublicApiPackSource {
+    Web = "web",
+    Cli = "cli"
+}
 /**
  * Information indicating where to upload the Pack source code, and an endpoint to mark the upload as complete.
  */
@@ -2322,6 +2333,10 @@ export interface PublicApiPackListing {
      * Publishing Categories associated with this Pack.
      */
     categories: PublicApiPublishingCategory[];
+    /**
+     * Makers associated with this Pack.
+     */
+    makers: PublicApiMakerSummary[];
     minimumFeatureSet?: PublicApiFeatureSet;
     unrestrictedFeatureSet?: PublicApiFeatureSet;
     /**
@@ -2369,6 +2384,10 @@ export interface PublicApiPackListingDetail {
      * Publishing Categories associated with this Pack.
      */
     categories: PublicApiPublishingCategory[];
+    /**
+     * Makers associated with this Pack.
+     */
+    makers: PublicApiMakerSummary[];
     minimumFeatureSet?: PublicApiFeatureSet;
     unrestrictedFeatureSet?: PublicApiFeatureSet;
     /**
@@ -2380,10 +2399,6 @@ export interface PublicApiPackListingDetail {
      */
     releaseId?: number;
     discoverability: PublicApiPackDiscoverability;
-    /**
-     * Makers associated with this Pack.
-     */
-    makers: PublicApiMakerSummary[];
     /**
      * The access capabilities the current user has for this Pack.
      */
@@ -2405,7 +2420,7 @@ export interface PublicApiPackListingList {
 /**
  * Metadata of a Pack system connection.
  */
-export declare type PublicApiPackSystemConnectionMetadata = PublicApiPackConnectionHeaderMetadata | PublicApiPackConnectionUrlParamMetadata | PublicApiPackConnectionHttpBasicMetadata;
+export declare type PublicApiPackSystemConnectionMetadata = PublicApiPackConnectionHeaderMetadata | PublicApiPackConnectionUrlParamMetadata | PublicApiPackConnectionHttpBasicMetadata | PublicApiPackConnectionCustomMetadata;
 /**
  * The Pack OAuth configuration metadata.
  */
@@ -2476,12 +2491,13 @@ export interface PublicApiGetNextPackVersionRequest {
 export declare enum PublicApiPackConnectionType {
     Header = "header",
     UrlParam = "urlParam",
-    HttpBasic = "httpBasic"
+    HttpBasic = "httpBasic",
+    Custom = "custom"
 }
 /**
  * Credentials of a Pack connection.
  */
-export declare type PublicApiPackSystemConnectionCredentials = PublicApiPackConnectionHeaderCredentials | PublicApiPackConnectionUrlParamCredentials | PublicApiPackConnectionHttpBasicCredentials;
+export declare type PublicApiPackSystemConnectionCredentials = PublicApiPackConnectionHeaderCredentials | PublicApiPackConnectionUrlParamCredentials | PublicApiPackConnectionHttpBasicCredentials | PublicApiPackConnectionCustomCredentials;
 export interface PublicApiPackConnectionHeaderMetadata {
     type: PublicApiPackConnectionType.Header;
     maskedToken?: string;
@@ -2502,6 +2518,24 @@ export interface PublicApiPackConnectionHttpBasicMetadata {
     maskedUsername?: string;
     maskedPassword?: string;
 }
+export interface PublicApiPackConnectionCustomMetadata {
+    type: PublicApiPackConnectionType.Custom;
+    /**
+     * An array of objects containing the parameter key and masked value.
+     */
+    params: {
+        key: string;
+        maskedValue: string;
+    }[];
+    /**
+     * The domain corresponding to the pre-authorized network domain in the pack.
+     */
+    domain: string;
+    /**
+     * An array containing the keys of parameters specified by the authentication config.
+     */
+    presetKeys: string[];
+}
 export interface PublicApiPackConnectionHeaderCredentials {
     type: PublicApiPackConnectionType.Header;
     token: string;
@@ -2517,6 +2551,13 @@ export interface PublicApiPackConnectionHttpBasicCredentials {
     type: PublicApiPackConnectionType.HttpBasic;
     username: string;
     password?: string;
+}
+export interface PublicApiPackConnectionCustomCredentials {
+    type: PublicApiPackConnectionType.Custom;
+    params: {
+        key: string;
+        value: string;
+    }[];
 }
 export interface PublicApiPackConnectionHeaderPatch {
     type: PublicApiPackConnectionType.Header;
@@ -2535,6 +2576,25 @@ export interface PublicApiPackConnectionHttpBasicPatch {
     password?: string;
 }
 /**
+ * List of grouped Pack logs.
+ */
+export interface PublicApiGroupedPackLogsList {
+    items: PublicApiGroupedPackLog[];
+    nextPageToken?: PublicApiNextPageToken;
+    nextPageLink?: PublicApiNextPageLink & string;
+    /**
+     * This flag will be set to true if the result doens't include all the related logs.
+     */
+    incompleteRelatedLogs: boolean;
+}
+export interface PublicApiPackConnectionCustomPatch {
+    type: PublicApiPackConnectionType.Custom;
+    paramsToPatch?: {
+        key: string;
+        value: string;
+    }[];
+}
+/**
  * List of Pack logs.
  */
 export interface PublicApiPackLogsList {
@@ -2542,6 +2602,10 @@ export interface PublicApiPackLogsList {
     nextPageToken?: PublicApiNextPageToken;
     nextPageLink?: PublicApiNextPageLink & string;
 }
+/**
+ * A record of grouped Pack log.
+ */
+export declare type PublicApiGroupedPackLog = PublicApiGroupedPackInvocationLog | PublicApiPackAuthLog;
 /**
  * A record of Pack log.
  */
@@ -2570,6 +2634,30 @@ export interface PublicApiPackLogContext {
      * Unique identifier of this log record.
      */
     logId: string;
+    /**
+     * Doc canvas object id where the formula was fired from.
+     */
+    docObjectId?: string;
+    /**
+     * Doc canvas row id where the formula was fired from.
+     */
+    docRowId?: string;
+    /**
+     * Doc canvas column id where the formula was fired from.
+     */
+    docColumnId?: string;
+    /**
+     * True if this is an execution of a sync table which received a pagination parameter.
+     */
+    isContinuedSyncTable?: boolean;
+    /**
+     * If this formula invocation was for a parameter auto-complete, this names the parameter.
+     */
+    autocompleteParameterName?: string;
+    /**
+     * If this formula was invoked by something other than a user action, this should say what that was.
+     */
+    invocationSource?: string;
 }
 /**
  * Pack log generated by developer's custom logging with context.logger.
@@ -2590,11 +2678,28 @@ export interface PublicApiPackInvocationLog {
     type: PublicApiPackLogType.Invocation;
     context: PublicApiPackLogContext;
     /**
+     * True if the formula returned a prior result without executing.
+     */
+    cacheHit?: boolean;
+    /**
+     * Duration of the formula exeuction in miliseconds.
+     */
+    duration?: number;
+    /**
      * Error info if this invocation resulted in an error.
      */
     error?: {
         message: string;
+        stack?: string;
     };
+}
+/**
+ * Grouped logs ofthe invocations of the Pack.
+ */
+export interface PublicApiGroupedPackInvocationLog {
+    type: PublicApiPackLogType.Invocation;
+    invocationLog: PublicApiPackInvocationLog;
+    relatedLogs: PublicApiPackLog[];
 }
 /**
  * System logs of Pack calls to context.fetcher.
@@ -2693,7 +2798,7 @@ export declare enum PublicApiFeatureSet {
 /**
  * The request to patch pack system connection credentials.
  */
-export declare type PublicApiPatchPackSystemConnectionRequest = PublicApiPackConnectionHeaderPatch | PublicApiPackConnectionUrlParamPatch | PublicApiPackConnectionHttpBasicPatch;
+export declare type PublicApiPatchPackSystemConnectionRequest = PublicApiPackConnectionHeaderPatch | PublicApiPackConnectionUrlParamPatch | PublicApiPackConnectionHttpBasicPatch | PublicApiPackConnectionCustomPatch;
 /**
  * Request to set the Pack OAuth configuration.
  */
@@ -2894,6 +2999,10 @@ export interface PublicApiPackAssetUploadCompleteResponse {
  */
 export interface PublicApiPackSourceCodeUploadCompleteRequest {
     filename: string;
+    /**
+     * A SHA-256 hash of the source code used to identify duplicate uploads.
+     */
+    codeHash: string;
 }
 /**
  * Response for noting a Pack source code upload is complete.
@@ -2912,6 +3021,7 @@ export interface PublicApiCreatePackVersionRequest {
      * Developer notes of the new Pack version.
      */
     notes?: string;
+    source?: PublicApiPackSource;
     [k: string]: unknown;
 }
 /**

--- a/dist/helpers/external-api/v1.js
+++ b/dist/helpers/external-api/v1.js
@@ -3,10 +3,10 @@
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PublicApiFeatureSet = exports.PublicApiLogLevel = exports.PublicApiPackLogType = exports.PublicApiPackLogRequestType = exports.PublicApiPackConnectionType = exports.PublicApiPackDiscoverability = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPacksSortBy = exports.PublicApiDocAnalyticsScale = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
+exports.PublicApiFeatureSet = exports.PublicApiLogLevel = exports.PublicApiPackLogType = exports.PublicApiPackLogRequestType = exports.PublicApiPackConnectionType = exports.PublicApiPackDiscoverability = exports.PublicApiPackSource = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPacksSortBy = exports.PublicApiDocAnalyticsScale = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
 /* eslint-disable */
-exports.OpenApiSpecHash = '3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d';
-exports.OpenApiSpecVersion = '1.2.1';
+exports.OpenApiSpecHash = 'e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c';
+exports.OpenApiSpecVersion = '1.2.3';
 /**
  * A constant identifying the type of the resource.
  */
@@ -78,6 +78,8 @@ var PublicApiLayout;
     PublicApiLayout["BubbleChart"] = "bubbleChart";
     PublicApiLayout["Calendar"] = "calendar";
     PublicApiLayout["Card"] = "card";
+    PublicApiLayout["Detail"] = "detail";
+    PublicApiLayout["Form"] = "form";
     PublicApiLayout["GanttChart"] = "ganttChart";
     PublicApiLayout["LineChart"] = "lineChart";
     PublicApiLayout["MasterDetail"] = "masterDetail";
@@ -173,6 +175,7 @@ var PublicApiColumnFormatType;
     PublicApiColumnFormatType["Select"] = "select";
     PublicApiColumnFormatType["PackObject"] = "packObject";
     PublicApiColumnFormatType["Reaction"] = "reaction";
+    PublicApiColumnFormatType["Canvas"] = "canvas";
     PublicApiColumnFormatType["Other"] = "other";
 })(PublicApiColumnFormatType = exports.PublicApiColumnFormatType || (exports.PublicApiColumnFormatType = {}));
 /**
@@ -285,6 +288,11 @@ var PublicApiPackAssetType;
     PublicApiPackAssetType["Cover"] = "cover";
     PublicApiPackAssetType["ExampleImage"] = "exampleImage";
 })(PublicApiPackAssetType = exports.PublicApiPackAssetType || (exports.PublicApiPackAssetType = {}));
+var PublicApiPackSource;
+(function (PublicApiPackSource) {
+    PublicApiPackSource["Web"] = "web";
+    PublicApiPackSource["Cli"] = "cli";
+})(PublicApiPackSource = exports.PublicApiPackSource || (exports.PublicApiPackSource = {}));
 /**
  * Widest principal a Pack is available to.
  */
@@ -302,6 +310,7 @@ var PublicApiPackConnectionType;
     PublicApiPackConnectionType["Header"] = "header";
     PublicApiPackConnectionType["UrlParam"] = "urlParam";
     PublicApiPackConnectionType["HttpBasic"] = "httpBasic";
+    PublicApiPackConnectionType["Custom"] = "custom";
 })(PublicApiPackConnectionType = exports.PublicApiPackConnectionType || (exports.PublicApiPackConnectionType = {}));
 /**
  * The context request type where a Pack log is generated.

--- a/helpers/external-api/coda.ts
+++ b/helpers/external-api/coda.ts
@@ -4,13 +4,13 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: 3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d
+ * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
  */
 
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
-import {withQueryParams} from '../url';
-import * as types from './v1';
+import {withQueryParams} from '@kr-modules/js-core/utils/url';
+import * as types from '@kr-modules/common/external-api/gen-types/v1';
 
 export class ResponseError extends Error {
   response: Response;
@@ -236,7 +236,13 @@ export class Client {
     return this._makeRequest('GET', codaUrl);
   }
 
-  async getTable(docId: string, tableIdOrName: string, params: {} = {}): Promise<types.PublicApiTable> {
+  async getTable(
+    docId: string,
+    tableIdOrName: string,
+    params: {
+      useUpdatedTableLayouts?: boolean;
+    } = {},
+  ): Promise<types.PublicApiTable> {
     const allParams = {
       ...params,
     };
@@ -985,7 +991,12 @@ export class Client {
     return this._makeRequest('GET', codaUrl);
   }
 
-  async getPackListing(packId: number, params: {} = {}): Promise<types.PublicApiPackListingDetail> {
+  async getPackListing(
+    packId: number,
+    params: {
+      workspaceId?: string;
+    } = {},
+  ): Promise<types.PublicApiPackListingDetail> {
     const allParams = {
       ...params,
     };
@@ -1002,6 +1013,7 @@ export class Client {
       afterTimestamp?: string;
       order?: string;
       q?: string;
+      requestIds?: string;
       limit?: number;
       pageToken?: string;
     } = {},
@@ -1012,6 +1024,29 @@ export class Client {
     const {pageToken, ...rest} = allParams;
     const codaUrl = withQueryParams(
       `${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/logs`,
+      pageToken ? {pageToken} : rest,
+    );
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listGroupedPackLogs(
+    packId: number,
+    docId: string,
+    params: {
+      beforeTimestamp?: string;
+      afterTimestamp?: string;
+      order?: string;
+      q?: string;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiGroupedPackLogsList> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/groupedLogs`,
       pageToken ? {pageToken} : rest,
     );
     return this._makeRequest('GET', codaUrl);

--- a/helpers/external-api/coda.ts
+++ b/helpers/external-api/coda.ts
@@ -9,8 +9,8 @@
 
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
-import {withQueryParams} from '@kr-modules/js-core/utils/url';
-import * as types from '@kr-modules/common/external-api/gen-types/v1';
+import {withQueryParams} from '../url';
+import * as types from './v1';
 
 export class ResponseError extends Error {
   response: Response;

--- a/helpers/external-api/v1.ts
+++ b/helpers/external-api/v1.ts
@@ -4,9 +4,9 @@
 
 /* eslint-disable */
 
-export const OpenApiSpecHash = '3aa501d45272807675d21bf05be9126605ebf1b875aca82ff56b077a3111af4d';
+export const OpenApiSpecHash = 'e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c';
 
-export const OpenApiSpecVersion = '1.2.1';
+export const OpenApiSpecVersion = '1.2.3';
 
 /**
  * A constant identifying the type of the resource.
@@ -560,6 +560,8 @@ export enum PublicApiLayout {
   BubbleChart = 'bubbleChart',
   Calendar = 'calendar',
   Card = 'card',
+  Detail = 'detail',
+  Form = 'form',
   GanttChart = 'ganttChart',
   LineChart = 'lineChart',
   MasterDetail = 'masterDetail',
@@ -1030,6 +1032,7 @@ export enum PublicApiColumnFormatType {
   Select = 'select',
   PackObject = 'packObject',
   Reaction = 'reaction',
+  Canvas = 'canvas',
   Other = 'other',
 }
 
@@ -1658,6 +1661,10 @@ export interface PublicApiPublishingCategory {
    * The name of the category.
    */
   categoryName: string;
+  /**
+   * The URL identifier of the category.
+   */
+  categorySlug: string;
 }
 
 /**
@@ -2407,6 +2414,11 @@ export interface PublicApiPackReleaseList {
   nextPageLink?: PublicApiNextPageLink & string;
 }
 
+export enum PublicApiPackSource {
+  Web = 'web',
+  Cli = 'cli',
+}
+
 /**
  * Information indicating where to upload the Pack source code, and an endpoint to mark the upload as complete.
  */
@@ -2497,6 +2509,10 @@ export interface PublicApiPackListing {
    * Publishing Categories associated with this Pack.
    */
   categories: PublicApiPublishingCategory[];
+  /**
+   * Makers associated with this Pack.
+   */
+  makers: PublicApiMakerSummary[];
   minimumFeatureSet?: PublicApiFeatureSet;
   unrestrictedFeatureSet?: PublicApiFeatureSet;
   /**
@@ -2545,6 +2561,10 @@ export interface PublicApiPackListingDetail {
    * Publishing Categories associated with this Pack.
    */
   categories: PublicApiPublishingCategory[];
+  /**
+   * Makers associated with this Pack.
+   */
+  makers: PublicApiMakerSummary[];
   minimumFeatureSet?: PublicApiFeatureSet;
   unrestrictedFeatureSet?: PublicApiFeatureSet;
   /**
@@ -2556,10 +2576,6 @@ export interface PublicApiPackListingDetail {
    */
   releaseId?: number;
   discoverability: PublicApiPackDiscoverability;
-  /**
-   * Makers associated with this Pack.
-   */
-  makers: PublicApiMakerSummary[];
   /**
    * The access capabilities the current user has for this Pack.
    */
@@ -2586,7 +2602,8 @@ export interface PublicApiPackListingList {
 export type PublicApiPackSystemConnectionMetadata =
   | PublicApiPackConnectionHeaderMetadata
   | PublicApiPackConnectionUrlParamMetadata
-  | PublicApiPackConnectionHttpBasicMetadata;
+  | PublicApiPackConnectionHttpBasicMetadata
+  | PublicApiPackConnectionCustomMetadata;
 
 /**
  * The Pack OAuth configuration metadata.
@@ -2663,6 +2680,7 @@ export enum PublicApiPackConnectionType {
   Header = 'header',
   UrlParam = 'urlParam',
   HttpBasic = 'httpBasic',
+  Custom = 'custom',
 }
 
 /**
@@ -2671,7 +2689,8 @@ export enum PublicApiPackConnectionType {
 export type PublicApiPackSystemConnectionCredentials =
   | PublicApiPackConnectionHeaderCredentials
   | PublicApiPackConnectionUrlParamCredentials
-  | PublicApiPackConnectionHttpBasicCredentials;
+  | PublicApiPackConnectionHttpBasicCredentials
+  | PublicApiPackConnectionCustomCredentials;
 
 export interface PublicApiPackConnectionHeaderMetadata {
   type: PublicApiPackConnectionType.Header;
@@ -2696,6 +2715,25 @@ export interface PublicApiPackConnectionHttpBasicMetadata {
   maskedPassword?: string;
 }
 
+export interface PublicApiPackConnectionCustomMetadata {
+  type: PublicApiPackConnectionType.Custom;
+  /**
+   * An array of objects containing the parameter key and masked value.
+   */
+  params: {
+    key: string;
+    maskedValue: string;
+  }[];
+  /**
+   * The domain corresponding to the pre-authorized network domain in the pack.
+   */
+  domain: string;
+  /**
+   * An array containing the keys of parameters specified by the authentication config.
+   */
+  presetKeys: string[];
+}
+
 export interface PublicApiPackConnectionHeaderCredentials {
   type: PublicApiPackConnectionType.Header;
   token: string;
@@ -2713,6 +2751,14 @@ export interface PublicApiPackConnectionHttpBasicCredentials {
   type: PublicApiPackConnectionType.HttpBasic;
   username: string;
   password?: string;
+}
+
+export interface PublicApiPackConnectionCustomCredentials {
+  type: PublicApiPackConnectionType.Custom;
+  params: {
+    key: string;
+    value: string;
+  }[];
 }
 
 export interface PublicApiPackConnectionHeaderPatch {
@@ -2735,6 +2781,27 @@ export interface PublicApiPackConnectionHttpBasicPatch {
 }
 
 /**
+ * List of grouped Pack logs.
+ */
+export interface PublicApiGroupedPackLogsList {
+  items: PublicApiGroupedPackLog[];
+  nextPageToken?: PublicApiNextPageToken;
+  nextPageLink?: PublicApiNextPageLink & string;
+  /**
+   * This flag will be set to true if the result doens't include all the related logs.
+   */
+  incompleteRelatedLogs: boolean;
+}
+
+export interface PublicApiPackConnectionCustomPatch {
+  type: PublicApiPackConnectionType.Custom;
+  paramsToPatch?: {
+    key: string;
+    value: string;
+  }[];
+}
+
+/**
  * List of Pack logs.
  */
 export interface PublicApiPackLogsList {
@@ -2742,6 +2809,11 @@ export interface PublicApiPackLogsList {
   nextPageToken?: PublicApiNextPageToken;
   nextPageLink?: PublicApiNextPageLink & string;
 }
+
+/**
+ * A record of grouped Pack log.
+ */
+export type PublicApiGroupedPackLog = PublicApiGroupedPackInvocationLog | PublicApiPackAuthLog;
 
 /**
  * A record of Pack log.
@@ -2777,6 +2849,30 @@ export interface PublicApiPackLogContext {
    * Unique identifier of this log record.
    */
   logId: string;
+  /**
+   * Doc canvas object id where the formula was fired from.
+   */
+  docObjectId?: string;
+  /**
+   * Doc canvas row id where the formula was fired from.
+   */
+  docRowId?: string;
+  /**
+   * Doc canvas column id where the formula was fired from.
+   */
+  docColumnId?: string;
+  /**
+   * True if this is an execution of a sync table which received a pagination parameter.
+   */
+  isContinuedSyncTable?: boolean;
+  /**
+   * If this formula invocation was for a parameter auto-complete, this names the parameter.
+   */
+  autocompleteParameterName?: string;
+  /**
+   * If this formula was invoked by something other than a user action, this should say what that was.
+   */
+  invocationSource?: string;
 }
 
 /**
@@ -2799,11 +2895,29 @@ export interface PublicApiPackInvocationLog {
   type: PublicApiPackLogType.Invocation;
   context: PublicApiPackLogContext;
   /**
+   * True if the formula returned a prior result without executing.
+   */
+  cacheHit?: boolean;
+  /**
+   * Duration of the formula exeuction in miliseconds.
+   */
+  duration?: number;
+  /**
    * Error info if this invocation resulted in an error.
    */
   error?: {
     message: string;
+    stack?: string;
   };
+}
+
+/**
+ * Grouped logs ofthe invocations of the Pack.
+ */
+export interface PublicApiGroupedPackInvocationLog {
+  type: PublicApiPackLogType.Invocation;
+  invocationLog: PublicApiPackInvocationLog;
+  relatedLogs: PublicApiPackLog[];
 }
 
 /**
@@ -2913,7 +3027,8 @@ export enum PublicApiFeatureSet {
 export type PublicApiPatchPackSystemConnectionRequest =
   | PublicApiPackConnectionHeaderPatch
   | PublicApiPackConnectionUrlParamPatch
-  | PublicApiPackConnectionHttpBasicPatch;
+  | PublicApiPackConnectionHttpBasicPatch
+  | PublicApiPackConnectionCustomPatch;
 
 /**
  * Request to set the Pack OAuth configuration.
@@ -3128,6 +3243,10 @@ export interface PublicApiPackAssetUploadCompleteResponse {
  */
 export interface PublicApiPackSourceCodeUploadCompleteRequest {
   filename: string;
+  /**
+   * A SHA-256 hash of the source code used to identify duplicate uploads.
+   */
+  codeHash: string;
 }
 
 /**
@@ -3148,6 +3267,7 @@ export interface PublicApiCreatePackVersionRequest {
    * Developer notes of the new Pack version.
    */
   notes?: string;
+  source?: PublicApiPackSource;
   [k: string]: unknown;
 }
 


### PR DESCRIPTION
To help with attribution of Pack version uploads, this PR sets the source as CLI for any Pack uploaded via our CLI tool.