### PR TITLE
Bump the SDK version number so that yarn won't resolve packs-sdk-for-web-editor the same commit hash accidentally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"


### PR DESCRIPTION
PTAL @huayang-codaio @patrick-codaio @dweitzman-codaio @coda/packs 