### PR TITLE
make deploy docs available on any commit to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,16 @@ jobs:
 workflows:
   version: 2
 
+  commit-validation:
+    jobs:
+      - build:
+          context:
+            - dockerhub
+          filters:
+            branches:
+              ignore:
+                - main
+
   commit-validation-and-deploy-docs:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,36 +179,31 @@ jobs:
 
 workflows:
   version: 2
-  commit_validation:
-    jobs:
-      - build:
-          context:
-            - dockerhub
-          filters:
-            branches:
-              ignore:
-                - release
 
-  build-and-deploy-docs:
+  commit-validation-and-deploy-docs:
     jobs:
       - build:
           context:
             - dockerhub
-          filters:
-            branches:
-              only:
-                - release
+          # filters:
+          #   branches:
+          #     only:
+          #       - main
       - utils/cancel-older-awaiting-approvals:
           context:
             - circleci
           circle_token: ${CIRCLECI_TOKEN}
           requires:
             - build
+      - wait-for-docs-approval:
+          type: approval
+          requires:
+            - utils/cancel-older-awaiting-approvals
       - build-docs-head:
           context:
             - dockerhub
           requires:  
-            - build
+            - wait-for-docs-approval
       - push-head-docs:
           context:
             - aws-head

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,10 +185,10 @@ workflows:
       - build:
           context:
             - dockerhub
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+          filters:
+            branches:
+              only:
+                - main
       - utils/cancel-older-awaiting-approvals:
           context:
             - circleci


### PR DESCRIPTION
realizing the `release` branch flow is a big pain to work with and with Github tags/releases that we're going to start using to tag new NPM releases i don't see the need for it. 

Instead, the new flow gives the option for any commit on main to deploy docs, as long as you first approve the doc deploy flow. It still maintains the extra approval to deploy to prod so you can manually verify on head/staging that docs are updated appropriately.

cc @coda/packs  @ekoleda-codaio @jonathan-codaio 