### PR TITLE
validate connection-requirement for no-auth packs

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -808,6 +808,31 @@ function validateFormulas(schema) {
         path: ['networkDomains'],
     })
         .superRefine((data, context) => {
+        if (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) {
+            return;
+        }
+        // if the pack has no default authentication, make sure all formulas don't set connection requirements.
+        (data.formulas || []).forEach((formula, i) => {
+            if (formula.connectionRequirement && formula.connectionRequirement !== api_types_1.ConnectionRequirement.None) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['formulas', i],
+                    message: 'Formula should not set connectionRequirement for no-auth Packs.',
+                });
+            }
+        });
+        (data.syncTables || []).forEach((syncTable, i) => {
+            const connectionRequirement = syncTable.getter.connectionRequirement;
+            if (connectionRequirement && connectionRequirement !== api_types_1.ConnectionRequirement.None) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['syncTables', i, 'getter', 'connectionRequirement'],
+                    message: 'Sync table formula should not set connectionRequirement for no-auth Packs.',
+                });
+            }
+        });
+    })
+        .superRefine((data, context) => {
         const formulas = (data.formulas || []);
         (data.formats || []).forEach((format, i) => {
             var _a;

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -980,6 +980,33 @@ function validateFormulas(schema: z.ZodObject<any>) {
       },
     )
     .superRefine((data, context) => {
+      if (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) {
+        return;
+      }
+
+      // if the pack has no default authentication, make sure all formulas don't set connection requirements.
+      ((data.formulas || []) as PackFormulaMetadata[]).forEach((formula, i) => {
+        if (formula.connectionRequirement && formula.connectionRequirement !== ConnectionRequirement.None) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['formulas', i],
+            message: 'Formula should not set connectionRequirement for no-auth Packs.',
+          });
+        }
+      });
+
+      ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
+        const connectionRequirement = syncTable.getter.connectionRequirement;
+        if (connectionRequirement && connectionRequirement !== ConnectionRequirement.None) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['syncTables', i, 'getter', 'connectionRequirement'],
+            message: 'Sync table formula should not set connectionRequirement for no-auth Packs.',
+          });
+        }
+      });
+    })
+    .superRefine((data, context) => {
       const formulas = (data.formulas || []) as PackFormulaMetadata[];
       ((data.formats as any[]) || []).forEach((format, i) => {
         const formula = formulas.find(f => f.name === format.formulaName);


### PR DESCRIPTION
This PR prevents makers to add connection requirement to a pack with `None` default authentication.

[bug-22350](https://golinks.io/bug/22350)

PTAL @coda/packs 