### PR TITLE
warn on deprecated fields

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,10 +14,11 @@ module.exports = {
     project: ['./tsconfig.eslint.json'],
     sourceType: 'module',
   },
-  plugins: ['ban', 'filenames', 'local', '@typescript-eslint'],
+  plugins: ['ban', 'filenames', 'local', '@typescript-eslint', 'deprecation'],
   settings: {},
   rules: {
     '@typescript-eslint/restrict-plus-operands': 'error',
+    "deprecation/deprecation": "warn",
     'max-len': [
       'error',
       {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "dts-bundle-generator": "^6.5.0",
     "eslint": "8.12.0",
     "eslint-plugin-ban": "^1.6.0",
+    "eslint-plugin-deprecation": "^1.3.2",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-prefer-let": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,7 +1215,7 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@5.19.0":
+"@typescript-eslint/experimental-utils@5.19.0", "@typescript-eslint/experimental-utils@^5.0.0":
   version "5.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.19.0.tgz#b7c8f1e22624d4f3d1b3683438530f5636086cb7"
   integrity sha512-F+X/TTzmb2UXbghY1LrNLNDjMcGZMhKzXuzvu0xD+YEB77EamLM7zMOLuz2kP5807IJRDLBoAFFPYa7HT62sYg==
@@ -2720,6 +2720,15 @@ eslint-plugin-ban@^1.6.0:
   integrity sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==
   dependencies:
     requireindex "~1.2.0"
+
+eslint-plugin-deprecation@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.2.tgz#a8125d28c56158cdfa1a685197e6be8ed86f189e"
+  integrity sha512-z93wbx9w7H/E3ogPw6AZMkkNJ6m51fTZRNZPNQqxQLmx+KKt7aLkMU9wN67s71i+VVHN4tLOZ3zT3QLbnlC0Mg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+    tslib "^2.3.1"
+    tsutils "^3.21.0"
 
 eslint-plugin-filenames@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
add an eslint rule to warn on deprecated field. 

I need to fix the deprecated warnings before merging though. 

PTAL @coda/packs 

```
/Users/huayang/code/packs-sdk/api.ts
  335:29  warning  'makeSimpleAutocompleteMetadataFormula' is deprecated. If you have a hardcoded array of autocomplete options, simply include that array
as the value of the `autocomplete` property in your parameter definition. There is no longer
any needed to wrap a value with this formula  deprecation/deprecation

/Users/huayang/code/packs-sdk/api_types.ts
  311:22  warning  'Network' is deprecated. use `isAction` and `connectionRequirement` on the formula definition instead  deprecation/deprecation
  377:25  warning  'NetworkConnection' is deprecated. use `ConnectionRequirement` instead                                 deprecation/deprecation

/Users/huayang/code/packs-sdk/builder.ts
   94:7   warning  'formulaNamespace' is deprecated.   deprecation/deprecation
  103:10  warning  'formulaNamespace' is deprecated.   deprecation/deprecation

/Users/huayang/code/packs-sdk/compiled_types.ts
  112:5  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation

/Users/huayang/code/packs-sdk/helpers/metadata.ts
  25:47  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  28:29  warning  'formulaNamespace' is deprecated.                                                                                                                                                                     deprecation/deprecation
  56:44  warning  'PackFormulas' is deprecated. Formulas should now only be defined as an array, as namespaces are deprecated                                                                                           deprecation/deprecation

/Users/huayang/code/packs-sdk/helpers/migration.ts
  15:52  warning  'id' is deprecated. Use {@link idProperty }                deprecation/deprecation
  19:57  warning  'primary' is deprecated. Use {@link displayProperty }      deprecation/deprecation
  23:60  warning  'featured' is deprecated. Use {@link featuredProperties }  deprecation/deprecation

/Users/huayang/code/packs-sdk/helpers/sample_utils.ts
  11:50  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  12:14  warning  'PackFormulas' is deprecated. Formulas should now only be defined as an array, as namespaces are deprecated                                                                                           deprecation/deprecation
  15:70  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation

/Users/huayang/code/packs-sdk/index.ts
    6:14  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations                                                                               deprecation/deprecation
    6:14  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations                                                                               deprecation/deprecation
    7:14  warning  'PackId' is deprecated. Use `number` in new code                                                                                                                                                                                                                                   deprecation/deprecation
    7:14  warning  'PackId' is deprecated. Use `number` in new code                                                                                                                                                                                                                                   deprecation/deprecation
   74:14  warning  'Network' is deprecated. use `isAction` and `connectionRequirement` on the formula definition instead                                                                                                                                                                              deprecation/deprecation
   74:14  warning  'Network' is deprecated. use `isAction` and `connectionRequirement` on the formula definition instead                                                                                                                                                                              deprecation/deprecation
   75:9   warning  'NetworkConnection' is deprecated. use `ConnectionRequirement` instead                                                                                                                                                                                                             deprecation/deprecation
   75:9   warning  'NetworkConnection' is deprecated. use `ConnectionRequirement` instead                                                                                                                                                                                                             deprecation/deprecation
   77:14  warning  'PackFormulas' is deprecated. Formulas should now only be defined as an array, as namespaces are deprecated                                                                                                                                                                        deprecation/deprecation
   77:14  warning  'PackFormulas' is deprecated. Formulas should now only be defined as an array, as namespaces are deprecated                                                                                                                                                                        deprecation/deprecation
  112:9   warning  'makeSimpleAutocompleteMetadataFormula' is deprecated. If you have a hardcoded array of autocomplete options, simply include that array
as the value of the `autocomplete` property in your parameter definition. There is no longer
any needed to wrap a value with this formula  deprecation/deprecation
  112:9   warning  'makeSimpleAutocompleteMetadataFormula' is deprecated. If you have a hardcoded array of autocomplete options, simply include that array
as the value of the `autocomplete` property in your parameter definition. There is no longer
any needed to wrap a value with this formula  deprecation/deprecation

/Users/huayang/code/packs-sdk/legacy_exports.ts
  26:9   warning  'PackCategory' is deprecated.                                               deprecation/deprecation
  26:9   warning  'PackCategory' is deprecated.                                               deprecation/deprecation
  29:14  warning  'RateLimit' is deprecated. Define these in the pack management UI instead   deprecation/deprecation
  29:14  warning  'RateLimit' is deprecated. Define these in the pack management UI instead   deprecation/deprecation
  30:14  warning  'RateLimits' is deprecated. Define these in the pack management UI instead  deprecation/deprecation
  30:14  warning  'RateLimits' is deprecated. Define these in the pack management UI instead  deprecation/deprecation

/Users/huayang/code/packs-sdk/test/auth_test.ts
    35:28  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   100:38  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   130:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   176:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   202:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   229:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   251:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   273:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   293:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   323:31  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   348:40  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   367:77  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   374:76  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   382:16  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   418:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   437:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   461:27  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   462:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   486:27  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   487:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   511:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   532:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   561:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   586:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   610:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   637:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   660:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   778:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   802:27  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   804:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   831:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
   855:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  1071:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  1125:27  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  1140:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  1163:27  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  1165:37  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation

/Users/huayang/code/packs-sdk/test/execution_test.ts
  348:29  warning  'makeSimpleAutocompleteMetadataFormula' is deprecated. If you have a hardcoded array of autocomplete options, simply include that array
as the value of the `autocomplete` property in your parameter definition. There is no longer
any needed to wrap a value with this formula  deprecation/deprecation

/Users/huayang/code/packs-sdk/test/packs/fake.ts
  28:24  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation

/Users/huayang/code/packs-sdk/test/test_utils.ts
  18:24  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  21:13  warning  'PackCategory' is deprecated.                                                                                                                                                                         deprecation/deprecation
  50:46  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation
  50:69  warning  'PackDefinition' is deprecated. use `#PackVersionDefinition`

The legacy complete definition of a Pack including un-versioned metadata.
This should only be used by legacy Coda pack implementations  deprecation/deprecation

/Users/huayang/code/packs-sdk/testing/upload_validation.ts
   484:30  warning  'Network' is deprecated. use `isAction` and `connectionRequirement` on the formula definition instead  deprecation/deprecation
   487:30  warning  'NetworkConnection' is deprecated. use `ConnectionRequirement` instead                                 deprecation/deprecation
  1096:28  warning  'PackCategory' is deprecated.                                                                          deprecation/deprecation

/Users/huayang/code/packs-sdk/types.ts
  800:13  warning  'RateLimit' is deprecated. Define these in the pack management UI instead                                    deprecation/deprecation
  801:19  warning  'RateLimit' is deprecated. Define these in the pack management UI instead                                    deprecation/deprecation
  855:14  warning  'PackFormulas' is deprecated. Formulas should now only be defined as an array, as namespaces are deprecated  deprecation/deprecation
  873:7   warning  'PackId' is deprecated. Use `number` in new code                                                             deprecation/deprecation
  878:14  warning  'PackCategory' is deprecated.                                                                                deprecation/deprecation
  884:16  warning  'RateLimits' is deprecated. Define these in the pack management UI instead                                   deprecation/deprecation

✖ 85 problems (0 errors, 85 warnings)

```