### PR TITLE
add manual release flow step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,14 @@
-
-on: 
+on:
   workflow_dispatch:
     inputs:
       increment:
-        description: 'Release version increment'     
+        description: 'Release version increment'
         required: true
         type: choice
         options:
           - patch
           - minor
-          - major 
+          - major
 
 jobs:
   release:
@@ -22,6 +21,7 @@ jobs:
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - run: make _bootstrap-node
       - run: make release $INCREMENT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,10 @@
 on:
   workflow_dispatch:
     inputs:
-      increment:
-        description: 'Release version increment'
+      version:
+        description: 'Release version increment (choose from "patch", "minor", "major", or a valid semantic version e.g. "1.12.2")'
         required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+        type: string
 
 jobs:
   release:
@@ -22,7 +18,7 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - run: make _bootstrap-node
-      - run: make release $INCREMENT
+      - run: make release $VERSION
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INCREMENT: ${{ github.event.inputs.increment }}
+          VERSION: ${{ github.event.inputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local-docs
 site
 .coda-pack.json
 .coda-credentials.json
+.npmrc

--- a/Makefile
+++ b/Makefile
@@ -247,16 +247,22 @@ release:
 	@echo "Checking for uncommitted/untracked changes..." && test -z "`git status --porcelain | grep -vE ''`" || \
 		(echo "Refusing to publish with these uncommitted/untracked changes:" && \
 		git status --porcelain | grep -vE '' && false)
-	# TODO(spencer): uncomment below when we move to auto release flow
-	# @echo "Checking for main branch..." && test main = "`git rev-parse --abbrev-ref HEAD`" || \
-	# 	(echo "Refusing to publish from non-main branch `git rev-parse --abbrev-ref HEAD`" && false)
-	# @echo "Checking for unpushed commits..." && git fetch
-	# @test "" = "`git cherry`" || (echo "Refusing to publish with unpushed commits" && false)
+	@echo "Checking for main branch..." && test main = "`git rev-parse --abbrev-ref HEAD`" || \
+		(echo "Refusing to publish from non-main branch `git rev-parse --abbrev-ref HEAD`" && false)
+	@echo "Checking for unpushed commits..." && git fetch
+	@test "" = "`git cherry`" || (echo "Refusing to publish with unpushed commits" && false)
 
-	# TODO(spencer): support specifying version and passing in here, takes in `minor`, `major`, or `patch`.
+	npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
 	npx release-it --npm.tag=latest --ci ${FLAGS}
 
-# TODO(spencer): after new releaes flow is in use, remove this
-.PHONY: npm-publish
-npm-publish:
-	npm publish --tag alpha --tag latest --access public
+.PHONY: release-manual
+release-manual:
+	# this set is taken from esbuild's process https://github.com/evanw/esbuild/blob/master/Makefile#L330
+	@npm --version > /dev/null || (echo "The 'npm' command must be in your path to-*///// publish" && false)
+	@echo "Checking for uncommitted/untracked changes..." && test -z "`git status --porcelain | grep -vE ''`" || \
+		(echo "Refusing to publish with these uncommitted/untracked changes:" && \
+		git status --porcelain | grep -vE '' && false)
+	@echo "Checking for unpushed commits..." && git fetch
+	@test "" = "`git cherry`" || (echo "Refusing to publish with unpushed commits" && false)
+
+	npx release-it --npm.tag=latest


### PR DESCRIPTION
spent a bit of time investigating this flow after going through it with @dweitzman-codaio and updating to at least have a single command that we can run manually along with some instructions on how to do so.

https://staging.coda.io/d/Packs-Platform-IA-o-packs_d36WK4zgrYx/Releasing-Packs-SDK-Versions_suerz#_luCH6

here's a video of what it looks like (the command is now `make release-manual`)
https://www.loom.com/share/9e85cf7638434e8d8feb1f242a8616e9


The automated flow still won't quite work because it needs to be set up with some NPM tokens and such, but I think that's something we can tackle down the line as we get more rigorous with regular deployment

@coda/packs @jonathan-codaio 