### PR TITLE
Add OAuth TokenUrl to our pack metadata

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -122,6 +122,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
     shouldAutoAuthSetup?: boolean;
     oauthScopes?: string[];
     oauthAuthorizationUrl?: string;
+    oauthTokenUrl?: string;
   };
   instructionsUrl?: string;
 

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -3479,6 +3479,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
 		shouldAutoAuthSetup?: boolean;
 		oauthScopes?: string[];
 		oauthAuthorizationUrl?: string;
+		oauthTokenUrl?: string;
 	};
 	instructionsUrl?: string;
 	formulas?: ExternalPackFormulas;

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -78,6 +78,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
         shouldAutoAuthSetup?: boolean;
         oauthScopes?: string[];
         oauthAuthorizationUrl?: string;
+        oauthTokenUrl?: string;
     };
     instructionsUrl?: string;
     formulas?: ExternalPackFormulas;


### PR DESCRIPTION
We want to be able to show everything about a pack's network activity in listings.