### PR TITLE
Update community category

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -12,15 +12,15 @@ We use a mixture of different platforms to provide support to Pack makers, so re
 
 ## Questions or advice
 
-For general questions about Packs, or advice on how to build them, we recommend you post in the [Coda Community "Packs" category][community_packs]. Codans actively monitor the community and answer questions, as well as other Pack makers that have experience with the platform. Posting questions and answers in a public forum helps build up a knowledge base of information that helps everyone.
+For general questions about Packs, or advice on how to build them, we recommend you post in the [Coda Community "Making Packs" category][community_packs]. Codans actively monitor the community and answer questions, as well as other Pack makers that have experience with the platform. Posting questions and answers in a public forum helps build up a knowledge base of information that helps everyone.
 
 <form action="https://community.coda.io/search">
   <p>
-    <input type="text" name="q" id="q" value="#developers-central:coda-packs " class="md-input md-input--stretch"/>
+    <input type="text" name="q" id="q" value="#developers-central:making-packs " class="md-input md-input--stretch"/>
   </p>
   <p>
     <button type="submit" class="md-button">Search existing questions</button>
-    <a href="https://community.coda.io/new-topic?category=developers-central/coda-packs" class="md-button md-button--primary">Post a new question</a>
+    <a href="https://community.coda.io/new-topic?category=developers-central/making-packs" class="md-button md-button--primary">Post a new question</a>
   </p>
 </form>
 
@@ -36,6 +36,6 @@ If you are experiencing a problem with your Pack or have identified a bug you ca
 <a href="mailto:partners@coda.io" class="md-button md-button--primary">Send email</a>
 
 
-[community_packs]: https://community.coda.io/c/developers-central/coda-packs/15
+[community_packs]: https://community.coda.io/c/15
 [partners_email]: mailto:partners@coda.io
 [hc_share]: https://help.coda.io/en/articles/1137949-sharing-your-doc#h_5061fdf96a


### PR DESCRIPTION
Today we renamed the category on the community to "Making Packs" to make the topic clearer. Updating the support page to point to the new name.