### PR TITLE
Improve visibility of recommended pack file structure

### DIFF
--- a/docs/guides/development/cli.md
+++ b/docs/guides/development/cli.md
@@ -63,7 +63,7 @@ You can now access the CLI in any directory by typing the command `coda`.
 
 ### Create Pack definition
 
-Run `coda init` to initialize an empty project with the recommended file structure and install the suggested npm dependencies.
+Run `coda init` to initialize an empty project with the recommended settings and dependencies.
 
 
 ## Running code locally
@@ -248,6 +248,20 @@ npx coda release path/to/pack.ts --notes "Added the formula MyNewFormula."
 -->
 
 
+## Recommended file structure
+
+When using the CLI to build a Pack you can split your code into multiple files, which can be really useful for large or complex Packs. You can organize your code however you like, as long as there is a file that exports the Pack definition with the name `pack` (typically named `pack.ts`).
+
+Coda engineers have built dozens of Packs over the years, and have settled on a the recommended file structure below:
+
+* `helpers.ts` - A place to define helper functions used by your Pack.
+* `pack.ts` - The core Pack definition, where all of the formulas, sync tables, and other building blocks are added.
+* `schemas.ts` - A place to define the schemas (structured data types) used by your Pack.
+* `types.ts` - A place to define TypeScript types for the data used by your Pack.
+
+To see this pattern in action check out the [CLI example Packs][github_examples] on GitHub.
+
+
 ## When to use Pack Studio
 
 Although a lot of Pack management can be done through the CLI, there are still some tasks that require you to visit the Pack Studio web interface. These include:
@@ -267,7 +281,7 @@ To migrate, first make sure you have the [required software](#requirements) inst
 npx coda clone "https://coda.io/p/123456"
 ```
 
-This will initialize the directory with the recommended file structure, download your existing Pack code into `pack.ts`, and create a `.coda-pack.json` file that links them together.
+This will initialize the directory with the recommended settings and dependencies, download your existing Pack code into `pack.ts`, and create a `.coda-pack.json` file that links them together.
 
 !!! info "Link only"
     If you've already setup your local project and just need to link it to the existing Pack use the `coda link` command instead. It will create the `.coda-pack.json` file and nothing else.
@@ -287,3 +301,4 @@ The next time you run `coda upload` your Pack will be updated to use the local c
 [isolated_vm_requirements]: https://github.com/laverdet/isolated-vm#requirements
 [testing]: testing.md#local
 [versions_history]: versions.md#history
+[github_examples]: https://github.com/coda/packs-examples

--- a/docs/samples/.nav.yml
+++ b/docs/samples/.nav.yml
@@ -1,4 +1,5 @@
 nav:
   - By topic: topic
   - full
+  - CLI examples on GitHub: https://github.com/coda/packs-examples
   - ...

--- a/docs/tutorials/get-started/cli.md
+++ b/docs/tutorials/get-started/cli.md
@@ -59,13 +59,11 @@ Lastly, one of the libraries used by the SDK requires that your machine has some
 
 Your directory should now contain the following files:
 
-* `helpers.ts` - A place to define helper functions used by your Pack.
-* `node_modules` - The dependencies downloaded from NPM (standard for Node.js projects).
-* `pack.ts` - The core Pack definition, where all of the formulas, sync tables, and other building blocks are added.
-* `package-lock.json` - The versions of the dependencies downloaded from NPM (standard for Node.js projects).
-* `package.json` - The project's dependencies from NPM (standard for Node.js projects).
-* `schemas.ts` - A place to define the schemas (structured data types) used by your Pack.
-* `types.ts` - A place to define TypeScript types for the data used by your Pack.
+- `node_modules` - The dependencies downloaded from NPM (standard for Node.js projects).
+- `pack.ts` - The core Pack definition, where all of the formulas, sync tables, and other building blocks are added.
+- `package-lock.json` - The versions of the dependencies downloaded from NPM (standard for Node.js projects).
+- `package.json` - The project's dependencies from NPM (standard for Node.js projects).
+- `tsconfig.json` - The TypeScript settings for the project (standard for TypeScript projects).
 
 
 ## Add code to the Pack
@@ -208,6 +206,16 @@ Now that you have your Pack up and running let's make a change to how it works.
 --8<-- "tutorials/get-started/.rebuild.md"
 
 
+## Next steps
+
+You've built your fist Pack, congrats! 🎉 Now that you have some experience with the mechanics of building and using Packs, here are some recommended next steps:
+
+- Learn about Pack basics by reading through the [available guides][guides].
+- Check out the [example Packs][github_examples] built using the CLI, as well as the other [code samples][samples].
+- Dive deeper into the command line tool by reading the [CLI guide][cli].
+
+
+
 [vs_code]: https://code.visualstudio.com/
 [github]: https://github.com
 [npm]: https://www.npmjs.com/
@@ -220,3 +228,7 @@ Now that you have your Pack up and running let's make a change to how it works.
 [gitignore]: https://git-scm.com/docs/gitignore
 [coda_home]: https://coda.io/docs
 [rebuild]: ../../images/cli_rebuild.gif
+[cli]: ../../guides/development/cli.md
+[github_examples]: https://github.com/coda/packs-examples
+[samples]: ../../samples/topic/formula.md
+[guides]: ../../guides/blocks/formulas.md

--- a/docs/tutorials/get-started/web.md
+++ b/docs/tutorials/get-started/web.md
@@ -73,6 +73,14 @@ Now that you have your Pack up and running let's make a change to how it works.
 --8<-- "tutorials/get-started/.rebuild.md"
 
 
+## Next steps
+
+You've built your fist Pack, congrats! 🎉 Now that you have some experience with the mechanics of building and using Packs, here are some recommended next steps:
+
+- Learn about Pack basics by reading through the [available guides][guides].
+- Check out the [code samples][samples] to see examples of specific Pack features as well as complete sample Packs.
+
+
 [coda_sign_up]: https://coda.io/signup
 [hc_doc_maker]: https://help.coda.io/en/articles/3388781-members-and-roles
 [coda_home]: https://coda.io/docs
@@ -80,3 +88,5 @@ Now that you have your Pack up and running let's make a change to how it works.
 [web_ide_build]: ../../images/web_ide_build.gif
 [samples_hello_world]: ../../samples/full/hello-world.md
 [rebuild]: ../../images/web_ide_rebuild.gif
+[samples]: ../../samples/topic/formula.md
+[guides]: ../../guides/blocks/formulas.md


### PR DESCRIPTION
Given the [recent PR](https://github.com/coda/packs-examples/pull/130) to trim down the template Pack, this PR adds some more visibility to the recommended file structure:

- Documents it in the CLI guide.
- Adds a callout to that guide, and the packs-examples repo, at the end of the CLI getting started guide.

Adds a next steps section to the end of the Pack Studio getting started guide as well, for consistency.