### PR TITLE
add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)
+![](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)
+![](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)
+![]()
+
 # Coda Packs SDK
 
 Coda Packs allow you to extend Coda by building new building blocks that can operate directly on Coda docs' canvas. You can write these extensions in JavaScript/TypeScript, using them to create functions that let you re-use a formula's complex logic across documents or even communicate with third-party APIs, with or without user authentication.
@@ -6,7 +11,8 @@ To learn more, see [our SDK documentation](https://coda.io/packs/build) or join 
 
 ## Publishing Changes Process
 
-Adjustments to the `CHANGELOG.md` file should be marked under `### Unreleased` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`. 
+Adjustments to the `CHANGELOG.md` file should be marked under `### Unreleased` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`.
 
 ### CHANGELOG
+
 Our `CHANGELOG.md` follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) standards, where there is a “Unreleased” section at the top for any unreleased changes. Upon release, it is named according to a semantic versioning system and dated.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)
-![](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)
-![](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)
+[![](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)](https://www.npmjs.com/package/@codahq/packs-sdk)
+[![](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)](https://coda.io/gallery?filter=Packs)
+[![](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)](https://community.coda.io)
 
 # Coda Packs SDK
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)](https://www.npmjs.com/package/@codahq/packs-sdk)
-[![](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)](https://coda.io/gallery?filter=Packs)
-[![](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)](https://community.coda.io)
+[![npm release](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)](https://www.npmjs.com/package/@codahq/packs-sdk)
+[![Downloads](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)](https://coda.io/gallery?filter=Packs)
+[![Community](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)](https://community.coda.io)
 
 # Coda Packs SDK
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![](https://img.shields.io/npm/v/@codahq/packs-sdk?color=%23F8AD40&logo=coda&logoColor=%23EE5A29&style=flat-square)
 ![](https://img.shields.io/npm/dt/@codahq/packs-sdk?color=%23F8AD40&label=npm%20downloads&style=flat-square)
 ![](https://img.shields.io/discourse/users?color=%23F8AD40&label=community&logo=coda&server=https%3A%2F%2Fcommunity.coda.io%2F&style=flat-square)
-![]()
 
 # Coda Packs SDK
 


### PR DESCRIPTION
adding some badges like is common on open-source repos to show:
* last npm release -> links to npm package
* npm downloads all-time -> links to packs gallery
* users in community.coda.io -> links to community

generated via https://shields.io/

<img width="907" alt="image" src="https://user-images.githubusercontent.com/81383639/160929252-0bfa7ba4-c161-4f19-a9d4-f11cffd9f75e.png">

@packs 