### PR TITLE
Update mkdocs config to fix bug

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,8 @@ markdown_extensions:
         - .
       check_paths: true
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - toc:


### PR DESCRIPTION
I noticed https://github.com/squidfunk/mkdocs-material/issues/3330 happening on our docs, which is caused by a backwards-incompatible change introduced in the latest version of mkdocs-material. Followed their [upgrade guide](https://squidfunk.github.io/mkdocs-material/upgrade/#pymdownxtabbed) to resolve the issue.