### PR TITLE
Check for deprecated field names in object schemas. Add a warning mode for validation that applies all schema extensions.

### DIFF
--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -16,7 +16,9 @@ export declare class PackMetadataValidationError extends Error {
     readonly validationErrors: ValidationError[] | undefined;
     constructor(message: string, originalError?: Error, validationErrors?: ValidationError[]);
 }
-export declare function validatePackVersionMetadata(metadata: Record<string, any>, sdkVersion: string | undefined): Promise<PackVersionMetadata>;
+export declare function validatePackVersionMetadata(metadata: Record<string, any>, sdkVersion: string | undefined, { warningMode }?: {
+    warningMode?: boolean;
+}): Promise<PackVersionMetadata>;
 export declare function validateVariousAuthenticationMetadata(auth: any): VariousAuthentication;
 export declare function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<any, any>>;
 export declare function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[];


### PR DESCRIPTION
Will update things on the `coda` side in my pending change to call this to generate warnings.

PTAL @dweitzman-codaio @coda/packs 