### PR TITLE
Added 'force' option to LinkSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog keeps track of all changes to the packs-sdk. We follow convention
 ### Unreleased
 - **Breaking Change** Added a validation rule that prevents the usage of varargsParameters for sync table getters
 which are not currently supported in the UI.
+- Added "force" option to `LinkSchema` for `LinkDisplayType.Embed`.
 
 ## [0.9.0] - 2022-03-17
 - **Breaking Change** ValueHintType.Url will now create a column of type "Link" instead of "Text".

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -438,6 +438,8 @@ export interface LinkSchema extends BaseStringSchema<ValueHintType.Url> {
 	codaType: ValueHintType.Url;
 	/** How the URL should be displayed in the UI. */
 	display?: LinkDisplayType;
+	/** Whether to force client embedding (only for LinkDisplayType.Embed) - for example, if user login required. */
+	force?: boolean;
 }
 /**
  * A schema representing a return value or object property that is provided as a string,

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -411,6 +411,8 @@ export interface LinkSchema extends BaseStringSchema<ValueHintType.Url> {
     codaType: ValueHintType.Url;
     /** How the URL should be displayed in the UI. */
     display?: LinkDisplayType;
+    /** Whether to force client embedding (only for LinkDisplayType.Embed) - for example, if user login required. */
+    force?: boolean;
 }
 /**
  * A schema representing a return value or object property that is provided as a string,

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -539,6 +539,7 @@ const linkPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_10.ValueType.String),
     codaType: zodDiscriminant(schema_9.ValueHintType.Url),
     display: z.nativeEnum(schema_5.LinkDisplayType).optional(),
+    force: z.boolean().optional(),
     ...basePropertyValidators,
 });
 const stringPropertySchema = z.union([

--- a/docs/reference/sdk/enums/AttributionNodeType.md
+++ b/docs/reference/sdk/enums/AttributionNodeType.md
@@ -18,7 +18,7 @@ An image, often a logo of the data source.
 
 #### Defined in
 
-[schema.ts:833](https://github.com/coda/packs-sdk/blob/main/schema.ts#L833)
+[schema.ts:835](https://github.com/coda/packs-sdk/blob/main/schema.ts#L835)
 
 ___
 
@@ -30,7 +30,7 @@ A hyperlink pointing to the data source.
 
 #### Defined in
 
-[schema.ts:829](https://github.com/coda/packs-sdk/blob/main/schema.ts#L829)
+[schema.ts:831](https://github.com/coda/packs-sdk/blob/main/schema.ts#L831)
 
 ___
 
@@ -42,4 +42,4 @@ Text attribution content.
 
 #### Defined in
 
-[schema.ts:825](https://github.com/coda/packs-sdk/blob/main/schema.ts#L825)
+[schema.ts:827](https://github.com/coda/packs-sdk/blob/main/schema.ts#L827)

--- a/docs/reference/sdk/enums/DurationUnit.md
+++ b/docs/reference/sdk/enums/DurationUnit.md
@@ -15,7 +15,7 @@ Indications a duration as a number of days.
 
 #### Defined in
 
-[schema.ts:564](https://github.com/coda/packs-sdk/blob/main/schema.ts#L564)
+[schema.ts:566](https://github.com/coda/packs-sdk/blob/main/schema.ts#L566)
 
 ___
 
@@ -27,7 +27,7 @@ Indications a duration as a number of hours.
 
 #### Defined in
 
-[schema.ts:568](https://github.com/coda/packs-sdk/blob/main/schema.ts#L568)
+[schema.ts:570](https://github.com/coda/packs-sdk/blob/main/schema.ts#L570)
 
 ___
 
@@ -39,7 +39,7 @@ Indications a duration as a number of minutes.
 
 #### Defined in
 
-[schema.ts:572](https://github.com/coda/packs-sdk/blob/main/schema.ts#L572)
+[schema.ts:574](https://github.com/coda/packs-sdk/blob/main/schema.ts#L574)
 
 ___
 
@@ -51,4 +51,4 @@ Indications a duration as a number of seconds.
 
 #### Defined in
 
-[schema.ts:576](https://github.com/coda/packs-sdk/blob/main/schema.ts#L576)
+[schema.ts:578](https://github.com/coda/packs-sdk/blob/main/schema.ts#L578)

--- a/docs/reference/sdk/functions/generateSchema.md
+++ b/docs/reference/sdk/functions/generateSchema.md
@@ -29,4 +29,4 @@ an object schema, those are left undefined.
 
 #### Defined in
 
-[schema.ts:1013](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1013)
+[schema.ts:1015](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1015)

--- a/docs/reference/sdk/functions/makeAttributionNode.md
+++ b/docs/reference/sdk/functions/makeAttributionNode.md
@@ -32,4 +32,4 @@ rendered any time a value with that identity is rendered in a doc.
 
 #### Defined in
 
-[schema.ts:919](https://github.com/coda/packs-sdk/blob/main/schema.ts#L919)
+[schema.ts:921](https://github.com/coda/packs-sdk/blob/main/schema.ts#L921)

--- a/docs/reference/sdk/functions/makeObjectSchema.md
+++ b/docs/reference/sdk/functions/makeObjectSchema.md
@@ -44,4 +44,4 @@ coda.makeObjectSchema({
 
 #### Defined in
 
-[schema.ts:1091](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1091)
+[schema.ts:1093](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1093)

--- a/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/makeReferenceSchemaFromObjectSchema.md
@@ -24,4 +24,4 @@ schema it provides better code reuse to derive a reference schema instead.
 
 #### Defined in
 
-[schema.ts:1198](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1198)
+[schema.ts:1200](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1200)

--- a/docs/reference/sdk/functions/makeSchema.md
+++ b/docs/reference/sdk/functions/makeSchema.md
@@ -44,4 +44,4 @@ coda.makeSchema({
 
 #### Defined in
 
-[schema.ts:1065](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1065)
+[schema.ts:1067](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1067)

--- a/docs/reference/sdk/interfaces/ArraySchema.md
+++ b/docs/reference/sdk/interfaces/ArraySchema.md
@@ -47,7 +47,7 @@ A schema for the items of this array.
 
 #### Defined in
 
-[schema.ts:645](https://github.com/coda/packs-sdk/blob/main/schema.ts#L645)
+[schema.ts:647](https://github.com/coda/packs-sdk/blob/main/schema.ts#L647)
 
 ___
 
@@ -59,4 +59,4 @@ Identifies this schema as an array.
 
 #### Defined in
 
-[schema.ts:643](https://github.com/coda/packs-sdk/blob/main/schema.ts#L643)
+[schema.ts:645](https://github.com/coda/packs-sdk/blob/main/schema.ts#L645)

--- a/docs/reference/sdk/interfaces/DurationSchema.md
+++ b/docs/reference/sdk/interfaces/DurationSchema.md
@@ -26,7 +26,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)
+[schema.ts:602](https://github.com/coda/packs-sdk/blob/main/schema.ts#L602)
 
 ___
 
@@ -58,7 +58,7 @@ and a value of "3 days 4 hours" is provided, it will be rendered as "3 days".
 
 #### Defined in
 
-[schema.ts:593](https://github.com/coda/packs-sdk/blob/main/schema.ts#L593)
+[schema.ts:595](https://github.com/coda/packs-sdk/blob/main/schema.ts#L595)
 
 ___
 
@@ -71,7 +71,7 @@ Currently only `1` is supported, which is the same as omitting a value.
 
 #### Defined in
 
-[schema.ts:588](https://github.com/coda/packs-sdk/blob/main/schema.ts#L588)
+[schema.ts:590](https://github.com/coda/packs-sdk/blob/main/schema.ts#L590)
 
 ___
 
@@ -87,4 +87,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/EmailSchema.md
+++ b/docs/reference/sdk/interfaces/EmailSchema.md
@@ -88,4 +88,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/Identity.md
+++ b/docs/reference/sdk/interfaces/Identity.md
@@ -27,7 +27,7 @@ See [makeAttributionNode](../functions/makeAttributionNode.md).
 
 #### Defined in
 
-[schema.ts:741](https://github.com/coda/packs-sdk/blob/main/schema.ts#L741)
+[schema.ts:743](https://github.com/coda/packs-sdk/blob/main/schema.ts#L743)
 
 ___
 
@@ -49,7 +49,7 @@ you wish to reference, again to distinguish which table instance you are trying 
 
 #### Defined in
 
-[schema.ts:735](https://github.com/coda/packs-sdk/blob/main/schema.ts#L735)
+[schema.ts:737](https://github.com/coda/packs-sdk/blob/main/schema.ts#L737)
 
 ___
 
@@ -66,7 +66,7 @@ For example, if you are defining a schema that represents a user object, "User" 
 
 #### Defined in
 
-[schema.ts:723](https://github.com/coda/packs-sdk/blob/main/schema.ts#L723)
+[schema.ts:725](https://github.com/coda/packs-sdk/blob/main/schema.ts#L725)
 
 ___
 
@@ -82,4 +82,4 @@ The ID of another pack, if you are trying to reference a value from different pa
 
 #### Defined in
 
-[schema.ts:748](https://github.com/coda/packs-sdk/blob/main/schema.ts#L748)
+[schema.ts:750](https://github.com/coda/packs-sdk/blob/main/schema.ts#L750)

--- a/docs/reference/sdk/interfaces/IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/IdentityDefinition.md
@@ -33,7 +33,7 @@ See [makeAttributionNode](../functions/makeAttributionNode.md).
 
 #### Defined in
 
-[schema.ts:741](https://github.com/coda/packs-sdk/blob/main/schema.ts#L741)
+[schema.ts:743](https://github.com/coda/packs-sdk/blob/main/schema.ts#L743)
 
 ___
 
@@ -51,7 +51,7 @@ you wish to reference, again to distinguish which table instance you are trying 
 
 #### Defined in
 
-[schema.ts:735](https://github.com/coda/packs-sdk/blob/main/schema.ts#L735)
+[schema.ts:737](https://github.com/coda/packs-sdk/blob/main/schema.ts#L737)
 
 ___
 
@@ -64,7 +64,7 @@ For example, if you are defining a schema that represents a user object, "User" 
 
 #### Defined in
 
-[schema.ts:723](https://github.com/coda/packs-sdk/blob/main/schema.ts#L723)
+[schema.ts:725](https://github.com/coda/packs-sdk/blob/main/schema.ts#L725)
 
 ___
 
@@ -76,4 +76,4 @@ The ID of another pack, if you are trying to reference a value from different pa
 
 #### Defined in
 
-[schema.ts:743](https://github.com/coda/packs-sdk/blob/main/schema.ts#L743)
+[schema.ts:745](https://github.com/coda/packs-sdk/blob/main/schema.ts#L745)

--- a/docs/reference/sdk/interfaces/ImageAttributionNode.md
+++ b/docs/reference/sdk/interfaces/ImageAttributionNode.md
@@ -27,7 +27,7 @@ The URL to link to.
 
 #### Defined in
 
-[schema.ts:899](https://github.com/coda/packs-sdk/blob/main/schema.ts#L899)
+[schema.ts:901](https://github.com/coda/packs-sdk/blob/main/schema.ts#L901)
 
 ___
 
@@ -39,7 +39,7 @@ The URL of the image to render.
 
 #### Defined in
 
-[schema.ts:901](https://github.com/coda/packs-sdk/blob/main/schema.ts#L901)
+[schema.ts:903](https://github.com/coda/packs-sdk/blob/main/schema.ts#L903)
 
 ___
 
@@ -51,4 +51,4 @@ Identifies this as an image attribution node.
 
 #### Defined in
 
-[schema.ts:897](https://github.com/coda/packs-sdk/blob/main/schema.ts#L897)
+[schema.ts:899](https://github.com/coda/packs-sdk/blob/main/schema.ts#L899)

--- a/docs/reference/sdk/interfaces/LinkAttributionNode.md
+++ b/docs/reference/sdk/interfaces/LinkAttributionNode.md
@@ -27,7 +27,7 @@ The text of the hyperlink.
 
 #### Defined in
 
-[schema.ts:877](https://github.com/coda/packs-sdk/blob/main/schema.ts#L877)
+[schema.ts:879](https://github.com/coda/packs-sdk/blob/main/schema.ts#L879)
 
 ___
 
@@ -39,7 +39,7 @@ The URL to link to.
 
 #### Defined in
 
-[schema.ts:875](https://github.com/coda/packs-sdk/blob/main/schema.ts#L875)
+[schema.ts:877](https://github.com/coda/packs-sdk/blob/main/schema.ts#L877)
 
 ___
 
@@ -51,4 +51,4 @@ Identifies this as a link attribution node.
 
 #### Defined in
 
-[schema.ts:873](https://github.com/coda/packs-sdk/blob/main/schema.ts#L873)
+[schema.ts:875](https://github.com/coda/packs-sdk/blob/main/schema.ts#L875)

--- a/docs/reference/sdk/interfaces/LinkSchema.md
+++ b/docs/reference/sdk/interfaces/LinkSchema.md
@@ -62,6 +62,18 @@ How the URL should be displayed in the UI.
 
 ___
 
+### force
+
+• `Optional` **force**: `boolean`
+
+Whether to force client embedding (only for LinkDisplayType.Embed) - for example, if user login required.
+
+#### Defined in
+
+[schema.ts:477](https://github.com/coda/packs-sdk/blob/main/schema.ts#L477)
+
+___
+
 ### type
 
 • **type**: [`String`](../enums/ValueType.md#string)
@@ -74,4 +86,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/ObjectSchemaDefinition.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaDefinition.md
@@ -32,7 +32,7 @@ render such a value as an @-reference to that person, rather than a basic object
 
 #### Defined in
 
-[schema.ts:778](https://github.com/coda/packs-sdk/blob/main/schema.ts#L778)
+[schema.ts:780](https://github.com/coda/packs-sdk/blob/main/schema.ts#L780)
 
 ___
 
@@ -74,7 +74,7 @@ projections have been created for them.
 
 #### Defined in
 
-[schema.ts:793](https://github.com/coda/packs-sdk/blob/main/schema.ts#L793)
+[schema.ts:795](https://github.com/coda/packs-sdk/blob/main/schema.ts#L795)
 
 ___
 
@@ -87,7 +87,7 @@ Sync table schemas must specify an id property, which uniquely identify each syn
 
 #### Defined in
 
-[schema.ts:763](https://github.com/coda/packs-sdk/blob/main/schema.ts#L763)
+[schema.ts:765](https://github.com/coda/packs-sdk/blob/main/schema.ts#L765)
 
 ___
 
@@ -100,7 +100,7 @@ See [IdentityDefinition](IdentityDefinition.md).
 
 #### Defined in
 
-[schema.ts:798](https://github.com/coda/packs-sdk/blob/main/schema.ts#L798)
+[schema.ts:800](https://github.com/coda/packs-sdk/blob/main/schema.ts#L800)
 
 ___
 
@@ -115,7 +115,7 @@ can be seen when hovering over the chip.
 
 #### Defined in
 
-[schema.ts:770](https://github.com/coda/packs-sdk/blob/main/schema.ts#L770)
+[schema.ts:772](https://github.com/coda/packs-sdk/blob/main/schema.ts#L772)
 
 ___
 
@@ -127,7 +127,7 @@ Definintion of the key-value pairs in this object.
 
 #### Defined in
 
-[schema.ts:758](https://github.com/coda/packs-sdk/blob/main/schema.ts#L758)
+[schema.ts:760](https://github.com/coda/packs-sdk/blob/main/schema.ts#L760)
 
 ___
 
@@ -139,4 +139,4 @@ Identifies this schema as an object schema.
 
 #### Defined in
 
-[schema.ts:756](https://github.com/coda/packs-sdk/blob/main/schema.ts#L756)
+[schema.ts:758](https://github.com/coda/packs-sdk/blob/main/schema.ts#L758)

--- a/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/ObjectSchemaProperty.md
@@ -44,7 +44,7 @@ whose value comes another field called "duration".
 
 #### Defined in
 
-[schema.ts:684](https://github.com/coda/packs-sdk/blob/main/schema.ts#L684)
+[schema.ts:686](https://github.com/coda/packs-sdk/blob/main/schema.ts#L686)
 
 ___
 
@@ -57,4 +57,4 @@ include a non-empty value for this property.
 
 #### Defined in
 
-[schema.ts:689](https://github.com/coda/packs-sdk/blob/main/schema.ts#L689)
+[schema.ts:691](https://github.com/coda/packs-sdk/blob/main/schema.ts#L691)

--- a/docs/reference/sdk/interfaces/SimpleStringSchema.md
+++ b/docs/reference/sdk/interfaces/SimpleStringSchema.md
@@ -32,7 +32,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)
+[schema.ts:602](https://github.com/coda/packs-sdk/blob/main/schema.ts#L602)
 
 ___
 
@@ -67,4 +67,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/StringDateSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateSchema.md
@@ -28,7 +28,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:486](https://github.com/coda/packs-sdk/blob/main/schema.ts#L486)
+[schema.ts:488](https://github.com/coda/packs-sdk/blob/main/schema.ts#L488)
 
 ___
 
@@ -62,7 +62,7 @@ Only applies when this is used as a sync table property.
 
 #### Defined in
 
-[schema.ts:493](https://github.com/coda/packs-sdk/blob/main/schema.ts#L493)
+[schema.ts:495](https://github.com/coda/packs-sdk/blob/main/schema.ts#L495)
 
 ___
 
@@ -78,4 +78,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/StringDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringDateTimeSchema.md
@@ -28,7 +28,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:540](https://github.com/coda/packs-sdk/blob/main/schema.ts#L540)
+[schema.ts:542](https://github.com/coda/packs-sdk/blob/main/schema.ts#L542)
 
 ___
 
@@ -43,7 +43,7 @@ Only applies when this is used as a sync table property.
 
 #### Defined in
 
-[schema.ts:547](https://github.com/coda/packs-sdk/blob/main/schema.ts#L547)
+[schema.ts:549](https://github.com/coda/packs-sdk/blob/main/schema.ts#L549)
 
 ___
 
@@ -77,7 +77,7 @@ Only applies when this is used as a sync table property.
 
 #### Defined in
 
-[schema.ts:554](https://github.com/coda/packs-sdk/blob/main/schema.ts#L554)
+[schema.ts:556](https://github.com/coda/packs-sdk/blob/main/schema.ts#L556)
 
 ___
 
@@ -93,4 +93,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/StringEmbedSchema.md
+++ b/docs/reference/sdk/interfaces/StringEmbedSchema.md
@@ -28,7 +28,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:504](https://github.com/coda/packs-sdk/blob/main/schema.ts#L504)
+[schema.ts:506](https://github.com/coda/packs-sdk/blob/main/schema.ts#L506)
 
 ___
 
@@ -64,7 +64,7 @@ but requires user consent per-domain to actually display the embed.
 
 #### Defined in
 
-[schema.ts:513](https://github.com/coda/packs-sdk/blob/main/schema.ts#L513)
+[schema.ts:515](https://github.com/coda/packs-sdk/blob/main/schema.ts#L515)
 
 ___
 
@@ -80,4 +80,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/StringTimeSchema.md
+++ b/docs/reference/sdk/interfaces/StringTimeSchema.md
@@ -26,7 +26,7 @@ BaseStringSchema.codaType
 
 #### Defined in
 
-[schema.ts:522](https://github.com/coda/packs-sdk/blob/main/schema.ts#L522)
+[schema.ts:524](https://github.com/coda/packs-sdk/blob/main/schema.ts#L524)
 
 ___
 
@@ -60,7 +60,7 @@ Only applies when this is used as a sync table property.
 
 #### Defined in
 
-[schema.ts:529](https://github.com/coda/packs-sdk/blob/main/schema.ts#L529)
+[schema.ts:531](https://github.com/coda/packs-sdk/blob/main/schema.ts#L531)
 
 ___
 
@@ -76,4 +76,4 @@ BaseStringSchema.type
 
 #### Defined in
 
-[schema.ts:598](https://github.com/coda/packs-sdk/blob/main/schema.ts#L598)
+[schema.ts:600](https://github.com/coda/packs-sdk/blob/main/schema.ts#L600)

--- a/docs/reference/sdk/interfaces/TextAttributionNode.md
+++ b/docs/reference/sdk/interfaces/TextAttributionNode.md
@@ -25,7 +25,7 @@ The text to render with the pack value.
 
 #### Defined in
 
-[schema.ts:853](https://github.com/coda/packs-sdk/blob/main/schema.ts#L853)
+[schema.ts:855](https://github.com/coda/packs-sdk/blob/main/schema.ts#L855)
 
 ___
 
@@ -37,4 +37,4 @@ Identifies this as a text attribution node.
 
 #### Defined in
 
-[schema.ts:851](https://github.com/coda/packs-sdk/blob/main/schema.ts#L851)
+[schema.ts:853](https://github.com/coda/packs-sdk/blob/main/schema.ts#L853)

--- a/docs/reference/sdk/types/AttributionNode.md
+++ b/docs/reference/sdk/types/AttributionNode.md
@@ -9,4 +9,4 @@ Union of attribution node types for rendering attribution for a pack value. See 
 
 #### Defined in
 
-[schema.ts:907](https://github.com/coda/packs-sdk/blob/main/schema.ts#L907)
+[schema.ts:909](https://github.com/coda/packs-sdk/blob/main/schema.ts#L909)

--- a/docs/reference/sdk/types/InferrableTypes.md
+++ b/docs/reference/sdk/types/InferrableTypes.md
@@ -9,4 +9,4 @@ Primitive types for which [generateSchema](../functions/generateSchema.md) can i
 
 #### Defined in
 
-[schema.ts:998](https://github.com/coda/packs-sdk/blob/main/schema.ts#L998)
+[schema.ts:1000](https://github.com/coda/packs-sdk/blob/main/schema.ts#L1000)

--- a/docs/reference/sdk/types/ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/ObjectSchemaProperties.md
@@ -17,4 +17,4 @@ definition for that property.
 
 #### Defined in
 
-[schema.ts:697](https://github.com/coda/packs-sdk/blob/main/schema.ts#L697)
+[schema.ts:699](https://github.com/coda/packs-sdk/blob/main/schema.ts#L699)

--- a/docs/reference/sdk/types/Schema.md
+++ b/docs/reference/sdk/types/Schema.md
@@ -9,4 +9,4 @@ The union of all of the schema types supported for return values and object prop
 
 #### Defined in
 
-[schema.ts:926](https://github.com/coda/packs-sdk/blob/main/schema.ts#L926)
+[schema.ts:928](https://github.com/coda/packs-sdk/blob/main/schema.ts#L928)

--- a/docs/reference/sdk/types/SchemaType.md
+++ b/docs/reference/sdk/types/SchemaType.md
@@ -28,4 +28,4 @@ to ensure that it matches the schema you have declared for that formula.
 
 #### Defined in
 
-[schema.ts:985](https://github.com/coda/packs-sdk/blob/main/schema.ts#L985)
+[schema.ts:987](https://github.com/coda/packs-sdk/blob/main/schema.ts#L987)

--- a/docs/reference/sdk/types/StringSchema.md
+++ b/docs/reference/sdk/types/StringSchema.md
@@ -9,4 +9,4 @@ The union of schema definition types whose underlying value is a string.
 
 #### Defined in
 
-[schema.ts:627](https://github.com/coda/packs-sdk/blob/main/schema.ts#L627)
+[schema.ts:629](https://github.com/coda/packs-sdk/blob/main/schema.ts#L629)

--- a/schema.ts
+++ b/schema.ts
@@ -473,6 +473,8 @@ export interface LinkSchema extends BaseStringSchema<ValueHintType.Url> {
   codaType: ValueHintType.Url;
   /** How the URL should be displayed in the UI. */
   display?: LinkDisplayType;
+  /** Whether to force client embedding (only for LinkDisplayType.Embed) - for example, if user login required. */
+  force?: boolean;
 }
 
 /**

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -657,6 +657,7 @@ const linkPropertySchema = zodCompleteStrictObject<LinkSchema & ObjectSchemaProp
   type: zodDiscriminant(ValueType.String),
   codaType: zodDiscriminant(ValueHintType.Url),
   display: z.nativeEnum(LinkDisplayType).optional(),
+  force: z.boolean().optional(),
   ...basePropertyValidators,
 });
 


### PR DESCRIPTION
Some embedded URLs will only render on the client, for example if user login is required.  For canvas embeds, our `Embed()` formula has a boolean `force` parameter that renders the embed on the client instead of the server.  However, there was no equivalent for Link columns.

Thus, we are adding a "force" property to the Link column config that triggers the same behavior.  This PR adds support to the packs-sdk for the new property.

IMPORTANT:
* The first commit contains the actual source changes.
* The second commit is the `make build` output.

Note:  Here is a [link to the corresponding Coda PR](https://github.com/coda/coda/pull/70334).

![force-property](https://user-images.githubusercontent.com/81393103/162544260-fa4da000-048b-446c-b366-a602750bc015.png)