### PR TITLE
Misc doc improvements

### DIFF
--- a/docs/guides/advanced/authentication.md
+++ b/docs/guides/advanced/authentication.md
@@ -379,7 +379,7 @@ pack.addFormula({
 ```
 
 
-## Setting account names
+## Setting account names {: #name}
 
 By default the accounts that users connect to will be given the same name as their Coda account. While this works fine the majority of the time, if they are connecting to a team account or multiple accounts it is not very helpful. Therefore we strongly recommend that you implement a [`getConnectionName`][getConnectionName] function in your authentication configuration to set a more meaningful account name. This is typically done by making a Fetcher request to a user information endpoint in the API and then returning the name of the account.
 

--- a/docs/guides/advanced/embeds.md
+++ b/docs/guides/advanced/embeds.md
@@ -9,6 +9,8 @@ Coda uses the 3rd party service [Iframely][iframely] to handle embeds. Many popu
 
 If you want to add embed support to your own application follow the instructions in the [Iframely documentation][iframely_docs]. This is most commonly done by adding support for the [oEmbed specification][oembed], which is used by many platforms. Once that is complete, [submit your application][iframely_submit] to Iframely to have it added to their registry.
 
+The iframe containing the embed is sandboxed by default has limited permissions (for example, it's can't present content fullscreen). If you need access to additional iframe sandbox permissions please [contact support][support].
+
 !!! note "User embeds"
     Users can [embed content in their docs][help_center_embed] directly, without Packs, using the `/embed` slash command or the `=Embed()` formula. Even if you aren't planning to build a Pack you may want to support embeds for your users that manually embed the content in their docs.
 
@@ -72,3 +74,4 @@ Once approved, Coda attempts to load the URL int an `<iframe>` element with [san
 [mdn_iframe_sandbox]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 [mdn_xfo]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 [mdn_csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+[support]: ../../support.md

--- a/docs/guides/advanced/embeds.md
+++ b/docs/guides/advanced/embeds.md
@@ -9,7 +9,7 @@ Coda uses the 3rd party service [Iframely][iframely] to handle embeds. Many popu
 
 If you want to add embed support to your own application follow the instructions in the [Iframely documentation][iframely_docs]. This is most commonly done by adding support for the [oEmbed specification][oembed], which is used by many platforms. Once that is complete, [submit your application][iframely_submit] to Iframely to have it added to their registry.
 
-The iframe containing the embed is sandboxed by default has limited permissions (for example, it's can't present content fullscreen). If you need access to additional iframe sandbox permissions please [contact support][support].
+The iframe containing the embed is sandboxed by default has limited permissions (for example, it can't present content fullscreen). If you need access to additional iframe sandbox permissions please [contact support][support].
 
 !!! note "User embeds"
     Users can [embed content in their docs][help_center_embed] directly, without Packs, using the `/embed` slash command or the `=Embed()` formula. Even if you aren't planning to build a Pack you may want to support embeds for your users that manually embed the content in their docs.

--- a/docs/guides/basics/parameters/index.md
+++ b/docs/guides/basics/parameters/index.md
@@ -127,7 +127,9 @@ JavaScript Date objects can only represent a specific moment in time. This means
 
 Use the `Image` parameter type to pass an image to your formula. The value passed to the `execute` function will be the URL of that image.
 
-Images that the user uploaded to the doc will be hosted on the `codahosted.io` domain and don't require authentication to access. If you need access to the binary content of the image you'll need to use the [fetcher][fetcher_binary_response] to retrieve it. Since you must declare the [network domains][network_domains] the fetcher will access, it's not possible to access the binary content of images coming from an **Image URL** column.
+Images that the user uploaded to the doc will be hosted on the `codahosted.io` domain and don't require authentication to access. These URLs are temporary, and you should not rely on them being accessible after the Pack execution has completed.
+
+If you need access to the binary content of the image you'll need to use the [fetcher][fetcher_binary_response] to retrieve it. The fetcher is automatically allowed access to the `codahosted.io` domain, so no need to declare it as a [network domain][network_domains]. It's not possible to access the binary content of images coming from an **Image URL** column, since they can come from any domain.
 
 
 ### Lists

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -34,9 +34,14 @@ While it's easy to get started building a Pack, there are lots of options to exp
 - [x] Set a few [featured columns][schemas_featured_columns] on your schema, for the most commonly used properties.
 
 
+## Authentication
+
+- [x] Set a meaningful [account name][auth_name] by implementing the `getConnectionName` function. This helps users that connect to multiple accounts distinguish them.
+- [x] Make sure to set the [`instructionsUrl`][instructionsUrl] field. Direct user to a help center article that provides information about where they can find the required tokens or credentials.
+
+
 ## General
 
-- [x] When using per-user authentication, make sure to set the [`instructionsUrl`][instructionsUrl] field. Direct user to a help center article that provides information about where they can find the required tokens or credentials.
 - [x] Throw a [`UserVisibleError`][UserVisibleError] for bad input or when an expected type of error occurs. This allows you to provide a more informative error message to the user.
 - [x] If accepting or returning an index value, start counting at 1. Although JavaScript is 0-based, Coda formula language is 1-based.
 
@@ -67,3 +72,4 @@ While it's easy to get started building a Pack, there are lots of options to exp
 [promotion]: https://coda.io/@hector/promotion-best-practices
 [schemas_row_identifier]: advanced/schemas.md#row-identifier
 [schemas_featured_columns]: advanced/schemas.md#featured-columns
+[auth_name]: advanced/authentication.md#name

--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -94,13 +94,13 @@ While it's possible to use multiple accounts within a document, each instance of
 
 For performance reasons formula results are cached by default. If your formula is called again with the same parameters, Coda will attempt to load the result from the cache instead of re-running your code. Building or releasing a new version of your Pack will invalidate this cache, ensuring you get fresh results using your new code.
 
+You can adjust the caching behavior by setting the [`cacheTtlSecs`][cacheTtlSecs] field on the formula definition, which specifies for how many seconds the result should be cached. To disable caching for a formula set `cacheTtlSecs` to zero.
+
 The following types of formulas are never cached:
 
 - [Action formulas][actions]
 - [Sync formulas][sync_formula]
 - Formulas that result in an error
-
-You can adjust the caching behavior by setting the [`cacheTtlSecs`][cacheTtlSecs] field on the formula definition, which specifies for how many seconds the result should be cached. To disable caching for a formula set `cacheTtlSecs` to zero.
 
 !!! info
     In addition to caching formula results, Coda also caches the [fetcher responses][fetcher_cache]. To get truly fresh results you may need to disable that caching as well.
@@ -174,3 +174,4 @@ examples: [
 [system_auth]: ../../reference/sdk/classes/PackDefinitionBuilder.md#setsystemauthentication
 [user_auth]: ../../reference/sdk/classes/PackDefinitionBuilder.md#setuserauthentication
 [connectionRequirement]: ../../reference/sdk/interfaces/PackFormulaDef.md#connectionrequirement
+[sync_formula]: sync-tables/index.md#formula

--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -92,7 +92,13 @@ While it's possible to use multiple accounts within a document, each instance of
 
 ## Caching
 
-For performance reasons all formula results are cached by default. If your formula is called again with the same parameters, Coda will attempt to load the result from the cache instead of re-running your code. Building or releasing a new version of your Pack will invalidate this cache, ensuring you get fresh results using your new code.
+For performance reasons formula results are cached by default. If your formula is called again with the same parameters, Coda will attempt to load the result from the cache instead of re-running your code. Building or releasing a new version of your Pack will invalidate this cache, ensuring you get fresh results using your new code.
+
+The following types of formulas are never cached:
+
+- [Action formulas][actions]
+- [Sync formulas][sync_formula]
+- Formulas that result in an error
 
 You can adjust the caching behavior by setting the [`cacheTtlSecs`][cacheTtlSecs] field on the formula definition, which specifies for how many seconds the result should be cached. To disable caching for a formula set `cacheTtlSecs` to zero.
 

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -64,7 +64,7 @@ pack.addSyncTable({
 It includes the name of the sync table, the schema for each row, and other metadata. The `identityName` property will be explained in the [Identity](#identity) section below.
 
 
-### Write the sync formula
+### Write the sync formula {: #formula}
 
 Inside each sync table definition is a formula definition, detailing the hidden formula used to sync data into the sync table. If you aren't already familiar with creating formulas, read the [Formulas guide][formulas] first.
 

--- a/docs/guides/development/troubleshooting.md
+++ b/docs/guides/development/troubleshooting.md
@@ -55,6 +55,8 @@ This error will appear at the bottom of the screen after pressing a button, and 
 
 ### HTTP response too large
 
+<!-- https://golinks.io/bug/22358 -->
+
 - `RESOURCE_EXHAUSTED: Received message larger than max`
 
 This error indicates that a fetcher request got back a response that is larger than the Packs runtime allows. If you are querying an external API for records, see if you can use a limit or paging parameter to get back a smaller response. If you need to work with large files you'll need to build an application outside of Packs that processes them. If you only need a small increase in the size limit you can [contact support][support] to request an adjustment.

--- a/docs/guides/development/troubleshooting.md
+++ b/docs/guides/development/troubleshooting.md
@@ -53,6 +53,13 @@ These errors can occur when installing the SDK locally, specifically during the 
 This error will appear at the bottom of the screen after pressing a button, and indicates that the formula used in the button isn't a valid action. In order for a formula to be used as an action within a button, it must be defined with `isAction: true`. See the [Actions guide][actions_create] for more information.
 
 
+### HTTP response too large
+
+- `RESOURCE_EXHAUSTED: Received message larger than max`
+
+This error indicates that a fetcher request got back a response that is larger than the Packs runtime allows. If you are querying an external API for records, see if you can use a limit or paging parameter to get back a smaller response. If you need to work with large files you'll need to build an application outside of Packs that processes them. If you only need a small increase in the size limit you can [contact support][support] to request an adjustment.
+
+
 [mdn_console]: https://developer.mozilla.org/en-US/docs/Web/API/console
 [support]: ../../support.md
 [isolated_vm_requirements]: https://github.com/laverdet/isolated-vm#requirements

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,0 +1,23 @@
+---
+title: FAQ
+---
+
+# Frequently asked questions
+
+## How do I verify ownership of the Packs redirect URI for Google OAuth verification?
+
+To connect to a Google API from a Pack you need to use OAuth2 authentication. Many APIs require scopes that Google deems "sensitive", meaning that Google must approve your integration before other users can sign in. This approval process is known as [OAuth verification][google_verification], and involves many steps and checks.
+
+One of those checks is that Google must verify you own the domain name for all of the domains used by the integration. This includes the redirect URI that users are sent to after they complete the approval screen. For Coda Packs this redirect URL is always:
+
+```
+https://coda.io/packsAuth/oauth2
+```
+
+To meet Google's verification requirements you would need to verify ownership of the `coda.io` domain, which isn't possible. While we hope to find a solution to this problem in the long run, at the moment it isn't possible to complete the verification process with Google.
+
+There are some [exceptions to Google's verification requirement][google_verification_exceptions], for example an app only used internally within a single organization. If you can adjust your Pack to meet one of these exceptions you can work around the problem.
+
+
+[google_verification]: https://support.google.com/cloud/answer/9110914
+[google_verification_exceptions]: https://support.google.com/cloud/answer/9110914#exceptions-ver-reqts&zippy=%2Cexceptions-to-verification-requirements


### PR DESCRIPTION
A bunch of small doc improvements I've been accumulating:
- How to request additional iframe permissions for an embed.
- Hosted image URLs are temporary.
- The fetcher can automatically access the `codahosted.io` domain.
- Add `getConnectionName()` as a best practice.
- Clarify formula caching behavior.
- Add troubleshooting section for response too larger errors.
- Document Google OAuth verification limitation.