### PR TITLE
More narrowly target linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 dist/** linguist-generated
-docs/** linguist-generated
+docs/embedded-snippets/** linguist-generated
+docs/reference/sdk/** linguist-generated
+docs/samples/** linguist-generated
+documentation/generated/** linguist-generated


### PR DESCRIPTION
There is a mixture of handwritten and auto-generated files in the `/docs` directory. Adjust the linguist settings to more narrowly target the generated portions.