### PR TITLE
Exclude documentation from the packs sdk npm to save 100mb

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+docs/
+site/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,17 @@
+# Documentation includes image files not needed in the node module.
 docs/
 site/
+
+# From .gitignore
+.coda
+.coda.json
+.DS_Store
+.vscode
+node_modules
+artifacts
+dist/test
+yarn-error.log
+local-docs
+site
+.coda-pack.json
+.coda-credentials.json


### PR DESCRIPTION
There are some animated .gif files in the documentation that account for nearly all of the node module size.

Tested by running `npm pack` and observing that the docs/ and site/ directories were omitted from the generated tarball