### PR TITLE
Add "link" command to associate with an existing Pack ID.

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -8,6 +8,7 @@ import {handleBuild} from './build';
 import {handleCreate} from './create';
 import {handleExecute} from './execute';
 import {handleInit} from './init';
+import {handleLink} from './link';
 import {handleRegister} from './register';
 import {handleRelease} from './release';
 import {handleSetOption} from './set_option';
@@ -156,6 +157,18 @@ if (require.main === module) {
         },
       },
       handler: handleCreate,
+    })
+    .command({
+      command: 'link <manifestDir> <packIdOrUrl>',
+      describe: "Link to a pre-existing Pack ID on Coda's servers",
+      builder: {
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: DEFAULT_API_ENDPOINT,
+        },
+      },
+      handler: handleLink,
     })
     .command({
       command: 'validate <manifestFile>',

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -42,7 +42,7 @@ export async function createPack(
   // flow if they don't have a Coda API token.
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+    printAndExit('Missing API key. Please run `coda register` to register one.');
   }
 
   if (!fs.existsSync(manifestFile)) {

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -22,8 +22,6 @@ interface LinkArgs {
 
 export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl}: ArgumentsCamelCase<LinkArgs>) {
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
-  // TODO(dweitzman): Redirect to the `coda register` if there's not
-  // an existing Coda API token.
   // TODO(dweitzman): Add a download command to fetch the latest code from
   // the server and ask people if they want to download after linking.
   const apiKey = getApiKey(codaApiEndpoint);

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -1,0 +1,65 @@
+import type {ArgumentsCamelCase} from 'yargs';
+import {createCodaClient} from './helpers';
+import {formatEndpoint} from './helpers';
+import {getApiKey} from './config_storage';
+import {getPackId} from './config_storage';
+import {printAndExit} from '../testing/helpers';
+import {promptForInput} from '../testing/helpers';
+import {storePackId} from './config_storage';
+
+// Regular expression that matches coda.io/p/<packId> or <packId>.
+const PackUrlRegex = /^(?:https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/)?([0-9]+)(:?[^0-9]*)$/;
+
+interface LinkArgs {
+  manifestDir: string;
+  codaApiEndpoint: string;
+  packIdOrUrl: string;
+}
+
+export function parsePackIdOrUrl(packIdOrUrl: string): number | null {
+  const match = packIdOrUrl.match(PackUrlRegex);
+  if (!match) {
+    return null;
+  }
+  const matchedNumber = match[1];
+  return Number(matchedNumber);
+}
+
+export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl}: ArgumentsCamelCase<LinkArgs>) {
+  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
+  // TODO(dweitzman): Redirect to the `coda register` if there's not
+  // an existing Coda API token.
+  // TODO(dweitzman): Add a download command to fetch the latest code from
+  // the server and ask people if they want to download after linking.
+  const apiKey = getApiKey(codaApiEndpoint);
+  if (!apiKey) {
+    printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+  }
+
+  const codaClient = createCodaClient(apiKey, formattedEndpoint);
+  const packId = parsePackIdOrUrl(packIdOrUrl);
+  if (packId === null) {
+    printAndExit(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
+  }
+
+  // Verify that the user has edit access to the pack. Currently only editors
+  // can call getPack().
+  await codaClient.getPack(packId);
+
+  const existingPackId = getPackId(manifestDir, codaApiEndpoint);
+  if (existingPackId) {
+    if (existingPackId === packId) {
+      printAndExit(`Already associated with pack ${existingPackId}. No change needed`, 0);
+    }
+
+    const input = promptForInput(
+      `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? Press "y" to overwrite or "n" to cancel: `,
+    );
+    if (input.toLocaleLowerCase() !== 'y') {
+      return process.exit(1);
+    }
+  }
+
+  storePackId(manifestDir, packId, codaApiEndpoint);
+  return printAndExit(`Linked successfully!`, 0);
+}

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -33,7 +33,7 @@ export async function handleRelease({
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
 
   if (!apiKey) {
-    return printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+    return printAndExit('Missing API key. Please run `coda register` to register one.');
   }
 
   const packId = getPackId(manifestDir, codaApiEndpoint);

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -89,7 +89,7 @@ export async function handleUpload({
 
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+    printAndExit('Missing API key. Please run `coda register` to register one.');
   }
 
   const client = createCodaClient(apiKey, formattedEndpoint);

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -12,6 +12,7 @@ const build_1 = require("./build");
 const create_1 = require("./create");
 const execute_1 = require("./execute");
 const init_1 = require("./init");
+const link_1 = require("./link");
 const register_1 = require("./register");
 const release_1 = require("./release");
 const set_option_1 = require("./set_option");
@@ -158,6 +159,18 @@ if (require.main === module) {
             },
         },
         handler: create_1.handleCreate,
+    })
+        .command({
+        command: 'link <manifestDir> <packIdOrUrl>',
+        describe: "Link to a pre-existing Pack ID on Coda's servers",
+        builder: {
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: config_storage_1.DEFAULT_API_ENDPOINT,
+            },
+        },
+        handler: link_1.handleLink,
     })
         .command({
         command: 'validate <manifestFile>',

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -47,7 +47,7 @@ async function createPack(manifestFile, codaApiEndpoint, { name, description, wo
     // flow if they don't have a Coda API token.
     const apiKey = (0, config_storage_2.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        (0, helpers_3.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+        (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
     }
     if (!fs_1.default.existsSync(manifestFile)) {
         return (0, helpers_3.printAndExit)(`${manifestFile} is not a valid pack definition file. Check the filename and try again.`);

--- a/dist/cli/link.d.ts
+++ b/dist/cli/link.d.ts
@@ -4,6 +4,6 @@ interface LinkArgs {
     codaApiEndpoint: string;
     packIdOrUrl: string;
 }
-export declare function parsePackIdOrUrl(packIdOrUrl: string): number | null;
 export declare function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
+export declare function parsePackIdOrUrl(packIdOrUrl: string): number | null;
 export {};

--- a/dist/cli/link.d.ts
+++ b/dist/cli/link.d.ts
@@ -1,0 +1,9 @@
+import type { ArgumentsCamelCase } from 'yargs';
+interface LinkArgs {
+    manifestDir: string;
+    codaApiEndpoint: string;
+    packIdOrUrl: string;
+}
+export declare function parsePackIdOrUrl(packIdOrUrl: string): number | null;
+export declare function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
+export {};

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -16,8 +16,6 @@ const PackPlainIdRegex = /^([0-9]+)$/;
 const PackRegexes = [PackEditUrlRegex, PackGalleryUrlRegex, PackPlainIdRegex];
 async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    // TODO(dweitzman): Redirect to the `coda register` if there's not
-    // an existing Coda API token.
     // TODO(dweitzman): Add a download command to fetch the latest code from
     // the server and ask people if they want to download after linking.
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -1,24 +1,19 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handleLink = exports.parsePackIdOrUrl = void 0;
+exports.parsePackIdOrUrl = exports.handleLink = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const config_storage_1 = require("./config_storage");
 const config_storage_2 = require("./config_storage");
+const coda_1 = require("../helpers/external-api/coda");
 const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const config_storage_3 = require("./config_storage");
 // Regular expression that matches coda.io/p/<packId> or <packId>.
-const PackUrlRegex = /^(?:https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/)?([0-9]+)(:?[^0-9]*)$/;
-function parsePackIdOrUrl(packIdOrUrl) {
-    const match = packIdOrUrl.match(PackUrlRegex);
-    if (!match) {
-        return null;
-    }
-    const matchedNumber = match[1];
-    return Number(matchedNumber);
-}
-exports.parsePackIdOrUrl = parsePackIdOrUrl;
+const PackEditUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/([0-9]+)(:?[^0-9].*)?$/;
+const PackGalleryUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/packs\/[^/]*-([0-9]+)$/;
+const PackPlainIdRegex = /^([0-9]+)$/;
+const PackRegexes = [PackEditUrlRegex, PackGalleryUrlRegex, PackPlainIdRegex];
 async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     // TODO(dweitzman): Redirect to the `coda register` if there's not
@@ -27,20 +22,33 @@ async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
     // the server and ask people if they want to download after linking.
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        (0, helpers_3.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+        return (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
     }
     const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     const packId = parsePackIdOrUrl(packIdOrUrl);
     if (packId === null) {
-        (0, helpers_3.printAndExit)(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
+        return (0, helpers_3.printAndExit)(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
     }
     // Verify that the user has edit access to the pack. Currently only editors
     // can call getPack().
-    await codaClient.getPack(packId);
+    try {
+        await codaClient.getPack(packId);
+    }
+    catch (err) {
+        if ((0, coda_1.isResponseError)(err)) {
+            switch (err.response.status) {
+                case 401:
+                case 403:
+                case 404:
+                    return (0, helpers_3.printAndExit)("You don't have permission to edit this pack");
+            }
+        }
+        throw err;
+    }
     const existingPackId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (existingPackId) {
         if (existingPackId === packId) {
-            (0, helpers_3.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
+            return (0, helpers_3.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
         }
         const input = (0, helpers_4.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? Press "y" to overwrite or "n" to cancel: `);
         if (input.toLocaleLowerCase() !== 'y') {
@@ -51,3 +59,14 @@ async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
     return (0, helpers_3.printAndExit)(`Linked successfully!`, 0);
 }
 exports.handleLink = handleLink;
+function parsePackIdOrUrl(packIdOrUrl) {
+    for (const regex of PackRegexes) {
+        const match = packIdOrUrl.match(regex);
+        if (match) {
+            const matchedNumber = match[1];
+            return Number(matchedNumber);
+        }
+    }
+    return null;
+}
+exports.parsePackIdOrUrl = parsePackIdOrUrl;

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -1,0 +1,53 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleLink = exports.parsePackIdOrUrl = void 0;
+const helpers_1 = require("./helpers");
+const helpers_2 = require("./helpers");
+const config_storage_1 = require("./config_storage");
+const config_storage_2 = require("./config_storage");
+const helpers_3 = require("../testing/helpers");
+const helpers_4 = require("../testing/helpers");
+const config_storage_3 = require("./config_storage");
+// Regular expression that matches coda.io/p/<packId> or <packId>.
+const PackUrlRegex = /^(?:https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/)?([0-9]+)(:?[^0-9]*)$/;
+function parsePackIdOrUrl(packIdOrUrl) {
+    const match = packIdOrUrl.match(PackUrlRegex);
+    if (!match) {
+        return null;
+    }
+    const matchedNumber = match[1];
+    return Number(matchedNumber);
+}
+exports.parsePackIdOrUrl = parsePackIdOrUrl;
+async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
+    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
+    // TODO(dweitzman): Redirect to the `coda register` if there's not
+    // an existing Coda API token.
+    // TODO(dweitzman): Add a download command to fetch the latest code from
+    // the server and ask people if they want to download after linking.
+    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+    if (!apiKey) {
+        (0, helpers_3.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+    }
+    const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    const packId = parsePackIdOrUrl(packIdOrUrl);
+    if (packId === null) {
+        (0, helpers_3.printAndExit)(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
+    }
+    // Verify that the user has edit access to the pack. Currently only editors
+    // can call getPack().
+    await codaClient.getPack(packId);
+    const existingPackId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
+    if (existingPackId) {
+        if (existingPackId === packId) {
+            (0, helpers_3.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
+        }
+        const input = (0, helpers_4.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? Press "y" to overwrite or "n" to cancel: `);
+        if (input.toLocaleLowerCase() !== 'y') {
+            return process.exit(1);
+        }
+    }
+    (0, config_storage_3.storePackId)(manifestDir, packId, codaApiEndpoint);
+    return (0, helpers_3.printAndExit)(`Linked successfully!`, 0);
+}
+exports.handleLink = handleLink;

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -38,7 +38,7 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     if (!apiKey) {
-        return (0, helpers_4.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+        return (0, helpers_4.printAndExit)('Missing API key. Please run `coda register` to register one.');
     }
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (!packId) {

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -82,7 +82,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     const codaPacksSDKVersion = packageJson.version;
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+        printAndExit('Missing API key. Please run `coda register` to register one.');
     }
     const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -1,5 +1,6 @@
 import type {PackVersionDefinition} from '../types';
 import {compilePackMetadata} from '../helpers/metadata';
+import {parsePackIdOrUrl} from '../cli/link';
 
 describe('CLI', () => {
   describe('compile pack metadata', () => {
@@ -11,6 +12,25 @@ describe('CLI', () => {
       assert.deepEqual(metadata.formulas, []);
       assert.deepEqual(metadata.syncTables, []);
       assert.deepEqual(metadata.formats, []);
+    });
+  });
+
+  describe('parse pack ID or URL', () => {
+    it('correctly parses valid IDs', () => {
+      assert.equal(parsePackIdOrUrl('1234'), 1234);
+      assert.equal(parsePackIdOrUrl('https://coda.io/p/1234'), 1234);
+      assert.equal(parsePackIdOrUrl('https://coda.io/p/1234?section=listing'), 1234);
+      assert.equal(parsePackIdOrUrl('https://subdomain.coda.io:6780/p/1234?section=listing'), 1234);
+    });
+
+    it('rejects bad IDs', () => {
+      assert.equal(parsePackIdOrUrl('not a number'), null);
+      assert.equal(parsePackIdOrUrl('12 34'), null);
+      assert.equal(parsePackIdOrUrl(''), null);
+      assert.equal(parsePackIdOrUrl('-10'), null);
+      assert.equal(parsePackIdOrUrl('https://coda.io/p/1234/5678'), null);
+      assert.equal(parsePackIdOrUrl('https://coda.io/d/1234'), null);
+      assert.equal(parsePackIdOrUrl('https://codadoc.io/p/1234'), null);
     });
   });
 });

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -19,8 +19,16 @@ describe('CLI', () => {
     it('correctly parses valid IDs', () => {
       assert.equal(parsePackIdOrUrl('1234'), 1234);
       assert.equal(parsePackIdOrUrl('https://coda.io/p/1234'), 1234);
+
+      // This in invalid but the regex allows it for now.
+      assert.equal(parsePackIdOrUrl('https://coda.io/p/1234/5678'), 1234);
+
       assert.equal(parsePackIdOrUrl('https://coda.io/p/1234?section=listing'), 1234);
       assert.equal(parsePackIdOrUrl('https://subdomain.coda.io:6780/p/1234?section=listing'), 1234);
+      assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo-1234'), 1234);
+      assert.equal(parsePackIdOrUrl('https://subdomain.coda.io:6789/packs/foo-1234'), 1234);
+
+      assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo-bar-1234-5678'), 5678);
     });
 
     it('rejects bad IDs', () => {
@@ -28,9 +36,10 @@ describe('CLI', () => {
       assert.equal(parsePackIdOrUrl('12 34'), null);
       assert.equal(parsePackIdOrUrl(''), null);
       assert.equal(parsePackIdOrUrl('-10'), null);
-      assert.equal(parsePackIdOrUrl('https://coda.io/p/1234/5678'), null);
       assert.equal(parsePackIdOrUrl('https://coda.io/d/1234'), null);
       assert.equal(parsePackIdOrUrl('https://codadoc.io/p/1234'), null);
+      assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo'), null);
+      assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo-1234/5678'), null);
     });
   });
 });


### PR DESCRIPTION
Updates .coda-pack.json to point at a pre-existing Pack that was created in the browser.