### PR TITLE
Small doc updates

### DIFF
--- a/docs/guides/advanced/fetcher.md
+++ b/docs/guides/advanced/fetcher.md
@@ -362,6 +362,15 @@ Making a request to an external API can be expensive, either due to quotas, comp
 You can set a total rate limit across all users of your Pack, or if your Pack uses [authentication][authentication] you can also set a per-user rate limit. When the limit is reached your formula will pause for a bit to see if more quota becomes available, and if not eventually fail with an error.
 
 
+## IP addresses
+
+HTTP requests originating from Packs will come from a few different IP addresses. The specific set of addresses will change over time, and without prior warning. You can query the current set of IP addresses by doing a DNS lookup on the domain `egress.coda.io`.
+
+```sh
+dig +short egress.coda.io
+```
+
+
 [Fetcher]: ../../reference/sdk/interfaces/Fetcher.md
 [samples]: ../../samples/topic/fetcher.md
 [addNetworkDomain]: ../../reference/sdk/classes/PackDefinitionBuilder.md#addnetworkdomain

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -218,6 +218,21 @@ pack.addFormula({
 });
 ```
 
+### Percentages
+
+Formulas that return a result as a percentage can use the value type `Number` and the value hint [`Percent`][Percent]. Return a fraction in your code and the doc will display the equivalent percentage.
+
+```ts
+pack.addFormula({
+  // ...
+  resultType: coda.ValueType.Number,
+  codaType: coda.ValueHintType.Percent,
+  execute: async function ([], context) {
+    return 0.5; // Displayed as "50%" in the doc.
+  },
+});
+```
+
 
 ### Images {: #images}
 
@@ -380,20 +395,21 @@ Some value types and hints support additional formatting options. For example, `
 
 The full set of formatting options for a given value type and hint can be found in the corresponding schema definition.
 
-| Value type           | Value hint | Formatting options                               |
-| -------------------- | ---------- | ------------------------------------------------ |
-| `Number`             |            | [`NumericSchema`][NumericSchema]                 |
-| `Number`             | `Percent`  | [`NumericSchema`][NumericSchema]                 |
-| `Number`             | `Currency` | [`CurrencySchema`][CurrencySchema]               |
-| `Number`             | `Slider`   | [`SliderSchema`][SliderSchema]                   |
-| `Number`             | `Scale`    | [`ScaleSchema`][ScaleSchema]                     |
-| `Number`             | `Date`     | [`NumericDateSchema`][NumericDateSchema]         |
-| `Number`             | `Time`     | [`NumericTimeSchema`][NumericTimeSchema]         |
-| `Number`             | `DateTime` | [`NumericDateTimeSchema`][NumericDateTimeSchema] |
-| `String` or `Number` | `Date`     | [`StringDateSchema`][StringDateSchema]           |
-| `String` or `Number` | `Time`     | [`StringTimeSchema`][StringTimeSchema]           |
-| `String` or `Number` | `DateTime` | [`StringDateTimeSchema`][StringDateTimeSchema]   |
-| `String`             | `Duration` | [`DurationSchema`][DurationSchema]               |
+| Value type | Value hint | Formatting options                               |
+| ---------- | ---------- | ------------------------------------------------ |
+| `Number`   |            | [`NumericSchema`][NumericSchema]                 |
+| `Number`   | `Percent`  | [`NumericSchema`][NumericSchema]                 |
+| `Number`   | `Currency` | [`CurrencySchema`][CurrencySchema]               |
+| `Number`   | `Slider`   | [`SliderSchema`][SliderSchema]                   |
+| `Number`   | `Scale`    | [`ScaleSchema`][ScaleSchema]                     |
+| `Number`   | `Date`     | [`NumericDateSchema`][NumericDateSchema]         |
+| `Number`   | `Time`     | [`NumericTimeSchema`][NumericTimeSchema]         |
+| `Number`   | `DateTime` | [`NumericDateTimeSchema`][NumericDateTimeSchema] |
+| `String`   | `Date`     | [`StringDateSchema`][StringDateSchema]           |
+| `String`   | `Time`     | [`StringTimeSchema`][StringTimeSchema]           |
+| `String`   | `DateTime` | [`StringDateTimeSchema`][StringDateTimeSchema]   |
+| `String`   | `Duration` | [`DurationSchema`][DurationSchema]               |
+|`String`|`Embed`|[`StringEmbedSchema`][StringEmbedSchema]
 
 
 
@@ -443,4 +459,5 @@ The full set of formatting options for a given value type and hint can be found 
 [StringTimeSchema]: ../../reference/sdk/interfaces/StringTimeSchema.md
 [StringDateTimeSchema]: ../../reference/sdk/interfaces/StringDateTimeSchema.md
 [DurationSchema]: ../../reference/sdk/interfaces/DurationSchema.md
+[StringEmbedSchema]: ../../reference/sdk/interfaces/StringEmbedSchema.md
 [formula_list]: https://coda.io/formulas#List

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -409,7 +409,7 @@ The full set of formatting options for a given value type and hint can be found 
 | `String`   | `Time`     | [`StringTimeSchema`][StringTimeSchema]           |
 | `String`   | `DateTime` | [`StringDateTimeSchema`][StringDateTimeSchema]   |
 | `String`   | `Duration` | [`DurationSchema`][DurationSchema]               |
-|`String`|`Embed`|[`StringEmbedSchema`][StringEmbedSchema]
+| `String`   | `Embed`    | [`StringEmbedSchema`][StringEmbedSchema]         |
 
 
 


### PR DESCRIPTION
- Document the outbound IP addresses Packs use.
- Clarify that percentage values should return a fraction (0.5) not a whole number (50).
- Include the new `StringEmbedSchema` in the formatting options section.