### PR TITLE
Fix a super minor typo in the migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ### Changed
 
-- **Breaking Change** Added a validation rule that prevents the usage of varargsParameters for sync table getters
-  which are not currently supported in the UI.
+- **Breaking Change** Added a validation rule that prevents the usage of varargsParameters for sync table getters which are not currently supported in the UI.
 - **Breaking Change** Packs with multiple network domains and user authentication must select only one of those domains to receive the authentication headers/parameters.
 - **Breaking Change** The `identityName` field of a sync table formerly silently overrode the `identity.name` of the table's schema (if present). Now, if those 2 values are both present, they must be equal. We recommend only specifying `identity.name` on reference schemas.
 - **Breaking Change** Fetcher will automatically decompress responses with a gzip or deflate content encoding.

--- a/docs/support/migration/v0.11.0.md
+++ b/docs/support/migration/v0.11.0.md
@@ -6,11 +6,10 @@ title: Version 0.11.0
 
 In preparation for a public launch, we intentionally introduced a number of breaking changes to make the SDK easier to use and understand. We hope to avoid breaking changes on this scale in the future.
 
-
 ### Rename schema fields `id`, `primary`, and `featured`
 
-__Affects__: Packs that define an [object schema][schemas_object].<br>
-__Action Required__: Rename only.
+**Affects**: Packs that define an [object schema][schemas_object].<br>
+**Action Required**: Rename only.
 
 To better reflect their meaning, we've renamed certain fields in the schema definition. Specifically:
 
@@ -35,11 +34,10 @@ let MovieSchema = coda.makeObjectSchema({
 });
 ```
 
-
 ### Add `identityName` to dynamic sync tables
 
-__Affects__: Packs that include a dynamic sync table.<br>
-__Action Required__: Add new code.
+**Affects**: Packs that include a dynamic sync table.<br>
+**Action Required**: Add new code.
 
 Like regular sync tables, dynamic sync tables now require the `identityName` field to be set. This will be used along with the dynamic URL to set the identity of the table. You no longer need to set the `identity` field of the schema generated in the `getSchema` function, as it will be constructed for you automatically.
 
@@ -54,11 +52,10 @@ pack.addDynamicSyncTable({
 });
 ```
 
-
 ### Rename `defaultValue` field of parameters
 
-__Affects__: Packs that have a parameter with a [suggested value][parameters_suggested].<br>
-__Action Required__: Rename only.
+**Affects**: Packs that have a parameter with a [suggested value][parameters_suggested].<br>
+**Action Required**: Rename only.
 
 To better reflect it's meaning, we've renamed the `defaultValue` field of parameter definitions:
 
@@ -75,11 +72,10 @@ coda.makeParameter({
 })
 ```
 
-
 ### Move `attribution` settings in schema
 
-__Affects__: Packs that define a schema that includes [`attribution`][schemas_attribution] information.<br>
-__Action Required__: Slight refactor.
+**Affects**: Packs that define a schema that includes [`attribution`][schemas_attribution] information.<br>
+**Action Required**: Slight refactor.
 
 For compatibility with other changes, we've relocated the attribution definitions within a schema.
 
@@ -99,13 +95,12 @@ let TaskSchema = coda.makeObjectSchema({
 });
 ```
 
-
 ### Rename authentication option `SetEndpoint.getOptionsFormula`
 
-__Affects__: Packs that [prompt users for an account-specific endpoint][authentication_setendpoint].<br>
-__Action Required__: Rename only.
+**Affects**: Packs that [prompt users for an account-specific endpoint][authentication_setendpoint].<br>
+**Action Required**: Rename only.
 
-For consistency with the rest of the SDK we've renamed the `getOptionsFormula` of the [`SetEndpoint`][SetEndpoint] object:
+For consistency with the rest of the SDK we've renamed the `getOptionsFormula` of the [`SetEndpoint`][setendpoint] object:
 
 - `getOptionsFormula` --> `getOptions`
 
@@ -125,11 +120,10 @@ pack.setUserAuthentication({
 });
 ```
 
-
 ### Use new `File` parameter type for files
 
-__Affects__: Packs that accept files as parameters using the `Image` or `ImageArray` parameter types.<br>
-__Action Required__: Slight refactor.
+**Affects**: Packs that accept files as parameters using the `Image` or `ImageArray` parameter types.<br>
+**Action Required**: Slight refactor.
 
 While previously there was no supported way to pass a non-image file as a parameter to a Pack formula, some developers may have noticed that using an `Image` or `ImageArray` parameter type would mostly work. We've now added a dedicated `File` and `FileArray` parameter for this purpose, and will eventually disable the previous loophole.
 
@@ -148,25 +142,23 @@ pack.addFormula({
 });
 ```
 
-
 ### Remove `varargsParameters` from sync tables
 
-__Affects__: Packs that have erroneously set [`varargsParameters`][parameters_vararg] on a sync table.<br>
-__Action Required__: Remove code.
+**Affects**: Packs that have erroneously set [`varargsParameters`][parameters_vararg] on a sync table.<br>
+**Action Required**: Remove code.
 
 Sync tables currently don't support [`varargsParameters`][parameters_vararg], as they aren't shown in the side panel. While we may fix this some day, for now we've introduced a validation rule to ensure they aren't set accidentally.
 
 If any of your sync tables have `varargsParameters` set (unlikely) you'll need to remove them. Given that they weren't used anyway this should have no effect on your Pack's functionality.
 
-
 ### Set `networkDomain` on authentication config (multi-domain only)
 
-__Affects__: Packs that use multiple [network domains][fetcher_network] (uncommon).<br>
-__Action Required__: Add new code.
+**Affects**: Packs that use multiple [network domains][fetcher_network] (uncommon).<br>
+**Action Required**: Add new code.
 
 Packs that make requests to multiple network domains must now specify which domain their authentication configuration applies to. This is done to prevent credentials from leaking from one service to another.
 
-For affected Packs, net the [`networkDomain`][BaseAuthentication_networkdomain] field of the authentication config to the domain it should apply to.
+For affected Packs, set the [`networkDomain`][baseauthentication_networkdomain] field of the authentication config to the domain it should apply to.
 
 ```{.ts hl_lines="6"}
 pack.addNetworkDomain("coda.io");
@@ -178,22 +170,20 @@ pack.setUserAuthentication({
 });
 ```
 
-
 ### Remove manual HTTP response decompression
 
-__Affects__: Packs that receive compressed HTTP responses and are manually decompressing them.<br>
-__Action Required__: Remove code.
+**Affects**: Packs that receive compressed HTTP responses and are manually decompressing them.<br>
+**Action Required**: Remove code.
 
 Some external services and APIs return their responses compressed to save network bandwidth. This is indicated by the `Content-Encoding` HTTP header, which specifies the type of compression used (typically gzip or deflate). While many other HTTP libraries automatically decompress these responses for you, the Fetcher was returning the response body still in a compressed form. This required you to install a library to manually decompress the content before you could use it.
 
 As of this SDK version the decompression will will be done automatically for you. You'll have to remove any code that was manually decompresses the responses.
 
-
 [parameters_vararg]: ../../guides/basics/parameters/index.md#vararg
 [fetcher_network]: ../../guides/advanced/fetcher.md#network-domains
-[BaseAuthentication_networkdomain]: ../../reference/sdk/interfaces/BaseAuthentication.md#networkdomain
+[baseauthentication_networkdomain]: ../../reference/sdk/interfaces/BaseAuthentication.md#networkdomain
 [schemas_object]: ../../guides/advanced/schemas.md#object
-[SetEndpoint]: ../../reference/sdk/interfaces/SetEndpoint.md
+[setendpoint]: ../../reference/sdk/interfaces/SetEndpoint.md
 [authentication_setendpoint]: ../../guides/advanced/authentication.md#setendpoint
 [schemas_attribution]: ../../guides/advanced/schemas.md#attribution
 [parameters_suggested]: ../../guides/basics/parameters/index.md#suggested


### PR DESCRIPTION
s/net/set/ in "For affected Packs, net the networkDomain field..."

Also removed a newline in the changelog that wraps a line early

All the other changes were automatically made by my format-on-save settings
in vscode. Using "**" instead of "__" for bold text does seem more common
in the rest of the codebase, but also happy to revert those changes (I really
just wanted to fix the typo).