### PR TITLE
fix marshalBuffer in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+- Fixed `temporaryBlobStorage.storeBlob` error from CLI built Packs.
+
 ## [0.12.1] - 2022-06-06
 
 ### Added

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -4384,7 +4384,8 @@ module.exports = (() => {
 
   // runtime/common/marshaling/marshal_buffer.ts
   function marshalBuffer(val) {
-    if (val instanceof Buffer2) {
+    var _a;
+    if (val instanceof Buffer2 || ((_a = global.Buffer) == null ? void 0 : _a.isBuffer(val))) {
       return {
         data: [...Uint8Array.from(val)],
         ["__coda_marshaler__" /* CodaMarshaler */]: "Buffer" /* Buffer */

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -4384,7 +4384,8 @@ module.exports = (() => {
 
   // runtime/common/marshaling/marshal_buffer.ts
   function marshalBuffer(val) {
-    if (val instanceof Buffer2) {
+    var _a;
+    if (val instanceof Buffer2 || ((_a = global.Buffer) == null ? void 0 : _a.isBuffer(val))) {
       return {
         data: [...Uint8Array.from(val)],
         ["__coda_marshaler__" /* CodaMarshaler */]: "Buffer" /* Buffer */

--- a/dist/runtime/common/marshaling/marshal_buffer.js
+++ b/dist/runtime/common/marshaling/marshal_buffer.js
@@ -4,8 +4,12 @@ exports.unmarshalBuffer = exports.marshalBuffer = void 0;
 const constants_1 = require("./constants");
 const constants_2 = require("./constants");
 function marshalBuffer(val) {
-    // Buffer is not provided by IVM. If the bundle is not browserified, global.Buffer will be undefined.
-    if (val instanceof Buffer) {
+    var _a;
+    // Usually `val instanceof Buffer` would be sufficient (e.g. imported as a regular module) to decide
+    // if `val` is a Buffer. In the compiled bundle, however there might be multiple instances of Buffer
+    // class as each build piece (e.g. bundle/thunk/etc) may come with its own buffer shim. Using
+    // `Buffer?.isBuffer` (which checks `val._isBuffer`) would allow us to bridge the gap.
+    if (val instanceof Buffer || ((_a = global.Buffer) === null || _a === void 0 ? void 0 : _a.isBuffer(val))) {
         return {
             data: [...Uint8Array.from(val)],
             [constants_2.MarshalingInjectedKeys.CodaMarshaler]: constants_1.CodaMarshalerType.Buffer,

--- a/runtime/common/marshaling/marshal_buffer.ts
+++ b/runtime/common/marshaling/marshal_buffer.ts
@@ -2,8 +2,11 @@ import {CodaMarshalerType} from './constants';
 import {MarshalingInjectedKeys} from './constants';
 
 export function marshalBuffer(val: any): object | undefined {
-  // Buffer is not provided by IVM. If the bundle is not browserified, global.Buffer will be undefined.
-  if (val instanceof Buffer) {
+  // Usually `val instanceof Buffer` would be sufficient (e.g. imported as a regular module) to decide
+  // if `val` is a Buffer. In the compiled bundle, however there might be multiple instances of Buffer
+  // class as each build piece (e.g. bundle/thunk/etc) may come with its own buffer shim. Using
+  // `Buffer?.isBuffer` (which checks `val._isBuffer`) would allow us to bridge the gap.
+  if (val instanceof Buffer || global.Buffer?.isBuffer(val)) {
     return {
       data: [...Uint8Array.from(val)],
       [MarshalingInjectedKeys.CodaMarshaler]: CodaMarshalerType.Buffer,

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -9,6 +9,7 @@ import {makeObjectSchema} from '../../schema';
 import {makeStringFormula} from '../../api';
 import {makeStringParameter} from '../../api';
 import {makeSyncTable} from '../../api';
+import {marshalBuffer} from '../../runtime/common/marshaling/marshal_buffer';
 import {v4} from 'uuid';
 import {withQueryParams} from '../../helpers/url';
 
@@ -77,6 +78,17 @@ export const manifest: PackDefinition = createFakePack({
       parameters: [],
       execute: ([]) => {
         return v4();
+      },
+    }),
+    makeFormula({
+      resultType: ValueType.String,
+      name: 'marshalBuffer',
+      description: 'Returns a marshaled buffer.',
+      examples: [],
+      parameters: [],
+      execute: async ([], context) => {
+        await context.temporaryBlobStorage.storeBlob(Buffer.from('test'), 'text/html');
+        return 'okay';
       },
     }),
     makeObjectFormula({

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -9,7 +9,6 @@ import {makeObjectSchema} from '../../schema';
 import {makeStringFormula} from '../../api';
 import {makeStringParameter} from '../../api';
 import {makeSyncTable} from '../../api';
-import {marshalBuffer} from '../../runtime/common/marshaling/marshal_buffer';
 import {v4} from 'uuid';
 import {withQueryParams} from '../../helpers/url';
 

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -164,3 +164,16 @@ pack.addFormula({
     return sum;
   },
 });
+
+pack.addFormula({
+  name: 'StoreBufferFromText',
+  description: '',
+  parameters: [],
+  resultType: coda.ValueType.String,
+  execute: async ([], context) => {
+    const buffer = Buffer.from('Hello World!');
+    const url = await context.temporaryBlobStorage.storeBlob(buffer, 'text/plain');
+    return url;
+  },
+  cacheTtlSecs: 0,
+});


### PR DESCRIPTION
https://golinks.io/bug/21508

Though both the web editor build and the CLI build may include multiple instances of Buffer shims, the CLI build runs into the situation where thunk.js doesn't recognize the Buffer shim from `bundle.js`. This is a bug that we are just lucky it works in web. 

This PR fixes the issue by using buffer shim's `isBuffer` for type checking. 

Tested for both the web build and CLI build that this works. Added a unittest and verified that it failed before this PR.

PTAL @jonathan-codaio @ekoleda-codaio 