### PR TITLE
Add samples index page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 dist/** linguist-generated
 docs/embedded-snippets/** linguist-generated
 docs/reference/sdk/** linguist-generated
-docs/samples/** linguist-generated
+docs/samples/*/** linguist-generated
 documentation/generated/** linguist-generated

--- a/dist/documentation/types.d.ts
+++ b/dist/documentation/types.d.ts
@@ -20,6 +20,8 @@ export interface CompiledExampleSnippet {
 }
 export interface Example {
     name: string;
+    description: string;
+    icon?: string;
     category: ExampleCategory;
     triggerTokens: string[];
     linkData: LinkData;
@@ -28,6 +30,8 @@ export interface Example {
 }
 export interface CompiledExample {
     name: string;
+    description: string;
+    icon?: string;
     category: ExampleCategory;
     triggerTokens: string[];
     exampleFooterLink: string;

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -75,23 +75,10 @@ li.no {
   }
 }
 
-.landing-box-row {
-  gap: 1em;
-}
-
 .landing-item {
   flex: 1;
   display: flex;
   flex-direction: column;
-}
-
-.landing-box-row .landing-item {
-  border: .05rem solid var(--md-default-fg-color--lightest);
-  padding: 0 2em;
-}
-
-.landing-box-row .landing-item p:first-of-type {
-  flex: 1;
 }
 
 .tutorial-row {
@@ -113,4 +100,26 @@ li.no {
 .tutorial-row img.screenshot {
   box-shadow: none;
   border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.box-row {
+  display: grid;
+  gap: 1em;
+}
+
+@media (min-width: 800px) {
+  .box-row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.box-item {
+  border: .05rem solid var(--md-default-fg-color--lightest);
+  padding: 0 2em;
+  display: flex;
+  flex-direction: column;
+}
+
+.box-item p:first-of-type {
+  flex: 1;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,9 @@ Our templates and examples make it easy to get started, and in minutes you'll ha
 
 <br>
 
-<section class="landing-row landing-box-row" markdown>
+<section class="box-row" markdown>
 
-<div class="landing-item" markdown>
+<div class="box-item" markdown>
 ### :octicons-terminal-16: Command line tool
 
 Use the CLI to develop Packs on your local machine, where you can use the IDE, tooling, and version control of your choice.
@@ -57,7 +57,7 @@ Use the CLI to develop Packs on your local machine, where you can use the IDE, t
 [Install CLI][cli]{ .md-button }
 </div>
 
-<div class="landing-item" markdown>
+<div class="box-item" markdown>
 ### :material-application-braces-outline: Sample code
 
 From Math to GitHub to Cat Photos, we've got dozens of examples written covering all major aspects of the SDK.
@@ -65,7 +65,7 @@ From Math to GitHub to Cat Photos, we've got dozens of examples written covering
 [Browse samples][samples]{ .md-button }
 </div>
 
-<div class="landing-item" markdown>
+<div class="box-item" markdown>
 ### :fontawesome-solid-people-group: Community
 
 Our passionate community of Pack makers and Coda experts can help answer your questions or share tips to get you started.
@@ -106,7 +106,7 @@ Coda makers have been busy building Packs of all types, and many have published 
 [get_started]: tutorials/get-started/web.md
 [cli]: guides/development/cli.md
 [beta]: https://coda.io/packsbeta
-[samples]: samples/full/hello-world.md
+[samples]: samples/index.md
 [changelog]: reference/changes.md
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [gallery]: https://coda.io/gallery?filter=packs

--- a/docs/samples/.nav.yml
+++ b/docs/samples/.nav.yml
@@ -1,4 +1,5 @@
 nav:
+  - index.md
   - By topic: topic
   - full
   - CLI examples on GitHub: https://github.com/coda/packs-examples

--- a/docs/samples/full/cats.md
+++ b/docs/samples/full/cats.md
@@ -1,5 +1,7 @@
 ---
 title: Cats
+description: A Pack that generates images of cats.
+icon: fontawesome/solid/cat
 ---
 
 # Cats sample

--- a/docs/samples/full/daylight.md
+++ b/docs/samples/full/daylight.md
@@ -1,5 +1,7 @@
 ---
 title: Daylight
+description: A Pack that fetches data about the expected hours of daylight at a location.
+icon: fontawesome/regular/sun
 ---
 
 # Daylight sample

--- a/docs/samples/full/dnd.md
+++ b/docs/samples/full/dnd.md
@@ -1,8 +1,10 @@
 ---
-title: Dungeons and Dragons
+title: Dungeons &amp; Dragons
+description: A Pack that uses an API to retrieve information about the game Dungeons &amp; Dragons.
+icon: fontawesome/solid/dragon
 ---
 
-# Dungeons and Dragons sample
+# Dungeons &amp; Dragons sample
 
 This Pack allows you to fetch information about spells in th game Dungeons and Dragons using the [D&D 5e API][dnd]. The Pack provides:
 

--- a/docs/samples/full/github.md
+++ b/docs/samples/full/github.md
@@ -1,5 +1,7 @@
 ---
 title: GitHub
+description: A Pack that integrates with GitHub.
+icon: fontawesome/brands/github
 ---
 
 # GitHub sample

--- a/docs/samples/full/hello-world.md
+++ b/docs/samples/full/hello-world.md
@@ -1,5 +1,7 @@
 ---
 title: Hello World
+description: A simple &quot;Hello World&quot; Pack.
+icon: material/hand-wave-outline
 ---
 
 # Hello World sample

--- a/docs/samples/full/math.md
+++ b/docs/samples/full/math.md
@@ -1,5 +1,7 @@
 ---
 title: Math
+description: A Pack that provides various math operations.
+icon: material/calculator-variant
 ---
 
 # Math sample

--- a/docs/samples/full/todoist.md
+++ b/docs/samples/full/todoist.md
@@ -1,5 +1,7 @@
 ---
 title: Todoist
+description: A Pack that integrates with the application Todoist.
+icon: octicons/tasklist-16
 ---
 
 # Todoist sample

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,0 +1,37 @@
+---
+title: Samples
+hide:
+- toc
+---
+
+# Sample code
+
+No need to start from scratch; we've got dozens of sample Packs for your to browse, copy, and learn from. Small Packs that demonstrate a single feature are organized by topic, while the larger and more complete Packs each have their own page.
+
+{% for section in page.parent.children|selectattr("is_section") %}
+
+## {{section.title}}
+
+<section class="box-row" markdown>
+
+{% for page in section.children %}
+
+<div class="box-item" markdown>
+{# Read the page's source, but don't output anything. This is required to populate the page title and metadata. #}
+{{ page.read_source(config) or "" }}
+
+### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{page.title}}
+
+{{page.meta.description}}
+
+[View]({{fix_url(page.url)}}){ .md-button }
+</div>
+
+{% endfor %}
+
+</section>
+
+{% endfor %}
+
+
+[packs_examples]: https://github.com/coda/packs-examples

--- a/docs/samples/topic/action.md
+++ b/docs/samples/topic/action.md
@@ -1,5 +1,7 @@
 ---
 title: Actions
+description: Samples that show how to create an action formula, for use in a button or automation.
+icon: material/cursor-default-click-outline
 ---
 
 # Action samples

--- a/docs/samples/topic/apis.md
+++ b/docs/samples/topic/apis.md
@@ -1,5 +1,7 @@
 ---
 title: API setup
+description: Samples that show how to configure a Pack to connect to various popular APIs.
+icon: material/api
 ---
 
 # API setup samples

--- a/docs/samples/topic/authentication.md
+++ b/docs/samples/topic/authentication.md
@@ -1,5 +1,7 @@
 ---
 title: Authentication
+description: Samples that show how to authenticate with an API.
+icon: material/account-key
 ---
 
 # Authentication samples

--- a/docs/samples/topic/autocomplete.md
+++ b/docs/samples/topic/autocomplete.md
@@ -1,5 +1,7 @@
 ---
 title: Autocomplete
+description: Samples that show how to provide autocomplete options for a parameter.
+icon: material/form-dropdown
 ---
 
 # Autocomplete samples

--- a/docs/samples/topic/column-format.md
+++ b/docs/samples/topic/column-format.md
@@ -1,5 +1,7 @@
 ---
 title: Column formats
+description: Samples that show how to create a column format.
+icon: material/table-column
 ---
 
 # Column format samples

--- a/docs/samples/topic/data-type.md
+++ b/docs/samples/topic/data-type.md
@@ -1,5 +1,7 @@
 ---
 title: Data types
+description: Samples that show how to return values of various data types.
+icon: material/format-list-group
 ---
 
 # Data type samples

--- a/docs/samples/topic/dates.md
+++ b/docs/samples/topic/dates.md
@@ -1,5 +1,7 @@
 ---
 title: Dates and times
+description: Samples that show how to work with dates and times.
+icon: material/calendar-clock
 ---
 
 # Dates and time samples

--- a/docs/samples/topic/dynamic-sync-table.md
+++ b/docs/samples/topic/dynamic-sync-table.md
@@ -1,5 +1,7 @@
 ---
 title: Dynamic sync tables
+description: Samples that show how to create a dynamic sync table.
+icon: material/cloud-sync-outline
 ---
 
 # Dynamic sync table samples

--- a/docs/samples/topic/fetcher.md
+++ b/docs/samples/topic/fetcher.md
@@ -1,5 +1,7 @@
 ---
 title: Fetcher
+description: Samples that show how to fetch data from an external source.
+icon: fontawesome/solid/cloud-arrow-down
 ---
 
 # Fetcher samples

--- a/docs/samples/topic/formula.md
+++ b/docs/samples/topic/formula.md
@@ -1,5 +1,7 @@
 ---
 title: Formulas
+description: Samples that show how to create a formula.
+icon: material/function
 ---
 
 # Formula samples

--- a/docs/samples/topic/image.md
+++ b/docs/samples/topic/image.md
@@ -1,5 +1,7 @@
 ---
 title: Images
+description: Samples that show how to work with images.
+icon: material/image
 ---
 
 # Image samples

--- a/docs/samples/topic/parameter.md
+++ b/docs/samples/topic/parameter.md
@@ -1,5 +1,7 @@
 ---
 title: Parameters
+description: Samples that show how to accept parameters from the user.
+icon: material/format-textbox
 ---
 
 # Parameter samples

--- a/docs/samples/topic/schema.md
+++ b/docs/samples/topic/schema.md
@@ -1,5 +1,7 @@
 ---
 title: Schemas
+description: Samples that show how to define a schema, to represent rich objects.
+icon: material/receipt-outline
 ---
 
 # Schema samples

--- a/docs/samples/topic/sync-table.md
+++ b/docs/samples/topic/sync-table.md
@@ -1,5 +1,7 @@
 ---
 title: Sync tables
+description: Samples that show how to create a sync table.
+icon: material/table-sync
 ---
 
 # Sync table samples

--- a/documentation/example_page_template.md
+++ b/documentation/example_page_template.md
@@ -1,5 +1,7 @@
 ---
 title: {{name}}
+description: {{description}}
+{{#if icon}}icon: {{icon}}{{/if}}
 ---
 
 # {{pageTitle this}}

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -1,6 +1,8 @@
 [
   {
     "name": "Column formats",
+    "description": "Samples that show how to create a column format.",
+    "icon": "material/table-column",
     "category": "Topic",
     "triggerTokens": [
       "addColumnFormat"
@@ -47,6 +49,8 @@
   },
   {
     "name": "Authentication",
+    "description": "Samples that show how to authenticate with an API.",
+    "icon": "material/account-key",
     "category": "Topic",
     "triggerTokens": [
       "setSystemAuthentication",
@@ -114,6 +118,8 @@
   },
   {
     "name": "Dynamic sync tables",
+    "description": "Samples that show how to create a dynamic sync table.",
+    "icon": "material/cloud-sync-outline",
     "category": "Topic",
     "triggerTokens": [
       "addDynamicSyncTable"
@@ -140,6 +146,8 @@
   },
   {
     "name": "Formulas",
+    "description": "Samples that show how to create a formula.",
+    "icon": "material/function",
     "category": "Topic",
     "triggerTokens": [
       "addFormula"
@@ -176,6 +184,8 @@
   },
   {
     "name": "Actions",
+    "description": "Samples that show how to create an action formula, for use in a button or automation.",
+    "icon": "material/cursor-default-click-outline",
     "category": "Topic",
     "triggerTokens": [
       "isAction"
@@ -212,6 +222,8 @@
   },
   {
     "name": "Parameters",
+    "description": "Samples that show how to accept parameters from the user.",
+    "icon": "material/format-textbox",
     "category": "Topic",
     "triggerTokens": [
       "makeParameter"
@@ -288,6 +300,8 @@
   },
   {
     "name": "Autocomplete",
+    "description": "Samples that show how to provide autocomplete options for a parameter.",
+    "icon": "material/form-dropdown",
     "category": "Topic",
     "triggerTokens": [
       "autocomplete"
@@ -319,6 +333,8 @@
   },
   {
     "name": "Sync tables",
+    "description": "Samples that show how to create a sync table.",
+    "icon": "material/table-sync",
     "category": "Topic",
     "triggerTokens": [
       "addSyncTable"
@@ -360,6 +376,8 @@
   },
   {
     "name": "Fetcher",
+    "description": "Samples that show how to fetch data from an external source.",
+    "icon": "fontawesome/solid/cloud-arrow-down",
     "category": "Topic",
     "triggerTokens": [
       "fetch"
@@ -391,6 +409,8 @@
   },
   {
     "name": "Data types",
+    "description": "Samples that show how to return values of various data types.",
+    "icon": "material/format-list-group",
     "category": "Topic",
     "triggerTokens": [
       "resultType",
@@ -468,6 +488,8 @@
   },
   {
     "name": "Schemas",
+    "description": "Samples that show how to define a schema, to represent rich objects.",
+    "icon": "material/receipt-outline",
     "category": "Topic",
     "triggerTokens": [
       "makeSchema",
@@ -505,6 +527,8 @@
   },
   {
     "name": "Dates and times",
+    "description": "Samples that show how to work with dates and times.",
+    "icon": "material/calendar-clock",
     "category": "Topic",
     "triggerTokens": [
       "Date",
@@ -548,6 +572,8 @@
   },
   {
     "name": "Images",
+    "description": "Samples that show how to work with images.",
+    "icon": "material/image",
     "category": "Topic",
     "triggerTokens": [
       "ImageReference",
@@ -607,6 +633,8 @@
   },
   {
     "name": "API setup",
+    "description": "Samples that show how to configure a Pack to connect to various popular APIs.",
+    "icon": "material/api",
     "category": "Topic",
     "triggerTokens": [],
     "linkData": {
@@ -704,6 +732,8 @@
   },
   {
     "name": "Hello World",
+    "description": "A simple \"Hello World\" Pack.",
+    "icon": "material/hand-wave-outline",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -721,6 +751,8 @@
   },
   {
     "name": "Daylight",
+    "description": "A Pack that fetches data about the expected hours of daylight at a location.",
+    "icon": "fontawesome/regular/sun",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -738,6 +770,8 @@
   },
   {
     "name": "Math",
+    "description": "A Pack that provides various math operations.",
+    "icon": "material/calculator-variant",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -755,6 +789,8 @@
   },
   {
     "name": "Todoist",
+    "description": "A Pack that integrates with the application Todoist.",
+    "icon": "octicons/tasklist-16",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -772,6 +808,8 @@
   },
   {
     "name": "Cats",
+    "description": "A Pack that generates images of cats.",
+    "icon": "fontawesome/solid/cat",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -788,7 +826,9 @@
     ]
   },
   {
-    "name": "Dungeons and Dragons",
+    "name": "Dungeons & Dragons",
+    "description": "A Pack that uses an API to retrieve information about the game Dungeons & Dragons.",
+    "icon": "fontawesome/solid/dragon",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {
@@ -806,6 +846,8 @@
   },
   {
     "name": "GitHub",
+    "description": "A Pack that integrates with GitHub.",
+    "icon": "fontawesome/brands/github",
     "category": "Full",
     "triggerTokens": [],
     "linkData": {

--- a/documentation/scripts/documentation_compiler.ts
+++ b/documentation/scripts/documentation_compiler.ts
@@ -68,6 +68,8 @@ function compileExamples() {
     }
     const compiledExample = {
       name: example.name,
+      description: example.description,
+      icon: example.icon,
       category: example.category,
       triggerTokens: example.triggerTokens,
       linkData: example.linkData,

--- a/documentation/scripts/documentation_config.ts
+++ b/documentation/scripts/documentation_config.ts
@@ -169,6 +169,8 @@ export const Snippets: AutocompleteSnippet[] = [
 export const Examples: Example[] = [
   {
     name: 'Column formats',
+    description: 'Samples that show how to create a column format.',
+    icon: 'material/table-column',
     category: ExampleCategory.Topic,
     triggerTokens: ['addColumnFormat'],
     contentFile: './examples/column-format/README.md',
@@ -215,6 +217,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Authentication',
+    description: 'Samples that show how to authenticate with an API.',
+    icon: 'material/account-key',
     category: ExampleCategory.Topic,
     triggerTokens: ['setSystemAuthentication', 'setUserAuthentication'],
     contentFile: './examples/authentication/README.md',
@@ -283,6 +287,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Dynamic sync tables',
+    description: 'Samples that show how to create a dynamic sync table.',
+    icon: 'material/cloud-sync-outline',
     category: ExampleCategory.Topic,
     triggerTokens: ['addDynamicSyncTable'],
     contentFile: './examples/dynamic-sync-table/README.md',
@@ -306,6 +312,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Formulas',
+    description: 'Samples that show how to create a formula.',
+    icon: 'material/function',
     category: ExampleCategory.Topic,
     triggerTokens: ['addFormula'],
     contentFile: './examples/formula/README.md',
@@ -342,6 +350,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Actions',
+    description: 'Samples that show how to create an action formula, for use in a button or automation.',
+    icon: 'material/cursor-default-click-outline',
     category: ExampleCategory.Topic,
     triggerTokens: ['isAction'],
     contentFile: './examples/action/README.md',
@@ -376,6 +386,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Parameters',
+    description: 'Samples that show how to accept parameters from the user.',
+    icon: 'material/format-textbox',
     category: ExampleCategory.Topic,
     triggerTokens: ['makeParameter'],
     contentFile: './examples/parameter/README.md',
@@ -456,6 +468,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Autocomplete',
+    description: 'Samples that show how to provide autocomplete options for a parameter.',
+    icon: 'material/form-dropdown',
     category: ExampleCategory.Topic,
     triggerTokens: ['autocomplete'],
     contentFile: './examples/autocomplete/README.md',
@@ -486,6 +500,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Sync tables',
+    description: 'Samples that show how to create a sync table.',
+    icon: 'material/table-sync',
     category: ExampleCategory.Topic,
     triggerTokens: ['addSyncTable'],
     contentFile: './examples/sync-table/README.md',
@@ -526,6 +542,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Fetcher',
+    description: 'Samples that show how to fetch data from an external source.',
+    icon: 'fontawesome/solid/cloud-arrow-down',
     category: ExampleCategory.Topic,
     triggerTokens: ['fetch'],
     contentFile: './examples/fetcher/README.md',
@@ -553,6 +571,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Data types',
+    description: 'Samples that show how to return values of various data types.',
+    icon: 'material/format-list-group',
     category: ExampleCategory.Topic,
     triggerTokens: ['resultType', 'type'],
     contentFile: './examples/data-type/README.md',
@@ -631,6 +651,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Schemas',
+    description: 'Samples that show how to define a schema, to represent rich objects.',
+    icon: 'material/receipt-outline',
     category: ExampleCategory.Topic,
     triggerTokens: ['makeSchema', 'makeObjectSchema'],
     contentFile: './examples/schema/README.md',
@@ -666,6 +688,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Dates and times',
+    description: 'Samples that show how to work with dates and times.',
+    icon: 'material/calendar-clock',
     category: ExampleCategory.Topic,
     triggerTokens: ['Date', 'Time', 'DateTime'],
     contentFile: './examples/dates/README.md',
@@ -707,6 +731,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Images',
+    description: 'Samples that show how to work with images.',
+    icon: 'material/image',
     category: ExampleCategory.Topic,
     triggerTokens: ['ImageReference', 'ImageAttachment', 'Image', 'ImageArray'],
     contentFile: './examples/image/README.md',
@@ -765,6 +791,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'API setup',
+    description: 'Samples that show how to configure a Pack to connect to various popular APIs.',
+    icon: 'material/api',
     category: ExampleCategory.Topic,
     triggerTokens: [],
     contentFile: './examples/apis/README.md',
@@ -861,6 +889,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Hello World',
+    description: 'A simple "Hello World" Pack.',
+    icon: 'material/hand-wave-outline',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/hello_world/README.md',
@@ -877,6 +907,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Daylight',
+    description: 'A Pack that fetches data about the expected hours of daylight at a location.',
+    icon: 'fontawesome/regular/sun',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/daylight/README.md',
@@ -893,6 +925,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Math',
+    description: 'A Pack that provides various math operations.',
+    icon: 'material/calculator-variant',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/math/README.md',
@@ -909,6 +943,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Todoist',
+    description: 'A Pack that integrates with the application Todoist.',
+    icon: 'octicons/tasklist-16',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/todoist/README.md',
@@ -925,6 +961,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'Cats',
+    description: 'A Pack that generates images of cats.',
+    icon: 'fontawesome/solid/cat',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/cats/README.md',
@@ -940,7 +978,9 @@ export const Examples: Example[] = [
     ],
   },
   {
-    name: 'Dungeons and Dragons',
+    name: 'Dungeons & Dragons',
+    description: 'A Pack that uses an API to retrieve information about the game Dungeons & Dragons.',
+    icon: 'fontawesome/solid/dragon',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/dnd/README.md',
@@ -957,6 +997,8 @@ export const Examples: Example[] = [
   },
   {
     name: 'GitHub',
+    description: 'A Pack that integrates with GitHub.',
+    icon: 'fontawesome/brands/github',
     category: ExampleCategory.Full,
     triggerTokens: [],
     contentFile: './examples/github/README.md',

--- a/documentation/types.ts
+++ b/documentation/types.ts
@@ -25,6 +25,8 @@ export interface CompiledExampleSnippet {
 
 export interface Example {
   name: string;
+  description: string;
+  icon?: string;
   category: ExampleCategory;
   triggerTokens: string[];
   linkData: LinkData;
@@ -34,6 +36,8 @@ export interface Example {
 
 export interface CompiledExample {
   name: string;
+  description: string;
+  icon?: string;
   category: ExampleCategory;
   triggerTokens: string[];
   exampleFooterLink: string;


### PR DESCRIPTION
Adds an index page for our samples, making it easier to link to all of the sample instead of a specific category. Uses a Python  macro to automatically generate the table from the navigation, so it remains in sync. Added a description and optional icon for each sample page to improve the UX.

Staged: https://coda-packs-sdk--2047.com.readthedocs.build/en/2047/samples/