### PR TITLE
Roll version back to 0.8.2 since 0.9.0 is unreleased

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.9.0",
+  "version": "0.8.2",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"


### PR DESCRIPTION
Oops!  I set my version to "Unreleased" in the change log, but forgot to roll it back in package.json.  Hope this temporary hiccup doesn't hose anything!