### PR TITLE
Fix base URL for footer links

### DIFF
--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -9,7 +9,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/column-formats"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/blocks/column-formats",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/column-formats",
     "learnMoreLink": "/guides/blocks/column-formats",
     "content": "A **column format** is a custom column type that you apply to any column in any Coda table. A column format tells Coda to interpret the value in a cell by executing a **formula** using that value, typically looking up data related to that value from an external API.\n\nFor example, the Weather pack has a column format `Current Weather`; when applied to a column, if you type a city or address into a cell in that column, that location will be used an input to a formula that fetches the current weather at that location, and the resulting object with weather info will be shown in the cell.",
     "exampleSnippets": [
@@ -56,7 +56,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/advanced/authentication"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/advanced/authentication",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/advanced/authentication",
     "learnMoreLink": "/guides/advanced/authentication",
     "content": "Adding authentication to your Pack allows you to pass credentials with your API requests. Simply specify the type of authentication to use and Coda will collect the credentials from the user, store them, and apply them to Fetcher requests. Per-user authentication is the most common, where each user connects to their own account, while system-wide authentication is used in cases where the Pack maker's keys are used for all users.\n\nCoda supports a fixed set of authentication types which cover the most common patterns that APIs use. In addition you can define your own form of custom token authentication to support more complex scenarios. It's not possible to write completely custom authentication code however, as Coda alone has access to the user's credentials.",
     "exampleSnippets": [
@@ -122,7 +122,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/sync-tables/dynamic"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/blocks/sync-tables/dynamic",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/sync-tables/dynamic",
     "learnMoreLink": "/guides/blocks/sync-tables/dynamic",
     "content": "Dynamic sync tables allow you to bring data from an external data source into your doc, even when the structure of that data is not known in advance. Instead of including a static schema in your sync table definition, you include a `getSchema` function that returns a schema based on the dataset the user selects. It can use the fetcher to make authenticated HTTP requests to an API so that you can determine the shape of the data.\n\nDynamic sync tables typically provide a list all of the datasets that the user has access to, using the `listDynamicUrls` function. Once a user selects a dataset from the side panel it will be available to other functions in `context.sync.dynamicUrl`. The dynamic sync table must also provide a user-visible URL for the selected dataset (using `getDisplayUrl`) and a name for the resulting table on the page (using `getName`).",
     "exampleSnippets": [
@@ -148,7 +148,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/formulas"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/blocks/formulas",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/formulas",
     "learnMoreLink": "/guides/blocks/formulas",
     "content": "A formula is a JavaScript function that is exposed as a Coda formula, that you can use anywhere in a Coda doc that you can use any built-in formula. Formulas take basic types as input, like strings, numbers, dates, booleans, and arrays of these types, and return any of these types or objects whose properties are any of these types.",
     "exampleSnippets": [
@@ -184,7 +184,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/actions"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/blocks/actions",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/actions",
     "learnMoreLink": "/guides/blocks/actions",
     "content": "Actions are special types of formulas that power buttons and automations. They usually send data to an external API, but can also be used for other one-time calculations.",
     "exampleSnippets": [
@@ -215,7 +215,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/basics/parameters"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/basics/parameters",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/basics/parameters",
     "learnMoreLink": "/guides/basics/parameters",
     "content": "Coda formulas, actions, and sync tables receive take in user input via parameters. They are required by default, but can by made optional. Variable argument (vararg) parameters can be used to allow for parameters to be set more than once.",
     "exampleSnippets": [
@@ -291,7 +291,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/basics/parameters/autocomplete"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/basics/parameters/autocomplete",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/basics/parameters/autocomplete",
     "learnMoreLink": "/guides/basics/parameters/autocomplete",
     "content": "Autocomplete can be configured for a parameter to provide a defined set of options for the user to select from. You can can pass either a static array or use a function to dynamically generate the options.",
     "exampleSnippets": [
@@ -322,7 +322,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/sync-tables"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/blocks/sync-tables",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/sync-tables",
     "learnMoreLink": "/guides/blocks/sync-tables",
     "content": "A **sync table** is how to bring structured data from a third-party into Coda. A sync table is a table that you can add to a Coda doc that gets its rows from a third-party data source, that can be refreshed regularly to pull in new or updated data. A sync table is powered by a **formula** that takes parameters that represent sync options and returns an array of objects representing row data. A sync table also includes a schema describing the structure of the returned objects.",
     "exampleSnippets": [
@@ -363,7 +363,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/advanced/fetcher"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/advanced/fetcher",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/advanced/fetcher",
     "learnMoreLink": "/guides/advanced/fetcher",
     "content": "Communicating with an API or external server is done through the `Fetcher`, a custom interface for making HTTP requests. The fetcher is made available through the `context` object passed in to formulas. The fetcher can only send requests to URLs that have have a domain name that's been registered using `addNetworkDomain`. The fetcher runs asynchronously, and is typically run within an `async` function that will `await` the result.",
     "exampleSnippets": [
@@ -395,7 +395,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/basics/data-types"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/basics/data-types",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/basics/data-types",
     "learnMoreLink": "/guides/basics/data-types",
     "content": "Packs can return various types of values, and apply hints that tell Coda how to display that data. Formulas and schema properties must declare the these types upfront, and the values you return in your code must match.",
     "exampleSnippets": [
@@ -472,7 +472,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/advanced/schemas"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/advanced/schemas",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/advanced/schemas",
     "learnMoreLink": "/guides/advanced/schemas",
     "content": "To return structured data in a Pack you must first define the shape of that data using a schema. Schemas describe the type of data that will be returned, as well as metadata about how Coda should render it, but not the data itself. Pack formulas and sync tables specify which schema they are using and return data that matches it.\n\nThe most common form of schema you'll need to define are object schemas. They are often used to bundle together multiple pieces of data returned by an API.",
     "exampleSnippets": [
@@ -510,7 +510,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/advanced/timezones"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/advanced/timezones",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/advanced/timezones",
     "learnMoreLink": "/guides/advanced/timezones",
     "content": "Working with dates and times can be tricky, especially in Coda due to documents and operating in different timezones. These samples demonstrate some patterns you can use when taking them are parameters or returning them as results.",
     "exampleSnippets": [
@@ -554,7 +554,7 @@
       "type": "SdkReferencePath",
       "url": "/guides/advanced/images"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/guides/advanced/images",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/guides/advanced/images",
     "learnMoreLink": "/guides/advanced/images",
     "content": "Packs have native support for accepting images as parameters and returning them as results, always passed as URLs. Packs can either return a \"live\" URL to a hosted image (`ImageReference`) or a temporary URL that Coda should upload the doc (`ImageAttachment`). The utility provided at `content.temporaryBlobStorage` can be used to save private images to a temporary location for later upload. Packs also provide support for embedded SVGs, including support for dark mode.",
     "exampleSnippets": [
@@ -602,7 +602,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/hello-world",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/hello-world",
     "content": "This is an example which creates a single formula called `Hello`, that takes in a string called `name` and returns `“Hello, <name>!“`.",
     "exampleSnippets": [
       {
@@ -619,7 +619,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/daylight",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/daylight",
     "content": "This Pack provides a `Daylight` formula that determines the daylight, sunrise,\n and sunset at a given location using the [Sunrise Sunset API][api]. It accepts\n a latitude, longitude, an optional date and returns a rich object (schema) as\n a result. It uses the `Fetcher` to pull data from an external API.\n\n [api]: https://sunrise-sunset.org/api",
     "exampleSnippets": [
       {
@@ -636,7 +636,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/math",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/math",
     "content": "This Pack contains a few mathematical formulas, including the [greatest common divisor][wikipedia_gcd] (GCD) and [least common multiple][wikipedia_lcm] (LCM).\n\n\n[wikipedia_gcd]: https://en.wikipedia.org/wiki/Greatest_common_divisor\n[wikipedia_lcm]: https://en.wikipedia.org/wiki/Least_common_multiple",
     "exampleSnippets": [
       {
@@ -653,7 +653,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/todoist",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/todoist",
     "content": "This Pack provides an integration with the task tracking app [Todoist][todoist]. It uses a variety of building blocks to allow users to work with their projects and tasks, including:\n\n- Formulas that provide rich data about an item given its URL.\n- Column formats that automatically apply those formulas to matching URLs.\n- Action formulas that create and update items, for use in button and automations.\n- Sync tables for pulling in all of the user's items.\n\nThe Pack uses OAuth2 to connect to a user's Todoist account, which you can create for free.\n\n[todoist]: https://todoist.com/",
     "exampleSnippets": [
       {
@@ -670,7 +670,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/cats",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/cats",
     "content": "This Pack allows you to fetch random cat photos using the [Cat-as-a-service API][cataas]. You can set various parameters for the cat image, such as the width and height, as well as add a text overlay. The Pack provides:\n\n- A formula for fetching a cat photo.\n- A column format that displays the text on top of a cat photo.\n- A sync table that retrieves all available cat photos.\n\n[cataas]: https://cataas.com/",
     "exampleSnippets": [
       {
@@ -687,7 +687,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/dnd",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/dnd",
     "content": "This Pack allows you to fetch information about spells in th game Dungeons and Dragons using the [D&D 5e API][dnd]. The Pack provides:\n\n- A formula for looking up a spell by name.\n- A column format that displays information about the spell name in the cell.\n- A sync table that retrieves all available spells.\n\n[dnd]: http://www.dnd5eapi.co/",
     "exampleSnippets": [
       {
@@ -704,7 +704,7 @@
     "linkData": {
       "type": "SamplePage"
     },
-    "exampleFooterLink": "https://coda.github.io/packs-sdk/samples/full/github",
+    "exampleFooterLink": "https://coda.io/packs/build/latest/samples/full/github",
     "content": "This Pack demonstrates a lightweight integration with [GitHub][github]. There is a lot of functionality provided by the GitHub API, but this sample just provides a few features related to repositories (repos):\n\n- A formula that provides rich data about a repo given its URL.\n- A column format that automatically applies that formula to matching URLs.\n- An action formula (button) that stars a repo given its URL.\n- A sync table that pulls in all of the user's repos.\n\nThe Pack uses OAuth2 to connect to a user's GitHub account. A more extensive GitHub sample that is deployed via the CLI is available in the [`packs-examples` repo][github_example].\n\n[github]: https://github.com/\n[github_example]: https://github.com/coda/packs-examples/tree/main/examples/github",
     "exampleSnippets": [
       {

--- a/documentation/scripts/documentation_compiler.ts
+++ b/documentation/scripts/documentation_compiler.ts
@@ -22,7 +22,7 @@ const ExamplePagesRoot = path.join(TypeDocsRoot, ExampleDirName);
 const ExamplePageTemplate = Handlebars.compile(
   fs.readFileSync(path.join(DocumentationRoot, 'example_page_template.md'), 'utf8'),
 );
-const SdkReferenceLink = 'https://coda.github.io/packs-sdk';
+const SdkReferenceLink = 'https://coda.io/packs/build/latest';
 const SamplePageLink = `${SdkReferenceLink}/${ExampleDirName}`;
 const PageFileExtension = 'md';
 const IndexPageFilename = 'index.md'


### PR DESCRIPTION
As discovered during today's SME Talk, the footer links for some sample still link out to GH pages. Updated the code to use the correct URL. CC @punit-codaio @alicia-codaio.