### PR TITLE
Update social metadata

### DIFF
--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -1,5 +1,6 @@
 ---
 title: Formulas
+description: "Formulas are one of the most basic building blocks in Coda, and using Packs you can add your own custom ones."
 ---
 
 # Add custom formulas

--- a/documentation/theme/main.html
+++ b/documentation/theme/main.html
@@ -1,23 +1,36 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+
 {% set title = config.site_name %}
-{% if page and page.meta and page.meta.title %}
-  {% set title = page.meta.title ~ " - " ~ title %}
+{% if page and page.toc|first is defined %}
+  {% set title = page.toc.items[0].title ~ " - " ~ title %}
+{% elif page and page.meta and page.meta.title %}
+    {% set title = page.meta.title ~ " - " ~ title %}
 {% elif page and page.title and not page.is_homepage %}
-{% set title = page.title ~ " - " ~ title %}
+  {% set title = page.title ~ " - " ~ title %}
 {% endif %}
 
-<!-- TODO: should shape these up and should cater to specific page -->
-<meta name="description" content="{{ config.site_description }}" />
+{% set description = config.site_description %}
+{% if page and page.meta and page.meta.description %}
+  {% set description = page.meta.description %}
+{% endif %}
+
+{% set url =  config.site_url %}
+{% if page %}
+  {% set url =  page.canonical_url %}
+{% endif %}
+
+
+<meta name="description" content="{{ description }}" />
 <meta name="image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 
 <!-- Twitter tags -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@coda_hq" />
 <meta name="twitter:title" content="{{ title }}" />
-<meta name="twitter:description" content="{{ config.site_description }}" />
-<meta name="twitter:url" content="{{ page.canonical_url }}" />
+<meta name="twitter:description" content="{{ description }}" />
+<meta name="twitter:url" content="{{ url }}" />
 <meta name="twitter:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 <meta name="twitter:card" content="summary_large_image" />
 
@@ -25,8 +38,8 @@
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="{{ config.site_name }}" />
 <meta property="og:title" content="{{ title }}" />
-<meta property="og:description" content="{{ config.site_description }}" />
-<meta property="og:url" content="{{ page.canonical_url }}" />
+<meta property="og:description" content="{{ description }}" />
+<meta property="og:url" content="{{ url }}" />
 <meta property="og:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 {% endblock %}
 

--- a/documentation/theme/main.html
+++ b/documentation/theme/main.html
@@ -1,23 +1,32 @@
-{% extends "base.html" %} 
+{% extends "base.html" %}
 
 {% block extrahead %}
+{% set title = config.site_name %}
+{% if page and page.meta and page.meta.title %}
+  {% set title = page.meta.title ~ " - " ~ title %}
+{% elif page and page.title and not page.is_homepage %}
+{% set title = page.title ~ " - " ~ title %}
+{% endif %}
+
 <!-- TODO: should shape these up and should cater to specific page -->
-<meta name="description" content="Documentation for the SDK to build Coda Packs." />
+<meta name="description" content="{{ config.site_description }}" />
 <meta name="image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 
 <!-- Twitter tags -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@coda_hq" />
-<meta name="twitter:title" content="Coda Pack SDK" />
-<meta name="twitter:description" content="Documentation for the SDK to build Coda Packs." />
+<meta name="twitter:title" content="{{ title }}" />
+<meta name="twitter:description" content="{{ config.site_description }}" />
+<meta name="twitter:url" content="{{ page.canonical_url }}" />
 <meta name="twitter:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 <meta name="twitter:card" content="summary_large_image" />
 
 <!-- Open graph tags -->
 <meta property="og:type" content="website" />
-<meta property="og:site_name" content="Coda Pack SDK" />
-<meta property="og:title" content="Coda Pack SDK" />
-<meta property="og:description" content="Documentation for the SDK to build Coda Packs." />
+<meta property="og:site_name" content="{{ config.site_name }}" />
+<meta property="og:title" content="{{ title }}" />
+<meta property="og:description" content="{{ config.site_description }}" />
+<meta property="og:url" content="{{ page.canonical_url }}" />
 <meta property="og:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 {% endblock %}
 

--- a/documentation/theme/main.html
+++ b/documentation/theme/main.html
@@ -3,24 +3,18 @@
 {% block extrahead %}
 
 {% set title = config.site_name %}
-{% if page and page.toc|first is defined %}
+{% if page.toc|first is defined %}
   {% set title = page.toc.items[0].title ~ " - " ~ title %}
-{% elif page and page.meta and page.meta.title %}
+{% elif page.meta and page.meta.title %}
     {% set title = page.meta.title ~ " - " ~ title %}
-{% elif page and page.title and not page.is_homepage %}
+{% elif page.title and not page.is_homepage %}
   {% set title = page.title ~ " - " ~ title %}
 {% endif %}
 
 {% set description = config.site_description %}
-{% if page and page.meta and page.meta.description %}
+{% if page.meta and page.meta.description %}
   {% set description = page.meta.description %}
 {% endif %}
-
-{% set url =  config.site_url %}
-{% if page %}
-  {% set url =  page.canonical_url %}
-{% endif %}
-
 
 <meta name="description" content="{{ description }}" />
 <meta name="image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
@@ -30,7 +24,7 @@
 <meta name="twitter:site" content="@coda_hq" />
 <meta name="twitter:title" content="{{ title }}" />
 <meta name="twitter:description" content="{{ description }}" />
-<meta name="twitter:url" content="{{ url }}" />
+<meta name="twitter:url" content="{{ page.canonical_url }}" />
 <meta name="twitter:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 <meta name="twitter:card" content="summary_large_image" />
 
@@ -39,7 +33,7 @@
 <meta property="og:site_name" content="{{ config.site_name }}" />
 <meta property="og:title" content="{{ title }}" />
 <meta property="og:description" content="{{ description }}" />
-<meta property="og:url" content="{{ url }}" />
+<meta property="og:url" content="{{ page.canonical_url }}" />
 <meta property="og:image" content="https://cdn.coda.io/external/img/doc-banner-compressed-2x-v2.jpg" />
 {% endblock %}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 # MkDocs options.
 # See: https://www.mkdocs.org/user-guide/configuration/
 site_name: Coda Pack SDK
+site_description: "Documentation for the SDK to build Coda Packs."
 site_url: !ENV MK_DOCS_SITE_URL
 repo_url: https://github.com/coda/packs-sdk
 repo_name: coda/packs-sdk


### PR DESCRIPTION
Improve the social cards for the documentation. Specifically, Slack wasn't showing the page's title in the card. Updated the social metadata to use the page's title (preferring the longer title in the h1) and the page's custom meta description (if defined).

Before and after:
<img width="617" alt="Screen Shot 2022-02-04 at 10 57 01 AM" src="https://user-images.githubusercontent.com/88106038/152560735-1b8f971d-3177-49b4-b346-d35efb47b369.png">