### PR TITLE
Build docs in strict mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
 
     steps:
       - checkout
+      - base-tools/install
       - bootstrap_node
       - bootstrap_pipenv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
     steps:
       - checkout
       - bootstrap_node
+      - bootstrap_pipenv
       - run:
           name: 'Lint'
           command: make lint
@@ -75,7 +76,7 @@ jobs:
   build-docs-head:
     executor: default_build_environment
     working_directory: ~/repo
-    
+
     steps:
       - checkout
       - base-tools/install
@@ -95,7 +96,7 @@ jobs:
   build-docs-staging:
     executor: default_build_environment
     working_directory: ~/repo
-    
+
     steps:
       - checkout
       - base-tools/install
@@ -115,7 +116,7 @@ jobs:
   build-docs-prod:
     executor: default_build_environment
     working_directory: ~/repo
-    
+
     steps:
       - checkout
       - base-tools/install
@@ -146,7 +147,7 @@ jobs:
           name: Deploy Head
           command: 'make publish-docs-head FLAGS=--forceUpload'
       # TODO: add a probe step here to validate?
-  
+
   push-staging-docs:
     executor: default_build_environment
     working_directory: ~/repo
@@ -161,7 +162,7 @@ jobs:
           name: Deploy Staging
           command: 'make publish-docs-staging FLAGS=--forceUpload'
       # TODO: add a probe step here to validate?
-  
+
   push-prod-docs:
     executor: default_build_environment
     working_directory: ~/repo
@@ -212,7 +213,7 @@ workflows:
       - build-docs-head:
           context:
             - dockerhub
-          requires:  
+          requires:
             - wait-for-docs-approval
       - push-head-docs:
           context:
@@ -224,7 +225,7 @@ workflows:
           context:
             - dockerhub
           requires:
-            - push-head-docs      
+            - push-head-docs
       - push-staging-docs:
           context:
             - aws-staging

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ typedoc:
 	node -r ts-node/register documentation/typedoc_post_process.ts
 
 .PHONY: docs
-docs: typedoc generated-documentation
+docs: typedoc generated-documentation build-mkdocs
 
 .PHONY: view-docs
 view-docs:
@@ -153,7 +153,7 @@ view-docs:
 # This step generates all the documentation for the SDK using mkdocs and dumps the contents in /site
 .PHONY: build-mkdocs
 build-mkdocs:
-	${PIPENV} run mkdocs build
+	${PIPENV} run mkdocs build --strict
 
 # This step uploads the documentation for the current package version.
 # TODO(spencer): probably need some user handling to make sure there is an update in package.json if the documentation has been updated.

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,14 @@ _bootstrap-node:
 .PHONY: _bootstrap-python
 _bootstrap-python:
 	${PIPENV} sync
+
+.PHONY: _bootstrap-python-requirements
+_bootstrap-python-requirements:
 	# Ensure requirements.txt (used by Read the Docs) is in sync.
+	# Keep this separate from _bootstrap-python since the output changes based
+	# on the version of pipenv installed.
 	${PIPENV} lock -r > requirements.txt
+
 
 .PHONY: _bootstrap-githooks
 _bootstrap-githooks: clean-githooks
@@ -41,6 +47,7 @@ _bootstrap-githooks: clean-githooks
 bootstrap:
 	$(MAKE) MAKEFLAGS= _bootstrap-node
 	$(MAKE) MAKEFLAGS= _bootstrap-python
+	$(MAKE) MAKEFLAGS= _bootstrap-python-requirements
 	$(MAKE) MAKEFLAGS= _bootstrap-githooks
 	echo
 	echo '  make bootstrap complete!'

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -272,4 +272,4 @@ It's recommended that you reduce or disable [HTTP caching][fetcher_caching] of t
 [sample_reference]: ../../../samples/topic/sync-table.md#with-row-references
 [parmeters]: ../../basics/parameters/index.md
 [fetcher_caching]: ../../advanced/fetcher.md#caching
-[parameters]: ../../basics/parameters.md
+[parameters]: ../../basics/parameters/index.md


### PR DESCRIPTION
mkdocs logs a warning when you link to a non-existent file. This change makes that warning an error, and builds the docs as part of the normal build process. 

```sh
INFO     -  [macros] - Macros arguments: {'module_name': 'main', 'modules': [], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '',
            'on_undefined': 'keep', 'verbose': False}
INFO     -  [macros] - Extra variables (config file): ['social', 'coda']
INFO     -  [macros] - Extra filters (module): ['pretty']
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /Users/EricKoleda/code/packs-sdk/site
WARNING  -  Documentation file 'guides/blocks/sync-tables/index.md' contains a link to 'guides/basics/parameters.md' which is not found in the documentation files.

Aborted with 1 warnings in strict mode!
make: *** [build-mkdocs] Error 1
(packs-sdk) FAIL
```

This should help prevent broken links. Also fixed the broken link that lead me to make this change.