### PR TITLE
"whoami" command for determining the owner of the API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.8.3
 
-- Added `whoami` command to see API token details.
-- Added `link` command to set up upload for an existing Pack ID instead of creating a new one.
+- Added `coda whoami` command to see API token details.
+- Added `coda link` command to set up upload for an existing Pack ID instead of creating a new one.
 
 ### 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+### 0.8.3
+
+- Added `whoami` command to see API token details.
+- Added `link` command to set up upload for an existing Pack ID instead of creating a new one.
+
 ### 0.8.2
+
 - Added `StringEmbedSchema` to handle configuration on how embed values appear in docs
 
 ### 0.8.1

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -86,7 +86,7 @@ if (require.main === module) {
     })
     .command({
       command: 'whoami [apiToken]',
-      describe: 'Looks up the api token owner',
+      describe: 'Looks up information about the API token that is registered in this environment',
       builder: {
         codaApiEndpoint: {
           string: true,

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -14,6 +14,7 @@ import {handleRelease} from './release';
 import {handleSetOption} from './set_option';
 import {handleUpload} from './upload';
 import {handleValidate} from './validate';
+import {handleWhoami} from './whoami';
 import yargs from 'yargs';
 
 if (require.main === module) {
@@ -82,6 +83,18 @@ if (require.main === module) {
         },
       },
       handler: handleRegister,
+    })
+    .command({
+      command: 'whoami [apiToken]',
+      describe: 'Looks up the api token owner',
+      builder: {
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: DEFAULT_API_ENDPOINT,
+        },
+      },
+      handler: handleWhoami,
     })
     .command({
       command: 'build <manifestFile>',

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -42,7 +42,7 @@ export async function createPack(
   // flow if they don't have a Coda API token.
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    printAndExit('Missing API key. Please run `coda register` to register one.');
+    printAndExit('Missing API token. Please run `coda register` to register one.');
   }
 
   if (!fs.existsSync(manifestFile)) {

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -26,7 +26,7 @@ export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl}: Ar
   // the server and ask people if they want to download after linking.
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    return printAndExit('Missing API key. Please run `coda register` to register one.');
+    return printAndExit('Missing API token. Please run `coda register` to register one.');
   }
 
   const codaClient = createCodaClient(apiKey, formattedEndpoint);

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -33,7 +33,7 @@ export async function handleRelease({
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
 
   if (!apiKey) {
-    return printAndExit('Missing API key. Please run `coda register` to register one.');
+    return printAndExit('Missing API token. Please run `coda register` to register one.');
   }
 
   const packId = getPackId(manifestDir, codaApiEndpoint);

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -89,7 +89,7 @@ export async function handleUpload({
 
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    printAndExit('Missing API key. Please run `coda register` to register one.');
+    printAndExit('Missing API token. Please run `coda register` to register one.');
   }
 
   const client = createCodaClient(apiKey, formattedEndpoint);

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -1,0 +1,37 @@
+import type {ArgumentsCamelCase} from 'yargs';
+import {createCodaClient} from './helpers';
+import {formatEndpoint} from './helpers';
+import {getApiKey} from './config_storage';
+import {isResponseError} from '../helpers/external-api/coda';
+import {printAndExit} from '../testing/helpers';
+import {tryParseSystemError} from './errors';
+
+interface WhoamiArgs {
+  apiToken?: string;
+  codaApiEndpoint: string;
+}
+
+export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCase<WhoamiArgs>) {
+  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
+  if (!apiToken) {
+    apiToken = getApiKey(codaApiEndpoint);
+    if (!apiToken) {
+      return printAndExit('Missing API key. Please run `coda register` to register one.');
+    }
+  }
+
+  const client = createCodaClient(apiToken, formattedEndpoint);
+
+  try {
+    const {name, loginId, workspace} = await client.whoami();
+
+    printAndExit(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+  } catch (err: any) {
+    if (isResponseError(err)) {
+      return printAndExit(`Invalid API token provided.`);
+    }
+
+    const errors = [`Unexpected error while checking owner of API token: ${err}`, tryParseSystemError(err)];
+    return printAndExit(errors.join('\n'));
+  }
+}

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -16,7 +16,7 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
   if (!apiToken) {
     apiToken = getApiKey(codaApiEndpoint);
     if (!apiToken) {
-      return printAndExit('Missing API key. Please run `coda register` to register one.');
+      return printAndExit('Missing API token. Please run `coda register` to register one.');
     }
   }
 
@@ -25,7 +25,7 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
   try {
     const {name, loginId, workspace} = await client.whoami();
 
-    printAndExit(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+    return printAndExit(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
   } catch (err: any) {
     if (isResponseError(err)) {
       return printAndExit(`Invalid API token provided.`);

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -37,10 +37,7 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
 }
 
 export function formatWhoami(user: PublicApiUser) {
-  const {name, loginId, scoped, tokenName} = user;
+  const {name, loginId, tokenName} = user;
 
-  return (
-    `You are ${name} (${loginId}) using token "${tokenName}" ` +
-    `which is scoped to ${scoped ? 'a specific pack.' : 'all your packs.'}`
-  );
+  return `You are ${name} (${loginId}) using token "${tokenName}"`;
 }

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -1,4 +1,5 @@
 import type {ArgumentsCamelCase} from 'yargs';
+import type {PublicApiUser} from '../helpers/external-api/v1';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {getApiKey} from './config_storage';
@@ -23,9 +24,8 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
   const client = createCodaClient(apiToken, formattedEndpoint);
 
   try {
-    const {name, loginId, workspace} = await client.whoami();
-
-    return printAndExit(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+    const response = await client.whoami();
+    return printAndExit(formatWhoami(response), 0);
   } catch (err: any) {
     if (isResponseError(err)) {
       return printAndExit(`Invalid API token provided.`);
@@ -34,4 +34,13 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
     const errors = [`Unexpected error while checking owner of API token: ${err}`, tryParseSystemError(err)];
     return printAndExit(errors.join('\n'));
   }
+}
+
+export function formatWhoami(user: PublicApiUser) {
+  const {name, loginId, scoped, tokenName} = user;
+
+  return (
+    `You are ${name} (${loginId}) using token "${tokenName}" ` +
+    `which is scoped to ${scoped ? 'a specific pack.' : 'all your packs.'}`
+  );
 }

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -37,7 +37,7 @@ export async function handleWhoami({apiToken, codaApiEndpoint}: ArgumentsCamelCa
 }
 
 export function formatWhoami(user: PublicApiUser) {
-  const {name, loginId, tokenName} = user;
+  const {name, loginId, tokenName, scoped} = user;
 
-  return `You are ${name} (${loginId}) using token "${tokenName}"`;
+  return `You are ${name} (${loginId}) using ${scoped ? 'scoped' : 'non-scoped'} token "${tokenName}"`;
 }

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -88,7 +88,7 @@ if (require.main === module) {
     })
         .command({
         command: 'whoami [apiToken]',
-        describe: 'Looks up the api token owner',
+        describe: 'Looks up information about the API token that is registered in this environment',
         builder: {
             codaApiEndpoint: {
                 string: true,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -18,6 +18,7 @@ const release_1 = require("./release");
 const set_option_1 = require("./set_option");
 const upload_1 = require("./upload");
 const validate_1 = require("./validate");
+const whoami_1 = require("./whoami");
 const yargs_1 = __importDefault(require("yargs"));
 if (require.main === module) {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -84,6 +85,18 @@ if (require.main === module) {
             },
         },
         handler: register_1.handleRegister,
+    })
+        .command({
+        command: 'whoami [apiToken]',
+        describe: 'Looks up the api token owner',
+        builder: {
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: config_storage_1.DEFAULT_API_ENDPOINT,
+            },
+        },
+        handler: whoami_1.handleWhoami,
     })
         .command({
         command: 'build <manifestFile>',

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -47,7 +47,7 @@ async function createPack(manifestFile, codaApiEndpoint, { name, description, wo
     // flow if they don't have a Coda API token.
     const apiKey = (0, config_storage_2.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
+        (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
     }
     if (!fs_1.default.existsSync(manifestFile)) {
         return (0, helpers_3.printAndExit)(`${manifestFile} is not a valid pack definition file. Check the filename and try again.`);

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -20,7 +20,7 @@ async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
     // the server and ask people if they want to download after linking.
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        return (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
+        return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
     }
     const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     const packId = parsePackIdOrUrl(packIdOrUrl);

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -38,7 +38,7 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     if (!apiKey) {
-        return (0, helpers_4.printAndExit)('Missing API key. Please run `coda register` to register one.');
+        return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
     }
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (!packId) {

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -82,7 +82,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     const codaPacksSDKVersion = packageJson.version;
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        printAndExit('Missing API key. Please run `coda register` to register one.');
+        printAndExit('Missing API token. Please run `coda register` to register one.');
     }
     const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);

--- a/dist/cli/whoami.d.ts
+++ b/dist/cli/whoami.d.ts
@@ -1,0 +1,7 @@
+import type { ArgumentsCamelCase } from 'yargs';
+interface WhoamiArgs {
+    apiToken?: string;
+    codaApiEndpoint: string;
+}
+export declare function handleWhoami({ apiToken, codaApiEndpoint }: ArgumentsCamelCase<WhoamiArgs>): Promise<never>;
+export {};

--- a/dist/cli/whoami.d.ts
+++ b/dist/cli/whoami.d.ts
@@ -1,7 +1,9 @@
 import type { ArgumentsCamelCase } from 'yargs';
+import type { PublicApiUser } from '../helpers/external-api/v1';
 interface WhoamiArgs {
     apiToken?: string;
     codaApiEndpoint: string;
 }
 export declare function handleWhoami({ apiToken, codaApiEndpoint }: ArgumentsCamelCase<WhoamiArgs>): Promise<never>;
+export declare function formatWhoami(user: PublicApiUser): string;
 export {};

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -30,7 +30,7 @@ async function handleWhoami({ apiToken, codaApiEndpoint }) {
 }
 exports.handleWhoami = handleWhoami;
 function formatWhoami(user) {
-    const { name, loginId, tokenName } = user;
-    return `You are ${name} (${loginId}) using token "${tokenName}"`;
+    const { name, loginId, tokenName, scoped } = user;
+    return `You are ${name} (${loginId}) using ${scoped ? 'scoped' : 'non-scoped'} token "${tokenName}"`;
 }
 exports.formatWhoami = formatWhoami;

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handleWhoami = void 0;
+exports.formatWhoami = exports.handleWhoami = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const config_storage_1 = require("./config_storage");
@@ -17,8 +17,8 @@ async function handleWhoami({ apiToken, codaApiEndpoint }) {
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     try {
-        const { name, loginId, workspace } = await client.whoami();
-        return (0, helpers_3.printAndExit)(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+        const response = await client.whoami();
+        return (0, helpers_3.printAndExit)(formatWhoami(response), 0);
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {
@@ -29,3 +29,9 @@ async function handleWhoami({ apiToken, codaApiEndpoint }) {
     }
 }
 exports.handleWhoami = handleWhoami;
+function formatWhoami(user) {
+    const { name, loginId, scoped, tokenName } = user;
+    return (`You are ${name} (${loginId}) using token "${tokenName}" ` +
+        `which is scoped to ${scoped ? 'a specific pack.' : 'all your packs.'}`);
+}
+exports.formatWhoami = formatWhoami;

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -12,13 +12,13 @@ async function handleWhoami({ apiToken, codaApiEndpoint }) {
     if (!apiToken) {
         apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
         if (!apiToken) {
-            return (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
+            return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
         }
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     try {
         const { name, loginId, workspace } = await client.whoami();
-        (0, helpers_3.printAndExit)(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+        return (0, helpers_3.printAndExit)(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleWhoami = void 0;
+const helpers_1 = require("./helpers");
+const helpers_2 = require("./helpers");
+const config_storage_1 = require("./config_storage");
+const coda_1 = require("../helpers/external-api/coda");
+const helpers_3 = require("../testing/helpers");
+const errors_1 = require("./errors");
+async function handleWhoami({ apiToken, codaApiEndpoint }) {
+    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
+    if (!apiToken) {
+        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+        if (!apiToken) {
+            return (0, helpers_3.printAndExit)('Missing API key. Please run `coda register` to register one.');
+        }
+    }
+    const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
+    try {
+        const { name, loginId, workspace } = await client.whoami();
+        (0, helpers_3.printAndExit)(`You are ${name} (${loginId}) in workspace ${workspace.id}`, 0);
+    }
+    catch (err) {
+        if ((0, coda_1.isResponseError)(err)) {
+            return (0, helpers_3.printAndExit)(`Invalid API token provided.`);
+        }
+        const errors = [`Unexpected error while checking owner of API token: ${err}`, (0, errors_1.tryParseSystemError)(err)];
+        return (0, helpers_3.printAndExit)(errors.join('\n'));
+    }
+}
+exports.handleWhoami = handleWhoami;

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -30,8 +30,7 @@ async function handleWhoami({ apiToken, codaApiEndpoint }) {
 }
 exports.handleWhoami = handleWhoami;
 function formatWhoami(user) {
-    const { name, loginId, scoped, tokenName } = user;
-    return (`You are ${name} (${loginId}) using token "${tokenName}" ` +
-        `which is scoped to ${scoped ? 'a specific pack.' : 'all your packs.'}`);
+    const { name, loginId, tokenName } = user;
+    return `You are ${name} (${loginId}) using token "${tokenName}"`;
 }
 exports.formatWhoami = formatWhoami;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -62,12 +62,12 @@ describe('CLI', () => {
       };
       assert.equal(
         formatWhoami(nonScopedToken),
-        `You are Some Name (email@example.com) using token "This Token's Name"`,
+        `You are Some Name (email@example.com) using non-scoped token "This Token's Name"`,
       );
 
       assert.equal(
         formatWhoami({...nonScopedToken, scoped: true}),
-        `You are Some Name (email@example.com) using token "This Token's Name"`,
+        `You are Some Name (email@example.com) using scoped token "This Token's Name"`,
       );
     });
   });

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -1,5 +1,7 @@
 import type {PackVersionDefinition} from '../types';
+import {PublicApiType} from '../helpers/external-api/v1';
 import {compilePackMetadata} from '../helpers/metadata';
+import {formatWhoami} from '../cli/whoami';
 import {parsePackIdOrUrl} from '../cli/link';
 
 describe('CLI', () => {
@@ -40,6 +42,33 @@ describe('CLI', () => {
       assert.equal(parsePackIdOrUrl('https://codadoc.io/p/1234'), null);
       assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo'), null);
       assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo-1234/5678'), null);
+    });
+  });
+
+  describe('format whoami result', () => {
+    it('represents the token', () => {
+      const nonScopedToken = {
+        name: 'Some Name',
+        loginId: 'email@example.com',
+        scoped: false,
+        tokenName: "This Token's Name",
+        type: PublicApiType.User as const,
+        href: 'some link',
+        workspace: {
+          id: 'abc',
+          type: PublicApiType.Workspace as const,
+          browserLink: 'browser link',
+        },
+      };
+      assert.equal(
+        formatWhoami(nonScopedToken),
+        `You are Some Name (email@example.com) using token "This Token's Name" which is scoped to all your packs.`,
+      );
+
+      assert.equal(
+        formatWhoami({...nonScopedToken, scoped: true}),
+        `You are Some Name (email@example.com) using token "This Token's Name" which is scoped to a specific pack.`,
+      );
     });
   });
 });

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -62,12 +62,12 @@ describe('CLI', () => {
       };
       assert.equal(
         formatWhoami(nonScopedToken),
-        `You are Some Name (email@example.com) using token "This Token's Name" which is scoped to all your packs.`,
+        `You are Some Name (email@example.com) using token "This Token's Name"`,
       );
 
       assert.equal(
         formatWhoami({...nonScopedToken, scoped: true}),
-        `You are Some Name (email@example.com) using token "This Token's Name" which is scoped to a specific pack.`,
+        `You are Some Name (email@example.com) using token "This Token's Name"`,
       );
     });
   });


### PR DESCRIPTION
Test plan:

Ran `npx ts-node ./cli/coda.ts whoami`, `npx ts-node ./cli/coda.ts whoami <valid token>`, and  `npx ts-node ./cli/coda.ts whoami <invalid token>`

I haven't tested a variety of token types (scoped vs non-scoped)