### PR TITLE
add default allowed get domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 - Added validation that `networkDomain` does not include slashes since it's a domain, not a path.
 - Changed Pack compilation to explicitly target Node version 14, to ensure compatibility with the Packs runtime.
 - Added parameter type validation for `execute` command.
+- Added several implicitly-allowed domains including codahosted.io to the `execute` command. 
 
 ## [1.0.0] - 2022-06-16
 

--- a/dist/testing/constants.d.ts
+++ b/dist/testing/constants.d.ts
@@ -1,4 +1,4 @@
 export declare enum HttpStatusCode {
     Unauthorized = 401
 }
-export declare const DEFAULT_ALLOWED_GET_DOMAINS: string[];
+export declare const DEFAULT_ALLOWED_GET_DOMAINS_REGEXES: RegExp[];

--- a/dist/testing/constants.d.ts
+++ b/dist/testing/constants.d.ts
@@ -1,3 +1,4 @@
 export declare enum HttpStatusCode {
     Unauthorized = 401
 }
+export declare const DEFAULT_ALLOWED_GET_DOMAINS: string[];

--- a/dist/testing/constants.js
+++ b/dist/testing/constants.js
@@ -1,15 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.DEFAULT_ALLOWED_GET_DOMAINS = exports.HttpStatusCode = void 0;
+exports.DEFAULT_ALLOWED_GET_DOMAINS_REGEXES = exports.HttpStatusCode = void 0;
 var HttpStatusCode;
 (function (HttpStatusCode) {
     HttpStatusCode[HttpStatusCode["Unauthorized"] = 401] = "Unauthorized";
 })(HttpStatusCode = exports.HttpStatusCode || (exports.HttpStatusCode = {}));
-exports.DEFAULT_ALLOWED_GET_DOMAINS = [
-    'coda-us-west-2-prod-blobs-upload.s3.us-west-2.amazonaws.com',
-    'coda-us-west-2-staging-blobs-upload.s3.us-west-2.amazonaws.com',
-    'coda-us-west-2-head-blobs-upload.s3.us-west-2.amazonaws.com',
-    'coda-us-west-2-adhoc-blobs-upload.s3.us-west-2.amazonaws.com',
-    'coda-us-west-2-dev-blobs-upload.s3.us-west-2.amazonaws.com',
-    'codahosted.io',
+// Note that this should be kept in sync with the "PacksAllowedPublicDomains" runtime config 
+exports.DEFAULT_ALLOWED_GET_DOMAINS_REGEXES = [
+    /^coda-us-west-2-\w+-blobs-upload\.s3\.us-west-2\.amazonaws\.com$/,
+    /^codahosted\.io$/,
 ];

--- a/dist/testing/constants.js
+++ b/dist/testing/constants.js
@@ -1,7 +1,15 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.HttpStatusCode = void 0;
+exports.DEFAULT_ALLOWED_GET_DOMAINS = exports.HttpStatusCode = void 0;
 var HttpStatusCode;
 (function (HttpStatusCode) {
     HttpStatusCode[HttpStatusCode["Unauthorized"] = 401] = "Unauthorized";
 })(HttpStatusCode = exports.HttpStatusCode || (exports.HttpStatusCode = {}));
+exports.DEFAULT_ALLOWED_GET_DOMAINS = [
+    'coda-us-west-2-prod-blobs-upload.s3.us-west-2.amazonaws.com',
+    'coda-us-west-2-staging-blobs-upload.s3.us-west-2.amazonaws.com',
+    'coda-us-west-2-head-blobs-upload.s3.us-west-2.amazonaws.com',
+    'coda-us-west-2-adhoc-blobs-upload.s3.us-west-2.amazonaws.com',
+    'coda-us-west-2-dev-blobs-upload.s3.us-west-2.amazonaws.com',
+    'codahosted.io',
+];

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -437,7 +437,7 @@ class AuthenticatingFetcher {
         const host = parsed.host.toLowerCase();
         const allowedDomains = this._networkDomains || [];
         if (!allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`)) &&
-            !(method === 'GET' ? constants_1.DEFAULT_ALLOWED_GET_DOMAINS : []).map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))) {
+            !(method === 'GET' ? constants_1.DEFAULT_ALLOWED_GET_DOMAINS_REGEXES : []).some(domain => domain.test(host.toLowerCase()))) {
             throw new Error(`Attempted to connect to undeclared host '${host}'`);
         }
     }

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -7,6 +7,7 @@ exports.newFetcherSyncExecutionContext = exports.newFetcherExecutionContext = ex
 const client_sts_1 = require("@aws-sdk/client-sts");
 const types_1 = require("../types");
 const constants_1 = require("./constants");
+const constants_2 = require("./constants");
 const client_sts_2 = require("@aws-sdk/client-sts");
 const sha256_js_1 = require("@aws-crypto/sha256-js");
 const signature_v4_1 = require("@aws-sdk/signature-v4");
@@ -44,7 +45,7 @@ class AuthenticatingFetcher {
     async fetch(request, isRetry) {
         var _a;
         const { url, headers, body, form } = await this._applyAuthentication(request);
-        this._validateHost(url);
+        this._validateHost(url, request.method);
         let response;
         try {
             response = await exports.requestHelper.makeRequest({
@@ -137,7 +138,7 @@ class AuthenticatingFetcher {
         if (!this._authDef || !this._credentials || !this._updateCredentialsCallback) {
             return false;
         }
-        if (requestFailure.statusCode !== constants_1.HttpStatusCode.Unauthorized || this._authDef.type !== types_1.AuthenticationType.OAuth2) {
+        if (requestFailure.statusCode !== constants_2.HttpStatusCode.Unauthorized || this._authDef.type !== types_1.AuthenticationType.OAuth2) {
             return false;
         }
         const { accessToken, refreshToken } = this._credentials;
@@ -176,7 +177,7 @@ class AuthenticatingFetcher {
             body: formParamsWithSecret,
             headers,
         });
-        if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
+        if (oauthResponse.status === constants_2.HttpStatusCode.Unauthorized) {
             // see testing/oauth_server.ts why we retry with header auth.
             headers.append('Authorization', `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`);
             oauthResponse = await fetch(tokenUrl, {
@@ -431,11 +432,12 @@ class AuthenticatingFetcher {
             return prefixUrl + path;
         }
     }
-    _validateHost(url) {
+    _validateHost(url, method) {
         const parsed = new url_1.URL(url);
         const host = parsed.host.toLowerCase();
         const allowedDomains = this._networkDomains || [];
-        if (!allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))) {
+        if (!allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`)) &&
+            !(method === 'GET' ? constants_1.DEFAULT_ALLOWED_GET_DOMAINS : []).map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))) {
             throw new Error(`Attempted to connect to undeclared host '${host}'`);
         }
     }

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1,3 +1,12 @@
 export enum HttpStatusCode {
   Unauthorized = 401,
 }
+
+export const DEFAULT_ALLOWED_GET_DOMAINS = [
+  'coda-us-west-2-prod-blobs-upload.s3.us-west-2.amazonaws.com',
+  'coda-us-west-2-staging-blobs-upload.s3.us-west-2.amazonaws.com',
+  'coda-us-west-2-head-blobs-upload.s3.us-west-2.amazonaws.com',
+  'coda-us-west-2-adhoc-blobs-upload.s3.us-west-2.amazonaws.com',
+  'coda-us-west-2-dev-blobs-upload.s3.us-west-2.amazonaws.com',
+  'codahosted.io',
+]

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2,11 +2,8 @@ export enum HttpStatusCode {
   Unauthorized = 401,
 }
 
-export const DEFAULT_ALLOWED_GET_DOMAINS = [
-  'coda-us-west-2-prod-blobs-upload.s3.us-west-2.amazonaws.com',
-  'coda-us-west-2-staging-blobs-upload.s3.us-west-2.amazonaws.com',
-  'coda-us-west-2-head-blobs-upload.s3.us-west-2.amazonaws.com',
-  'coda-us-west-2-adhoc-blobs-upload.s3.us-west-2.amazonaws.com',
-  'coda-us-west-2-dev-blobs-upload.s3.us-west-2.amazonaws.com',
-  'codahosted.io',
+// Note that this should be kept in sync with the "PacksAllowedPublicDomains" runtime config 
+export const DEFAULT_ALLOWED_GET_DOMAINS_REGEXES = [
+  /^coda-us-west-2-\w+-blobs-upload\.s3\.us-west-2\.amazonaws\.com$/,
+  /^codahosted\.io$/,
 ]

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -6,7 +6,7 @@ import type {Authentication} from '../types';
 import {AuthenticationType} from '../types';
 import type {Credentials} from './auth_types';
 import type {CustomCredentials} from './auth_types';
-import {DEFAULT_ALLOWED_GET_DOMAINS} from './constants';
+import {DEFAULT_ALLOWED_GET_DOMAINS_REGEXES} from './constants';
 import type {ExecutionContext} from '../api';
 import type {FetchMethodType} from '../api_types';
 import type {FetchRequest} from '../api_types';
@@ -569,7 +569,7 @@ export class AuthenticatingFetcher implements Fetcher {
     const allowedDomains = this._networkDomains || [];
     if (
       !allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`)) &&
-      !(method === 'GET' ? DEFAULT_ALLOWED_GET_DOMAINS : []).map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))
+      !(method === 'GET' ? DEFAULT_ALLOWED_GET_DOMAINS_REGEXES : []).some(domain => domain.test(host.toLowerCase()))
     ) {
       throw new Error(`Attempted to connect to undeclared host '${host}'`);
     }

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -6,7 +6,9 @@ import type {Authentication} from '../types';
 import {AuthenticationType} from '../types';
 import type {Credentials} from './auth_types';
 import type {CustomCredentials} from './auth_types';
+import {DEFAULT_ALLOWED_GET_DOMAINS} from './constants';
 import type {ExecutionContext} from '../api';
+import type {FetchMethodType} from '../api_types';
 import type {FetchRequest} from '../api_types';
 import type {FetchResponse} from '../api_types';
 import type {Fetcher} from '../api_types';
@@ -82,7 +84,7 @@ export class AuthenticatingFetcher implements Fetcher {
 
   async fetch<T = any>(request: FetchRequest, isRetry?: boolean): Promise<FetchResponse<T>> {
     const {url, headers, body, form} = await this._applyAuthentication(request);
-    this._validateHost(url);
+    this._validateHost(url, request.method);
 
     let response: FetcherFullResponse;
 
@@ -561,12 +563,13 @@ export class AuthenticatingFetcher implements Fetcher {
     }
   }
 
-  private _validateHost(url: string): void {
+  private _validateHost(url: string, method: FetchMethodType): void {
     const parsed = new URL(url);
     const host = parsed.host.toLowerCase();
     const allowedDomains = this._networkDomains || [];
     if (
-      !allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))
+      !allowedDomains.map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`)) &&
+      !(method === 'GET' ? DEFAULT_ALLOWED_GET_DOMAINS : []).map(domain => domain.toLowerCase()).some(domain => host === domain || host.endsWith(`.${domain}`))
     ) {
       throw new Error(`Attempted to connect to undeclared host '${host}'`);
     }


### PR DESCRIPTION
For https://coda-final.oslash.com/o/bug/23665

Verified this works with
```import * as coda from "@codahq/packs-sdk";
export const pack = coda.newPack();

// Regular expression that matches Coda-hosted images.
const HostedImageUrlRegex = new RegExp("^https://(?:[^/]*\.)?codahosted.io/.*");

// Formula that calculates the file size of an image.
pack.addFormula({
  name: "FileSize",
  description: "Gets the file size of an image, in bytes.",
  parameters: [
    coda.makeParameter({
      type: coda.ParameterType.Image,
      name: "image",
      description:
        "The image to operate on. Not compatible with Image URL columns.",
    }),
  ],
  resultType: coda.ValueType.Number,
  execute: async function ([imageUrl], context) {
    // Throw an error if the image isn't Coda-hosted. Image URL columns can
    // contain images on any domain, but by default Packs can only access image
    // attachments hosted on codahosted.io.
    if (!imageUrl.match(HostedImageUrlRegex)) {
      throw new coda.UserVisibleError("Not compatible with Image URL columns.");
    }
    // Fetch the image content.
    let response = await context.fetcher.fetch({
      method: "GET",
      url: imageUrl,
      isBinaryResponse: true, // Required when fetching binary content.
    });
    // The binary content of the response is returned as a Node.js Buffer.
    // See: https://nodejs.org/api/buffer.html
    let buffer = response.body as Buffer;
    // Return the length, in bytes.
    return buffer.length;
  },
});
```
![image](https://user-images.githubusercontent.com/100240943/175106357-28d9c929-bcd8-45d5-b16c-d81a3eee0c76.png)

Not sure there's a good way to keep this in sync with the runtime config on the coda side