### PR TITLE
Add "coda clone <packIdOrUrl>"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.8.3
 
-- Added "coda clone --version <packVersion> <packId>", similar to "coda init" but for packs that were already created in a browser.
+- Added "coda clone --version <packVersion> <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
 ### 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.8.3
 
-- Added "coda clone --version <packVersion> <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
+- Added "coda clone --packVersion <packVersion> <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
 ### 0.8.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.8.3
+
+- Added "coda clone --version <packVersion> <packId>", similar to "coda init" but for packs that were already created in a browser.
+
 ### 0.8.2
 
 - Added `coda whoami` command to see API token details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-### 0.8.3
-
-- Added "coda clone <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
-
 ### 0.8.2
 
 - Added `coda whoami` command to see API token details.
 - Added `coda link` command to set up upload for an existing Pack ID instead of creating a new one.
 - Added `StringEmbedSchema` to handle configuration on how embed values appear in docs
+- Added "coda clone <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
 ### 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.8.3
 
-- Added "coda clone --packVersion <packVersion> <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
+- Added "coda clone <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
 ### 0.8.2
 

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -1,0 +1,133 @@
+import type {ArgumentsCamelCase} from 'yargs';
+import type {Client} from '../helpers/external-api/coda';
+import {createCodaClient} from './helpers';
+import {formatEndpoint} from './helpers';
+import fs from 'fs-extra';
+import {getApiKey} from './config_storage';
+import {handleInit} from './init';
+import {isResponseError} from '../helpers/external-api/coda';
+import {parsePackIdOrUrl} from './link';
+import path from 'path';
+import {print} from '../testing/helpers';
+import {printAndExit} from '../testing/helpers';
+import {promptForInput} from '../testing/helpers';
+import {storePackId} from './config_storage';
+
+interface CloneArgs {
+  packIdOrUrl: string;
+  codaApiEndpoint: string;
+  packVersion?: string;
+}
+
+export async function handleClone({packIdOrUrl, codaApiEndpoint, packVersion}: ArgumentsCamelCase<CloneArgs>) {
+  const packId = parsePackIdOrUrl(packIdOrUrl);
+  if (!packId) {
+    return printAndExit(`Not a valid pack ID or URL: ${packIdOrUrl}`);
+  }
+  const manifestDir = process.cwd();
+
+  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
+
+  const apiKey = getApiKey(codaApiEndpoint);
+  if (!apiKey) {
+    printAndExit('Missing API key. Please run `coda register <apiKey>` to register one.');
+  }
+
+  const codeAlreadyExists = fs.existsSync(path.join(process.cwd(), 'pack.ts'));
+  if (codeAlreadyExists) {
+    const shouldOverwrite = promptForInput('A pack.ts file already exists. Do you want to overwrite it? (y/N)?');
+    if (!shouldOverwrite.toLocaleLowerCase().startsWith('y')) {
+      return printAndExit('Aborting');
+    }
+  }
+
+  const client = createCodaClient(apiKey, formattedEndpoint);
+
+  if (!packVersion) {
+    try {
+      const maybeVersion = await getPackLatestVersion(client, packId);
+      if (!maybeVersion) {
+        return printAndExit(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
+      }
+      packVersion = maybeVersion;
+    } catch (err: any) {
+      maybeHandleClientError(err);
+      throw err;
+    }
+  }
+
+  let sourceCode: string | null;
+  try {
+    sourceCode = await getPackSource(client, packId, packVersion);
+  } catch (err: any) {
+    maybeHandleClientError(err);
+    throw err;
+  }
+
+  if (!sourceCode) {
+    print(
+      `Unable to download typescript source for Pack version ${packVersion}. Packs built with the SDK can't be cloned.`,
+    );
+
+    const shouldInitializeWithoutDownload = promptForInput(
+      'Do you want to continue initializing with template starter code instead (y/N)?',
+    );
+    if (!shouldInitializeWithoutDownload.toLocaleLowerCase().startsWith('y')) {
+      return process.exit(1);
+    }
+
+    await handleInit();
+    storePackId(manifestDir, packId, codaApiEndpoint);
+    return;
+  }
+
+  print(`Fetched source at version ${packVersion}`);
+
+  await handleInit();
+  storePackId(manifestDir, packId, codaApiEndpoint);
+
+  fs.writeFileSync(path.join(process.cwd(), 'pack.ts'), sourceCode);
+  printAndExit("Successfully updated pack.ts with the Pack's code!", 0);
+}
+
+function maybeHandleClientError(err: any) {
+  if (isResponseError(err)) {
+    switch (err.response.status) {
+      case 401:
+      case 403:
+      case 404:
+        return printAndExit("You don't seem to have permission to edit this pack");
+    }
+  }
+}
+
+async function getPackLatestVersion(client: Client, packId: number) {
+  const {items} = await client.listPackVersions(packId, {limit: 1});
+  if (!items || !items[0]) {
+    return null;
+  }
+  return items[0].packVersion;
+}
+
+async function getPackSource(client: Client, packId: number, version: string) {
+  const {files} = await client.getPackSourceCode(packId, version);
+
+  if (files.length !== 1 || !files[0].filename.endsWith('.ts')) {
+    return null;
+  }
+
+  const onlyFile = files[0];
+
+  // Fetch existing source code
+  const response = await fetch(onlyFile.url, {
+    headers: {
+      'Content-Type': 'application/javascript',
+      'User-Agent': 'Coda-Typescript-API-Client',
+    },
+  });
+  if (response.status >= 400) {
+    return printAndExit(`Error while fetching pack source code: ${response.statusText}`);
+  }
+  const sourceCode = await response.text();
+  return sourceCode;
+}

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -65,9 +65,7 @@ export async function handleClone({packIdOrUrl, codaApiEndpoint, packVersion}: A
   }
 
   if (!sourceCode) {
-    print(
-      `Unable to download typescript source for Pack version ${packVersion}. Packs built with the SDK can't be cloned.`,
-    );
+    print(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
 
     const shouldInitializeWithoutDownload = promptForInput(
       'Do you want to continue initializing with template starter code instead (y/N)?',
@@ -96,7 +94,7 @@ function maybeHandleClientError(err: any) {
       case 401:
       case 403:
       case 404:
-        return printAndExit("You don't seem to have permission to edit this pack");
+        return printAndExit("You don't have permission to edit this pack.");
     }
   }
 }

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -5,6 +5,7 @@ import {DEFAULT_OAUTH_SERVER_PORT} from '../testing/auth';
 import {TimerShimStrategy} from '../testing/compile';
 import {handleAuth} from './auth';
 import {handleBuild} from './build';
+import {handleClone} from './clone';
 import {handleCreate} from './create';
 import {handleExecute} from './execute';
 import {handleInit} from './init';
@@ -72,6 +73,24 @@ if (require.main === module) {
       command: 'init',
       describe: 'Initialize an empty Pack',
       handler: handleInit,
+    })
+    .command({
+      command: 'clone <packIdOrUrl>',
+      describe: 'Clone an existing web pack',
+      builder: {
+        // NOTE: yargs doesn't like "version" as a flag name since that's reserved.
+        // Seems like you can override that behavior, but "packVersion" seems fine.
+        packVersion: {
+          string: true,
+          desc: 'A build version from which to to download code. Defaults to the latest build.',
+        },
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: DEFAULT_API_ENDPOINT,
+        },
+      },
+      handler: handleClone,
     })
     .command({
       command: 'register [apiToken]',

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -76,14 +76,8 @@ if (require.main === module) {
     })
     .command({
       command: 'clone <packIdOrUrl>',
-      describe: 'Clone an existing web pack',
+      describe: 'Clone an existing Pack that was created using Pack Studio',
       builder: {
-        // NOTE: yargs doesn't like "version" as a flag name since that's reserved.
-        // Seems like you can override that behavior, but "packVersion" seems fine.
-        packVersion: {
-          string: true,
-          desc: 'A build version from which to to download code. Defaults to the latest build.',
-        },
         codaApiEndpoint: {
           string: true,
           hidden: true,

--- a/dist/cli/clone.d.ts
+++ b/dist/cli/clone.d.ts
@@ -2,7 +2,6 @@ import type { ArgumentsCamelCase } from 'yargs';
 interface CloneArgs {
     packIdOrUrl: string;
     codaApiEndpoint: string;
-    packVersion?: string;
 }
 export declare function handleClone({ packIdOrUrl, codaApiEndpoint }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/clone.d.ts
+++ b/dist/cli/clone.d.ts
@@ -4,5 +4,5 @@ interface CloneArgs {
     codaApiEndpoint: string;
     packVersion?: string;
 }
-export declare function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
+export declare function handleClone({ packIdOrUrl, codaApiEndpoint }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/clone.d.ts
+++ b/dist/cli/clone.d.ts
@@ -1,0 +1,8 @@
+import type { ArgumentsCamelCase } from 'yargs';
+interface CloneArgs {
+    packIdOrUrl: string;
+    codaApiEndpoint: string;
+    packVersion?: string;
+}
+export declare function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
+export {};

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -16,12 +16,12 @@ const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
 const config_storage_2 = require("./config_storage");
-async function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }) {
+async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
+    const manifestDir = process.cwd();
     const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
     if (!packId) {
         return (0, helpers_4.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
     }
-    const manifestDir = process.cwd();
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
@@ -35,18 +35,17 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }) {
         }
     }
     const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
-    if (!packVersion) {
-        try {
-            const maybeVersion = await getPackLatestVersion(client, packId);
-            if (!maybeVersion) {
-                return (0, helpers_4.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
-            }
-            packVersion = maybeVersion;
+    let packVersion;
+    try {
+        const maybeVersion = await getPackLatestVersion(client, packId);
+        if (!maybeVersion) {
+            return (0, helpers_4.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
         }
-        catch (err) {
-            maybeHandleClientError(err);
-            throw err;
-        }
+        packVersion = maybeVersion;
+    }
+    catch (err) {
+        maybeHandleClientError(err);
+        throw err;
     }
     let sourceCode;
     try {
@@ -69,7 +68,7 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }) {
     (0, helpers_3.print)(`Fetched source at version ${packVersion}`);
     await (0, init_1.handleInit)();
     (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
-    fs_extra_1.default.writeFileSync(path_1.default.join(process.cwd(), 'pack.ts'), sourceCode);
+    fs_extra_1.default.writeFileSync(path_1.default.join(manifestDir, 'pack.ts'), sourceCode);
     (0, helpers_4.printAndExit)("Successfully updated pack.ts with the Pack's code!", 0);
 }
 exports.handleClone = handleClone;

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -1,0 +1,111 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.handleClone = void 0;
+const helpers_1 = require("./helpers");
+const helpers_2 = require("./helpers");
+const fs_extra_1 = __importDefault(require("fs-extra"));
+const config_storage_1 = require("./config_storage");
+const init_1 = require("./init");
+const coda_1 = require("../helpers/external-api/coda");
+const link_1 = require("./link");
+const path_1 = __importDefault(require("path"));
+const helpers_3 = require("../testing/helpers");
+const helpers_4 = require("../testing/helpers");
+const helpers_5 = require("../testing/helpers");
+const config_storage_2 = require("./config_storage");
+async function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }) {
+    const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
+    if (!packId) {
+        return (0, helpers_4.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
+    }
+    const manifestDir = process.cwd();
+    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
+    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+    if (!apiKey) {
+        (0, helpers_4.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+    }
+    const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(process.cwd(), 'pack.ts'));
+    if (codeAlreadyExists) {
+        const shouldOverwrite = (0, helpers_5.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?');
+        if (!shouldOverwrite.toLocaleLowerCase().startsWith('y')) {
+            return (0, helpers_4.printAndExit)('Aborting');
+        }
+    }
+    const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    if (!packVersion) {
+        try {
+            const maybeVersion = await getPackLatestVersion(client, packId);
+            if (!maybeVersion) {
+                return (0, helpers_4.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
+            }
+            packVersion = maybeVersion;
+        }
+        catch (err) {
+            maybeHandleClientError(err);
+            throw err;
+        }
+    }
+    let sourceCode;
+    try {
+        sourceCode = await getPackSource(client, packId, packVersion);
+    }
+    catch (err) {
+        maybeHandleClientError(err);
+        throw err;
+    }
+    if (!sourceCode) {
+        (0, helpers_3.print)(`Unable to download typescript source for Pack version ${packVersion}. Packs built with the SDK can't be cloned.`);
+        const shouldInitializeWithoutDownload = (0, helpers_5.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?');
+        if (!shouldInitializeWithoutDownload.toLocaleLowerCase().startsWith('y')) {
+            return process.exit(1);
+        }
+        await (0, init_1.handleInit)();
+        (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
+        return;
+    }
+    (0, helpers_3.print)(`Fetched source at version ${packVersion}`);
+    await (0, init_1.handleInit)();
+    (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
+    fs_extra_1.default.writeFileSync(path_1.default.join(process.cwd(), 'pack.ts'), sourceCode);
+    (0, helpers_4.printAndExit)("Successfully updated pack.ts with the Pack's code!", 0);
+}
+exports.handleClone = handleClone;
+function maybeHandleClientError(err) {
+    if ((0, coda_1.isResponseError)(err)) {
+        switch (err.response.status) {
+            case 401:
+            case 403:
+            case 404:
+                return (0, helpers_4.printAndExit)("You don't seem to have permission to edit this pack");
+        }
+    }
+}
+async function getPackLatestVersion(client, packId) {
+    const { items } = await client.listPackVersions(packId, { limit: 1 });
+    if (!items || !items[0]) {
+        return null;
+    }
+    return items[0].packVersion;
+}
+async function getPackSource(client, packId, version) {
+    const { files } = await client.getPackSourceCode(packId, version);
+    if (files.length !== 1 || !files[0].filename.endsWith('.ts')) {
+        return null;
+    }
+    const onlyFile = files[0];
+    // Fetch existing source code
+    const response = await fetch(onlyFile.url, {
+        headers: {
+            'Content-Type': 'application/javascript',
+            'User-Agent': 'Coda-Typescript-API-Client',
+        },
+    });
+    if (response.status >= 400) {
+        return (0, helpers_4.printAndExit)(`Error while fetching pack source code: ${response.statusText}`);
+    }
+    const sourceCode = await response.text();
+    return sourceCode;
+}

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -57,7 +57,7 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint, packVersion }) {
         throw err;
     }
     if (!sourceCode) {
-        (0, helpers_3.print)(`Unable to download typescript source for Pack version ${packVersion}. Packs built with the SDK can't be cloned.`);
+        (0, helpers_3.print)(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
         const shouldInitializeWithoutDownload = (0, helpers_5.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?');
         if (!shouldInitializeWithoutDownload.toLocaleLowerCase().startsWith('y')) {
             return process.exit(1);
@@ -79,7 +79,7 @@ function maybeHandleClientError(err) {
             case 401:
             case 403:
             case 404:
-                return (0, helpers_4.printAndExit)("You don't seem to have permission to edit this pack");
+                return (0, helpers_4.printAndExit)("You don't have permission to edit this pack.");
         }
     }
 }

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -25,9 +25,9 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        (0, helpers_4.printAndExit)('Missing API key. Please run `coda register <apiKey>` to register one.');
+        return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register <apiKey>` to register one.');
     }
-    const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(process.cwd(), 'pack.ts'));
+    const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(manifestDir, 'pack.ts'));
     if (codeAlreadyExists) {
         const shouldOverwrite = (0, helpers_5.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?');
         if (!shouldOverwrite.toLocaleLowerCase().startsWith('y')) {
@@ -37,11 +37,10 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
     const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
     let packVersion;
     try {
-        const maybeVersion = await getPackLatestVersion(client, packId);
-        if (!maybeVersion) {
+        packVersion = await getPackLatestVersion(client, packId);
+        if (!packVersion) {
             return (0, helpers_4.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
         }
-        packVersion = maybeVersion;
     }
     catch (err) {
         maybeHandleClientError(err);
@@ -105,6 +104,5 @@ async function getPackSource(client, packId, version) {
     if (response.status >= 400) {
         return (0, helpers_4.printAndExit)(`Error while fetching pack source code: ${response.statusText}`);
     }
-    const sourceCode = await response.text();
-    return sourceCode;
+    return response.text();
 }

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -78,14 +78,8 @@ if (require.main === module) {
     })
         .command({
         command: 'clone <packIdOrUrl>',
-        describe: 'Clone an existing web pack',
+        describe: 'Clone an existing Pack that was created using Pack Studio',
         builder: {
-            // NOTE: yargs doesn't like "version" as a flag name since that's reserved.
-            // Seems like you can override that behavior, but "packVersion" seems fine.
-            packVersion: {
-                string: true,
-                desc: 'A build version from which to to download code. Defaults to the latest build.',
-            },
             codaApiEndpoint: {
                 string: true,
                 hidden: true,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -9,6 +9,7 @@ const auth_1 = require("../testing/auth");
 const compile_1 = require("../testing/compile");
 const auth_2 = require("./auth");
 const build_1 = require("./build");
+const clone_1 = require("./clone");
 const create_1 = require("./create");
 const execute_1 = require("./execute");
 const init_1 = require("./init");
@@ -74,6 +75,24 @@ if (require.main === module) {
         command: 'init',
         describe: 'Initialize an empty Pack',
         handler: init_1.handleInit,
+    })
+        .command({
+        command: 'clone <packIdOrUrl>',
+        describe: 'Clone an existing web pack',
+        builder: {
+            // NOTE: yargs doesn't like "version" as a flag name since that's reserved.
+            // Seems like you can override that behavior, but "packVersion" seems fine.
+            packVersion: {
+                string: true,
+                desc: 'A build version from which to to download code. Defaults to the latest build.',
+            },
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: config_storage_1.DEFAULT_API_ENDPOINT,
+            },
+        },
+        handler: clone_1.handleClone,
     })
         .command({
         command: 'register [apiToken]',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.8.3",
+  "version": "0.8.2",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"


### PR DESCRIPTION
The behavior is similar to "coda init", but additionally:
- Downloads typescript code if the existing pack was created in a web browser
- Prompt to overwrite if pack.ts already exists.
- If the existing pack wasn't created in a browser, prompt to initialize a template pack.ts
  and also set up .coda-pack.json
- Set the Pack ID in .coda-pack.json, avoiding the need for a separate run of "coda link"

Test strategy:
- "coda clone <pack ID>" with a bad pack ID (error message about access)
- "coda clone <pack ID>" with a good pack ID (works)
- "coda clone --packVersion <version> <pack ID>" with a good pack ID (works)
- "coda clone <pack ID>" with a good pack ID and an SDK-written build (prompts to continue without source code)
- "coda clone <pack ID>" when pack.ts already exists (prompts to overwrite)