### PR TITLE
add workflow for dependabot to automerge based on allowlist

### DIFF
--- a/.github/workflows/dependabot-approve-and-automerge.yml
+++ b/.github/workflows/dependabot-approve-and-automerge.yml
@@ -1,0 +1,42 @@
+name: Dependabot Pull Request Approve and Merge
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Checking the actor will prevent your Action run failing on non-Dependabot
+    # PRs but also ensures that it only does work for Dependabot PRs.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      # This first step will fail if there's no metadata and so the approval
+      # will not occur.
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      # Here the PR gets approved.
+      - name: Approve a PR
+        # NOTE(spencer): this only works when the dependabot PR has only one dependency, which seems to always be the case right now
+        # because `dependency_names` is a comma-separated string of all the dependencies, and `contains` syntax only works with one array.
+        if: ${{ contains(fromJson(env.ALLOWED_DEPENDENCIES), steps.dependabot-metadata.outputs.dependency-names }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE(spencer): ideally, we could support regex matching here like @types/*, but that's not supported by the Github Actions syntax.
+          # We would need to do a custom bash script to "exit" based on a match.
+          ALLOWED_DEPENDENCIES: '["@types/xml2js"]'
+      # Finally, this sets the PR to allow auto-merging for patch and minor
+      # updates if all checks pass
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary
For dependabot rotations, often many of them are just approving + merging the PR. Trying to set up some automation here using an allow-list for automerges to save some time. 

adapted from https://blog.somewhatabstract.com/2021/10/11/setting-up-dependabot-with-github-actions-to-approve-and-merge/ and https://github.com/dependabot/fetch-metadata

This PR sets up a github action that will start approving and auto-merging dependabot PRs that are updating a package in an allow list if CI passes AND if it is not a major update (under the assumption that major updates may cause more breaking changes that we would want to manually validate)

will try to test on this branch not sure if i can manually simulate a dependabot

i only set one allow list for now to test with this PR https://github.com/coda/packs-sdk/pull/1953. If that works, can add all the `@types...` ones and more during dependabot rotations for packages that feel safe

@coda/packs