### PR TITLE
Link to specific commit hashes from reference documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: make docs
+          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://staging.coda.io/packs/build/latest/" make build-mkdocs
@@ -125,7 +125,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: make docs
+          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://coda.io/packs/build/latest/" make build-mkdocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
+          command: DOC_GIT_REVISION="$(git rev-parse HEAD)" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://head.coda.io/packs/build/latest/" make build-mkdocs
@@ -105,7 +105,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
+          command: DOC_GIT_REVISION="$(git rev-parse HEAD)" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://staging.coda.io/packs/build/latest/" make build-mkdocs
@@ -125,7 +125,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
+          command: DOC_GIT_REVISION="$(git rev-parse HEAD)" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://coda.io/packs/build/latest/" make build-mkdocs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - bootstrap_pipenv
       - run:
           name: 'Typedoc'
-          command: make docs
+          command: DOC_GIT_REVISION="git rev-parse HEAD" make docs
       - run:
           name: "MkDocs"
           command: MK_DOCS_SITE_URL="https://head.coda.io/packs/build/latest/" make build-mkdocs

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ ISOLATED_VM_VERSION=$(shell node -p -e $(ISOLATED_VM_VERSION_COMMAND))
 
 PIPENV := PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 pipenv
 
+DOC_GIT_REVISION ?= main
+
+
 # Aliases
 bs: bootstrap
 
@@ -149,7 +152,7 @@ typedoc:
 	fi
 	# Most options loaded from typedoc.js.
 	# If you changes this, also update the similar command in typedoc_coverage_test.ts.
-	${ROOTDIR}/node_modules/.bin/typedoc index.ts --options typedoc.js --out ${ROOTDIR}/docs/reference/sdk
+	${ROOTDIR}/node_modules/.bin/typedoc index.ts --options typedoc.js --gitRevision "${DOC_GIT_REVISION}" --out ${ROOTDIR}/docs/reference/sdk
 	node -r ts-node/register documentation/typedoc_post_process.ts
 
 .PHONY: docs

--- a/typedoc.js
+++ b/typedoc.js
@@ -5,7 +5,6 @@ module.exports = {
   excludeExternals: true,
   excludePrivate: true,
   excludeProtected: true,
-  gitRevision: 'main',
   plugin: 'typedoc-plugin-markdown',
   // Don't include the repo's README in the generated docs.
   readme: 'none',


### PR DESCRIPTION
This is defense against the documentation links getting out-of-date every time
the types get updated in code.

Not 100% sure how to test this with circleci, but I tested the command locally

Testing:

Built with circleci on a devbox (mac OS was having a docker issue) and also changed the build command to this because I wasn't seeing output files saved anywhere on local disk:
```
DOC_GIT_REVISION="$(git rev-parse HEAD)" make docs && grep types.ts docs/reference/sdk/types/SystemAuthentication.md
```

This output printed shows that the new code is working (the commit hash is from this PR):
```
[types.ts:636](https://github.com/coda/packs-sdk/blob/e31687b1ca6b8940422948d7c1ddbf83b4f91ebd/types.ts#L636)
```