### PR TITLE
add intermediateOutputDirectory option for coda build

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -8,18 +8,26 @@ interface BuildArgs {
   outputDir?: string;
   minify: boolean;
   timerStrategy: TimerShimStrategy;
+  intermediateOutputDirectory?: string;
 }
 
-export async function handleBuild({outputDir, manifestFile, minify, timerStrategy}: ArgumentsCamelCase<BuildArgs>) {
-  const {bundlePath, intermediateOutputDirectory} = await compilePackBundle({
+export async function handleBuild({
+  outputDir,
+  manifestFile,
+  minify,
+  timerStrategy,
+  intermediateOutputDirectory,
+}: ArgumentsCamelCase<BuildArgs>) {
+  const {bundlePath, intermediateOutputDirectory: actualIntermediateOutputDirectory} = await compilePackBundle({
     manifestPath: manifestFile,
     minify,
     outputDirectory: outputDir,
     timerStrategy,
+    intermediateOutputDirectory,
   });
   if (outputDir) {
     print(
-      `Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${intermediateOutputDirectory}`,
+      `Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${actualIntermediateOutputDirectory}`,
     );
   } else {
     print(`Pack built successfully. Compiled output is in ${bundlePath}.`);

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -128,6 +128,10 @@ if (require.main === module) {
           default: TimerShimStrategy.None,
           desc: 'Options: none, error, fake.',
         },
+        intermediateOutputDirectory: {
+          string: true,
+          default: undefined,
+        },
       },
       handler: handleBuild,
     })

--- a/dist/cli/build.d.ts
+++ b/dist/cli/build.d.ts
@@ -5,8 +5,9 @@ interface BuildArgs {
     outputDir?: string;
     minify: boolean;
     timerStrategy: TimerShimStrategy;
+    intermediateOutputDirectory?: string;
 }
-export declare function handleBuild({ outputDir, manifestFile, minify, timerStrategy }: ArgumentsCamelCase<BuildArgs>): Promise<void>;
+export declare function handleBuild({ outputDir, manifestFile, minify, timerStrategy, intermediateOutputDirectory, }: ArgumentsCamelCase<BuildArgs>): Promise<void>;
 export declare function build(manifestFile: string, { timerStrategy }?: {
     timerStrategy?: TimerShimStrategy;
 }): Promise<string>;

--- a/dist/cli/build.js
+++ b/dist/cli/build.js
@@ -3,15 +3,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.build = exports.handleBuild = void 0;
 const compile_1 = require("../testing/compile");
 const helpers_1 = require("../testing/helpers");
-async function handleBuild({ outputDir, manifestFile, minify, timerStrategy }) {
-    const { bundlePath, intermediateOutputDirectory } = await (0, compile_1.compilePackBundle)({
+async function handleBuild({ outputDir, manifestFile, minify, timerStrategy, intermediateOutputDirectory, }) {
+    const { bundlePath, intermediateOutputDirectory: actualIntermediateOutputDirectory } = await (0, compile_1.compilePackBundle)({
         manifestPath: manifestFile,
         minify,
         outputDirectory: outputDir,
         timerStrategy,
+        intermediateOutputDirectory,
     });
     if (outputDir) {
-        (0, helpers_1.print)(`Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${intermediateOutputDirectory}`);
+        (0, helpers_1.print)(`Pack built successfully. Compiled output is in ${bundlePath}. Intermediate files are in ${actualIntermediateOutputDirectory}`);
     }
     else {
         (0, helpers_1.print)(`Pack built successfully. Compiled output is in ${bundlePath}.`);

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -130,6 +130,10 @@ if (require.main === module) {
                 default: compile_1.TimerShimStrategy.None,
                 desc: 'Options: none, error, fake.',
             },
+            intermediateOutputDirectory: {
+                string: true,
+                default: undefined,
+            },
         },
         handler: build_1.handleBuild,
     })


### PR DESCRIPTION
when I was adding https://github.com/coda/coda/pull/71606, I realized that without setting the intermediate directory, the output isn't stable after each build because a randomly generated temp directory will go into source map & source code. 

this PR adds the option for `coda build`. 

PTAL @dweitzman-codaio @coda/packs 