### PR TITLE
update workflow to run via manual trigger

### DIFF
--- a/.github/actions/release.yml
+++ b/.github/actions/release.yml
@@ -7,9 +7,9 @@ on:
         required: true
         type: choice
         options:
-        - patch
-        - minor
-        - major 
+          - patch
+          - minor
+          - major 
 
 jobs:
   release:

--- a/.github/actions/release.yml
+++ b/.github/actions/release.yml
@@ -1,3 +1,16 @@
+
+on: 
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: 'Release version increment'     
+        required: true
+        type: choice
+        options:
+        - patch
+        - minor
+        - major 
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -9,6 +22,7 @@ jobs:
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - run: make release
+      - run: make release $INCREMENT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCREMENT: ${{ github.event.inputs.increment }}

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ release:
 	# @test "" = "`git cherry`" || (echo "Refusing to publish with unpushed commits" && false)
 
 	# TODO(spencer): support specifying version and passing in here, takes in `minor`, `major`, or `patch`.
-	npx release-it --npm.tag=latest --ci 
+	npx release-it --npm.tag=latest --ci ${FLAGS}
 
 # TODO(spencer): after new releaes flow is in use, remove this
 .PHONY: npm-publish


### PR DESCRIPTION
also allows for release type input

apparently it doesn't show up in the "Actions" tab unless you configure it to run on `workflow_dispatch`