### PR TITLE
skip marshaling deep-nested value instead of throwing

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -4525,7 +4525,7 @@ module.exports = (() => {
   }
   function processValue(val, depth = 0) {
     if (depth >= MaxTraverseDepth) {
-      throw new Error("marshaling value is too deep or containing circular strcture");
+      return val;
     }
     if (val === void 0) {
       return HACK_UNDEFINED_JSON_VALUE;

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -4525,7 +4525,7 @@ module.exports = (() => {
   }
   function processValue(val, depth = 0) {
     if (depth >= MaxTraverseDepth) {
-      throw new Error("marshaling value is too deep or containing circular strcture");
+      return val;
     }
     if (val === void 0) {
       return HACK_UNDEFINED_JSON_VALUE;

--- a/dist/runtime/common/marshaling/index.js
+++ b/dist/runtime/common/marshaling/index.js
@@ -36,7 +36,9 @@ function deserialize(_, val) {
 }
 function processValue(val, depth = 0) {
     if (depth >= MaxTraverseDepth) {
-        throw new Error('marshaling value is too deep or containing circular strcture');
+        // this is either a circular reference or a super nested value that we mostly likely
+        // don't care about marshalling.
+        return val;
     }
     if (val === undefined) {
         return HACK_UNDEFINED_JSON_VALUE;

--- a/runtime/common/marshaling/index.ts
+++ b/runtime/common/marshaling/index.ts
@@ -42,7 +42,9 @@ function deserialize(_: string, val: any): any {
 
 function processValue(val: any, depth: number = 0): any {
   if (depth >= MaxTraverseDepth) {
-    throw new Error('marshaling value is too deep or containing circular strcture');
+    // this is either a circular reference or a super nested value that we mostly likely
+    // don't care about marshalling.
+    return val;
   }
 
   if (val === undefined) {


### PR DESCRIPTION
https://codaproject.slack.com/archives/C02K6EABVMK/p1649435284318259

turns out there's a legit case that Pack may return deep nested object. 

@jonathan-codaio @alan-codaio @coda/packs 