### PR TITLE
Undo bad auto-formatting

### DIFF
--- a/docs/guides/advanced/authentication.md
+++ b/docs/guides/advanced/authentication.md
@@ -8,11 +8,13 @@ One of the key use cases for Packs is integrating Coda with other apps and servi
 
 [View Sample Code][samples]{ .md-button }
 
+
 ## Using a Pack with authentication
 
 Packs that use system-wide authentication (all users use the Pack makers's credentials) don't require any additional setup by the user, and can be used just like Packs without any authentication.
 
 Packs that support per-user authentication require some additional setup. Users must sign in to their accounts and connect them to Coda, as well as choose which account to authenticate with when using the building blocks from that Pack.
+
 
 ### Connecting an account
 
@@ -20,20 +22,22 @@ The listing for the Pack will display a **Sign in to install** button in place o
 
 <img src="../../../images/auth_sign_in.gif" class="screenshot" alt="Sign-in when installing a Pack with authentication">
 
-Users can sign in to additional accounts and change their sharing settings from the **Settings** tab of the Pack's side panel. Accounts can be reused across docs, and users can manage all of their connected accounts on the [Account settings][account_settings] page.
+Users can sign in to additional accounts and change their sharing settings from the **Settings** tab of the Pack's side panel. Accounts can be reused across docs, and  users can manage all of their connected accounts on the [Account settings][account_settings] page.
+
 
 ### Selecting an account
 
 In the formula editor the account is shown as the first parameter to the formula, and in the other dialogs the account to use is displayed as a dropdown list.
 
 === "In the formula editor"
-<img src="../../../images/auth_formula.png" srcset="../../../images/auth_formula_2x.png 2x" class="screenshot" alt="Account selection in the formula editor">
+    <img src="../../../images/auth_formula.png" srcset="../../../images/auth_formula_2x.png 2x" class="screenshot" alt="Account selection in the formula editor">
 === "In the action builder"
-<img src="../../../images/auth_action.png" srcset="../../../images/auth_action_2x.png 2x" class="screenshot" alt="Account selection in the action builder">
+    <img src="../../../images/auth_action.png" srcset="../../../images/auth_action_2x.png 2x" class="screenshot" alt="Account selection in the action builder">
 === "In the column format settings"
-<img src="../../../images/auth_column_format.png" srcset="../../../images/auth_column_format_2x.png 2x" class="screenshot" alt="Account selection in the column format settings">
+    <img src="../../../images/auth_column_format.png" srcset="../../../images/auth_column_format_2x.png 2x" class="screenshot" alt="Account selection in the column format settings">
 === "In the sync table settings"
-<img src="../../../images/auth_sync_table.png" srcset="../../../images/auth_sync_table_2x.png 2x" class="screenshot" alt="Account selection in the sync table settings">
+    <img src="../../../images/auth_sync_table.png" srcset="../../../images/auth_sync_table_2x.png 2x" class="screenshot" alt="Account selection in the sync table settings">
+
 
 ## Adding authentication to your Pack
 
@@ -71,11 +75,13 @@ After adding the code, build a new version of your Pack and then navigate to the
 
 The types of authentication supported, as well as the additional settings, are described in the sections below.
 
+
 ## Authentication types
 
 Coda supports a fixed set of authentication types which cover the most common patterns that APIs use. In addition you can define your own form of [custom token authentication](#custom-tokens) to support more complex scenarios. It's not possible to write completely custom authentication code however, as Coda alone has access to the user's credentials. If your API's authentication needs can't be met by any of these types please [contact support][support].
 
-The sections below will cover some of the most common types of authentication, and you can see the full set in the [`AuthenticationType`][authenticationtype] enum.
+The sections below will cover some of the most common types of authentication, and you can see the full set in the [`AuthenticationType`][AuthenticationType] enum.
+
 
 ### Single token
 
@@ -147,12 +153,18 @@ When using per-user authentication, the user will be prompted to enter their tok
 <img src="../../../images/auth_token.png" srcset="../../../images/auth_token_2x.png 2x" class="screenshot" alt="Users entering an auth token">
 
 !!! tip "Set an instructions URL"
-It may not be obvious to users where they can find their API token. You can set the `instructionsUrl` field of the authentication configuration to a relevant help center article, or in some cases directly to the screen within the application that lists the API token. Coda will link to this URL in the dialog.
-`ts pack.setUserAuthentication({ type: coda.AuthenticationType.HeaderBearerToken, instructionsUrl: "https://help.example.com/where-is-my-api-token", }); `
+    It may not be obvious to users where they can find their API token. You can set the `instructionsUrl` field of the authentication configuration to a relevant help center article, or in some cases directly to the screen within the application that lists the API token. Coda will link to this URL in the dialog.
+    ```ts
+    pack.setUserAuthentication({
+      type: coda.AuthenticationType.HeaderBearerToken,
+      instructionsUrl: "https://help.example.com/where-is-my-api-token",
+    });
+    ```
+
 
 ### Custom tokens
 
-Some APIs require a combination of tokens to be used, or for them to be passed in the request body or URL. In these cases you can use the [`Custom`][custom] authentication type. Consider this example, where a key is passed in the URL and an additional token is passed in the request body:
+Some APIs require a combination of tokens to be used, or for them to be passed in the request body or URL. In these cases you can use the [`Custom`][Custom] authentication type. Consider this example, where a key is passed in the URL and an additional token is passed in the request body:
 
 ```
 POST /api/<key>/users
@@ -171,8 +183,8 @@ This can be accomplished using a `Custom` authentication configuration like:
 pack.setSystemAuthentication({
   type: coda.AuthenticationType.Custom,
   params: [
-    {name: 'key', description: 'The API key'},
-    {name: 'token', description: 'The account token'},
+    {name: "key", description: "The API key"},
+    {name: "token", description: "The account token"},
   ],
 });
 ```
@@ -186,24 +198,23 @@ Unlike with other authentication types where the values are added to your fetch 
 {% endraw %}
 
 {% raw %}
-
 ```ts
 pack.addFormula({
   // ...
   execute: async function ([], context) {
     let invocationToken = context.invocationToken;
-    let keyPlaceholder = '{{key-' + invocationToken + '}}';
-    let tokenPlaceholder = '{{token-' + invocationToken + '}}';
-    let url = 'https://api.example.com/api/' + keyPlaceholder + '/users';
+    let keyPlaceholder = "{{key-" + invocationToken + "}}";
+    let tokenPlaceholder = "{{token-" + invocationToken + "}}";
+    let url = "https://api.example.com/api/" + keyPlaceholder + "/users";
     let body = {
       token: tokenPlaceholder,
-      name: 'Art Vandelay',
+      name: "Art Vandelay",
     };
     let response = await context.fetcher.fetch({
-      method: 'POST',
+      method: "POST",
       url: url,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
     });
@@ -211,8 +222,8 @@ pack.addFormula({
   },
 });
 ```
-
 {% endraw %}
+
 
 ### Username and password
 
@@ -224,7 +235,7 @@ Host: api.example.com
 Authorization: Basic <base64 encoded username & password>
 ```
 
-You can support this by using [`WebBasic`][webbasic] authentication in your Pack:
+You can support this by using [`WebBasic`][WebBasic] authentication in your Pack:
 
 ```ts
 pack.setUserAuthentication({
@@ -237,21 +248,30 @@ pack.setUserAuthentication({
 [View Sample Code][sample_web_basic]{ .md-button }
 
 !!! tip "Customize the dialog"
-Sometimes Basic authentication is used for other types of identifiers and secrets, and the terms "Username" and "Password" in the dialog can be misleading. You can customize the dialog using the `uxOptions` field of the authentication configuration.
-`ts pack.setUserAuthentication({ type: coda.AuthenticationType.WebBasic, uxConfig: { placeholderUsername: "Account ID", placeholderPassword: "Secret Token", }, }); `
+    Sometimes Basic authentication is used for other types of identifiers and secrets, and the terms "Username" and "Password" in the dialog can be misleading. You can customize the dialog using the `uxOptions` field of the authentication configuration.
+    ```ts
+    pack.setUserAuthentication({
+      type: coda.AuthenticationType.WebBasic,
+      uxConfig: {
+        placeholderUsername: "Account ID",
+        placeholderPassword: "Secret Token",
+      },
+    });
+    ```
+
 
 ### OAuth 2.0
 
 [OAuth 2.0][oauth_definition] is a modern, more secure alternative to passing usernames and passwords that has been adopted by many APIs. The details of this protocol can get complicated, but when building a Pack you only need to specify some configuration options and Coda handles the token exchange, storage, refresh, etc.
 
-To configure [`OAuth2`][oauth] authentication you must specify the authorization URL and the token URL. These URLs are found in the technical documentation of the API you are connecting to, and will be different for each API.
+To configure [`OAuth2`][OAuth] authentication you must specify the authorization URL and the token URL. These URLs are found in the technical documentation of the API you are connecting to, and will be different for each API.
 
 ```ts
 pack.setUserAuthentication({
   type: coda.AuthenticationType.OAuth2,
   // These URLs come from the API's developer documentation.
-  authorizationUrl: 'https://example.com/authorize',
-  tokenUrl: 'https://api.example.com/token',
+  authorizationUrl: "https://example.com/authorize",
+  tokenUrl: "https://api.example.com/token",
 });
 ```
 
@@ -267,14 +287,14 @@ When registering you application in the API provider's console you will be asked
 https://coda.io/packsAuth/oauth2
 ```
 
-There are many subtle variations to the OAuth2 flow, and Coda can accommodate a variety of them. You can find the additional configuration options in the [`OAuth2Authentication`][oauth2authentication] documentation.
+There are many subtle variations to the OAuth2 flow, and Coda can accommodate a variety of them. You can find the additional configuration options in the [`OAuth2Authentication`][OAuth2Authentication] documentation.
 
 However if the API provider deviates too far from the OAuth 2.0 specification it may not be possible to find a configuration that will work. Additionally, Coda currently only supports the [Authorization Code][oauth2_code] grant type, and others like [Client Credentials][oauth2_client] can't be used. If you get stuck please [contact support][support] to explore other options.
 
 [View Sample Code][sample_oauth2]{ .md-button }
 
 ??? note "Flexible authentication during token exchange"
-The OAuth2 specification doesn't require a specific authentication schema your app must use when exchanging tokens. Coda supports the two most popular variants:
+    The OAuth2 specification doesn't require a specific authentication schema your app must use when exchanging tokens. Coda supports the two most popular variants:
 
     1. Sending the `client_secret` in the JSON body
     1. Sending an `Authorization: Basic` header using the client ID and secret.
@@ -282,28 +302,29 @@ The OAuth2 specification doesn't require a specific authentication schema your a
     No configuration is required, Coda will try them both to see what works.
 
 ??? warning "OAuth 1.0a not supported"
-Coda doesn't currently support the older 1.0 or 1.0a versions of the OAuth specification. If you would like to connect to an API that only supports these versions of the standard please [contact support][support] so that we can continue to gauge interest.
+    Coda doesn't currently support the older 1.0 or 1.0a versions of the OAuth specification. If you would like to connect to an API that only supports these versions of the standard please [contact support][support] so that we can continue to gauge interest.
+
 
 #### Incremental OAuth
 
 As your pack grows you may find that you need to request more OAuth scopes than you initially did when your existing users connected. Coda allows new scopes to be added to Pack OAuth settings in a non-breaking way: we don't prompt the user to re-authorize until they try to use a Pack feature that fails. Once that happens, we notice that the connection the user was using was created with a stale list of OAuth scopes and we prompt them to re-authenticate it to get your new scopes.
 
-Even when you do know all of the scopes you need, you may not want to request them all at once. An approval screen with a long list of permissions can be intimidating to new users and some my choose to abandon your Pack. In these cases you may want to use incremental authorization, made possible in Packs by the formula field [`extraOAuthScopes`][extraoauthscopes]. You can use it to specify additional scopes that are needed in order to run a specific formula.
+Even when you do know all of the scopes you need, you may not want to request them all at once. An approval screen with a long list of permissions can be intimidating to new users and some my choose to abandon your Pack. In these cases you may want to use incremental authorization, made possible in Packs by the formula field [`extraOAuthScopes`][extraOAuthScopes]. You can use it to specify additional scopes that are needed in order to run a specific formula.
 
 ```ts
 pack.setUserAuthentication({
   type: coda.AuthenticationType.OAuth2,
   // ...
-  scopes: ['read'],
+  scopes: ["read"],
 });
 
 // ...
 
 pack.addFormula({
-  name: 'UpdateItem',
+  name: "UpdateItem",
   // ...
   isAction: true,
-  extraOAuthScopes: ['update'],
+  extraOAuthScopes: ["update"],
   // ...
 });
 ```
@@ -313,6 +334,7 @@ When the Pack above is installed the user will only be required to grant access 
 <img src="../../../images/auth_oauth_incremental.png" srcset="../../../images/auth_oauth_incremental_2x.png 2x" class="screenshot" alt="Prompting the user for additional permissions">
 
 When the user signs in again they will be prompted to approve the additional scopes, after which they will be able to use the formula successfully.
+
 
 ## Requiring authentication
 
@@ -324,12 +346,12 @@ pack.setUserAuthentication({
 });
 
 pack.addFormula({
-  name: 'NeedsAuthFormula',
+  name: "NeedsAuthFormula",
   // ...
 });
 
 pack.addFormula({
-  name: 'NoAuthNeededFormula',
+  name: "NoAuthNeededFormula",
   // ...
   connectionRequirement: coda.ConnectionRequirement.None,
 });
@@ -344,14 +366,14 @@ pack.setUserAuthentication({
 });
 
 pack.addFormula({
-  name: 'NeedsAuthFormula',
+  name: "NeedsAuthFormula",
   // ...
   connectionRequirement: coda.ConnectionRequirement.Required,
   // ...
 });
 
 pack.addFormula({
-  name: 'NoAuthNeededFormula',
+  name: "NoAuthNeededFormula",
   // ...
 });
 ```
@@ -359,15 +381,15 @@ pack.addFormula({
 
 ## Setting account names {: #name}
 
-By default the accounts that users connect to will be given the same name as their Coda account. While this works fine the majority of the time, if they are connecting to a team account or multiple accounts it is not very helpful. Therefore we strongly recommend that you implement a [`getConnectionName`][getconnectionname] function in your authentication configuration to set a more meaningful account name. This is typically done by making a Fetcher request to a user information endpoint in the API and then returning the name of the account.
+By default the accounts that users connect to will be given the same name as their Coda account. While this works fine the majority of the time, if they are connecting to a team account or multiple accounts it is not very helpful. Therefore we strongly recommend that you implement a [`getConnectionName`][getConnectionName] function in your authentication configuration to set a more meaningful account name. This is typically done by making a Fetcher request to a user information endpoint in the API and then returning the name of the account.
 
 ```ts
 pack.setUserAuthentication({
   // ...
-  getConnectionName: async function (context) {
+  getConnectionName: async function(context) {
     let response = await context.fetcher.fetch({
-      method: 'GET',
-      url: 'https://api.example.com/users/me',
+      method: "GET",
+      url: "https://api.example.com/users/me",
     });
     return response.body.username;
   },
@@ -379,7 +401,8 @@ This function is run after the user has entered their credentials, and the crede
 [View Sample Code][sample_oauth2]{ .md-button }
 
 !!! tip "Use detailed account names"
-If your service allows users to [connect to multiple endpoints](#endpoints), we recommend that you include the endpoint name as well. For example, a pattern like "User Name (Endpoint Name)".
+    If your service allows users to [connect to multiple endpoints](#endpoints), we recommend that you include the endpoint name as well. For example, a pattern like "User Name (Endpoint Name)".
+
 
 ## Account-specific endpoints {: #endpoints}
 
@@ -393,7 +416,7 @@ pack.addFormula({
   execute: async function ([], context) {
     // Retrieve the endpoint that the user set.
     let endpoint = context.endpoint;
-    let url = endpoint + '/api/v1/users/me';
+    let url = endpoint + "/api/v1/users/me";
     // ...
   },
 });
@@ -406,11 +429,12 @@ pack.addFormula({
   // ...
   execute: async function ([], context) {
     // The endpoint URL will be automatically prepended.
-    let url = '/api/v1/users/me';
+    let url = "/api/v1/users/me";
     // ...
   },
 });
 ```
+
 
 ### Entering manually
 
@@ -420,7 +444,7 @@ To require the user to enter the endpoint URL, set the `requiresEndpointUrl` fie
 pack.setUserAuthentication({
   // ...
   requiresEndpointUrl: true,
-  endpointDomain: 'example.com',
+  endpointDomain: "example.com",
 });
 ```
 
@@ -431,7 +455,8 @@ When the user connects to their account they will now also be asked to provide t
 [View Sample Code][sample_manual_endpoint]{ .md-button }
 
 !!! warning "Not compatible with OAuth2"
-Packs that use OAuth2 authentication don't support a manual prompt for the endpoint URL. They should instead use one of the alternate options listed below.
+    Packs that use OAuth2 authentication don't support a manual prompt for the endpoint URL. They should instead use one of the alternate options listed below.
+
 
 ### Extracting from token exchange
 
@@ -451,7 +476,7 @@ You can automatically extract this value and use it as the endpoint URL by setti
 pack.setUserAuthentication({
   type: coda.AuthenticationType.OAuth2,
   // ...
-  endpointKey: 'site_url',
+  endpointKey: "site_url",
 });
 ```
 
@@ -465,25 +490,23 @@ If the service allows the same user account to access multiple endpoints, and th
 pack.setUserAuthentication({
   // After approving access, the user should select which instance they want to
   // connect to.
-  postSetup: [
-    {
-      type: coda.PostSetupType.SetEndpoint,
-      name: 'SelectEndpoint',
-      description: 'Select the site to connect to:',
-      // Generate the list of endpoint options.
-      getOptions: async function (context) {
-        // Make a request to the API to retrieve the sites they can access.
-        let response = await context.fetcher.fetch({
-          method: 'GET',
-          url: 'https://api.example.com/my/sites',
-        });
-        let sites = response.body.sites;
-        return sites.map(site => {
-          return {display: site.name, value: site.url};
-        });
-      },
+  postSetup: [{
+    type: coda.PostSetupType.SetEndpoint,
+    name: "SelectEndpoint",
+    description: "Select the site to connect to:",
+    // Generate the list of endpoint options.
+    getOptions: async function (context) {
+      // Make a request to the API to retrieve the sites they can access.
+      let response = await context.fetcher.fetch({
+        method: "GET",
+        url: "https://api.example.com/my/sites",
+      });
+      let sites = response.body.sites;
+      return sites.map(site => {
+        return { display: site.name, value: site.url };
+      });
     },
-  ],
+  }],
 });
 ```
 
@@ -494,7 +517,8 @@ The step's `getOptions` works like [dynamic autocomplete][autocomplete_dynamic],
 [View Sample Code][sample_selected_endpoint]{ .md-button }
 
 !!! warning "Connection name generated twice"
-When using this feature the [`getConnectionName` function](#setting-account-names) is run multiple times: once before the endpoint is selected and again after. Make sure your code works correctly in both cases. Before the endpoint is available you can return a generic name, which will get overwritten later.
+    When using this feature the [`getConnectionName` function](#setting-account-names) is run multiple times: once before the endpoint is selected and again after. Make sure your code works correctly in both cases. Before the endpoint is available you can return a generic name, which will get overwritten later.
+
 
 ### Network domains
 
@@ -512,24 +536,25 @@ There are services however where each account is associated with a distinct doma
 [sample_manual_endpoint]: ../../samples/topic/authentication.md#manual-endpoint
 [sample_automatic_endpoint]: ../../samples/topic/authentication.md#automatic-endpoint
 [sample_selected_endpoint]: ../../samples/topic/authentication.md#selected-endpoint
+
 [hc_account_sharing]: https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs
 [account_settings]: https://coda.io/account
-[authenticationtype]: ../../reference/sdk/enums/AuthenticationType.md
+[AuthenticationType]: ../../reference/sdk/enums/AuthenticationType.md
 [support]: ../../support/index.md
 [coda_api_auth]: https://coda.io/developers/apis/v1#section/Authentication
-[headerbearertoken]: ../../reference/sdk/enums/AuthenticationType.md#headerbearertoken
-[customheadertoken]: ../../reference/sdk/enums/AuthenticationType.md#customheadertoken
-[queryparamtoken]: ../../reference/sdk/enums/AuthenticationType.md#queryparamtoken
-[queryparamtoken]: ../../reference/sdk/enums/AuthenticationType.md#custom
+[HeaderBearerToken]: ../../reference/sdk/enums/AuthenticationType.md#headerbearertoken
+[CustomHeaderToken]: ../../reference/sdk/enums/AuthenticationType.md#customheadertoken
+[QueryParamToken]: ../../reference/sdk/enums/AuthenticationType.md#queryparamtoken
+[QueryParamToken]: ../../reference/sdk/enums/AuthenticationType.md#custom
 [wikipedia_basic_auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
-[webbasic]: ../../reference/sdk/enums/AuthenticationType.md#webbasic
-[custom]: ../../reference/sdk/enums/AuthenticationType.md#custom
+[WebBasic]: ../../reference/sdk/enums/AuthenticationType.md#webbasic
+[Custom]: ../../reference/sdk/enums/AuthenticationType.md#custom
 [oauth_definition]: https://oauth.net/2/
-[oauth]: ../../reference/sdk/enums/AuthenticationType.md#oauth2
-[oauth2authentication]: ../../reference/sdk/interfaces/OAuth2Authentication.md
+[OAuth]: ../../reference/sdk/enums/AuthenticationType.md#oauth2
+[OAuth2Authentication]: ../../reference/sdk/interfaces/OAuth2Authentication.md
 [oauth2_code]: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
 [oauth2_client]: https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
-[getconnectionname]: ../../reference/sdk/interfaces/BaseAuthentication.md#getconnectionname
+[getConnectionName]: ../../reference/sdk/interfaces/BaseAuthentication.md#getconnectionname
 [network_domains]: fetcher.md#network-domains
 [autocomplete_dynamic]: ../basics/parameters/autocomplete.md#dynamic-options
-[extraoauthscopes]: ../../reference/sdk/interfaces/BaseFormulaDef.md#extraoauthscopes
+[extraOAuthScopes]: ../../reference/sdk/interfaces/BaseFormulaDef.md#extraoauthscopes


### PR DESCRIPTION
The file `authentication.md` was touched in PR #1907 and it looks like an auto-formatter went awry. Our documentation is using some plugins that introduce non-standard markdown syntax that broken when reformatted.

I used the approach [documented here](https://stackoverflow.com/a/7196615) to revert the change to this file.