### PR TITLE
Allow multiple auth domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog keeps track of all changes to the Packs SDK. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Added support for multiple domains in the `networkDomain` parameter of `setUserAuthentication()`.
+
 ## [0.12.0] - 2022-05-04
 
 ### Added

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2875,10 +2875,12 @@ export interface BaseAuthentication {
 	 */
 	postSetup?: PostSetup[];
 	/**
-	 * Which domain should get auth credentials, when a pack is configured with multiple domains.
+	 * Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 	 * Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+	 *
+	 * Using multiple authenticated network domains is uncommon and requires Coda approval.
 	 */
-	networkDomain?: string;
+	networkDomain?: string | string[];
 }
 /**
  * Authenticate using an HTTP header of the form `Authorization: Bearer <token>`.

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -237,6 +237,12 @@ const setEndpointPostSetupValidator = zodCompleteObject({
     getOptions: z.unknown().optional(),
     getOptionsFormula: z.unknown().optional(),
 }).refine(data => data.getOptions || data.getOptionsFormula, 'Either getOptions or getOptionsFormula must be specified.');
+const singleAuthDomainSchema = z
+    .string()
+    .nonempty()
+    .refine(domain => domain.indexOf(' ') < 0, {
+    message: 'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+});
 const baseAuthenticationValidators = {
     // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
     // in the full bundle, not the metadata.
@@ -247,7 +253,7 @@ const baseAuthenticationValidators = {
     endpointDomain: z.string().optional(),
     // The items are technically a discriminated union type but that union currently only has one member.
     postSetup: z.array(setEndpointPostSetupValidator).optional(),
-    networkDomain: z.union([z.string().nonempty(), z.string().nonempty().array().nonempty()]).optional(),
+    networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
 };
 const defaultAuthenticationValidators = {
     [types_1.AuthenticationType.None]: zodCompleteStrictObject({

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -238,10 +238,12 @@ export interface BaseAuthentication {
      */
     postSetup?: PostSetup[];
     /**
-     * Which domain should get auth credentials, when a pack is configured with multiple domains.
+     * Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
      * Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+     *
+     * Using multiple authenticated network domains is uncommon and requires Coda approval.
      */
-    networkDomain?: string;
+    networkDomain?: string | string[];
 }
 /**
  * Authenticate using an HTTP header of the form `Authorization: Bearer <token>`.

--- a/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAccessKeyAuthentication.md
@@ -74,10 +74,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -85,7 +87,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -133,7 +135,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:558](https://github.com/coda/packs-sdk/blob/main/types.ts#L558)
+[types.ts:560](https://github.com/coda/packs-sdk/blob/main/types.ts#L560)
 
 ___
 
@@ -145,4 +147,4 @@ Identifies this as AWSAccessKey authentication.
 
 #### Defined in
 
-[types.ts:556](https://github.com/coda/packs-sdk/blob/main/types.ts#L556)
+[types.ts:558](https://github.com/coda/packs-sdk/blob/main/types.ts#L558)

--- a/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/AWSAssumeRoleAuthentication.md
@@ -76,10 +76,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -87,7 +89,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -135,7 +137,7 @@ The AWS service to authenticate with, like "s3", "iam", or "route53".
 
 #### Defined in
 
-[types.ts:571](https://github.com/coda/packs-sdk/blob/main/types.ts#L571)
+[types.ts:573](https://github.com/coda/packs-sdk/blob/main/types.ts#L573)
 
 ___
 
@@ -147,4 +149,4 @@ Identifies this as AWSAssumeRole authentication.
 
 #### Defined in
 
-[types.ts:569](https://github.com/coda/packs-sdk/blob/main/types.ts#L569)
+[types.ts:571](https://github.com/coda/packs-sdk/blob/main/types.ts#L571)

--- a/docs/reference/sdk/interfaces/BaseAuthentication.md
+++ b/docs/reference/sdk/interfaces/BaseAuthentication.md
@@ -79,14 +79,16 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 

--- a/docs/reference/sdk/interfaces/CodaApiBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/CodaApiBearerTokenAuthentication.md
@@ -29,7 +29,7 @@ order to install the pack.
 
 #### Defined in
 
-[types.ts:287](https://github.com/coda/packs-sdk/blob/main/types.ts#L287)
+[types.ts:289](https://github.com/coda/packs-sdk/blob/main/types.ts#L289)
 
 ___
 
@@ -93,10 +93,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -104,7 +106,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -154,7 +156,7 @@ as a shared account that allows actions.
 
 #### Defined in
 
-[types.ts:293](https://github.com/coda/packs-sdk/blob/main/types.ts#L293)
+[types.ts:295](https://github.com/coda/packs-sdk/blob/main/types.ts#L295)
 
 ___
 
@@ -166,4 +168,4 @@ Identifies this as CodaApiHeaderBearerToken authentication.
 
 #### Defined in
 
-[types.ts:282](https://github.com/coda/packs-sdk/blob/main/types.ts#L282)
+[types.ts:284](https://github.com/coda/packs-sdk/blob/main/types.ts#L284)

--- a/docs/reference/sdk/interfaces/CustomAuthParameter.md
+++ b/docs/reference/sdk/interfaces/CustomAuthParameter.md
@@ -15,7 +15,7 @@ A description shown to the user indicating what value they should provide for th
 
 #### Defined in
 
-[types.ts:478](https://github.com/coda/packs-sdk/blob/main/types.ts#L478)
+[types.ts:480](https://github.com/coda/packs-sdk/blob/main/types.ts#L480)
 
 ___
 
@@ -27,4 +27,4 @@ The name used to refer to this parameter and to generate the template replacemen
 
 #### Defined in
 
-[types.ts:473](https://github.com/coda/packs-sdk/blob/main/types.ts#L473)
+[types.ts:475](https://github.com/coda/packs-sdk/blob/main/types.ts#L475)

--- a/docs/reference/sdk/interfaces/CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomAuthentication.md
@@ -128,10 +128,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -139,7 +141,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -153,7 +155,7 @@ replacement inside the constructed network request.
 
 #### Defined in
 
-[types.ts:547](https://github.com/coda/packs-sdk/blob/main/types.ts#L547)
+[types.ts:549](https://github.com/coda/packs-sdk/blob/main/types.ts#L549)
 
 ___
 
@@ -201,4 +203,4 @@ Identifies this as Custom authentication.
 
 #### Defined in
 
-[types.ts:541](https://github.com/coda/packs-sdk/blob/main/types.ts#L541)
+[types.ts:543](https://github.com/coda/packs-sdk/blob/main/types.ts#L543)

--- a/docs/reference/sdk/interfaces/CustomHeaderTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/CustomHeaderTokenAuthentication.md
@@ -64,7 +64,7 @@ The name of the HTTP header.
 
 #### Defined in
 
-[types.ts:306](https://github.com/coda/packs-sdk/blob/main/types.ts#L306)
+[types.ts:308](https://github.com/coda/packs-sdk/blob/main/types.ts#L308)
 
 ___
 
@@ -86,10 +86,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -97,7 +99,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -148,7 +150,7 @@ The HTTP header will be of the form `<headerName>: <tokenPrefix> <token>`
 
 #### Defined in
 
-[types.ts:313](https://github.com/coda/packs-sdk/blob/main/types.ts#L313)
+[types.ts:315](https://github.com/coda/packs-sdk/blob/main/types.ts#L315)
 
 ___
 
@@ -160,4 +162,4 @@ Identifies this as CustomHeaderToken authentication.
 
 #### Defined in
 
-[types.ts:302](https://github.com/coda/packs-sdk/blob/main/types.ts#L302)
+[types.ts:304](https://github.com/coda/packs-sdk/blob/main/types.ts#L304)

--- a/docs/reference/sdk/interfaces/Format.md
+++ b/docs/reference/sdk/interfaces/Format.md
@@ -40,7 +40,7 @@ This must correspond to the name of a regular, public formula defined in this pa
 
 #### Defined in
 
-[types.ts:734](https://github.com/coda/packs-sdk/blob/main/types.ts#L734)
+[types.ts:736](https://github.com/coda/packs-sdk/blob/main/types.ts#L736)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[types.ts:729](https://github.com/coda/packs-sdk/blob/main/types.ts#L729)
+[types.ts:731](https://github.com/coda/packs-sdk/blob/main/types.ts#L731)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[types.ts:736](https://github.com/coda/packs-sdk/blob/main/types.ts#L736)
+[types.ts:738](https://github.com/coda/packs-sdk/blob/main/types.ts#L738)
 
 ___
 
@@ -77,7 +77,7 @@ of values they should put in columns using this format.
 
 #### Defined in
 
-[types.ts:741](https://github.com/coda/packs-sdk/blob/main/types.ts#L741)
+[types.ts:743](https://github.com/coda/packs-sdk/blob/main/types.ts#L743)
 
 ___
 
@@ -90,7 +90,7 @@ is capable of handling. As described in [Format](Format.md), this is a discovery
 
 #### Defined in
 
-[types.ts:746](https://github.com/coda/packs-sdk/blob/main/types.ts#L746)
+[types.ts:748](https://github.com/coda/packs-sdk/blob/main/types.ts#L748)
 
 ___
 
@@ -102,7 +102,7 @@ The name of this column format. This will show to users in the column type choos
 
 #### Defined in
 
-[types.ts:727](https://github.com/coda/packs-sdk/blob/main/types.ts#L727)
+[types.ts:729](https://github.com/coda/packs-sdk/blob/main/types.ts#L729)
 
 ___
 
@@ -114,4 +114,4 @@ ___
 
 #### Defined in
 
-[types.ts:750](https://github.com/coda/packs-sdk/blob/main/types.ts#L750)
+[types.ts:752](https://github.com/coda/packs-sdk/blob/main/types.ts#L752)

--- a/docs/reference/sdk/interfaces/HeaderBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/HeaderBearerTokenAuthentication.md
@@ -73,10 +73,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -84,7 +86,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -132,4 +134,4 @@ Identifies this as HeaderBearerToken authentication.
 
 #### Defined in
 
-[types.ts:267](https://github.com/coda/packs-sdk/blob/main/types.ts#L267)
+[types.ts:269](https://github.com/coda/packs-sdk/blob/main/types.ts#L269)

--- a/docs/reference/sdk/interfaces/MultiQueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/MultiQueryParamTokenAuthentication.md
@@ -76,10 +76,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -87,7 +89,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -99,7 +101,7 @@ Names and descriptions of the query parameters used for authentication.
 
 #### Defined in
 
-[types.ts:344](https://github.com/coda/packs-sdk/blob/main/types.ts#L344)
+[types.ts:346](https://github.com/coda/packs-sdk/blob/main/types.ts#L346)
 
 ___
 
@@ -147,4 +149,4 @@ Identifies this as MultiQueryParamToken authentication.
 
 #### Defined in
 
-[types.ts:340](https://github.com/coda/packs-sdk/blob/main/types.ts#L340)
+[types.ts:342](https://github.com/coda/packs-sdk/blob/main/types.ts#L342)

--- a/docs/reference/sdk/interfaces/OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/OAuth2Authentication.md
@@ -30,7 +30,7 @@ user to the [authorizationUrl](OAuth2Authentication.md#authorizationurl).
 
 #### Defined in
 
-[types.ts:404](https://github.com/coda/packs-sdk/blob/main/types.ts#L404)
+[types.ts:406](https://github.com/coda/packs-sdk/blob/main/types.ts#L406)
 
 ___
 
@@ -45,7 +45,7 @@ they may be specified using [additionalParams](OAuth2Authentication.md#additiona
 
 #### Defined in
 
-[types.ts:372](https://github.com/coda/packs-sdk/blob/main/types.ts#L372)
+[types.ts:374](https://github.com/coda/packs-sdk/blob/main/types.ts#L374)
 
 ___
 
@@ -82,7 +82,7 @@ as [ExecutionContext.endpoint](ExecutionContext.md#endpoint).
 
 #### Defined in
 
-[types.ts:414](https://github.com/coda/packs-sdk/blob/main/types.ts#L414)
+[types.ts:416](https://github.com/coda/packs-sdk/blob/main/types.ts#L416)
 
 ___
 
@@ -126,10 +126,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -137,7 +139,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -188,7 +190,7 @@ If the API you are using requires a different delimiter, say a comma, specify it
 
 #### Defined in
 
-[types.ts:391](https://github.com/coda/packs-sdk/blob/main/types.ts#L391)
+[types.ts:393](https://github.com/coda/packs-sdk/blob/main/types.ts#L393)
 
 ___
 
@@ -203,7 +205,7 @@ the documentation for the API you are connecting to.
 
 #### Defined in
 
-[types.ts:384](https://github.com/coda/packs-sdk/blob/main/types.ts#L384)
+[types.ts:386](https://github.com/coda/packs-sdk/blob/main/types.ts#L386)
 
 ___
 
@@ -219,7 +221,7 @@ When sending authenticated requests, a HTTP header of the form
 
 #### Defined in
 
-[types.ts:399](https://github.com/coda/packs-sdk/blob/main/types.ts#L399)
+[types.ts:401](https://github.com/coda/packs-sdk/blob/main/types.ts#L401)
 
 ___
 
@@ -233,7 +235,7 @@ that should contain the token.
 
 #### Defined in
 
-[types.ts:421](https://github.com/coda/packs-sdk/blob/main/types.ts#L421)
+[types.ts:423](https://github.com/coda/packs-sdk/blob/main/types.ts#L423)
 
 ___
 
@@ -246,7 +248,7 @@ at the end of the OAuth handshake flow.
 
 #### Defined in
 
-[types.ts:377](https://github.com/coda/packs-sdk/blob/main/types.ts#L377)
+[types.ts:379](https://github.com/coda/packs-sdk/blob/main/types.ts#L379)
 
 ___
 
@@ -258,7 +260,7 @@ Identifies this as OAuth2 authentication.
 
 #### Defined in
 
-[types.ts:365](https://github.com/coda/packs-sdk/blob/main/types.ts#L365)
+[types.ts:367](https://github.com/coda/packs-sdk/blob/main/types.ts#L367)
 
 ___
 
@@ -277,4 +279,4 @@ See https://datatracker.ietf.org/doc/html/rfc7636 for more details.
 
 #### Defined in
 
-[types.ts:433](https://github.com/coda/packs-sdk/blob/main/types.ts#L433)
+[types.ts:435](https://github.com/coda/packs-sdk/blob/main/types.ts#L435)

--- a/docs/reference/sdk/interfaces/PackDefinition.md
+++ b/docs/reference/sdk/interfaces/PackDefinition.md
@@ -22,7 +22,7 @@ This should only be used by legacy Coda pack implementations.
 
 #### Defined in
 
-[types.ts:894](https://github.com/coda/packs-sdk/blob/main/types.ts#L894)
+[types.ts:896](https://github.com/coda/packs-sdk/blob/main/types.ts#L896)
 
 ___
 
@@ -38,7 +38,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:841](https://github.com/coda/packs-sdk/blob/main/types.ts#L841)
+[types.ts:843](https://github.com/coda/packs-sdk/blob/main/types.ts#L843)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[types.ts:892](https://github.com/coda/packs-sdk/blob/main/types.ts#L892)
+[types.ts:894](https://github.com/coda/packs-sdk/blob/main/types.ts#L894)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[types.ts:896](https://github.com/coda/packs-sdk/blob/main/types.ts#L896)
+[types.ts:898](https://github.com/coda/packs-sdk/blob/main/types.ts#L898)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[types.ts:897](https://github.com/coda/packs-sdk/blob/main/types.ts#L897)
+[types.ts:899](https://github.com/coda/packs-sdk/blob/main/types.ts#L899)
 
 ___
 
@@ -84,7 +84,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
+[types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
 
 ___
 
@@ -119,7 +119,7 @@ with `isAction: true`.
 
 #### Defined in
 
-[types.ts:871](https://github.com/coda/packs-sdk/blob/main/types.ts#L871)
+[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[types.ts:889](https://github.com/coda/packs-sdk/blob/main/types.ts#L889)
+[types.ts:891](https://github.com/coda/packs-sdk/blob/main/types.ts#L891)
 
 ___
 
@@ -141,7 +141,7 @@ Whether this is a pack that will be used by Coda internally and not exposed dire
 
 #### Defined in
 
-[types.ts:904](https://github.com/coda/packs-sdk/blob/main/types.ts#L904)
+[types.ts:906](https://github.com/coda/packs-sdk/blob/main/types.ts#L906)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 #### Defined in
 
-[types.ts:895](https://github.com/coda/packs-sdk/blob/main/types.ts#L895)
+[types.ts:897](https://github.com/coda/packs-sdk/blob/main/types.ts#L897)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[types.ts:898](https://github.com/coda/packs-sdk/blob/main/types.ts#L898)
+[types.ts:900](https://github.com/coda/packs-sdk/blob/main/types.ts#L900)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[types.ts:890](https://github.com/coda/packs-sdk/blob/main/types.ts#L890)
+[types.ts:892](https://github.com/coda/packs-sdk/blob/main/types.ts#L892)
 
 ___
 
@@ -193,7 +193,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:856](https://github.com/coda/packs-sdk/blob/main/types.ts#L856)
+[types.ts:858](https://github.com/coda/packs-sdk/blob/main/types.ts#L858)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[types.ts:893](https://github.com/coda/packs-sdk/blob/main/types.ts#L893)
+[types.ts:895](https://github.com/coda/packs-sdk/blob/main/types.ts#L895)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[types.ts:899](https://github.com/coda/packs-sdk/blob/main/types.ts#L899)
+[types.ts:901](https://github.com/coda/packs-sdk/blob/main/types.ts#L901)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[types.ts:900](https://github.com/coda/packs-sdk/blob/main/types.ts#L900)
+[types.ts:902](https://github.com/coda/packs-sdk/blob/main/types.ts#L902)
 
 ___
 
@@ -233,7 +233,7 @@ ___
 
 #### Defined in
 
-[types.ts:891](https://github.com/coda/packs-sdk/blob/main/types.ts#L891)
+[types.ts:893](https://github.com/coda/packs-sdk/blob/main/types.ts#L893)
 
 ___
 
@@ -249,7 +249,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
+[types.ts:881](https://github.com/coda/packs-sdk/blob/main/types.ts#L881)
 
 ___
 
@@ -266,7 +266,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
+[types.ts:848](https://github.com/coda/packs-sdk/blob/main/types.ts#L848)
 
 ___
 
@@ -283,4 +283,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:837](https://github.com/coda/packs-sdk/blob/main/types.ts#L837)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)

--- a/docs/reference/sdk/interfaces/PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/PackVersionDefinition.md
@@ -22,7 +22,7 @@ If specified, the user must provide personal authentication credentials before u
 
 #### Defined in
 
-[types.ts:841](https://github.com/coda/packs-sdk/blob/main/types.ts#L841)
+[types.ts:843](https://github.com/coda/packs-sdk/blob/main/types.ts#L843)
 
 ___
 
@@ -34,7 +34,7 @@ Definitions of this pack's column formats. See [Format](Format.md).
 
 #### Defined in
 
-[types.ts:875](https://github.com/coda/packs-sdk/blob/main/types.ts#L875)
+[types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[types.ts:863](https://github.com/coda/packs-sdk/blob/main/types.ts#L863)
+[types.ts:865](https://github.com/coda/packs-sdk/blob/main/types.ts#L865)
 
 ___
 
@@ -61,7 +61,7 @@ with `isAction: true`.
 
 #### Defined in
 
-[types.ts:871](https://github.com/coda/packs-sdk/blob/main/types.ts#L871)
+[types.ts:873](https://github.com/coda/packs-sdk/blob/main/types.ts#L873)
 
 ___
 
@@ -79,7 +79,7 @@ contact Coda support for approval.
 
 #### Defined in
 
-[types.ts:856](https://github.com/coda/packs-sdk/blob/main/types.ts#L856)
+[types.ts:858](https://github.com/coda/packs-sdk/blob/main/types.ts#L858)
 
 ___
 
@@ -91,7 +91,7 @@ Definitions of this pack's sync tables. See [SyncTable](../types/SyncTable.md).
 
 #### Defined in
 
-[types.ts:879](https://github.com/coda/packs-sdk/blob/main/types.ts#L879)
+[types.ts:881](https://github.com/coda/packs-sdk/blob/main/types.ts#L881)
 
 ___
 
@@ -104,7 +104,7 @@ explicit connection is specified by the user.
 
 #### Defined in
 
-[types.ts:846](https://github.com/coda/packs-sdk/blob/main/types.ts#L846)
+[types.ts:848](https://github.com/coda/packs-sdk/blob/main/types.ts#L848)
 
 ___
 
@@ -117,4 +117,4 @@ When uploading a pack version, the semantic version must be greater than any pre
 
 #### Defined in
 
-[types.ts:837](https://github.com/coda/packs-sdk/blob/main/types.ts#L837)
+[types.ts:839](https://github.com/coda/packs-sdk/blob/main/types.ts#L839)

--- a/docs/reference/sdk/interfaces/QueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/QueryParamTokenAuthentication.md
@@ -76,10 +76,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -87,7 +89,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -100,7 +102,7 @@ e.g. "foo" if a token is passed as "foo=bar".
 
 #### Defined in
 
-[types.ts:329](https://github.com/coda/packs-sdk/blob/main/types.ts#L329)
+[types.ts:331](https://github.com/coda/packs-sdk/blob/main/types.ts#L331)
 
 ___
 
@@ -148,4 +150,4 @@ Identifies this as QueryParamToken authentication.
 
 #### Defined in
 
-[types.ts:324](https://github.com/coda/packs-sdk/blob/main/types.ts#L324)
+[types.ts:326](https://github.com/coda/packs-sdk/blob/main/types.ts#L326)

--- a/docs/reference/sdk/interfaces/VariousAuthentication.md
+++ b/docs/reference/sdk/interfaces/VariousAuthentication.md
@@ -15,4 +15,4 @@ Identifies this as Various authentication.
 
 #### Defined in
 
-[types.ts:579](https://github.com/coda/packs-sdk/blob/main/types.ts#L579)
+[types.ts:581](https://github.com/coda/packs-sdk/blob/main/types.ts#L581)

--- a/docs/reference/sdk/interfaces/WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/WebBasicAuthentication.md
@@ -76,10 +76,12 @@ ___
 
 ### networkDomain
 
-• `Optional` **networkDomain**: `string`
+• `Optional` **networkDomain**: `string` \| `string`[]
 
-Which domain should get auth credentials, when a pack is configured with multiple domains.
+Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
 Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+
+Using multiple authenticated network domains is uncommon and requires Coda approval.
 
 #### Inherited from
 
@@ -87,7 +89,7 @@ Packs configured with only one domain or with requiredsEndpointUrl set to true c
 
 #### Defined in
 
-[types.ts:259](https://github.com/coda/packs-sdk/blob/main/types.ts#L259)
+[types.ts:261](https://github.com/coda/packs-sdk/blob/main/types.ts#L261)
 
 ___
 
@@ -135,7 +137,7 @@ Identifies this as WebBasic authentication.
 
 #### Defined in
 
-[types.ts:444](https://github.com/coda/packs-sdk/blob/main/types.ts#L444)
+[types.ts:446](https://github.com/coda/packs-sdk/blob/main/types.ts#L446)
 
 ___
 
@@ -155,4 +157,4 @@ Configuration for labels to show in the UI when the user sets up a new acount.
 
 #### Defined in
 
-[types.ts:448](https://github.com/coda/packs-sdk/blob/main/types.ts#L448)
+[types.ts:450](https://github.com/coda/packs-sdk/blob/main/types.ts#L450)

--- a/docs/reference/sdk/types/Authentication.md
+++ b/docs/reference/sdk/types/Authentication.md
@@ -9,4 +9,4 @@ The union of supported authentication methods.
 
 #### Defined in
 
-[types.ts:585](https://github.com/coda/packs-sdk/blob/main/types.ts#L585)
+[types.ts:587](https://github.com/coda/packs-sdk/blob/main/types.ts#L587)

--- a/docs/reference/sdk/types/BasicPackDefinition.md
+++ b/docs/reference/sdk/types/BasicPackDefinition.md
@@ -10,4 +10,4 @@ editor where Coda will manage versioning on behalf of the pack author.
 
 #### Defined in
 
-[types.ts:826](https://github.com/coda/packs-sdk/blob/main/types.ts#L826)
+[types.ts:828](https://github.com/coda/packs-sdk/blob/main/types.ts#L828)

--- a/docs/reference/sdk/types/SystemAuthentication.md
+++ b/docs/reference/sdk/types/SystemAuthentication.md
@@ -10,4 +10,4 @@ where the pack author provides credentials used in HTTP requests rather than the
 
 #### Defined in
 
-[types.ts:648](https://github.com/coda/packs-sdk/blob/main/types.ts#L648)
+[types.ts:650](https://github.com/coda/packs-sdk/blob/main/types.ts#L650)

--- a/docs/reference/sdk/types/SystemAuthenticationDef.md
+++ b/docs/reference/sdk/types/SystemAuthenticationDef.md
@@ -12,4 +12,4 @@ an [SystemAuthentication](SystemAuthentication.md) value, which is the value Cod
 
 #### Defined in
 
-[types.ts:664](https://github.com/coda/packs-sdk/blob/main/types.ts#L664)
+[types.ts:666](https://github.com/coda/packs-sdk/blob/main/types.ts#L666)

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2219,6 +2219,24 @@ describe('Pack metadata Validation', () => {
       assert.deepEqual(result, metadata);
     });
 
+    it('networkDomain has spaces', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['foo bar'],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+          networkDomain: 'foo bar',
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+          path: 'defaultAuthentication.networkDomain',
+        },
+      ]);
+    });
+
     it('good networkDomains when specifying authentication, multi-domain', async () => {
       const metadata = createFakePackVersionMetadata({
         networkDomains: ['foo.com', 'bar.com'],

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2122,7 +2122,7 @@ describe('Pack metadata Validation', () => {
       ]);
     });
 
-    it('missing networkDomains when specifying authentication', async () => {
+    it('missing auth networkDomains when specifying authentication', async () => {
       const metadata = createFakePackVersionMetadata({
         networkDomains: ['foo.com', 'bar.com'],
         defaultAuthentication: {
@@ -2131,6 +2131,28 @@ describe('Pack metadata Validation', () => {
       });
       const err = await validateJsonAndAssertFails(metadata, '1.0.0');
       assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
+          path: 'defaultAuthentication.networkDomain',
+        },
+      ]);
+    });
+
+    it('empty auth networkDomains when specifying authentication', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['foo.com', 'bar.com'],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+          networkDomain: [],
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'Array must contain at least 1 element(s)',
+          path: 'defaultAuthentication.networkDomain',
+        },
         {
           message:
             'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
@@ -2168,12 +2190,41 @@ describe('Pack metadata Validation', () => {
       ]);
     });
 
+    it('bad networkDomains when specifying authentication, multi-domain', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['foo.com', 'bar.com'],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+          networkDomain: ['bar.com', 'baz.com'],
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
+          path: 'defaultAuthentication.networkDomain',
+        },
+      ]);
+    });
+
     it('good networkDomains when specifying authentication', async () => {
       const metadata = createFakePackVersionMetadata({
         networkDomains: ['foo.com', 'bar.com'],
         defaultAuthentication: {
           type: AuthenticationType.HeaderBearerToken,
           networkDomain: 'bar.com',
+        },
+      });
+      const result = await validateJson(deepCopy(metadata));
+      assert.deepEqual(result, metadata);
+    });
+
+    it('good networkDomains when specifying authentication, multi-domain', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['foo.com', 'bar.com'],
+        defaultAuthentication: {
+          type: AuthenticationType.HeaderBearerToken,
+          networkDomain: ['bar.com', 'foo.com'],
         },
       });
       const result = await validateJson(deepCopy(metadata));

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -308,6 +308,13 @@ const setEndpointPostSetupValidator = zodCompleteObject<SetEndpoint>({
   'Either getOptions or getOptionsFormula must be specified.',
 );
 
+const singleAuthDomainSchema = z
+  .string()
+  .nonempty()
+  .refine(domain => domain.indexOf(' ') < 0, {
+    message: 'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+  });
+
 const baseAuthenticationValidators = {
   // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
   // in the full bundle, not the metadata.
@@ -318,7 +325,7 @@ const baseAuthenticationValidators = {
   endpointDomain: z.string().optional(),
   // The items are technically a discriminated union type but that union currently only has one member.
   postSetup: z.array(setEndpointPostSetupValidator).optional(),
-  networkDomain: z.union([z.string().nonempty(), z.string().nonempty().array().nonempty()]).optional(),
+  networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
 };
 
 const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> = {

--- a/types.ts
+++ b/types.ts
@@ -253,10 +253,12 @@ export interface BaseAuthentication {
   postSetup?: PostSetup[];
 
   /**
-   * Which domain should get auth credentials, when a pack is configured with multiple domains.
+   * Which domain(s) should get auth credentials, when a pack is configured with multiple domains.
    * Packs configured with only one domain or with requiredsEndpointUrl set to true can omit this.
+   *
+   * Using multiple authenticated network domains is uncommon and requires Coda approval.
    */
-  networkDomain?: string;
+  networkDomain?: string | string[];
 }
 
 /**


### PR DESCRIPTION
While uncommon, some APIs do seem to require the same credentials to be used across multiple domains.

An example would be the Google Drive API, which serves thumbnail images off a different domain than file metadata but still requires thumbnail requests to send credentials.

The change here is to modify the type of the authentication `networkDomain` from `string` to `string | string[]` and update `upload_validation.ts` accordingly.