### PR TITLE
Various small doc improvements

### DIFF
--- a/docs/guides/advanced/fetcher.md
+++ b/docs/guides/advanced/fetcher.md
@@ -322,10 +322,13 @@ try {
 The HTTP headers returned can be accessed using the `headers` field of the response. The header names are normalized (changed to lowercase) for convenience, so you can access them consistently regardless of how they are sent by the server.
 
 ```
-let contentType = response.headers["content-type"];
+let contentType = response.headers["content-type"].toString();
 ```
 
 Unless it's a known safe header, all the header values will be redacted by Coda (contain the value `<<<REDACTED by Coda>>>` instead of the actual value). To request that a specific header be unredacted you will need to [contact support][support].
+
+!!! info "Multiple header values"
+    A server may return multiple headers with the same name. In this case, the header value will be a string array instead of a single string. As per [the spec][spec_headers], this should only happen for headers that return comma-separated values. Adding a `.toString()` call after retrieving the header value is an easy way to collapse both cases down to a single string.
 
 
 ## Authentication
@@ -377,3 +380,4 @@ You can set a total rate limit across all users of your Pack, or if your Pack us
 [cacheTtlSecs]: ../../reference/sdk/interfaces/FetchRequest.md#cacheTtlSecs
 [formula_cache]: ../blocks/formulas.md#caching
 [authentication]: ../advanced/authentication.md
+[spec_headers]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -185,6 +185,26 @@ pack.addFormula({
 });
 ```
 
+??? "Using `fromKey` with existing schemas"
+    When mapping a response field to an existing schema, it isn't clear where to put the `fromKey` field. The best approach is to use the [spread operator (`...`)][mdn_spread_object] to copy the schema and then add on the `fromKey` field.
+
+    ```ts
+    let PersonSchema = coda.makeObjectSchema({
+      // ...
+    });
+
+    let MovieSchema = coda.makeObjectSchema({
+      properties: {
+        director: {
+          ...PersonSchema,
+          fromKey: "director_info",
+        },
+        // ...
+      },
+      // ...
+    });
+    ```
+
 The `fromKey` field works for simple renaming, but doesn't handle more complex cases such as pulling up a nested field. A more flexible approach is to rearrange the data from the API before you return it to ensure it matches the schema.
 
 ```ts
@@ -438,3 +458,4 @@ In your sync formula you only need to populate the fields of the reference objec
 [makeReferenceSchemaFromObjectSchema]: ../../reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
 [sync_tables_references]: ../blocks/sync-tables/index.md#references
 [data_types_objects]: ../basics/data-types.md#objects
+[mdn_spread_object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -30,12 +30,15 @@ While it's easy to get started building a Pack, there are lots of options to exp
 - [x] Set the [`description`][SyncTableOptions.description] field for each sync table. The description is shown on the Pack's listing page and helps a user understand what data it retrieves.
 - [x] [Add parameters][sync_tables_parameters] to sync tables to allow for filtering. Filtering is particularly important when a table can return a large number of rows.
 - [x] Consider the [caching behavior][sync_tables_caching] of your sync tables. Most fetcher requests should have their caching reduced or disabled to ensure the latest results are synced.
+- [x] For the schema property containing the [row identifier][schemas_row_identifier] use a descriptive name like `{thing}Id` instead of simply `id`.
+- [x] Set a few [featured columns][schemas_featured_columns] on your schema, for the most commonly used properties.
 
 
 ## General
 
 - [x] When using per-user authentication, make sure to set the [`instructionsUrl`][instructionsUrl] field. Direct user to a help center article that provides information about where they can find the required tokens or credentials.
 - [x] Throw a [`UserVisibleError`][UserVisibleError] for bad input or when an expected type of error occurs. This allows you to provide a more informative error message to the user.
+- [x] If accepting or returning an index value, start counting at 1. Although JavaScript is 0-based, Coda formula language is 1-based.
 
 
 ## Launching
@@ -62,3 +65,5 @@ While it's easy to get started building a Pack, there are lots of options to exp
 [SyncTableOptions.description]: ../reference/sdk/interfaces/SyncTableOptions.md#description
 [launching]: https://coda.io/@joebauer/best-practices-for-launching-your-pack
 [promotion]: https://coda.io/@hector/promotion-best-practices
+[schemas_row_identifier]: advanced/schemas.md#row-identifier
+[schemas_featured_columns]: advanced/schemas.md#featured-columns

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -144,7 +144,7 @@ In most sync tables, parameters are used to allow users to filter the results in
 
 ## Row limits
 
-Each sync table has a user-defined maximum number of rows, which defaults to 1000 but can be set as high as 10,000. Any items returned by your sync table beyond that limit will be dropped.
+Each sync table has a user-defined maximum number of rows, which defaults to 1000 but can be set as high as 10,000. Once a sync table reaches the limit Coda will stop the sync (even if the code returned a [continuation](#longrunning)) and truncate the resulting rows to fit within the limit.
 
 
 ## Long-running syncs {: #longrunning}

--- a/docs/guides/development/cli.md
+++ b/docs/guides/development/cli.md
@@ -231,6 +231,26 @@ Although a lot of Pack management can be done through the CLI, there are still s
 - Editing your Pack's listing page (name, icon, etc).
 
 
+## Migrating from Web IDE to the CLI
+
+It's possible to start development of a Pack in the Pack Studio Web IDE and later migrate to using the CLI. For example, to take advantage of an NPM library, which isn't possible in the Web IDE.
+
+To migrate, follow all of the steps described in the [Getting started tutorial][quickstart_cli] up until the point of running `npx coda create`. Instead, manually create a file in the same directory as the pack definition called `.coda-pack.json` with the following content:
+
+```json
+{
+  "packId": 123456
+}
+```
+
+Replace `123456` with the ID of your existing Pack. You can find this ID in the Pack Studio URL:
+
+```
+https://coda.io/p/123456
+```
+
+Then replace the contents of `pack.ts` with your existing code from the Web IDE and continue on with the tutorial. Once you run `npx coda upload` the Pack will start using your local code.
+
 
 [libraries]: libraries.md
 [quickstart_cli]: ../../tutorials/get-started/cli.md

--- a/docs/guides/development/cli.md
+++ b/docs/guides/development/cli.md
@@ -231,7 +231,7 @@ Although a lot of Pack management can be done through the CLI, there are still s
 - Editing your Pack's listing page (name, icon, etc).
 
 
-## Migrating from Web IDE
+## Migrating from the Web IDE
 
 It's possible to start development of a Pack in the Pack Studio Web IDE and later migrate to using the CLI. For example, to take advantage of an NPM library, which isn't possible in the Web IDE.
 

--- a/docs/guides/development/cli.md
+++ b/docs/guides/development/cli.md
@@ -231,7 +231,7 @@ Although a lot of Pack management can be done through the CLI, there are still s
 - Editing your Pack's listing page (name, icon, etc).
 
 
-## Migrating from Web IDE to the CLI
+## Migrating from Web IDE
 
 It's possible to start development of a Pack in the Pack Studio Web IDE and later migrate to using the CLI. For example, to take advantage of an NPM library, which isn't possible in the Web IDE.
 


### PR DESCRIPTION
- [Handling multiple header values](https://coda-packs-sdk--1795.com.readthedocs.build/en/1795/guides/advanced/fetcher/#headers)
- [Using `fromKey` with an existing schema](https://coda-packs-sdk--1795.com.readthedocs.build/en/1795/guides/advanced/schemas/#object-mapping)
- [More best practices](https://coda-packs-sdk--1795.com.readthedocs.build/en/1795/guides/best-practices/#sync-tables)
- [Sync table behavior when row limit hit](https://coda-packs-sdk--1795.com.readthedocs.build/en/1795/guides/blocks/sync-tables/#row-limits)
- [Migrating from the Web IDE to the CLI](https://coda-packs-sdk--1795.com.readthedocs.build/en/1795/guides/development/cli/#migrating-from-the-web-ide)