### PR TITLE
Fix external metadata auth network domain type

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -156,7 +156,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
     oauthScopes?: string[];
     oauthAuthorizationUrl?: string;
     oauthTokenUrl?: string;
-    networkDomain?: string;
+    networkDomain?: string | string[];
   };
   instructionsUrl?: string;
 

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -3688,7 +3688,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
 		oauthScopes?: string[];
 		oauthAuthorizationUrl?: string;
 		oauthTokenUrl?: string;
-		networkDomain?: string;
+		networkDomain?: string | string[];
 	};
 	instructionsUrl?: string;
 	formulas?: ExternalPackFormulas;

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -109,7 +109,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
         oauthScopes?: string[];
         oauthAuthorizationUrl?: string;
         oauthTokenUrl?: string;
-        networkDomain?: string;
+        networkDomain?: string | string[];
     };
     instructionsUrl?: string;
     formulas?: ExternalPackFormulas;


### PR DESCRIPTION
`networkDomain` can also be an array now