### PR TITLE
Fix validation of auth network domains

### DIFF
--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2181,7 +2181,7 @@ describe('Pack metadata Validation', () => {
           networkDomain: 'baz.com',
         },
       });
-      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
+      const err = await validateJsonAndAssertFails(metadata, '0.2.0');
       assert.deepEqual(err.validationErrors, [
         {
           message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
@@ -2198,7 +2198,7 @@ describe('Pack metadata Validation', () => {
           networkDomain: ['bar.com', 'baz.com'],
         },
       });
-      const err = await validateJsonAndAssertFails(metadata, '1.0.0');
+      const err = await validateJsonAndAssertFails(metadata, '0.1.0');
       assert.deepEqual(err.validationErrors, [
         {
           message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',


### PR DESCRIPTION
Auth network domains are optional until a future SDK release, but if someone
chooses to set them now we still want to ensure the value they choose matches
a pack network domain