### PR TITLE
Fix screenshot style in tutorials

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -109,3 +109,8 @@ li.no {
 .tutorial-row > * {
   overflow: auto;
 }
+
+.tutorial-row img.screenshot {
+  box-shadow: none;
+  border: 1px solid var(--md-default-fg-color--lightest);
+}


### PR DESCRIPTION
The drop shadows on the screenshots were being clipped on the side in the tutorial. Couldn't find an easy way to size the images to prevent that, so using a border for those cases instead.

Before:
<img width="553" alt="Screen Shot 2022-05-13 at 2 35 28 PM" src="https://user-images.githubusercontent.com/88106038/168346129-2b1fbf28-9d65-4bac-af30-9a925bffd2fe.png">

After:
<img width="553" alt="Screen Shot 2022-05-13 at 2 35 52 PM" src="https://user-images.githubusercontent.com/88106038/168346147-a627898f-7bed-4594-97a5-78d10e2db8ef.png">

