### PR TITLE
Add link to sharing and publishing guide

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1,8 +1,12 @@
 /* Create a custom Coda color scheme. */
 [data-md-color-scheme="coda"] {
+  /* Theme overrides. */
   --md-primary-fg-color: #006838; /* Emerald */
   --md-accent-fg-color: #EE5A29; /* Tomato Soup */
   --md-code-hl-color: #FFE6C9; /* Peach */
+
+  /* Custom variables. */
+  --coda-external-link-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M256 64c0-17.67 14.3-32 32-32h127.1c5.2 0 9.4.86 13.1 2.43 2.9 1.55 7.3 3.84 10.4 6.87 0 .05 0 .1.1.14 6.2 6.22 8.4 14.34 9.3 22.46V192c0 17.7-14.3 32-32 32s-32-14.3-32-32v-50.7L214.6 310.6c-12.5 12.5-32.7 12.5-45.2 0s-12.5-32.7 0-45.2L338.7 96H288c-17.7 0-32-14.33-32-32zM0 128c0-35.35 28.65-64 64-64h96c17.7 0 32 14.33 32 32 0 17.7-14.3 32-32 32H64v288h288v-96c0-17.7 14.3-32 32-32s32 14.3 32 32v96c0 35.3-28.7 64-64 64H64c-35.35 0-64-28.7-64-64V128z"/></svg>')
 }
 
 /* Don't use link colors in the announcement banner, for readability. */
@@ -36,4 +40,21 @@ li.yes {
 
 li.no {
   list-style-type: "❌";
+}
+
+/* Add an icon next to external links in the nav. */
+.md-sidebar a[href]:where(
+  [href^="https://"],
+):after {
+  background-color: currentColor;
+  mask-image: var(--coda-external-link-image);
+  -webkit-mask-image: var(--coda-external-link-image);
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  content:"";
 }

--- a/docs/guides/development/.nav.yml
+++ b/docs/guides/development/.nav.yml
@@ -1,0 +1,9 @@
+nav:
+  - pack-maker-tools.md
+  - Sharing & publishing: https://help.coda.io/en/articles/5987280-sharing-and-publishing-a-pack
+  - testing.md
+  - troubleshooting.md
+  - cli.md
+  - libraries.md
+  - versions.md
+  - ...


### PR DESCRIPTION
Guide is already written in the help center documentation, linking off to it. Added a `.nav.yml` to link to it, and sorted the section alphabetically while I was there. Also addd some CSS to style an external link icon for nav items that link outside the SDK docs. The MkDocs Material theme we use embeds SVG icons in the CSS directly, so following that pattern here as well.

![Screen Shot 2022-04-06 at 4 44 12 PM](https://user-images.githubusercontent.com/88106038/162067600-e3815b16-dc9e-497f-9cca-6bcd9f062da3.png)

