### PR TITLE
Don't hard fail on breaking changes until future version 1.0.0.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1021,8 +1021,8 @@ const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSc
 const packMetadataSchemaBySdkVersion = [
     {
         // Check that packs with multiple network domains explicitly choose which domain gets auth.
-        // This is a backward-incompatible validation that takes effect in any pack release after 0.9.0.
-        versionRange: '>0.9.0',
+        // This is a backward-incompatible validation that takes effect in any pack release after 1.0.0.
+        versionRange: '>=1.0.0',
         schemaExtend: schema => {
             return schema.superRefine((untypedData, context) => {
                 var _a;
@@ -1060,7 +1060,7 @@ const packMetadataSchemaBySdkVersion = [
         },
     },
     {
-        versionRange: '>0.9.0',
+        versionRange: '>=1.0.0',
         schemaExtend: schema => {
             return schema.superRefine((untypedData, context) => {
                 const data = untypedData;

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2066,7 +2066,7 @@ describe('Pack metadata Validation', () => {
           type: AuthenticationType.HeaderBearerToken,
         },
       });
-      const err = await validateJsonAndAssertFails(metadata, '0.9.1');
+      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
       assert.deepEqual(err.validationErrors, [
         {
           message:
@@ -2096,7 +2096,7 @@ describe('Pack metadata Validation', () => {
           networkDomain: 'baz.com',
         },
       });
-      const err = await validateJsonAndAssertFails(metadata, '0.9.1');
+      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
       assert.deepEqual(err.validationErrors, [
         {
           message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
@@ -2360,7 +2360,7 @@ describe('Pack metadata Validation', () => {
   });
 
   describe('deprecation warnings', () => {
-    const sdkVersionTriggeringDeprecationWarnings = '0.10.0';
+    const sdkVersionTriggeringDeprecationWarnings = '1.0.0';
 
     it('deprecated schema properties in formula schema', async () => {
       const metadata = createFakePackVersionMetadata({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1227,8 +1227,8 @@ interface SchemaExtension {
 const packMetadataSchemaBySdkVersion: SchemaExtension[] = [
   {
     // Check that packs with multiple network domains explicitly choose which domain gets auth.
-    // This is a backward-incompatible validation that takes effect in any pack release after 0.9.0.
-    versionRange: '>0.9.0',
+    // This is a backward-incompatible validation that takes effect in any pack release after 1.0.0.
+    versionRange: '>=1.0.0',
     schemaExtend: schema => {
       return schema.superRefine((untypedData, context) => {
         const data = untypedData as PackVersionMetadata;
@@ -1272,7 +1272,7 @@ const packMetadataSchemaBySdkVersion: SchemaExtension[] = [
     },
   },
   {
-    versionRange: '>0.9.0',
+    versionRange: '>=1.0.0',
     schemaExtend: schema => {
       return schema.superRefine((untypedData, context) => {
         const data = untypedData as PackVersionMetadata;


### PR DESCRIPTION
Our intent is that our next SDK version will expose the new fields and allow for a transition period, and 2 releases from now is when we would actually start enforcing them, so we need our semver filters to reflect that.

PTAL @dweitzman-codaio @huayang-codaio @alexd-codaio @coda/packs 