### PR TITLE
allow look up sync table by identity name

### DIFF
--- a/dist/runtime/common/helpers.js
+++ b/dist/runtime/common/helpers.js
@@ -31,8 +31,6 @@ function findSyncFormula(packDef, syncFormulaName) {
     }
     for (const syncTable of packDef.syncTables) {
         const syncFormula = syncTable.getter;
-        // TODO(huayang): it seems like a bug that client passes syncTable.name in, instead of syncTable.identityName or
-        // syncTable.getter.name.
         if (syncTable.name === syncFormulaName) {
             return syncFormula;
         }

--- a/runtime/common/helpers.ts
+++ b/runtime/common/helpers.ts
@@ -38,8 +38,6 @@ export function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: s
 
   for (const syncTable of packDef.syncTables) {
     const syncFormula = syncTable.getter;
-    // TODO(huayang): it seems like a bug that client passes syncTable.name in, instead of syncTable.identityName or
-    // syncTable.getter.name.
     if (syncTable.name === syncFormulaName) {
       return syncFormula;
     }


### PR DESCRIPTION
https://staging.coda.io/d/Quality-Tracker_d-GJF-DmEUK/Bugs_sucBW#Bugs_tuq-W/r19750&view=modal

after thinking about this again, I feel like it was a mistake to attempt looking up sync table by identity name. They are two separate things. 

PTAL @jonathan-codaio @coda/packs 