### PR TITLE
Show deprecation warnings in coda validate.

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -200,6 +200,13 @@ if (require.main === module) {
     .command({
       command: 'validate <manifestFile>',
       describe: 'Validate your Pack definition',
+      builder: {
+        checkDeprecationWarnings: {
+          boolean: true,
+          desc: 'Also check for warnings about deprecated properties and features that will become errors in a future SDK version.',
+          default: true,
+        },
+      },
       handler: handleValidate,
     })
     .command({

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -202,6 +202,13 @@ if (require.main === module) {
         .command({
         command: 'validate <manifestFile>',
         describe: 'Validate your Pack definition',
+        builder: {
+            checkDeprecationWarnings: {
+                boolean: true,
+                desc: 'Also check for warnings about deprecated properties and features that will become errors in a future SDK version.',
+                default: true,
+            },
+        },
         handler: validate_1.handleValidate,
     })
         .command({

--- a/dist/cli/validate.d.ts
+++ b/dist/cli/validate.d.ts
@@ -2,7 +2,10 @@ import type { ArgumentsCamelCase } from 'yargs';
 import type { PackVersionMetadata } from '../compiled_types';
 interface ValidateArgs {
     manifestFile: string;
+    checkDeprecationWarnings: boolean;
 }
-export declare function handleValidate({ manifestFile }: ArgumentsCamelCase<ValidateArgs>): Promise<void>;
-export declare function validateMetadata(metadata: PackVersionMetadata): Promise<void>;
+export declare function handleValidate({ manifestFile, checkDeprecationWarnings }: ArgumentsCamelCase<ValidateArgs>): Promise<void>;
+export declare function validateMetadata(metadata: PackVersionMetadata, { checkDeprecationWarnings }?: {
+    checkDeprecationWarnings?: boolean;
+}): Promise<void>;
 export {};

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,3 +1,7 @@
+# Run `source setup-env.sh` as a convenience to add node_modules/.bin to your path,
+# which allows you to run binaries from npm packages unqualified, e.g. just
+# `ts-node cli/coda.ts` instead of `node_modules/.bin/ts-node cli/coda.ts`
+
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export PATH=${BASEDIR}/build/node/bin:${BASEDIR}/node_modules/.bin:${PATH}

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,0 +1,3 @@
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export PATH=${BASEDIR}/build/node/bin:${BASEDIR}/node_modules/.bin:${PATH}


### PR DESCRIPTION
To finish this off, we should next read the server-generated deprecation warnings that come back in the API response from `coda upload` and render those too. But this is helpful to allow people to (eventually) check most things for themselves locally. The major issue though is that if they're on an SDK version before this is supported, the ability to check for deprecation warnings locally doesn't exist, and so they would only know they're using deprecated stuff when `coda upload` tells them.

PTAL @dweitzman-codaio @coda/packs 