### PR TITLE
Add tutorials landing page

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -123,3 +123,8 @@ li.no {
 .box-item p:first-of-type {
   flex: 1;
 }
+
+/* Hide the anchor link for headings in boxes. */
+.box-item .headerlink {
+  display: none;
+}

--- a/docs/tutorials/.nav.yml
+++ b/docs/tutorials/.nav.yml
@@ -1,4 +1,5 @@
 nav:
+  - Overview: index.md
   - get-started
   - Learn to build: build
   - ...

--- a/docs/tutorials/build/fetcher.md
+++ b/docs/tutorials/build/fetcher.md
@@ -1,5 +1,7 @@
 ---
 title: Call an API
+description: Learn how to call an external API from within a Pack.
+icon: material/api
 hide:
 - toc
 ---
@@ -9,7 +11,7 @@ hide:
 <section class="tutorial-row" markdown>
 <div markdown>
 
-One of the primary use cases for a Pack is to integrate with an external API, allowing users to bring in data or functionality not native to Coda. In this tutorial we'll create a formula that converts an amount of money in another currency to US dollars.
+One of the primary use cases for a Pack is to integrate with an external API, allowing users to bring in data or functionality not native to Coda. In this tutorial you'll create a formula that converts an amount of money in another currency to US dollars.
 
 </div>
 <div markdown>

--- a/docs/tutorials/build/formula.md
+++ b/docs/tutorials/build/formula.md
@@ -1,5 +1,7 @@
 ---
 title: Basic formula
+description: Learn how to build a basic formula from scratch.
+icon: material/function
 hide:
 - toc
 ---

--- a/docs/tutorials/build/oauth.md
+++ b/docs/tutorials/build/oauth.md
@@ -1,5 +1,7 @@
 ---
 title: Using OAuth2
+description: Learn how to access private data in an API using OAuth2.
+icon: material/shield-key
 hide:
 - toc
 ---
@@ -11,7 +13,7 @@ hide:
 
 Before a Pack can use an API to fetch private data, it must first be given access by the user. The most popular technology for granting that authorization is OAuth2.
 
-In this tutorial we'll create a formula that access a user's tasks in the Todoist application, using their API and OAuth2.
+In this tutorial you'll create a formula that access a user's tasks in the Todoist application, using their API and OAuth2.
 
 </div>
 <div markdown>

--- a/docs/tutorials/get-started/cli.md
+++ b/docs/tutorials/get-started/cli.md
@@ -1,5 +1,7 @@
 ---
 title: On your local machine
+description: Build your first Pack on your local machine using the CLI.
+icon: octicons/terminal-16
 ---
 
 # Get started on your local machine

--- a/docs/tutorials/get-started/web.md
+++ b/docs/tutorials/get-started/web.md
@@ -1,5 +1,7 @@
 ---
 title: In the browser
+description: Build your first Pack in minutes using the Pack Studio web editor.
+icon: octicons/browser-16
 ---
 
 # Get started in the browser

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,34 @@
+---
+title: Tutorials
+hide:
+- toc
+---
+
+# Tutorials
+
+The tutorials below provide step-by-step instructions and sample code to help you get started building Packs and learn key concepts.
+
+{% for section in page.parent.children|selectattr("is_section") %}
+
+## {{section.title}}
+
+<section class="box-row" markdown>
+
+{% for page in section.children %}
+
+<div class="box-item" markdown>
+{# Read the page's source, but don't output anything. This is required to populate the page title and metadata. #}
+{{ page.read_source(config) or "" }}
+
+### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{page.title}}
+
+{% if page.meta.description %}{{page.meta.description}}{% endif %}
+
+[View]({{fix_url(page.url)}}){ .md-button }
+</div>
+
+{% endfor %}
+
+</section>
+
+{% endfor %}


### PR DESCRIPTION
Uses the same logic as the Samples index page. Added icons and descriptions to the existing tutorials to power it.

Staged: https://coda-packs-sdk--2078.com.readthedocs.build/en/2078/tutorials/