### PR TITLE
Create guide on two-way sync

### DIFF
--- a/docs/guides/advanced/two-way-sync.md
+++ b/docs/guides/advanced/two-way-sync.md
@@ -104,7 +104,7 @@ While there is no solution for the general case, there is for the common case wh
 
 
 [actions]: ../blocks/actions.md
-[data_type_object]: ../../basics/data-types.md#objects
+[data_type_object]: ../basics/data-types.md#objects
 [schemas]: schemas.md
 [getSchema]: ../blocks/sync-tables/dynamic.md#get-schema
 [includeUnknownProperties]: ../../reference/sdk/interfaces/ObjectSchemaDefinition.md#includeunknownproperties

--- a/docs/guides/advanced/two-way-sync.md
+++ b/docs/guides/advanced/two-way-sync.md
@@ -51,9 +51,9 @@ The returned object is merged into the existing row, such that any top-level pro
 [View Sample Code][samples_action_todoist]{ .md-button }
 
 
-### Dynamic schemas {: #dynamic-schemas}
+### Handling dynamic schemas {: #dynamic-schemas}
 
-Action formulas must declare the schema of the object they return, which presents a challenge when trying to update rows in sync tables that use the `getSchema` method to [dynamically generate their schemas][getSchema]. It's possible to work around this incompatibility as long as there is a predictable `idProperty` for the dynamic schema.
+Action formulas must declare the schema of the object they return, which presents a challenge when trying to update rows in sync tables that use the `getSchema` method to [dynamically generate their schemas][getSchema]. It's possible to work around this incompatibility however, as long as there is a predictable `idProperty` for the dynamic schema.
 
 Create a "base schema" for your action formula to use, which at a minimum includes an `idProperty` (and the corresponding property definition). Additionally, set the schema field [`includeUnknownProperties`][includeUnknownProperties] to true. This tells Coda not to strip out extra data in the response that doesn't match a defined property, allowing it to flow through to the sync table.
 
@@ -96,9 +96,9 @@ pack.addFormula({
     When you enable the `includeUnknownProperties` feature, all of the data returned by the formula or sync table ends up in the object chip, even when it doesn't match any schema property in the sync table. Only the fields corresponding to properties will be available to "dot" into in the Coda formula language however. You should therefore remove any data from the API response that you don't intend the user to see.
 
 
-### Dynamic sync tables
+### Handling dynamic URLs
 
-Dynamic sync tables have dynamic schemas, and therefore need to use the technique [described above](#dynamic-schemas) to update their rows from an action. However they have the additional complication that they are not uniquely identified by an `identityName` alone, but in combination with their specific `dynamicUrl`. While it is possible to set the `identity.dynamicUrl` field of the schema, hardcoding it to a specific URL isn't likely to be useful.
+Dynamic sync tables have dynamic schemas, and therefore need to use the technique [described above](#dynamic-schemas) to update their rows from an action. However they have the additional complication that they are not uniquely identified by an `identityName` alone, but in combination with their specific dynamic URL. While it is possible to set the `identity.dynamicUrl` field of the schema, hardcoding it to a specific URL isn't likely to be useful.
 
 While there is no solution for the general case, there is for the common case where a button appears in a column of the same table. As long as the `identity.name` of the schema matches that of the dynamic sync table containing the button, the dynamic URL will be automatically populated and the row update will work. Using that same action elsewhere in the doc however will not update the existing row.
 

--- a/docs/guides/advanced/two-way-sync.md
+++ b/docs/guides/advanced/two-way-sync.md
@@ -1,0 +1,111 @@
+---
+title: Two-way sync
+---
+
+# Approximating two-way sync
+
+The sync process used by sync tables is one-way only; data is pulled in from an external source and is displayed in a read-only column. It's not possible to directly edit the items in the sync table and sync the changes back out.
+
+You can approximate a two-way sync however using a combinations of additional columns, buttons, and [custom actions][actions]. While most of the setup is at the doc-level, it does require that you build certain features into your Pack.
+
+
+## Actions updating sync table rows
+
+An action can update a record in an external API, but it won't be reflected in the sync table until the next time it syncs. To update the corresponding row immediately, have your action return an [Object][data_type_object] representing the updated state of the row.
+
+If an action formula uses the same [schema][schemas] as a sync table, Coda will look up the corresponding row in the table and update it with the returned object. The schema must have an `identity.name` field set, matching the `identityName` field of the sync table.
+
+```ts
+const TaskSchema = coda.makeObjectSchema({
+  // ...
+  identity: {
+    name: "Task",
+  },
+});
+
+pack.addSyncTable({
+  name: "Tasks",
+  schema: TaskSchema,
+  identityName: "Task",
+  // ...
+});
+
+pack.addFormula({
+  name: "UpdateTask",
+  description: "Updates the name of a task.",
+  // ...
+  resultType: coda.ValueType.Object,
+  schema: TaskSchema,
+  isAction: true,
+  execute: async function ([taskId, name], context) {
+    // Call the API to update the task and get back the updated content.
+    let task = updateTask(taskId, name, context);
+    // The existing row will be updated with this value.
+    return task;
+  },
+});
+```
+
+The returned object is merged into the existing row, such that any top-level properties that are undefined or null in the response will retain their previously synced value. It currently isn't possible to reset a top-level property to a blank state.
+
+[View Sample Code][samples_action_todoist]{ .md-button }
+
+
+### Dynamic schemas {: #dynamic-schemas}
+
+Action formulas must declare the schema of the object they return, which presents a challenge when trying to update rows in sync tables that use the `getSchema` method to [dynamically generate their schemas][getSchema]. It's possible to work around this incompatibility as long as there is a predictable `idProperty` for the dynamic schema.
+
+Create a "base schema" for your action formula to use, which at a minimum includes an `idProperty` (and the corresponding property definition). Additionally, set the schema field [`includeUnknownProperties`][includeUnknownProperties] to true. This tells Coda not to strip out extra data in the response that doesn't match a defined property, allowing it to flow through to the sync table.
+
+```ts
+const BaseTaskSchema = coda.makeObjectSchema({
+  properties: {
+    taskId: { type: coda.ValueType.String },
+  },
+  idProperty: "taskId",
+  includeUnknownProperties: true,
+});
+
+pack.addSyncTable({
+  name: "Tasks",
+  schema: BaseTaskSchema,
+  dynamicOptions: {
+    getSchema: async function (context) {
+      // Extend BaseTaskSchema with additional properties.
+    },
+  },
+  // ...
+});
+
+pack.addFormula({
+  name: "UpdateTask",
+  // ...
+  resultType: coda.ValueType.Object,
+  schema: BaseTaskSchema,
+  isAction: true,
+  execute: async function ([taskId, name], context) {
+    let task = updateTask(taskId, name, context);
+    // Return the updated task, which can include values corresponding to the
+    // dynamic properties.
+    return task;
+  },
+});
+```
+
+!!! warning "Remove unused fields"
+    When you enable the `includeUnknownProperties` feature, all of the data returned by the formula or sync table ends up in the object chip, even when it doesn't match any schema property in the sync table. Only the fields corresponding to properties will be available to "dot" into in the Coda formula language however. You should therefore remove any data from the API response that you don't intend the user to see.
+
+
+### Dynamic sync tables
+
+Dynamic sync tables have dynamic schemas, and therefore need to use the technique [described above](#dynamic-schemas) to update their rows from an action. However they have the additional complication that they are not uniquely identified by an `identityName` alone, but in combination with their specific `dynamicUrl`. While it is possible to set the `identity.dynamicUrl` field of the schema, hardcoding it to a specific URL isn't likely to be useful.
+
+While there is no solution for the general case, there is for the common case where a button appears in a column of the same table. As long as the `identity.name` of the schema matches that of the dynamic sync table containing the button, the dynamic URL will be automatically populated and the row update will work. Using that same action elsewhere in the doc however will not update the existing row.
+
+
+[actions]: ../blocks/actions.md
+[data_type_object]: ../../basics/data-types.md#objects
+[schemas]: schemas.md
+[getSchema]: ../blocks/sync-tables/dynamic.md#get-schema
+[includeUnknownProperties]: ../../reference/sdk/interfaces/ObjectSchemaDefinition.md#includeunknownproperties
+[samples_action_todoist]: ../../samples/topic/action.md#update-row-in-sync-table

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -114,3 +114,4 @@ Learn more about this approach in the [two-way sync guide][two_way_sync].
 [data-types]: ../basics/data-types.md
 [sync_table]: sync-tables/index.md
 [schemas]: ../advanced/schemas.md
+[two_way_sync]: ../../advanced/two-way-sync.md

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -114,4 +114,4 @@ Learn more about this approach in the [two-way sync guide][two_way_sync].
 [data-types]: ../basics/data-types.md
 [sync_table]: sync-tables/index.md
 [schemas]: ../advanced/schemas.md
-[two_way_sync]: ../../advanced/two-way-sync.md
+[two_way_sync]: ../advanced/two-way-sync.md

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -97,6 +97,14 @@ Actions can use authentication to access private resources, but unlike other for
 Unlike other formulas, actions are never cached or automatically recalculated. The action is only run when the button is pressed or automation triggered, and the code is run each time, even if the inputs haven't changed.
 
 
+## Update sync table rows
+
+It's common for a Pack to have a [sync table][sync_table] that brings in records from an external API, and an action that allows the user to update those records. The changes made by the action will be reflected in the table the next time it syncs, but you can update the row immediately by selecting the correct return value for your formula.
+
+Learn more about this approach in the [two-way sync guide][two_way_sync].
+
+
+
 [help_buttons]: https://help.coda.io/en/articles/2033889-overview-of-buttons
 [help_automations]: https://help.coda.io/en/articles/2423860-automations-in-coda
 [fetcher]: ../advanced/fetcher.md
@@ -104,3 +112,5 @@ Unlike other formulas, actions are never cached or automatically recalculated. T
 [formulas]: formulas.md
 [parameters]: ../basics/parameters/index.md
 [data-types]: ../basics/data-types.md
+[sync_table]: sync-tables/index.md
+[schemas]: ../advanced/schemas.md

--- a/docs/guides/blocks/sync-tables/dynamic.md
+++ b/docs/guides/blocks/sync-tables/dynamic.md
@@ -131,7 +131,7 @@ pack.addDynamicSyncTable({
 ```
 
 
-### Generate the row schema
+### Generate the row schema {:. #get-schema}
 
 The [`getSchema`][getSchema] function is responsible for generating the schema that represents each row of the sync table. Unlike regular sync tables that can define their sync table at build time, the schema for a dynamic sync table must be generated at run-time based on the dataset selected.
 

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -213,44 +213,11 @@ pack.addSyncTable({
 [View Sample Code][sample_continuation]{ .md-button }
 
 
-## Approximating two-way sync with actions {: #actions}
+## Approximating two-way sync {: #actions}
 
-The sync process used by sync tables is one-way only; data is pulled in from an external source and is displayed in a read-only column. It's not possible to directly edit the items in the sync table and sync the changes back out.
+The sync process used by sync tables is one-way only; data is pulled in from an external source and is displayed in a read-only column. It's not possible to directly edit the items in the sync table and sync the changes back out. However it is possible to approximate a two-way sync using a combinations of additional columns, buttons, and custom actions.
 
-You can approximate a two-way sync using buttons with [custom actions][actions]. For example, the [Todoist sample][sample_todoist] has an `UpdateTask` action that updates the name of a task. Sync tables can't include buttons directly, but Makers can add them on to a sync table and sample docs can demonstrate this pattern.
-
-If an action updates an item that has been synced, it’s natural to want to see the row for that synced item get updated immediately, rather than having to wait for the next sync. To address this, you can have an action formula return an [Object][data_type_object], representing the item after the changes have been applied. If this object uses the same schema as a sync table, when the formula completes, Coda will look for a row in that sync table and update the row’s value with the return value of the action. The schema must have the `identity.name` field populated and it must match the `identityName` field of the sync table.
-
-```ts
-const TaskSchema = coda.makeObjectSchema({
-  // ...
-  identity: {
-    name: "Task",
-  },
-});
-
-pack.addSyncTable({
-  name: "Tasks",
-  schema: TaskSchema,
-  identityName: "Task",
-  // ...
-});
-
-pack.addFormula({
-  name: "UpdateTask",
-  description: "Updates the name of a task.",
-  // ...
-  resultType: coda.ValueType.Object,
-  schema: TaskSchema,
-  isAction: true,
-  execute: async function ([taskId, name], context) {
-    // Call the API to update the task and get back the updated content.
-    let task = updateTask(taskId, name, context);
-    // The existing row will be updated with this value.
-    return task;
-  },
-});
-```
+Learn more about this approach in the [two-way sync guide][two_way_sync].
 
 
 ## Referencing rows from other sync tables {: #references}
@@ -291,7 +258,6 @@ It's recommended that you reduce or disable [HTTP caching][fetcher_caching] of t
 [schema_references]: ../../advanced/schemas.md#references
 [dynamicOptions]: ../../../reference/sdk/interfaces/SyncTableOptions/#dynamicoptions
 [actions]: ../actions.md
-[data_type_object]: ../../basics/data-types.md#objects
 [dynamic_sync_tables]: dynamic.md
 [dynamic_sync_tables_schema_only]: dynamic.md#schema-only
 [hc_lookups]: https://help.coda.io/en/articles/1385997-using-lookups#the-lookup-column-format
@@ -300,3 +266,4 @@ It's recommended that you reduce or disable [HTTP caching][fetcher_caching] of t
 [parmeters]: ../../basics/parameters/index.md
 [fetcher_caching]: ../../advanced/fetcher.md#caching
 [parameters]: ../../basics/parameters/index.md
+[two_way_sync]: ../../advanced/two-way-sync.md


### PR DESCRIPTION
I wanted to add the new information about `includeUnknownProperties` and dynamic URLs, but the content was getting a bit too long for its existing home in the actions page. Broke it out to a new advanced guide on two-way sync. In the future it would be nice to add more information to that page on how to setup a doc/template using the patterns @punit-codaio developed for the Jira Pack, but I don't consider that blocking.

Staged here: https://coda-packs-sdk--2010.com.readthedocs.build/en/2010/guides/advanced/two-way-sync/