### PR TITLE
restrict coda-api-auth network domains

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -775,6 +775,14 @@ function validateFormulas(schema) {
         }
         return true;
     }, { message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace'] })
+        .refine(metadata => {
+        var _a, _b;
+        return !(((_a = metadata.defaultAuthentication) === null || _a === void 0 ? void 0 : _a.type) === types_1.AuthenticationType.CodaApiHeaderBearerToken &&
+            ((_b = metadata.networkDomains) === null || _b === void 0 ? void 0 : _b.some((domain) => !['coda.io', 'codahosted.io', 'localhost', 'calc-grpc-proxy'].includes(domain))));
+    }, {
+        message: 'CodaApiHeaderBearerToken can only be used for coda.io domains',
+        path: ['networkDomains'],
+    })
         .superRefine((data, context) => {
         const formulas = (data.formulas || []);
         (data.formats || []).forEach((format, i) => {

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1573,8 +1573,27 @@ describe('Pack metadata Validation', () => {
           deferConnectionSetup: true,
           shouldAutoAuthSetup: true,
         },
+        networkDomains: ['coda.io'],
       });
       await validateJson(metadata);
+    });
+
+    it('CodaApiHeaderBearerToken, invalid domain', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.CodaApiHeaderBearerToken,
+          deferConnectionSetup: true,
+          shouldAutoAuthSetup: true,
+        },
+        networkDomains: ['coda.io', 'other.domain'],
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'CodaApiHeaderBearerToken can only be used for coda.io domains',
+          path: 'networkDomains',
+        },
+      ]);
     });
 
     it('CustomHeaderToken', async () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -936,6 +936,19 @@ function validateFormulas(schema: z.ZodObject<any>) {
       },
       {message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace']},
     )
+    .refine(
+      metadata =>
+        !(
+          metadata.defaultAuthentication?.type === AuthenticationType.CodaApiHeaderBearerToken &&
+          metadata.networkDomains?.some(
+            (domain: string) => !['coda.io', 'codahosted.io', 'localhost', 'calc-grpc-proxy'].includes(domain),
+          )
+        ),
+      {
+        message: 'CodaApiHeaderBearerToken can only be used for coda.io domains',
+        path: ['networkDomains'],
+      },
+    )
     .superRefine((data, context) => {
       const formulas = (data.formulas || []) as PackFormulaMetadata[];
       ((data.formats as any[]) || []).forEach((format, i) => {


### PR DESCRIPTION
I am adding network domains to the add-connection UI dialog, except the coda api auth type. In which case, user would assume that it only talks to coda api.

However I realized that this is not enforced in our validation. 

@coda/packs @patrick-codaio 