### PR TITLE
Show server-generated deprecation warnings at the end of coda upload.

### DIFF
--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -171,7 +171,7 @@ export async function handleUpload({
     }
 
     const {deprecationWarnings} = uploadCompleteResponse;
-    if (deprecationWarnings) {
+    if (deprecationWarnings?.length) {
       print(
         '\nYour Pack version uploaded successfully. ' +
           'However, your Pack is using deprecated properties or features that will become errors in a future SDK version.\n',

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -2,6 +2,7 @@ import type {ArgumentsCamelCase} from 'yargs';
 import type {Logger} from '../api_types';
 import type {PackUpload} from '../compiled_types';
 import type {PackVersionDefinition} from '..';
+import type {PublicApiCreatePackVersionResponse} from '../helpers/external-api/v1';
 import {PublicApiPackSource} from '../helpers/external-api/v1';
 import type {PublicApiPackVersionUploadInfo} from '../helpers/external-api/v1';
 import type {TimerShimStrategy} from '../testing/compile';
@@ -135,7 +136,7 @@ export async function handleUpload({
     const bundleHash = computeSha256(uploadPayload);
 
     logger.info('Validating Pack metadata...');
-    await validateMetadata(metadata);
+    await validateMetadata(metadata, {checkDeprecationWarnings: false});
 
     logger.info('Registering new Pack version...');
     let registerResponse: PublicApiPackVersionUploadInfo;
@@ -154,13 +155,30 @@ export async function handleUpload({
     await uploadPack(uploadUrl, uploadPayload, headers);
 
     logger.info('Validating upload...');
+    let uploadCompleteResponse: PublicApiCreatePackVersionResponse;
     try {
-      await client.packVersionUploadComplete(packId, packVersion, {}, {notes, source: PublicApiPackSource.Cli});
+      uploadCompleteResponse = await client.packVersionUploadComplete(
+        packId,
+        packVersion,
+        {},
+        {notes, source: PublicApiPackSource.Cli},
+      );
     } catch (err: any) {
       if (isResponseError(err)) {
         printAndExit(`Error while finalizing pack version: ${await formatResponseError(err)}`);
       }
       throw err;
+    }
+
+    const {deprecationWarnings} = uploadCompleteResponse;
+    if (deprecationWarnings) {
+      print(
+        '\nYour Pack version uploaded successfully. ' +
+          'However, your Pack is using deprecated properties or features that will become errors in a future SDK version.\n',
+      );
+      for (const {path, message} of deprecationWarnings) {
+        print(`Warning in field at path "${path}": ${message}`);
+      }
     }
   } catch (err: any) {
     const errors = [`Unexpected error during Pack upload: ${formatError(err)}`, tryParseSystemError(err)];

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -142,7 +142,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
             throw err;
         }
         const { deprecationWarnings } = uploadCompleteResponse;
-        if (deprecationWarnings) {
+        if (deprecationWarnings === null || deprecationWarnings === void 0 ? void 0 : deprecationWarnings.length) {
             (0, helpers_5.print)('\nYour Pack version uploaded successfully. ' +
                 'However, your Pack is using deprecated properties or features that will become errors in a future SDK version.\n');
             for (const { path, message } of deprecationWarnings) {

--- a/dist/helpers/external-api/coda.d.ts
+++ b/dist/helpers/external-api/coda.d.ts
@@ -3,7 +3,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
+ * Hash: 3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad
  */
 import 'es6-promise/auto';
 import 'isomorphic-fetch';
@@ -37,6 +37,11 @@ export declare class Client {
         pageToken?: string;
     }): Promise<types.PublicApiDocList>;
     createDoc(params: {} | undefined, payload: types.PublicApiDocCreate): Promise<types.PublicApiDoc>;
+    getDocsCount(params?: {
+        isPublished?: boolean;
+        isOwner?: boolean;
+        workspaceId?: string;
+    }): Promise<types.PublicApiCountResponse>;
     getDoc(docId: string, params?: {}): Promise<types.PublicApiDoc>;
     deleteDoc(docId: string, params?: {}): Promise<types.PublicApiDocDelete>;
     getSharingMetadata(docId: string, params?: {}): Promise<types.PublicApiAcl>;
@@ -106,14 +111,56 @@ export declare class Client {
         degradeGracefully?: boolean;
     }): Promise<types.PublicApiApiLink>;
     getMutationStatus(requestId: string, params?: {}): Promise<types.PublicApiMutationStatus>;
+    triggerWebhookAutomation(docId: string, ruleId: string, params: {} | undefined, payload: types.PublicApiWebhookTriggerPayload): Promise<types.PublicApiWebhookTriggerResult>;
     listDocAnalytics(params?: {
         isPublished?: boolean;
         sinceDate?: string;
         untilDate?: string;
-        scale?: types.PublicApiDocAnalyticsScale;
+        scale?: types.PublicApiAnalyticsScale;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiDocAnalyticsCollection>;
+    listDocAnalyticsDeprecated(params?: {
+        isPublished?: boolean;
+        sinceDate?: string;
+        untilDate?: string;
+        scale?: types.PublicApiAnalyticsScale;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiDeprecatedDocAnalyticsCollection>;
+    listDocAnalyticsSummary(params?: {
+        isPublished?: boolean;
+        sinceDate?: string;
+        untilDate?: string;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiDocAnalyticsSummary>;
+    listPackAnalytics(params?: {
+        packIds?: string;
+        workspaceId?: string;
+        sinceDate?: string;
+        untilDate?: string;
+        scale?: types.PublicApiAnalyticsScale;
+        orderBy?: types.PublicApiPackAnalyticsOrderBy;
+        direction?: types.PublicApiSortDirection;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiPackAnalyticsCollection>;
+    listPackAnalyticsSummary(params?: {
+        packIds?: string;
+        workspaceId?: string;
+        sinceDate?: string;
+        untilDate?: string;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiPackAnalyticsSummary>;
+    listPackFormulaAnalytics(packId: number, params?: {
+        sinceDate?: string;
+        untilDate?: string;
+        scale?: types.PublicApiAnalyticsScale;
+        limit?: number;
+        pageToken?: string;
+    }): Promise<types.PublicApiPackFormulaAnalyticsCollection>;
     listWorkspaceMembers(workspaceId: string, params?: {
         includedRoles?: string;
         limit?: number;
@@ -127,13 +174,17 @@ export declare class Client {
     listPacks(params?: {
         accessType?: types.PublicApiPackAccessType;
         sortBy?: types.PublicApiPacksSortBy;
-        workspaceId?: string;
+        onlyWorkspaceId?: string;
+        excludePublicPacks?: boolean;
+        excludeIndividualAcls?: boolean;
+        excludeWorkspaceAcls?: boolean;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackSummaryList>;
     createPack(params: {} | undefined, payload: types.PublicApiCreatePackRequest): Promise<types.PublicApiCreatePackResponse>;
     getPack(packId: number, params?: {}): Promise<types.PublicApiPack>;
     updatePack(packId: number, params: {} | undefined, payload: types.PublicApiUpdatePackRequest): Promise<types.PublicApiPack>;
+    deletePack(packId: number, params?: {}): Promise<types.PublicApiDeletePackResponse>;
     listPackVersions(packId: number, params?: {
         limit?: number;
         pageToken?: string;
@@ -175,7 +226,12 @@ export declare class Client {
     listPackListings(params?: {
         packAccessTypes?: types.PublicApiPackAccessTypes;
         packIds?: string;
+        onlyWorkspaceId?: string;
         excludePublicPacks?: boolean;
+        excludeWorkspaceAcls?: boolean;
+        excludeIndividualAcls?: boolean;
+        orderBy?: types.PublicApiPackListingsSortBy;
+        direction?: types.PublicApiSortDirection;
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiPackListingList>;
@@ -200,4 +256,9 @@ export declare class Client {
         limit?: number;
         pageToken?: string;
     }): Promise<types.PublicApiGroupedPackLogsList>;
+    getPackCount(params?: {
+        isPublished?: boolean;
+        accessType?: types.PublicApiPackAccessType;
+        excludePublicPacks?: boolean;
+    }): Promise<types.PublicApiCountResponse>;
 }

--- a/dist/helpers/external-api/coda.js
+++ b/dist/helpers/external-api/coda.js
@@ -5,7 +5,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
+ * Hash: 3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Client = exports.isResponseError = exports.ResponseError = void 0;
@@ -65,6 +65,13 @@ class Client {
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs`, allParams);
         return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+    }
+    async getDocsCount(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/count`, allParams);
+        return this._makeRequest('GET', codaUrl);
     }
     async getDoc(docId, params = {}) {
         const allParams = {
@@ -276,12 +283,59 @@ class Client {
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/mutationStatus/${requestId}`, allParams);
         return this._makeRequest('GET', codaUrl);
     }
+    async triggerWebhookAutomation(docId, ruleId, params = {}, payload) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/docs/${docId}/hooks/automation/${ruleId}`, allParams);
+        return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+    }
     async listDocAnalytics(params = {}) {
         const allParams = {
             ...params,
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/docs`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listDocAnalyticsDeprecated(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/docs/legacy`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listDocAnalyticsSummary(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/docs/summary`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listPackAnalytics(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/packs`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listPackAnalyticsSummary(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/packs/summary`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async listPackFormulaAnalytics(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const { pageToken, ...rest } = allParams;
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/analytics/packs/${packId}/formulas`, pageToken ? { pageToken } : rest);
         return this._makeRequest('GET', codaUrl);
     }
     async listWorkspaceMembers(workspaceId, params = {}) {
@@ -335,6 +389,13 @@ class Client {
         };
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
         return this._makeRequest('PATCH', codaUrl, JSON.stringify(payload));
+    }
+    async deletePack(packId, params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
+        return this._makeRequest('DELETE', codaUrl);
     }
     async listPackVersions(packId, params = {}) {
         const allParams = {
@@ -551,6 +612,13 @@ class Client {
         };
         const { pageToken, ...rest } = allParams;
         const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/groupedLogs`, pageToken ? { pageToken } : rest);
+        return this._makeRequest('GET', codaUrl);
+    }
+    async getPackCount(params = {}) {
+        const allParams = {
+            ...params,
+        };
+        const codaUrl = (0, url_1.withQueryParams)(`${this.protocolAndHost}/apis/v1/packs/count`, allParams);
         return this._makeRequest('GET', codaUrl);
     }
 }

--- a/dist/helpers/external-api/v1.d.ts
+++ b/dist/helpers/external-api/v1.d.ts
@@ -1,8 +1,8 @@
 /**
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
-export declare const OpenApiSpecHash = "e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c";
-export declare const OpenApiSpecVersion = "1.2.3";
+export declare const OpenApiSpecHash = "3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad";
+export declare const OpenApiSpecVersion = "1.2.5";
 /**
  * A constant identifying the type of the resource.
  */
@@ -10,17 +10,23 @@ export declare enum PublicApiType {
     AclMetadata = "aclMetadata",
     AclPermissions = "aclPermissions",
     ApiLink = "apiLink",
+    Automation = "automation",
     Column = "column",
     Control = "control",
     Doc = "doc",
     DocAnalytics = "docAnalytics",
+    DocAnalyticsSummary = "docAnalyticsSummary",
+    DocAnalyticsV2 = "docAnalyticsV2",
     Folder = "folder",
     Formula = "formula",
     MutationStatus = "mutationStatus",
     Pack = "pack",
     PackAclPermissions = "packAclPermissions",
+    PackAnalytics = "packAnalytics",
+    PackAnalyticsSummary = "packAnalyticsSummary",
     PackAsset = "packAsset",
     PackCategory = "packCategory",
+    PackFormulaAnalytics = "packFormulaAnalytics",
     PackLog = "packLog",
     PackMaker = "packMaker",
     PackOauthConfig = "packOauthConfig",
@@ -574,6 +580,15 @@ export interface PublicApiValidationError {
     message: string;
 }
 /**
+ * A response that represents a count
+ */
+export interface PublicApiCountResponse {
+    /**
+     * The count of an item.
+     */
+    count: number;
+}
+/**
  * Reference to a table or view.
  */
 export interface PublicApiTableReference {
@@ -829,6 +844,26 @@ export declare enum PublicApiEmailDisplayType {
     EmailOnly = "emailOnly"
 }
 /**
+ * Format of a link column.
+ */
+export declare type PublicApiLinkColumnFormat = PublicApiSimpleColumnFormat & {
+    display?: PublicApiLinkDisplayType;
+    /**
+     * Force embeds to render on the client instead of the server (for sites that require user login).
+     */
+    force?: boolean;
+};
+/**
+ * How a link should be displayed in the user interface.
+ */
+export declare enum PublicApiLinkDisplayType {
+    IconOnly = "iconOnly",
+    Url = "url",
+    Title = "title",
+    Card = "card",
+    Embed = "embed"
+}
+/**
  * Format of a time column.
  */
 export declare type PublicApiTimeColumnFormat = PublicApiSimpleColumnFormat & {
@@ -933,7 +968,7 @@ export declare type PublicApiScaleColumnFormat = PublicApiSimpleColumnFormat & {
 /**
  * Format of a column.
  */
-export declare type PublicApiColumnFormat = PublicApiButtonColumnFormat | PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiEmailColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
+export declare type PublicApiColumnFormat = PublicApiButtonColumnFormat | PublicApiDateColumnFormat | PublicApiDateTimeColumnFormat | PublicApiDurationColumnFormat | PublicApiEmailColumnFormat | PublicApiLinkColumnFormat | PublicApiCurrencyColumnFormat | PublicApiNumericColumnFormat | PublicApiReferenceColumnFormat | PublicApiSimpleColumnFormat | PublicApiScaleColumnFormat | PublicApiSliderColumnFormat | PublicApiTimeColumnFormat;
 /**
  * Format type of the column
  */
@@ -949,6 +984,7 @@ export declare enum PublicApiColumnFormatType {
     Time = "time",
     Duration = "duration",
     Email = "email",
+    Link = "link",
     Slider = "slider",
     Scale = "scale",
     Image = "image",
@@ -1289,8 +1325,11 @@ export declare type PublicApiRowsDeleteResult = PublicApiDocumentMutateResponse 
 export interface PublicApiRowsUpsert {
     rows: PublicApiRowEdit[];
     /**
+     * Optional unique row IDs to make the request idempotent. Must match the row id format.
+     */
+    rowIds?: string[];
+    /**
      * Optional column IDs, URLs, or names (fragile and discouraged), specifying columns to be used as upsert keys.
-     *
      */
     keyColumns?: string[];
 }
@@ -1541,7 +1580,7 @@ export interface PublicApiPublishingCategory {
     /**
      * The URL identifier of the category.
      */
-    categorySlug: string;
+    categorySlug?: string;
 }
 /**
  * Info about the maker
@@ -1725,6 +1764,16 @@ export interface PublicApiMutationStatus {
     completed: boolean;
 }
 /**
+ * Payload for webhook trigger
+ */
+export interface PublicApiWebhookTriggerPayload {
+    [k: string]: unknown;
+}
+/**
+ * The result of triggering a webhook
+ */
+export declare type PublicApiWebhookTriggerResult = PublicApiDocumentMutateResponse & {};
+/**
  * Reference to a Coda folder.
  */
 export interface PublicApiFolderReference {
@@ -1905,9 +1954,17 @@ export interface PublicApiChangeRoleResult {
     roleChangedAt: string;
 }
 /**
+ * List of analytics for Coda docs over a date range.
+ */
+export interface PublicApiDeprecatedDocAnalyticsCollection {
+    items: PublicApiDeprecatedDocAnalyticsItem[];
+    nextPageToken?: PublicApiNextPageToken;
+    nextPageLink?: PublicApiNextPageLink & string;
+}
+/**
  * Analytics data for a Coda doc.
  */
-export interface PublicApiDocAnalyticsItem {
+export interface PublicApiDeprecatedDocAnalyticsItem {
     doc: PublicApiDocReference & {
         /**
          * Title of the doc.
@@ -1944,6 +2001,13 @@ export interface PublicApiDocAnalyticsItem {
     sessionsOther: number;
 }
 /**
+ * Analytics data for a Coda doc.
+ */
+export interface PublicApiDocAnalyticsItem {
+    doc: PublicApiDocAnalyticsDetails;
+    metrics: PublicApiDocAnalyticsMetrics[];
+}
+/**
  * List of analytics for Coda docs over a date range.
  */
 export interface PublicApiDocAnalyticsCollection {
@@ -1952,11 +2016,295 @@ export interface PublicApiDocAnalyticsCollection {
     nextPageLink?: PublicApiNextPageLink & string;
 }
 /**
+ * Analytics metrics for a Coda Doc.
+ */
+export interface PublicApiDocAnalyticsMetrics {
+    /**
+     * Date of the analytics data.
+     */
+    date: string;
+    /**
+     * Number of times the doc was viewed.
+     */
+    views: number;
+    /**
+     * Number of times the doc was copied.
+     */
+    copies: number;
+    /**
+     * Number of times the doc was liked.
+     */
+    likes: number;
+    /**
+     * Number of unique visitors to this doc from a mobile device.
+     */
+    sessionsMobile: number;
+    /**
+     * Number of unique visitors to this doc from a desktop device.
+     */
+    sessionsDesktop: number;
+    /**
+     * Number of unique visitors to this doc from an unknown device type.
+     */
+    sessionsOther: number;
+}
+export declare type PublicApiDocAnalyticsDetails = PublicApiDocReference & {
+    /**
+     * The name of the doc.
+     */
+    title: string;
+    icon?: PublicApiIcon;
+    /**
+     * Publish time for this doc.
+     */
+    publishTimestamp: number;
+};
+/**
+ * Summarized metrics for Coda docs.
+ */
+export interface PublicApiDocAnalyticsSummary {
+    /**
+     * Total number of sessions across all docs.
+     */
+    totalSessions: number;
+}
+/**
+ * Metadata about a Pack relevant to analytics.
+ */
+export interface PublicApiPackAnalyticsDetails {
+    /**
+     * ID of the Pack.
+     */
+    id: number;
+    /**
+     * The name of the Pack.
+     */
+    name: string;
+    /**
+     * The link to the logo of the Pack.
+     */
+    logoUrl?: string;
+    /**
+     * Creation time of the Pack.
+     */
+    createdAt: string;
+}
+/**
+ * List of analytics for Coda Packs over a date range.
+ */
+export interface PublicApiPackAnalyticsCollection {
+    items: PublicApiPackAnalyticsItem[];
+    nextPageToken?: PublicApiNextPageToken;
+    nextPageLink?: PublicApiNextPageLink & string;
+}
+/**
+ * Analytics data for a Coda Pack.
+ */
+export interface PublicApiPackAnalyticsItem {
+    pack: PublicApiPackAnalyticsDetails;
+    metrics: PublicApiPackAnalyticsMetrics[];
+}
+/**
+ * Analytics metrics for a Coda Pack.
+ */
+export interface PublicApiPackAnalyticsMetrics {
+    /**
+     * Date of the analytics data.
+     */
+    date: string;
+    /**
+     * Number of unique documents that have installed this Pack.
+     */
+    docInstalls: number;
+    /**
+     * Number of unique workspaces that have installed this Pack.
+     */
+    workspaceInstalls: number;
+    /**
+     * Number of times regular formulas have been called.
+     */
+    numFormulaInvocations: number;
+    /**
+     * Number of times action formulas have been called.
+     */
+    numActionInvocations: number;
+    /**
+     * Number of times sync table formulas have been called.
+     */
+    numSyncInvocations: number;
+    /**
+     * Number of times metadata formulas have been called.
+     */
+    numMetadataInvocations: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past day.
+     */
+    docsActivelyUsing: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 7 days.
+     */
+    docsActivelyUsing7Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 30 days.
+     */
+    docsActivelyUsing30Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 90 days.
+     */
+    docsActivelyUsing90Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack ever.
+     */
+    docsActivelyUsingAllTime: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past day.
+     */
+    workspacesActivelyUsing: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 7 days.
+     */
+    workspacesActivelyUsing7Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 30 days.
+     */
+    workspacesActivelyUsing30Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 90 days.
+     */
+    workspacesActivelyUsing90Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack ever.
+     */
+    workspacesActivelyUsingAllTime: number;
+}
+/**
+ * Determines how the Pack analytics returned are sorted.
+ */
+export declare enum PublicApiPackAnalyticsOrderBy {
+    AnalyticsDate = "date",
+    PackId = "packId",
+    Name = "name",
+    CreatedAt = "createdAt",
+    DocInstalls = "docInstalls",
+    WorkspaceInstalls = "workspaceInstalls",
+    NumFormulaInvocations = "numFormulaInvocations",
+    NumActionInvocations = "numActionInvocations",
+    NumSyncInvocations = "numSyncInvocations",
+    NumMetadataInvocations = "numMetadataInvocations",
+    DocsActivelyUsing = "docsActivelyUsing",
+    DocsActivelyUsing7Day = "docsActivelyUsing7Day",
+    DocsActivelyUsing30Day = "docsActivelyUsing30Day",
+    DocsActivelyUsing90Day = "docsActivelyUsing90Day",
+    DocsActivelyUsingAllTime = "docsActivelyUsingAllTime",
+    WorkspacesActivelyUsing = "workspacesActivelyUsing",
+    WorkspacesActivelyUsing7Day = "workspacesActivelyUsing7Day",
+    WorkspacesActivelyUsing30Day = "workspacesActivelyUsing30Day",
+    WorkspacesActivelyUsing90Day = "workspacesActivelyUsing90Day",
+    WorkspacesActivelyUsingAllTime = "workspacesActivelyUsingAllTime"
+}
+/**
+ * Summary analytics for Packs.
+ */
+export interface PublicApiPackAnalyticsSummary {
+    /**
+     * The times this Pack was installed in docs.
+     */
+    totalDocInstalls: number;
+    /**
+     * The times this Pack was installed in workspaces.
+     */
+    totalWorkspaceInstalls: number;
+    /**
+     * The number of times formulas in this Pack were invoked.
+     */
+    totalInvocations: number;
+}
+/**
  * Quantization period over which to view analytics.
  */
-export declare enum PublicApiDocAnalyticsScale {
-    Day = "daily",
+export declare enum PublicApiAnalyticsScale {
+    Daily = "daily",
     Cumulative = "cumulative"
+}
+/**
+ * Analytics metrics for a Coda Pack formula.
+ */
+export interface PublicApiPackFormulaAnalyticsMetrics {
+    /**
+     * Date of the analytics data.
+     */
+    date: string;
+    /**
+     * Number of times this formula has been invoked.
+     */
+    formulaInvocations: number;
+    /**
+     * Number of errors from invocations.
+     */
+    errors: number;
+    /**
+     * Median latency of an invocation in milliseconds. Only present for daily metrics.
+     */
+    medianLatencyMs?: number;
+    /**
+     * Median response size in bytes. Only present for daily metrics.
+     */
+    medianResponseSizeBytes?: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past day.
+     */
+    docsActivelyUsing: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 7 days.
+     */
+    docsActivelyUsing7Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 30 days.
+     */
+    docsActivelyUsing30Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack in the past 90 days.
+     */
+    docsActivelyUsing90Day: number;
+    /**
+     * Number of unique docs that have invoked a formula from this Pack ever.
+     */
+    docsActivelyUsingAllTime: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past day.
+     */
+    workspacesActivelyUsing: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 7 days.
+     */
+    workspacesActivelyUsing7Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 30 days.
+     */
+    workspacesActivelyUsing30Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack in the past 90 days.
+     */
+    workspacesActivelyUsing90Day: number;
+    /**
+     * Number of unique workspaces that have invoked a formula from this Pack ever.
+     */
+    workspacesActivelyUsingAllTime: number;
+}
+/**
+ * Analytics data for a Coda Pack formula.
+ */
+export interface PublicApiPackFormulaAnalyticsItem {
+    formula: PublicApiPackFormulaIdentifier;
+    metrics: PublicApiPackFormulaAnalyticsMetrics[];
+}
+/**
+ * A collection of analytics for Coda Packs formulas over a date range.
+ */
+export interface PublicApiPackFormulaAnalyticsCollection {
+    items: PublicApiPackFormulaAnalyticsItem[];
+    nextPageToken?: PublicApiNextPageToken;
+    nextPageLink?: PublicApiNextPageLink & string;
 }
 /**
  * Details about a Pack.
@@ -1998,8 +2346,21 @@ export interface PublicApiPack {
      * A contact email for the Pack.
      */
     supportEmail?: string;
+    /**
+     * A Terms of Service URL for the Pack.
+     */
+    termsOfServiceUrl?: string;
+    /**
+     * A Privacy Policy URL for the Pack.
+     */
+    privacyPolicyUrl?: string;
+    /**
+     * A Featured Doc URL for the Pack.
+     */
+    featuredDocUrl?: string;
     overallRateLimit?: PublicApiPackRateLimit;
     perConnectionRateLimit?: PublicApiPackRateLimit;
+    featuredDocStatus?: PublicApiFeaturedDocStatus;
 }
 /**
  * Summary of a Pack.
@@ -2041,6 +2402,18 @@ export interface PublicApiPackSummary {
      * A contact email for the Pack.
      */
     supportEmail?: string;
+    /**
+     * A Terms of Service URL for the Pack.
+     */
+    termsOfServiceUrl?: string;
+    /**
+     * A Privacy Policy URL for the Pack.
+     */
+    privacyPolicyUrl?: string;
+    /**
+     * A Featured Doc URL for the Pack.
+     */
+    featuredDocUrl?: string;
 }
 /**
  * List of Pack summaries.
@@ -2070,6 +2443,15 @@ export declare enum PublicApiPacksSortBy {
     Title = "title",
     CreatedAt = "createdAt",
     UpdatedAt = "updatedAt"
+}
+/**
+ * Determines how the Pack listings returned are sorted.
+ */
+export declare enum PublicApiPackListingsSortBy {
+    PackId = "packId",
+    Name = "name",
+    PackVersion = "packVersion",
+    PackVersionModifiedAt = "packVersionModifiedAt"
 }
 /**
  * Information indicating where to upload the Pack version definition.
@@ -2192,6 +2574,7 @@ export interface PublicApiPackVersion {
      * The semantic format of the Pack version.
      */
     packVersion: string;
+    source?: PublicApiPackSource;
 }
 /**
  * List of Pack versions.
@@ -2306,6 +2689,10 @@ export interface PublicApiPackListing {
      */
     packVersion: string;
     /**
+     * The current release number of the Pack if released, otherwise undefined.
+     */
+    releaseId?: number;
+    /**
      * The link to the logo of the Pack.
      */
     logoUrl: string;
@@ -2329,6 +2716,18 @@ export interface PublicApiPackListing {
      * A contact email for the Pack.
      */
     supportEmail?: string;
+    /**
+     * A Terms of Service URL for the Pack.
+     */
+    termsOfServiceUrl?: string;
+    /**
+     * A Privacy Policy URL for the Pack.
+     */
+    privacyPolicyUrl?: string;
+    /**
+     * A Featured Doc ID for the Pack.
+     */
+    featuredDocId?: string;
     /**
      * Publishing Categories associated with this Pack.
      */
@@ -2357,6 +2756,10 @@ export interface PublicApiPackListingDetail {
      */
     packVersion: string;
     /**
+     * The current release number of the Pack if released, otherwise undefined.
+     */
+    releaseId?: number;
+    /**
      * The link to the logo of the Pack.
      */
     logoUrl: string;
@@ -2381,6 +2784,18 @@ export interface PublicApiPackListingDetail {
      */
     supportEmail?: string;
     /**
+     * A Terms of Service URL for the Pack.
+     */
+    termsOfServiceUrl?: string;
+    /**
+     * A Privacy Policy URL for the Pack.
+     */
+    privacyPolicyUrl?: string;
+    /**
+     * A Featured Doc ID for the Pack.
+     */
+    featuredDocId?: string;
+    /**
      * Publishing Categories associated with this Pack.
      */
     categories: PublicApiPublishingCategory[];
@@ -2394,10 +2809,6 @@ export interface PublicApiPackListingDetail {
      * The url where complete metadata about the contents of the Pack version can be downloaded.
      */
     externalMetadataUrl: string;
-    /**
-     * The release number of the Pack version if it has one.
-     */
-    releaseId?: number;
     discoverability: PublicApiPackDiscoverability;
     /**
      * The access capabilities the current user has for this Pack.
@@ -2707,7 +3118,15 @@ export interface PublicApiGroupedPackInvocationLog {
 export interface PublicApiPackFetcherLog {
     type: PublicApiPackLogType.Fetcher;
     context: PublicApiPackLogContext;
+    /**
+     * The number of bytes in the HTTP request sent
+     */
+    requestSizeBytes?: number;
     responseCode?: number;
+    /**
+     * The number of bytes in the HTTP response received
+     */
+    responseSizeBytes?: number;
     method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
     /**
      * base url of the fetcher request, with all query parameters stripped off.
@@ -2796,6 +3215,29 @@ export declare enum PublicApiFeatureSet {
     Enterprise = "Enterprise"
 }
 /**
+ * Status of featured doc in pack listing.
+ */
+export declare enum PublicApiFeaturedDocStatus {
+    DocInaccessibleOrDoesNotExist = "docInaccessibleOrDoesNotExist",
+    InvalidPublishedDocUrl = "invalidPublishedDocUrl"
+}
+export interface PublicApiPackFormulaIdentifier {
+    /**
+     * The Pack formula name.
+     */
+    name: string;
+    type: PublicApiPackFormulaType;
+}
+/**
+ * The pack formula type.
+ */
+export declare enum PublicApiPackFormulaType {
+    Action = "action",
+    Formula = "formula",
+    Sync = "sync",
+    Metadata = "metadata"
+}
+/**
  * The request to patch pack system connection credentials.
  */
 export declare type PublicApiPatchPackSystemConnectionRequest = PublicApiPackConnectionHeaderPatch | PublicApiPackConnectionUrlParamPatch | PublicApiPackConnectionHttpBasicPatch | PublicApiPackConnectionCustomPatch;
@@ -2803,8 +3245,8 @@ export declare type PublicApiPatchPackSystemConnectionRequest = PublicApiPackCon
  * Request to set the Pack OAuth configuration.
  */
 export interface PublicApiSetPackOauthConfigRequest {
-    clientId: string;
-    clientSecret: string;
+    clientId?: string;
+    clientSecret?: string;
 }
 /**
  * The request to set pack system connection credentials.
@@ -2820,7 +3262,14 @@ export interface PublicApiRegisterPackVersionRequest {
      * The SHA-256 hash of the file to be uploaded.
      */
     bundleHash: string;
-    [k: string]: unknown;
+    /**
+     * Internal field for cross-environment pack import.
+     */
+    dangerouslyAllowCrossEnvPack?: boolean;
+    /**
+     * Internal field that allows the api to use the non-latest pack version.
+     */
+    dangerouslyAllowNonLatestVersionNumber?: boolean;
 }
 /**
  * Payload for updating a Pack.
@@ -2880,11 +3329,29 @@ export interface PublicApiUpdatePackRequest {
      * A contact email for the Pack.
      */
     supportEmail?: string;
+    /**
+     * A Terms of Service URL for the Pack.
+     */
+    termsOfServiceUrl?: string;
+    /**
+     * A Privacy Policy URL for the Pack.
+     */
+    privacyPolicyUrl?: string;
+    /**
+     * A Featured Doc URL for the Pack.
+     */
+    featuredDocUrl?: string;
 }
 /**
  * Confirmation of successful Pack version creation.
  */
 export interface PublicApiCreatePackVersionResponse {
+    deprecationWarnings?: PublicApiValidationError[];
+}
+/**
+ * Confirmation of successful Pack deletion.
+ */
+export interface PublicApiDeletePackResponse {
 }
 /**
  * Confirmation of successfully retrieving Pack makers.
@@ -3022,7 +3489,10 @@ export interface PublicApiCreatePackVersionRequest {
      */
     notes?: string;
     source?: PublicApiPackSource;
-    [k: string]: unknown;
+    /**
+     * Internal field for cross-environment pack import.
+     */
+    dangerouslyAllowCrossEnvPack?: boolean;
 }
 /**
  * Payload for creating a new Pack release.
@@ -3036,7 +3506,10 @@ export interface PublicApiCreatePackReleaseRequest {
      * Developers notes.
      */
     releaseNotes?: string;
-    [k: string]: unknown;
+    /**
+     * Internal field for cross-environment pack import.
+     */
+    dangerouslyAllowCrossEnvPack?: boolean;
 }
 /**
  * Payload for a Pack asset upload.

--- a/dist/helpers/external-api/v1.js
+++ b/dist/helpers/external-api/v1.js
@@ -3,10 +3,10 @@
  * This file is auto-generated from OpenAPI definitions by `make build-openapi`. Do not edit manually.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PublicApiFeatureSet = exports.PublicApiLogLevel = exports.PublicApiPackLogType = exports.PublicApiPackLogRequestType = exports.PublicApiPackConnectionType = exports.PublicApiPackDiscoverability = exports.PublicApiPackSource = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPacksSortBy = exports.PublicApiDocAnalyticsScale = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
+exports.PublicApiPackFormulaType = exports.PublicApiFeaturedDocStatus = exports.PublicApiFeatureSet = exports.PublicApiLogLevel = exports.PublicApiPackLogType = exports.PublicApiPackLogRequestType = exports.PublicApiPackConnectionType = exports.PublicApiPackDiscoverability = exports.PublicApiPackSource = exports.PublicApiPackAssetType = exports.PublicApiPackAccessType = exports.PublicApiPackPrincipalType = exports.PublicApiPackListingsSortBy = exports.PublicApiPacksSortBy = exports.PublicApiAnalyticsScale = exports.PublicApiPackAnalyticsOrderBy = exports.PublicApiWorkspaceUserRole = exports.PublicApiTableType = exports.PublicApiSortBy = exports.PublicApiControlType = exports.PublicApiValueFormat = exports.PublicApiRowsSortBy = exports.PublicApiImageStatus = exports.PublicApiLinkedDataType = exports.PublicApiColumnFormatType = exports.PublicApiIconSet = exports.PublicApiDurationUnit = exports.PublicApiLinkDisplayType = exports.PublicApiEmailDisplayType = exports.PublicApiCurrencyFormatType = exports.PublicApiSortDirection = exports.PublicApiLayout = exports.PublicApiDocPublishMode = exports.PublicApiAccessType = exports.PublicApiPrincipalType = exports.PublicApiType = exports.OpenApiSpecVersion = exports.OpenApiSpecHash = void 0;
 /* eslint-disable */
-exports.OpenApiSpecHash = 'e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c';
-exports.OpenApiSpecVersion = '1.2.3';
+exports.OpenApiSpecHash = '3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad';
+exports.OpenApiSpecVersion = '1.2.5';
 /**
  * A constant identifying the type of the resource.
  */
@@ -15,17 +15,23 @@ var PublicApiType;
     PublicApiType["AclMetadata"] = "aclMetadata";
     PublicApiType["AclPermissions"] = "aclPermissions";
     PublicApiType["ApiLink"] = "apiLink";
+    PublicApiType["Automation"] = "automation";
     PublicApiType["Column"] = "column";
     PublicApiType["Control"] = "control";
     PublicApiType["Doc"] = "doc";
     PublicApiType["DocAnalytics"] = "docAnalytics";
+    PublicApiType["DocAnalyticsSummary"] = "docAnalyticsSummary";
+    PublicApiType["DocAnalyticsV2"] = "docAnalyticsV2";
     PublicApiType["Folder"] = "folder";
     PublicApiType["Formula"] = "formula";
     PublicApiType["MutationStatus"] = "mutationStatus";
     PublicApiType["Pack"] = "pack";
     PublicApiType["PackAclPermissions"] = "packAclPermissions";
+    PublicApiType["PackAnalytics"] = "packAnalytics";
+    PublicApiType["PackAnalyticsSummary"] = "packAnalyticsSummary";
     PublicApiType["PackAsset"] = "packAsset";
     PublicApiType["PackCategory"] = "packCategory";
+    PublicApiType["PackFormulaAnalytics"] = "packFormulaAnalytics";
     PublicApiType["PackLog"] = "packLog";
     PublicApiType["PackMaker"] = "packMaker";
     PublicApiType["PackOauthConfig"] = "packOauthConfig";
@@ -115,6 +121,17 @@ var PublicApiEmailDisplayType;
     PublicApiEmailDisplayType["EmailOnly"] = "emailOnly";
 })(PublicApiEmailDisplayType = exports.PublicApiEmailDisplayType || (exports.PublicApiEmailDisplayType = {}));
 /**
+ * How a link should be displayed in the user interface.
+ */
+var PublicApiLinkDisplayType;
+(function (PublicApiLinkDisplayType) {
+    PublicApiLinkDisplayType["IconOnly"] = "iconOnly";
+    PublicApiLinkDisplayType["Url"] = "url";
+    PublicApiLinkDisplayType["Title"] = "title";
+    PublicApiLinkDisplayType["Card"] = "card";
+    PublicApiLinkDisplayType["Embed"] = "embed";
+})(PublicApiLinkDisplayType = exports.PublicApiLinkDisplayType || (exports.PublicApiLinkDisplayType = {}));
+/**
  * A time unit used as part of a duration value.
  */
 var PublicApiDurationUnit;
@@ -166,6 +183,7 @@ var PublicApiColumnFormatType;
     PublicApiColumnFormatType["Time"] = "time";
     PublicApiColumnFormatType["Duration"] = "duration";
     PublicApiColumnFormatType["Email"] = "email";
+    PublicApiColumnFormatType["Link"] = "link";
     PublicApiColumnFormatType["Slider"] = "slider";
     PublicApiColumnFormatType["Scale"] = "scale";
     PublicApiColumnFormatType["Image"] = "image";
@@ -251,13 +269,39 @@ var PublicApiWorkspaceUserRole;
     PublicApiWorkspaceUserRole["Editor"] = "Editor";
 })(PublicApiWorkspaceUserRole = exports.PublicApiWorkspaceUserRole || (exports.PublicApiWorkspaceUserRole = {}));
 /**
+ * Determines how the Pack analytics returned are sorted.
+ */
+var PublicApiPackAnalyticsOrderBy;
+(function (PublicApiPackAnalyticsOrderBy) {
+    PublicApiPackAnalyticsOrderBy["AnalyticsDate"] = "date";
+    PublicApiPackAnalyticsOrderBy["PackId"] = "packId";
+    PublicApiPackAnalyticsOrderBy["Name"] = "name";
+    PublicApiPackAnalyticsOrderBy["CreatedAt"] = "createdAt";
+    PublicApiPackAnalyticsOrderBy["DocInstalls"] = "docInstalls";
+    PublicApiPackAnalyticsOrderBy["WorkspaceInstalls"] = "workspaceInstalls";
+    PublicApiPackAnalyticsOrderBy["NumFormulaInvocations"] = "numFormulaInvocations";
+    PublicApiPackAnalyticsOrderBy["NumActionInvocations"] = "numActionInvocations";
+    PublicApiPackAnalyticsOrderBy["NumSyncInvocations"] = "numSyncInvocations";
+    PublicApiPackAnalyticsOrderBy["NumMetadataInvocations"] = "numMetadataInvocations";
+    PublicApiPackAnalyticsOrderBy["DocsActivelyUsing"] = "docsActivelyUsing";
+    PublicApiPackAnalyticsOrderBy["DocsActivelyUsing7Day"] = "docsActivelyUsing7Day";
+    PublicApiPackAnalyticsOrderBy["DocsActivelyUsing30Day"] = "docsActivelyUsing30Day";
+    PublicApiPackAnalyticsOrderBy["DocsActivelyUsing90Day"] = "docsActivelyUsing90Day";
+    PublicApiPackAnalyticsOrderBy["DocsActivelyUsingAllTime"] = "docsActivelyUsingAllTime";
+    PublicApiPackAnalyticsOrderBy["WorkspacesActivelyUsing"] = "workspacesActivelyUsing";
+    PublicApiPackAnalyticsOrderBy["WorkspacesActivelyUsing7Day"] = "workspacesActivelyUsing7Day";
+    PublicApiPackAnalyticsOrderBy["WorkspacesActivelyUsing30Day"] = "workspacesActivelyUsing30Day";
+    PublicApiPackAnalyticsOrderBy["WorkspacesActivelyUsing90Day"] = "workspacesActivelyUsing90Day";
+    PublicApiPackAnalyticsOrderBy["WorkspacesActivelyUsingAllTime"] = "workspacesActivelyUsingAllTime";
+})(PublicApiPackAnalyticsOrderBy = exports.PublicApiPackAnalyticsOrderBy || (exports.PublicApiPackAnalyticsOrderBy = {}));
+/**
  * Quantization period over which to view analytics.
  */
-var PublicApiDocAnalyticsScale;
-(function (PublicApiDocAnalyticsScale) {
-    PublicApiDocAnalyticsScale["Day"] = "daily";
-    PublicApiDocAnalyticsScale["Cumulative"] = "cumulative";
-})(PublicApiDocAnalyticsScale = exports.PublicApiDocAnalyticsScale || (exports.PublicApiDocAnalyticsScale = {}));
+var PublicApiAnalyticsScale;
+(function (PublicApiAnalyticsScale) {
+    PublicApiAnalyticsScale["Daily"] = "daily";
+    PublicApiAnalyticsScale["Cumulative"] = "cumulative";
+})(PublicApiAnalyticsScale = exports.PublicApiAnalyticsScale || (exports.PublicApiAnalyticsScale = {}));
 /**
  * Determines how the Packs returned are sorted.
  */
@@ -267,6 +311,16 @@ var PublicApiPacksSortBy;
     PublicApiPacksSortBy["CreatedAt"] = "createdAt";
     PublicApiPacksSortBy["UpdatedAt"] = "updatedAt";
 })(PublicApiPacksSortBy = exports.PublicApiPacksSortBy || (exports.PublicApiPacksSortBy = {}));
+/**
+ * Determines how the Pack listings returned are sorted.
+ */
+var PublicApiPackListingsSortBy;
+(function (PublicApiPackListingsSortBy) {
+    PublicApiPackListingsSortBy["PackId"] = "packId";
+    PublicApiPackListingsSortBy["Name"] = "name";
+    PublicApiPackListingsSortBy["PackVersion"] = "packVersion";
+    PublicApiPackListingsSortBy["PackVersionModifiedAt"] = "packVersionModifiedAt";
+})(PublicApiPackListingsSortBy = exports.PublicApiPackListingsSortBy || (exports.PublicApiPackListingsSortBy = {}));
 /**
  * Type of Pack permissions.
  */
@@ -358,3 +412,21 @@ var PublicApiFeatureSet;
     PublicApiFeatureSet["Team"] = "Team";
     PublicApiFeatureSet["Enterprise"] = "Enterprise";
 })(PublicApiFeatureSet = exports.PublicApiFeatureSet || (exports.PublicApiFeatureSet = {}));
+/**
+ * Status of featured doc in pack listing.
+ */
+var PublicApiFeaturedDocStatus;
+(function (PublicApiFeaturedDocStatus) {
+    PublicApiFeaturedDocStatus["DocInaccessibleOrDoesNotExist"] = "docInaccessibleOrDoesNotExist";
+    PublicApiFeaturedDocStatus["InvalidPublishedDocUrl"] = "invalidPublishedDocUrl";
+})(PublicApiFeaturedDocStatus = exports.PublicApiFeaturedDocStatus || (exports.PublicApiFeaturedDocStatus = {}));
+/**
+ * The pack formula type.
+ */
+var PublicApiPackFormulaType;
+(function (PublicApiPackFormulaType) {
+    PublicApiPackFormulaType["Action"] = "action";
+    PublicApiPackFormulaType["Formula"] = "formula";
+    PublicApiPackFormulaType["Sync"] = "sync";
+    PublicApiPackFormulaType["Metadata"] = "metadata";
+})(PublicApiPackFormulaType = exports.PublicApiPackFormulaType || (exports.PublicApiPackFormulaType = {}));

--- a/helpers/external-api/coda.ts
+++ b/helpers/external-api/coda.ts
@@ -4,7 +4,7 @@
  * available at https://coda.io/developers/apis/v1
  *
  * Version: v1
- * Hash: e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c
+ * Hash: 3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad
  */
 
 import 'es6-promise/auto';
@@ -96,6 +96,20 @@ export class Client {
     };
     const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/docs`, allParams);
     return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+  }
+
+  async getDocsCount(
+    params: {
+      isPublished?: boolean;
+      isOwner?: boolean;
+      workspaceId?: string;
+    } = {},
+  ): Promise<types.PublicApiCountResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/docs/count`, allParams);
+    return this._makeRequest('GET', codaUrl);
   }
 
   async getDoc(docId: string, params: {} = {}): Promise<types.PublicApiDoc> {
@@ -506,12 +520,28 @@ export class Client {
     return this._makeRequest('GET', codaUrl);
   }
 
+  async triggerWebhookAutomation(
+    docId: string,
+    ruleId: string,
+    params: {} = {},
+    payload: types.PublicApiWebhookTriggerPayload,
+  ): Promise<types.PublicApiWebhookTriggerResult> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/docs/${docId}/hooks/automation/${ruleId}`,
+      allParams,
+    );
+    return this._makeRequest('POST', codaUrl, JSON.stringify(payload));
+  }
+
   async listDocAnalytics(
     params: {
       isPublished?: boolean;
       sinceDate?: string;
       untilDate?: string;
-      scale?: types.PublicApiDocAnalyticsScale;
+      scale?: types.PublicApiAnalyticsScale;
       limit?: number;
       pageToken?: string;
     } = {},
@@ -521,6 +551,110 @@ export class Client {
     };
     const {pageToken, ...rest} = allParams;
     const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/analytics/docs`, pageToken ? {pageToken} : rest);
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listDocAnalyticsDeprecated(
+    params: {
+      isPublished?: boolean;
+      sinceDate?: string;
+      untilDate?: string;
+      scale?: types.PublicApiAnalyticsScale;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiDeprecatedDocAnalyticsCollection> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/analytics/docs/legacy`,
+      pageToken ? {pageToken} : rest,
+    );
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listDocAnalyticsSummary(
+    params: {
+      isPublished?: boolean;
+      sinceDate?: string;
+      untilDate?: string;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiDocAnalyticsSummary> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/analytics/docs/summary`,
+      pageToken ? {pageToken} : rest,
+    );
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listPackAnalytics(
+    params: {
+      packIds?: string;
+      workspaceId?: string;
+      sinceDate?: string;
+      untilDate?: string;
+      scale?: types.PublicApiAnalyticsScale;
+      orderBy?: types.PublicApiPackAnalyticsOrderBy;
+      direction?: types.PublicApiSortDirection;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiPackAnalyticsCollection> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/analytics/packs`, pageToken ? {pageToken} : rest);
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listPackAnalyticsSummary(
+    params: {
+      packIds?: string;
+      workspaceId?: string;
+      sinceDate?: string;
+      untilDate?: string;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiPackAnalyticsSummary> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/analytics/packs/summary`,
+      pageToken ? {pageToken} : rest,
+    );
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async listPackFormulaAnalytics(
+    packId: number,
+    params: {
+      sinceDate?: string;
+      untilDate?: string;
+      scale?: types.PublicApiAnalyticsScale;
+      limit?: number;
+      pageToken?: string;
+    } = {},
+  ): Promise<types.PublicApiPackFormulaAnalyticsCollection> {
+    const allParams = {
+      ...params,
+    };
+    const {pageToken, ...rest} = allParams;
+    const codaUrl = withQueryParams(
+      `${this.protocolAndHost}/apis/v1/analytics/packs/${packId}/formulas`,
+      pageToken ? {pageToken} : rest,
+    );
     return this._makeRequest('GET', codaUrl);
   }
 
@@ -577,7 +711,10 @@ export class Client {
     params: {
       accessType?: types.PublicApiPackAccessType;
       sortBy?: types.PublicApiPacksSortBy;
-      workspaceId?: string;
+      onlyWorkspaceId?: string;
+      excludePublicPacks?: boolean;
+      excludeIndividualAcls?: boolean;
+      excludeWorkspaceAcls?: boolean;
       limit?: number;
       pageToken?: string;
     } = {},
@@ -619,6 +756,14 @@ export class Client {
     };
     const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
     return this._makeRequest('PATCH', codaUrl, JSON.stringify(payload));
+  }
+
+  async deletePack(packId: number, params: {} = {}): Promise<types.PublicApiDeletePackResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/${packId}`, allParams);
+    return this._makeRequest('DELETE', codaUrl);
   }
 
   async listPackVersions(
@@ -978,7 +1123,12 @@ export class Client {
     params: {
       packAccessTypes?: types.PublicApiPackAccessTypes;
       packIds?: string;
+      onlyWorkspaceId?: string;
       excludePublicPacks?: boolean;
+      excludeWorkspaceAcls?: boolean;
+      excludeIndividualAcls?: boolean;
+      orderBy?: types.PublicApiPackListingsSortBy;
+      direction?: types.PublicApiSortDirection;
       limit?: number;
       pageToken?: string;
     } = {},
@@ -1049,6 +1199,20 @@ export class Client {
       `${this.protocolAndHost}/apis/v1/packs/${packId}/docs/${docId}/groupedLogs`,
       pageToken ? {pageToken} : rest,
     );
+    return this._makeRequest('GET', codaUrl);
+  }
+
+  async getPackCount(
+    params: {
+      isPublished?: boolean;
+      accessType?: types.PublicApiPackAccessType;
+      excludePublicPacks?: boolean;
+    } = {},
+  ): Promise<types.PublicApiCountResponse> {
+    const allParams = {
+      ...params,
+    };
+    const codaUrl = withQueryParams(`${this.protocolAndHost}/apis/v1/packs/count`, allParams);
     return this._makeRequest('GET', codaUrl);
   }
 }

--- a/helpers/external-api/v1.ts
+++ b/helpers/external-api/v1.ts
@@ -4,9 +4,9 @@
 
 /* eslint-disable */
 
-export const OpenApiSpecHash = 'e8edcd565f1c5ea5e9f682b9b9df68563d730643a6e9477a997cf57baa7d8f4c';
+export const OpenApiSpecHash = '3cb65a92b168c432b6eb8cad28cd0cc16911c3536d86f2d256c7ddb6007de8ad';
 
-export const OpenApiSpecVersion = '1.2.3';
+export const OpenApiSpecVersion = '1.2.5';
 
 /**
  * A constant identifying the type of the resource.
@@ -15,17 +15,23 @@ export enum PublicApiType {
   AclMetadata = 'aclMetadata',
   AclPermissions = 'aclPermissions',
   ApiLink = 'apiLink',
+  Automation = 'automation',
   Column = 'column',
   Control = 'control',
   Doc = 'doc',
   DocAnalytics = 'docAnalytics',
+  DocAnalyticsSummary = 'docAnalyticsSummary',
+  DocAnalyticsV2 = 'docAnalyticsV2',
   Folder = 'folder',
   Formula = 'formula',
   MutationStatus = 'mutationStatus',
   Pack = 'pack',
   PackAclPermissions = 'packAclPermissions',
+  PackAnalytics = 'packAnalytics',
+  PackAnalyticsSummary = 'packAnalyticsSummary',
   PackAsset = 'packAsset',
   PackCategory = 'packCategory',
+  PackFormulaAnalytics = 'packFormulaAnalytics',
   PackLog = 'packLog',
   PackMaker = 'packMaker',
   PackOauthConfig = 'packOauthConfig',
@@ -612,6 +618,16 @@ export interface PublicApiValidationError {
 }
 
 /**
+ * A response that represents a count
+ */
+export interface PublicApiCountResponse {
+  /**
+   * The count of an item.
+   */
+  count: number;
+}
+
+/**
  * Reference to a table or view.
  */
 export interface PublicApiTableReference {
@@ -881,6 +897,28 @@ export enum PublicApiEmailDisplayType {
 }
 
 /**
+ * Format of a link column.
+ */
+export type PublicApiLinkColumnFormat = PublicApiSimpleColumnFormat & {
+  display?: PublicApiLinkDisplayType;
+  /**
+   * Force embeds to render on the client instead of the server (for sites that require user login).
+   */
+  force?: boolean;
+};
+
+/**
+ * How a link should be displayed in the user interface.
+ */
+export enum PublicApiLinkDisplayType {
+  IconOnly = 'iconOnly',
+  Url = 'url',
+  Title = 'title',
+  Card = 'card',
+  Embed = 'embed',
+}
+
+/**
  * Format of a time column.
  */
 export type PublicApiTimeColumnFormat = PublicApiSimpleColumnFormat & {
@@ -1000,6 +1038,7 @@ export type PublicApiColumnFormat =
   | PublicApiDateTimeColumnFormat
   | PublicApiDurationColumnFormat
   | PublicApiEmailColumnFormat
+  | PublicApiLinkColumnFormat
   | PublicApiCurrencyColumnFormat
   | PublicApiNumericColumnFormat
   | PublicApiReferenceColumnFormat
@@ -1023,6 +1062,7 @@ export enum PublicApiColumnFormatType {
   Time = 'time',
   Duration = 'duration',
   Email = 'email',
+  Link = 'link',
   Slider = 'slider',
   Scale = 'scale',
   Image = 'image',
@@ -1395,8 +1435,11 @@ export type PublicApiRowsDeleteResult = PublicApiDocumentMutateResponse & {
 export interface PublicApiRowsUpsert {
   rows: PublicApiRowEdit[];
   /**
+   * Optional unique row IDs to make the request idempotent. Must match the row id format.
+   */
+  rowIds?: string[];
+  /**
    * Optional column IDs, URLs, or names (fragile and discouraged), specifying columns to be used as upsert keys.
-   *
    */
   keyColumns?: string[];
 }
@@ -1664,7 +1707,7 @@ export interface PublicApiPublishingCategory {
   /**
    * The URL identifier of the category.
    */
-  categorySlug: string;
+  categorySlug?: string;
 }
 
 /**
@@ -1859,6 +1902,18 @@ export interface PublicApiMutationStatus {
 }
 
 /**
+ * Payload for webhook trigger
+ */
+export interface PublicApiWebhookTriggerPayload {
+  [k: string]: unknown;
+}
+
+/**
+ * The result of triggering a webhook
+ */
+export type PublicApiWebhookTriggerResult = PublicApiDocumentMutateResponse & {};
+
+/**
  * Reference to a Coda folder.
  */
 export interface PublicApiFolderReference {
@@ -2049,9 +2104,18 @@ export interface PublicApiChangeRoleResult {
 }
 
 /**
+ * List of analytics for Coda docs over a date range.
+ */
+export interface PublicApiDeprecatedDocAnalyticsCollection {
+  items: PublicApiDeprecatedDocAnalyticsItem[];
+  nextPageToken?: PublicApiNextPageToken;
+  nextPageLink?: PublicApiNextPageLink & string;
+}
+
+/**
  * Analytics data for a Coda doc.
  */
-export interface PublicApiDocAnalyticsItem {
+export interface PublicApiDeprecatedDocAnalyticsItem {
   doc: PublicApiDocReference & {
     /**
      * Title of the doc.
@@ -2089,6 +2153,14 @@ export interface PublicApiDocAnalyticsItem {
 }
 
 /**
+ * Analytics data for a Coda doc.
+ */
+export interface PublicApiDocAnalyticsItem {
+  doc: PublicApiDocAnalyticsDetails;
+  metrics: PublicApiDocAnalyticsMetrics[];
+}
+
+/**
  * List of analytics for Coda docs over a date range.
  */
 export interface PublicApiDocAnalyticsCollection {
@@ -2098,11 +2170,307 @@ export interface PublicApiDocAnalyticsCollection {
 }
 
 /**
+ * Analytics metrics for a Coda Doc.
+ */
+export interface PublicApiDocAnalyticsMetrics {
+  /**
+   * Date of the analytics data.
+   */
+  date: string;
+  /**
+   * Number of times the doc was viewed.
+   */
+  views: number;
+  /**
+   * Number of times the doc was copied.
+   */
+  copies: number;
+  /**
+   * Number of times the doc was liked.
+   */
+  likes: number;
+  /**
+   * Number of unique visitors to this doc from a mobile device.
+   */
+  sessionsMobile: number;
+  /**
+   * Number of unique visitors to this doc from a desktop device.
+   */
+  sessionsDesktop: number;
+  /**
+   * Number of unique visitors to this doc from an unknown device type.
+   */
+  sessionsOther: number;
+}
+
+export type PublicApiDocAnalyticsDetails = PublicApiDocReference & {
+  /**
+   * The name of the doc.
+   */
+  title: string;
+  icon?: PublicApiIcon;
+  /**
+   * Publish time for this doc.
+   */
+  publishTimestamp: number;
+};
+
+/**
+ * Summarized metrics for Coda docs.
+ */
+export interface PublicApiDocAnalyticsSummary {
+  /**
+   * Total number of sessions across all docs.
+   */
+  totalSessions: number;
+}
+
+/**
+ * Metadata about a Pack relevant to analytics.
+ */
+export interface PublicApiPackAnalyticsDetails {
+  /**
+   * ID of the Pack.
+   */
+  id: number;
+  /**
+   * The name of the Pack.
+   */
+  name: string;
+  /**
+   * The link to the logo of the Pack.
+   */
+  logoUrl?: string;
+  /**
+   * Creation time of the Pack.
+   */
+  createdAt: string;
+}
+
+/**
+ * List of analytics for Coda Packs over a date range.
+ */
+export interface PublicApiPackAnalyticsCollection {
+  items: PublicApiPackAnalyticsItem[];
+  nextPageToken?: PublicApiNextPageToken;
+  nextPageLink?: PublicApiNextPageLink & string;
+}
+
+/**
+ * Analytics data for a Coda Pack.
+ */
+export interface PublicApiPackAnalyticsItem {
+  pack: PublicApiPackAnalyticsDetails;
+  metrics: PublicApiPackAnalyticsMetrics[];
+}
+
+/**
+ * Analytics metrics for a Coda Pack.
+ */
+export interface PublicApiPackAnalyticsMetrics {
+  /**
+   * Date of the analytics data.
+   */
+  date: string;
+  /**
+   * Number of unique documents that have installed this Pack.
+   */
+  docInstalls: number;
+  /**
+   * Number of unique workspaces that have installed this Pack.
+   */
+  workspaceInstalls: number;
+  /**
+   * Number of times regular formulas have been called.
+   */
+  numFormulaInvocations: number;
+  /**
+   * Number of times action formulas have been called.
+   */
+  numActionInvocations: number;
+  /**
+   * Number of times sync table formulas have been called.
+   */
+  numSyncInvocations: number;
+  /**
+   * Number of times metadata formulas have been called.
+   */
+  numMetadataInvocations: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past day.
+   */
+  docsActivelyUsing: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 7 days.
+   */
+  docsActivelyUsing7Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 30 days.
+   */
+  docsActivelyUsing30Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 90 days.
+   */
+  docsActivelyUsing90Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack ever.
+   */
+  docsActivelyUsingAllTime: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past day.
+   */
+  workspacesActivelyUsing: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 7 days.
+   */
+  workspacesActivelyUsing7Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 30 days.
+   */
+  workspacesActivelyUsing30Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 90 days.
+   */
+  workspacesActivelyUsing90Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack ever.
+   */
+  workspacesActivelyUsingAllTime: number;
+}
+
+/**
+ * Determines how the Pack analytics returned are sorted.
+ */
+export enum PublicApiPackAnalyticsOrderBy {
+  AnalyticsDate = 'date',
+  PackId = 'packId',
+  Name = 'name',
+  CreatedAt = 'createdAt',
+  DocInstalls = 'docInstalls',
+  WorkspaceInstalls = 'workspaceInstalls',
+  NumFormulaInvocations = 'numFormulaInvocations',
+  NumActionInvocations = 'numActionInvocations',
+  NumSyncInvocations = 'numSyncInvocations',
+  NumMetadataInvocations = 'numMetadataInvocations',
+  DocsActivelyUsing = 'docsActivelyUsing',
+  DocsActivelyUsing7Day = 'docsActivelyUsing7Day',
+  DocsActivelyUsing30Day = 'docsActivelyUsing30Day',
+  DocsActivelyUsing90Day = 'docsActivelyUsing90Day',
+  DocsActivelyUsingAllTime = 'docsActivelyUsingAllTime',
+  WorkspacesActivelyUsing = 'workspacesActivelyUsing',
+  WorkspacesActivelyUsing7Day = 'workspacesActivelyUsing7Day',
+  WorkspacesActivelyUsing30Day = 'workspacesActivelyUsing30Day',
+  WorkspacesActivelyUsing90Day = 'workspacesActivelyUsing90Day',
+  WorkspacesActivelyUsingAllTime = 'workspacesActivelyUsingAllTime',
+}
+
+/**
+ * Summary analytics for Packs.
+ */
+export interface PublicApiPackAnalyticsSummary {
+  /**
+   * The times this Pack was installed in docs.
+   */
+  totalDocInstalls: number;
+  /**
+   * The times this Pack was installed in workspaces.
+   */
+  totalWorkspaceInstalls: number;
+  /**
+   * The number of times formulas in this Pack were invoked.
+   */
+  totalInvocations: number;
+}
+
+/**
  * Quantization period over which to view analytics.
  */
-export enum PublicApiDocAnalyticsScale {
-  Day = 'daily',
+export enum PublicApiAnalyticsScale {
+  Daily = 'daily',
   Cumulative = 'cumulative',
+}
+
+/**
+ * Analytics metrics for a Coda Pack formula.
+ */
+export interface PublicApiPackFormulaAnalyticsMetrics {
+  /**
+   * Date of the analytics data.
+   */
+  date: string;
+  /**
+   * Number of times this formula has been invoked.
+   */
+  formulaInvocations: number;
+  /**
+   * Number of errors from invocations.
+   */
+  errors: number;
+  /**
+   * Median latency of an invocation in milliseconds. Only present for daily metrics.
+   */
+  medianLatencyMs?: number;
+  /**
+   * Median response size in bytes. Only present for daily metrics.
+   */
+  medianResponseSizeBytes?: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past day.
+   */
+  docsActivelyUsing: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 7 days.
+   */
+  docsActivelyUsing7Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 30 days.
+   */
+  docsActivelyUsing30Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack in the past 90 days.
+   */
+  docsActivelyUsing90Day: number;
+  /**
+   * Number of unique docs that have invoked a formula from this Pack ever.
+   */
+  docsActivelyUsingAllTime: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past day.
+   */
+  workspacesActivelyUsing: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 7 days.
+   */
+  workspacesActivelyUsing7Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 30 days.
+   */
+  workspacesActivelyUsing30Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack in the past 90 days.
+   */
+  workspacesActivelyUsing90Day: number;
+  /**
+   * Number of unique workspaces that have invoked a formula from this Pack ever.
+   */
+  workspacesActivelyUsingAllTime: number;
+}
+
+/**
+ * Analytics data for a Coda Pack formula.
+ */
+export interface PublicApiPackFormulaAnalyticsItem {
+  formula: PublicApiPackFormulaIdentifier;
+  metrics: PublicApiPackFormulaAnalyticsMetrics[];
+}
+
+/**
+ * A collection of analytics for Coda Packs formulas over a date range.
+ */
+export interface PublicApiPackFormulaAnalyticsCollection {
+  items: PublicApiPackFormulaAnalyticsItem[];
+  nextPageToken?: PublicApiNextPageToken;
+  nextPageLink?: PublicApiNextPageLink & string;
 }
 
 /**
@@ -2145,8 +2513,21 @@ export interface PublicApiPack {
    * A contact email for the Pack.
    */
   supportEmail?: string;
+  /**
+   * A Terms of Service URL for the Pack.
+   */
+  termsOfServiceUrl?: string;
+  /**
+   * A Privacy Policy URL for the Pack.
+   */
+  privacyPolicyUrl?: string;
+  /**
+   * A Featured Doc URL for the Pack.
+   */
+  featuredDocUrl?: string;
   overallRateLimit?: PublicApiPackRateLimit;
   perConnectionRateLimit?: PublicApiPackRateLimit;
+  featuredDocStatus?: PublicApiFeaturedDocStatus;
 }
 
 /**
@@ -2189,6 +2570,18 @@ export interface PublicApiPackSummary {
    * A contact email for the Pack.
    */
   supportEmail?: string;
+  /**
+   * A Terms of Service URL for the Pack.
+   */
+  termsOfServiceUrl?: string;
+  /**
+   * A Privacy Policy URL for the Pack.
+   */
+  privacyPolicyUrl?: string;
+  /**
+   * A Featured Doc URL for the Pack.
+   */
+  featuredDocUrl?: string;
 }
 
 /**
@@ -2221,6 +2614,16 @@ export enum PublicApiPacksSortBy {
   Title = 'title',
   CreatedAt = 'createdAt',
   UpdatedAt = 'updatedAt',
+}
+
+/**
+ * Determines how the Pack listings returned are sorted.
+ */
+export enum PublicApiPackListingsSortBy {
+  PackId = 'packId',
+  Name = 'name',
+  PackVersion = 'packVersion',
+  PackVersionModifiedAt = 'packVersionModifiedAt',
 }
 
 /**
@@ -2359,6 +2762,7 @@ export interface PublicApiPackVersion {
    * The semantic format of the Pack version.
    */
   packVersion: string;
+  source?: PublicApiPackSource;
 }
 
 /**
@@ -2482,6 +2886,10 @@ export interface PublicApiPackListing {
    */
   packVersion: string;
   /**
+   * The current release number of the Pack if released, otherwise undefined.
+   */
+  releaseId?: number;
+  /**
    * The link to the logo of the Pack.
    */
   logoUrl: string;
@@ -2505,6 +2913,18 @@ export interface PublicApiPackListing {
    * A contact email for the Pack.
    */
   supportEmail?: string;
+  /**
+   * A Terms of Service URL for the Pack.
+   */
+  termsOfServiceUrl?: string;
+  /**
+   * A Privacy Policy URL for the Pack.
+   */
+  privacyPolicyUrl?: string;
+  /**
+   * A Featured Doc ID for the Pack.
+   */
+  featuredDocId?: string;
   /**
    * Publishing Categories associated with this Pack.
    */
@@ -2534,6 +2954,10 @@ export interface PublicApiPackListingDetail {
    */
   packVersion: string;
   /**
+   * The current release number of the Pack if released, otherwise undefined.
+   */
+  releaseId?: number;
+  /**
    * The link to the logo of the Pack.
    */
   logoUrl: string;
@@ -2558,6 +2982,18 @@ export interface PublicApiPackListingDetail {
    */
   supportEmail?: string;
   /**
+   * A Terms of Service URL for the Pack.
+   */
+  termsOfServiceUrl?: string;
+  /**
+   * A Privacy Policy URL for the Pack.
+   */
+  privacyPolicyUrl?: string;
+  /**
+   * A Featured Doc ID for the Pack.
+   */
+  featuredDocId?: string;
+  /**
    * Publishing Categories associated with this Pack.
    */
   categories: PublicApiPublishingCategory[];
@@ -2571,10 +3007,6 @@ export interface PublicApiPackListingDetail {
    * The url where complete metadata about the contents of the Pack version can be downloaded.
    */
   externalMetadataUrl: string;
-  /**
-   * The release number of the Pack version if it has one.
-   */
-  releaseId?: number;
   discoverability: PublicApiPackDiscoverability;
   /**
    * The access capabilities the current user has for this Pack.
@@ -2926,7 +3358,15 @@ export interface PublicApiGroupedPackInvocationLog {
 export interface PublicApiPackFetcherLog {
   type: PublicApiPackLogType.Fetcher;
   context: PublicApiPackLogContext;
+  /**
+   * The number of bytes in the HTTP request sent
+   */
+  requestSizeBytes?: number;
   responseCode?: number;
+  /**
+   * The number of bytes in the HTTP response received
+   */
+  responseSizeBytes?: number;
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   /**
    * base url of the fetcher request, with all query parameters stripped off.
@@ -3022,6 +3462,32 @@ export enum PublicApiFeatureSet {
 }
 
 /**
+ * Status of featured doc in pack listing.
+ */
+export enum PublicApiFeaturedDocStatus {
+  DocInaccessibleOrDoesNotExist = 'docInaccessibleOrDoesNotExist',
+  InvalidPublishedDocUrl = 'invalidPublishedDocUrl',
+}
+
+export interface PublicApiPackFormulaIdentifier {
+  /**
+   * The Pack formula name.
+   */
+  name: string;
+  type: PublicApiPackFormulaType;
+}
+
+/**
+ * The pack formula type.
+ */
+export enum PublicApiPackFormulaType {
+  Action = 'action',
+  Formula = 'formula',
+  Sync = 'sync',
+  Metadata = 'metadata',
+}
+
+/**
  * The request to patch pack system connection credentials.
  */
 export type PublicApiPatchPackSystemConnectionRequest =
@@ -3034,8 +3500,8 @@ export type PublicApiPatchPackSystemConnectionRequest =
  * Request to set the Pack OAuth configuration.
  */
 export interface PublicApiSetPackOauthConfigRequest {
-  clientId: string;
-  clientSecret: string;
+  clientId?: string;
+  clientSecret?: string;
 }
 
 /**
@@ -3053,7 +3519,14 @@ export interface PublicApiRegisterPackVersionRequest {
    * The SHA-256 hash of the file to be uploaded.
    */
   bundleHash: string;
-  [k: string]: unknown;
+  /**
+   * Internal field for cross-environment pack import.
+   */
+  dangerouslyAllowCrossEnvPack?: boolean;
+  /**
+   * Internal field that allows the api to use the non-latest pack version.
+   */
+  dangerouslyAllowNonLatestVersionNumber?: boolean;
 }
 
 /**
@@ -3114,12 +3587,31 @@ export interface PublicApiUpdatePackRequest {
    * A contact email for the Pack.
    */
   supportEmail?: string;
+  /**
+   * A Terms of Service URL for the Pack.
+   */
+  termsOfServiceUrl?: string;
+  /**
+   * A Privacy Policy URL for the Pack.
+   */
+  privacyPolicyUrl?: string;
+  /**
+   * A Featured Doc URL for the Pack.
+   */
+  featuredDocUrl?: string;
 }
 
 /**
  * Confirmation of successful Pack version creation.
  */
-export interface PublicApiCreatePackVersionResponse {}
+export interface PublicApiCreatePackVersionResponse {
+  deprecationWarnings?: PublicApiValidationError[];
+}
+
+/**
+ * Confirmation of successful Pack deletion.
+ */
+export interface PublicApiDeletePackResponse {}
 
 /**
  * Confirmation of successfully retrieving Pack makers.
@@ -3268,7 +3760,10 @@ export interface PublicApiCreatePackVersionRequest {
    */
   notes?: string;
   source?: PublicApiPackSource;
-  [k: string]: unknown;
+  /**
+   * Internal field for cross-environment pack import.
+   */
+  dangerouslyAllowCrossEnvPack?: boolean;
 }
 
 /**
@@ -3283,7 +3778,10 @@ export interface PublicApiCreatePackReleaseRequest {
    * Developers notes.
    */
   releaseNotes?: string;
-  [k: string]: unknown;
+  /**
+   * Internal field for cross-environment pack import.
+   */
+  dangerouslyAllowCrossEnvPack?: boolean;
 }
 
 /**


### PR DESCRIPTION
Should be the last piece of the puzzle. Makes the CLI show the same output as the web editor when uploading a new pack version if the server determines there are deprecation warnings. In theory this is the same output as what `validateMetadata()` with `checkDeprecationWarnings: true` would return locally, but we should consider the server authoritative in case we add server-side only checks.

All the changes are in `upload.ts`. The rest is just bringing the API codegen up to date to get the new type def that includes deprecation warnings on the upload response.

PTAL @dweitzman-codaio @patrick-codaio @coda/packs 