### PR TITLE
Allow empty auth network domain with multiple networks

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1061,26 +1061,18 @@ const packMetadataSchemaBySdkVersion = [
                 else if (data.defaultAuthentication.networkDomain) {
                     authNetworkDomains = [data.defaultAuthentication.networkDomain];
                 }
-                if (!(authNetworkDomains === null || authNetworkDomains === void 0 ? void 0 : authNetworkDomains.length)) {
-                    if (data.networkDomains && data.networkDomains.length > 1) {
-                        context.addIssue({
-                            code: z.ZodIssueCode.custom,
-                            path: ['defaultAuthentication.networkDomain'],
-                            message: 'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-                        });
-                    }
-                    return;
-                }
-                // Pack has multiple network domains and user auth. The code needs to clarify which domain gets the auth
-                // headers.
-                for (const authNetworkDomain of authNetworkDomains) {
-                    if (!((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.includes(authNetworkDomain))) {
-                        context.addIssue({
-                            code: z.ZodIssueCode.custom,
-                            path: ['defaultAuthentication.networkDomain'],
-                            message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
-                        });
-                        return;
+                if (authNetworkDomains === null || authNetworkDomains === void 0 ? void 0 : authNetworkDomains.length) {
+                    // Pack has multiple network domains and user auth. The code needs to clarify which domain gets the auth
+                    // headers.
+                    for (const authNetworkDomain of authNetworkDomains) {
+                        if (!((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.includes(authNetworkDomain))) {
+                            context.addIssue({
+                                code: z.ZodIssueCode.custom,
+                                path: ['defaultAuthentication.networkDomain'],
+                                message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
+                            });
+                            return;
+                        }
                     }
                 }
             });

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2122,45 +2122,6 @@ describe('Pack metadata Validation', () => {
       ]);
     });
 
-    it('missing auth networkDomains when specifying authentication', async () => {
-      const metadata = createFakePackVersionMetadata({
-        networkDomains: ['foo.com', 'bar.com'],
-        defaultAuthentication: {
-          type: AuthenticationType.HeaderBearerToken,
-        },
-      });
-      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
-      assert.deepEqual(err.validationErrors, [
-        {
-          message:
-            'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-          path: 'defaultAuthentication.networkDomain',
-        },
-      ]);
-    });
-
-    it('empty auth networkDomains when specifying authentication', async () => {
-      const metadata = createFakePackVersionMetadata({
-        networkDomains: ['foo.com', 'bar.com'],
-        defaultAuthentication: {
-          type: AuthenticationType.HeaderBearerToken,
-          networkDomain: [],
-        },
-      });
-      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
-      assert.deepEqual(err.validationErrors, [
-        {
-          message: 'Array must contain at least 1 element(s)',
-          path: 'defaultAuthentication.networkDomain',
-        },
-        {
-          message:
-            'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-          path: 'defaultAuthentication.networkDomain',
-        },
-      ]);
-    });
-
     it('missing networkDomains when specifying authentication allowed for old SDK versions', async () => {
       const metadata = createFakePackVersionMetadata({
         networkDomains: ['foo.com', 'bar.com'],

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1268,17 +1268,19 @@ const packMetadataSchemaBySdkVersion: SchemaExtension[] = [
           authNetworkDomains = [data.defaultAuthentication.networkDomain];
         }
 
-        // Pack has multiple network domains and user auth. The code needs to clarify which domain gets the auth
-        // headers.
-        for (const authNetworkDomain of authNetworkDomains) {
-          if (!data.networkDomains?.includes(authNetworkDomain)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['defaultAuthentication.networkDomain'],
-              message:
-                'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
-            });
-            return;
+        if (authNetworkDomains?.length) {
+          // Pack has multiple network domains and user auth. The code needs to clarify which domain gets the auth
+          // headers.
+          for (const authNetworkDomain of authNetworkDomains) {
+            if (!data.networkDomains?.includes(authNetworkDomain)) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['defaultAuthentication.networkDomain'],
+                message:
+                  'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
+              });
+              return;
+            }
           }
         }
       });

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1268,18 +1268,6 @@ const packMetadataSchemaBySdkVersion: SchemaExtension[] = [
           authNetworkDomains = [data.defaultAuthentication.networkDomain];
         }
 
-        if (!authNetworkDomains?.length) {
-          if (data.networkDomains && data.networkDomains.length > 1) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['defaultAuthentication.networkDomain'],
-              message:
-                'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-            });
-          }
-          return;
-        }
-
         // Pack has multiple network domains and user auth. The code needs to clarify which domain gets the auth
         // headers.
         for (const authNetworkDomain of authNetworkDomains) {


### PR DESCRIPTION
Now that we have multi-domain credential pinning, we can just infer all
networks as auth networks if nothing explicit is specified. Using multiple
auth networks would still be blocked on the server-side without manual
approval from Coda.