### PR TITLE
Add validation rule preventing usage of varargParameters for sync tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This changelog keeps track of all changes to the packs-sdk. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
+### Unreleased
+- **Breaking Change** Added a validation rule that prevents the usage of varargsParameters for sync table getters
+which are not currently supported in the UI.
+
 ## [0.9.0] - 2022-03-17
 - **Breaking Change** ValueHintType.Url will now create a column of type "Link" instead of "Text".
 - Added ValueHintType.Email for new column type "Email".

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -730,7 +730,17 @@ const genericDynamicSyncTableSchema = zodCompleteObject({
     listDynamicUrls: formulaMetadataSchema.optional(),
     getSchema: formulaMetadataSchema,
 }).strict();
-const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTableSchema]);
+const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTableSchema])
+    .superRefine((data, context) => {
+    const syncTable = data;
+    if (syncTable.getter.varargParameters) {
+        context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['getter', 'varargParameters'],
+            message: 'Sync table formulas do not currently support varargParameters.',
+        });
+    }
+});
 // Make sure to call the refiners on this after removing legacyPackMetadataSchema.
 // (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
 // schema we actually use.)

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -733,7 +733,7 @@ const genericDynamicSyncTableSchema = zodCompleteObject({
 const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTableSchema])
     .superRefine((data, context) => {
     const syncTable = data;
-    if (syncTable.getter.varargParameters) {
+    if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
         context.addIssue({
             code: z.ZodIssueCode.custom,
             path: ['getter', 'varargParameters'],

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -412,6 +412,46 @@ describe('Pack metadata Validation', () => {
       ]);
     });
 
+    it('reject sync table formulas with varargParameters', async () => {
+      const syncTable = makeSyncTable({
+        name: 'SyncTable',
+        identityName: 'Sync',
+        schema: makeObjectSchema({
+          type: ValueType.Object,
+          primary: 'foo',
+          id: 'foo',
+          identity: {packId: 424242, name: 'foo'},
+          properties: {
+            Foo: {type: ValueType.String},
+          },
+        }),
+        formula: {
+          name: 'SyncTable',
+          description: 'A simple sync table',
+          async execute([], _context) {
+            return {result: []};
+          },
+          parameters: [],
+          varargParameters: [makeParameter({type: ParameterType.String, name: 'param', description: 'param'})],
+          examples: [],
+        },
+      });
+      const metadata = createFakePackVersionMetadata({
+        syncTables: [syncTable],
+        defaultAuthentication: {
+          type: AuthenticationType.None,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            'Sync table formulas do not currently support varargParameters.',
+          path: 'syncTables[0].getter.varargParameters',
+        },
+      ]);
+    });
+
     // Evidently we allow this.
     it('valid object formula with no schema', async () => {
       const formula = makeObjectFormula({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -56,6 +56,7 @@ import type {StringEmbedSchema} from '../schema';
 import type {StringPackFormula} from '../api';
 import type {StringTimeSchema} from '../schema';
 import type {SyncFormula} from '../api';
+import type {SyncTable} from '../api';
 import type {SyncTableDef} from '../api';
 import type {SystemAuthenticationTypes} from '../types';
 import {Type} from '../api_types';
@@ -885,7 +886,19 @@ const genericDynamicSyncTableSchema = zodCompleteObject<
   getSchema: formulaMetadataSchema,
 }).strict();
 
-const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTableSchema]);
+const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTableSchema])
+  .superRefine((data, context) => {
+    const syncTable = data as SyncTable;
+
+    if (syncTable.getter.varargParameters) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['getter', 'varargParameters'],
+        message:
+          'Sync table formulas do not currently support varargParameters.',
+      });
+    }
+});
 
 // Make sure to call the refiners on this after removing legacyPackMetadataSchema.
 // (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
@@ -995,7 +1008,7 @@ function validateFormulas(schema: z.ZodObject<any>) {
         }
       });
 
-      ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
+      ((data.syncTables as SyncTable[]) || []).forEach((syncTable, i) => {
         const connectionRequirement = syncTable.getter.connectionRequirement;
         if (connectionRequirement && connectionRequirement !== ConnectionRequirement.None) {
           context.addIssue({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -890,7 +890,7 @@ const syncTableSchema = z.union([genericDynamicSyncTableSchema, genericSyncTable
   .superRefine((data, context) => {
     const syncTable = data as SyncTable;
 
-    if (syncTable.getter.varargParameters) {
+    if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['getter', 'varargParameters'],


### PR DESCRIPTION
@jonathan-codaio @coda/packs PTAL

Since the UI does not currently support varargs in this context, just throw an error until we can fix it.