### PR TITLE
Cleanup CircleCI config: update utils orb and use orb command to unpack AWS creds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@1.3.0
   jq: circleci/jq@1.9.1
-  utils: coda/utils@0.4.0
+  utils: coda/utils@2.3.0
   base-tools:
     commands:
       install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
           key: v2-dependencies-{{ checksum "package.json" }}
   bootstrap_aws_cli:
     steps:
-      - run: make bootstrap-aws-context-creds-ci
+      - utils/boostrap-aws-context-creds
       - aws-cli/install
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,6 @@ workflows:
             branches:
               only:
                 - release
-                - /jc-.*/ # Temporary, forcing jobs to run on my branch
       - utils/cancel-older-awaiting-approvals:
           context:
             - circleci

--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,6 @@ _bootstrap-python:
 _bootstrap-githooks: clean-githooks
 	-(cd ${ROOTDIR}; scripts/dev/git-hooks.sh --install)
 
-# Each CI context can inject an AWS credential to the environment.
-# Unpack all context variables required and combine into a single credentials file.
-# Should only be needed for CI rather than locally.
-.PHONY: bootstrap-aws-context-creds-ci
-bootstrap-aws-context-creds-ci:
-	rm -f ~/.aws/credentials
-	mkdir -p ~/.aws
-	set | grep ^CTX_AWS_BASE_64_CREDS_ | cut -d= -f2- | while read -r base64creds; do \
-		echo $$base64creds | base64 -d >> ~/.aws/credentials; \
-	done;
-
 .PHONY: bootstrap
 bootstrap:
 	$(MAKE) MAKEFLAGS= _bootstrap-node


### PR DESCRIPTION
## Description
1. The `bootstrap-aws-context-creds-ci` make command is used in nearly every project repo, so I refactored it into an orb command for `utils`.

2. Noticed that some jobs weren't cancelling and it looks like the orb command is a bit bugged. This is also fixed in the latest orb version for `utils` 

Below is a really old job in `packs-sdk` that was never canceled automatically
![image](https://user-images.githubusercontent.com/92751744/153923517-6e96e1a8-5811-47c0-bf7c-b4fccb9e4abd.png)

## Test Plan
Ran the deploy for this PR
https://app.circleci.com/pipelines/github/coda/packs-sdk/5435/workflows/635fe4d7-2411-4135-a4e1-00ea7f38ab18
<img width="1495" alt="Screen Shot 2022-02-14 at 3 43 40 PM" src="https://user-images.githubusercontent.com/92751744/153965651-840e153a-c8c6-4c7d-b06c-757b305424d2.png">

