### PR TITLE
Upgrade TypeDoc markdown plugin

### DIFF
--- a/dist/documentation/typedoc_post_process.js
+++ b/dist/documentation/typedoc_post_process.js
@@ -48,7 +48,6 @@ async function process(file) {
     const buf = await fs.promises.readFile(file);
     let content = buf.toString();
     content = addFrontmatter(file, content);
-    content = fixCodeBlocks(file, content);
     return fs.promises.writeFile(file, content);
 }
 /**
@@ -68,11 +67,5 @@ function addFrontmatter(file, content) {
     const title = match[1];
     const frontmatter = `---\ntitle: "${title}"\n---\n`;
     return frontmatter + content;
-}
-/**
- * Fix code blocks. See https://github.com/tgreyuk/typedoc-plugin-markdown/issues/324#issuecomment-1175320510
- */
-function fixCodeBlocks(file, content) {
-    return content.replace(/^\s+```/gm, '```');
 }
 main().catch(helpers_1.print);

--- a/docs/reference/sdk/classes/core.PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/core.PackDefinitionBuilder.md
@@ -66,8 +66,6 @@ ___
 
 **`Deprecated`**
 
- 
-
 #### Implementation of
 
 BasicPackDefinition.formulaNamespace
@@ -163,6 +161,7 @@ Adds a column format definition to this pack.
 In the web editor, the `/ColumnFormat` shortcut will insert a snippet of a skeleton format.
 
 **`Example`**
+
 ```
 pack.addColumnFormat({
   name: 'MyColumn',
@@ -191,6 +190,7 @@ Adds a dynamic sync table definition to this pack.
 In the web editor, the `/DynamicSyncTable` shortcut will insert a snippet of a skeleton sync table.
 
 **`Example`**
+
 ```
 pack.addDynamicSyncTable({
   name: "MySyncTable",
@@ -236,6 +236,7 @@ Adds a formula definition to this pack.
 In the web editor, the `/Formula` shortcut will insert a snippet of a skeleton formula.
 
 **`Example`**
+
 ```
 pack.addFormula({
   resultType: ValueType.String,
@@ -290,6 +291,7 @@ You are allowed one network domain per pack by default. If your pack needs
 to connect to multiple domains, contact Coda Support for approval.
 
 **`Example`**
+
 ```
 pack.addNetworkDomain('example.com');
 ```
@@ -315,6 +317,7 @@ Adds a sync table definition to this pack.
 In the web editor, the `/SyncTable` shortcut will insert a snippet of a skeleton sync table.
 
 **`Example`**
+
 ```
 pack.addSyncTable({
   name: 'MySyncTable',
@@ -363,6 +366,7 @@ In the web editor, the `/SystemAuthentication` shortcut will insert a snippet of
 authentication definition.
 
 **`Example`**
+
 ```
 pack.setSystemAuthentication({
   type: AuthenticationType.HeaderBearerToken,
@@ -399,6 +403,7 @@ formula. To change the default, you can pass a `defaultConnectionRequirement` op
 this method.
 
 **`Example`**
+
 ```
 pack.setUserAuthentication({
   type: AuthenticationType.HeaderBearerToken,
@@ -429,6 +434,7 @@ and the web editor will automatically provide an appropriate semantic version
 each time you build a version.
 
 **`Example`**
+
 ```
 pack.setVersion('1.2.3');
 ```

--- a/docs/reference/sdk/classes/core.UserVisibleError.md
+++ b/docs/reference/sdk/classes/core.UserVisibleError.md
@@ -25,6 +25,7 @@ and the Coda UI will display the message.
 Use to construct a user-visible error.
 
 **`Example`**
+
 ```
 if (!url.startsWith("http")) {
   throw new coda.UserVisibleError("Please provide a valid url.");

--- a/docs/reference/sdk/enums/core.CurrencyFormat.md
+++ b/docs/reference/sdk/enums/core.CurrencyFormat.md
@@ -17,6 +17,7 @@ These affect how a numeric value is rendered in docs.
 
 Indicates the value should be rendered as a number with a currency symbol as a prefix, but padded
 to allow the numeric values to line up vertically, e.g.
+
 ```
 $       2.50
 $      29.99

--- a/docs/reference/sdk/enums/core.NetworkConnection.md
+++ b/docs/reference/sdk/enums/core.NetworkConnection.md
@@ -7,7 +7,7 @@ title: "NetworkConnection"
 
 **`Deprecated`**
 
- use `ConnectionRequirement` instead
+use `ConnectionRequirement` instead
 
 ## Enumeration Members
 

--- a/docs/reference/sdk/enums/core.ValueHintType.md
+++ b/docs/reference/sdk/enums/core.ValueHintType.md
@@ -169,6 +169,7 @@ an object whose `id` property is an email address, which Coda will try to resolv
 and render an @-reference to the user.
 
 **`Example`**
+
 ```
 makeObjectSchema({
   type: ValueType.Object,
@@ -200,6 +201,7 @@ Normally a reference schema is constructed from the schema object being referenc
 [makeReferenceSchemaFromObjectSchema](../functions/core.makeReferenceSchemaFromObjectSchema.md).
 
 **`Example`**
+
 ```
 makeObjectSchema({
   type: ValueType.Object,

--- a/docs/reference/sdk/functions/core.assertCondition.md
+++ b/docs/reference/sdk/functions/core.assertCondition.md
@@ -14,6 +14,7 @@ to all code that follows call to this function.
 See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
 
 **`Example`**
+
 ```
 function foo(value: string | number) {
   assertCondtion(typeof value === 'string');

--- a/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
@@ -19,6 +19,7 @@ and then to take the user's partial input and search over those entities
 for matches. The helper generalizes this use case.
 
 **`Example`**
+
 ```
 coda.makeParameter({
   type: ParameterType.Number,

--- a/docs/reference/sdk/functions/core.ensureUnreachable.md
+++ b/docs/reference/sdk/functions/core.ensureUnreachable.md
@@ -11,6 +11,7 @@ Helper for TypeScript to make sure that handling of code forks is exhaustive,
 most commonly with a `switch` statement.
 
 **`Example`**
+
 ```
 enum MyEnum {
   Foo = 'Foo',

--- a/docs/reference/sdk/functions/core.getQueryParams.md
+++ b/docs/reference/sdk/functions/core.getQueryParams.md
@@ -10,6 +10,7 @@ title: "getQueryParams"
 Helper to take a URL string and return the parameters (if any) as a JavaScript object.
 
 **`Example`**
+
 ```
 // Returns `{token: "asdf", limit: "5"}`
 let params = getQueryParams("/someApi/someEndpoint?token=asdf&limit=5");

--- a/docs/reference/sdk/functions/core.makeDynamicSyncTable.md
+++ b/docs/reference/sdk/functions/core.makeDynamicSyncTable.md
@@ -10,6 +10,7 @@ title: "makeDynamicSyncTable"
 Creates a dynamic sync table definition.
 
 **`Example`**
+
 ```
 coda.makeDynamicSyncTable({
   name: "MySyncTable",

--- a/docs/reference/sdk/functions/core.makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/core.makeEmptyFormula.md
@@ -12,6 +12,7 @@ to define an implementation for the formula rather than implementing an actual `
 in JavaScript.
 
 **`Example`**
+
 ```
 coda.makeEmptyFormula({
    name: "GetWidget",

--- a/docs/reference/sdk/functions/core.makeFormula.md
+++ b/docs/reference/sdk/functions/core.makeFormula.md
@@ -26,21 +26,25 @@ indicating that the array elements are all just strings, or it could be an objec
 created using [makeObjectSchema](core.makeObjectSchema.md) if the elements are objects.
 
 **`Example`**
+
 ```
 makeFormula({resultType: ValueType.String, name: 'Hello', ...});
 ```
 
 **`Example`**
+
 ```
 makeFormula({resultType: ValueType.String, codaType: ValueType.Html, name: 'HelloHtml', ...});
 ```
 
 **`Example`**
+
 ```
 makeFormula({resultType: ValueType.Array, items: {type: ValueType.String}, name: 'HelloStringArray', ...});
 ```
 
 **`Example`**
+
 ```
 makeFormula({
   resultType: ValueType.Object,
@@ -51,6 +55,7 @@ makeFormula({
 ```
 
 **`Example`**
+
 ```
 makeFormula({
   resultType: ValueType.Array,

--- a/docs/reference/sdk/functions/core.makeObjectSchema.md
+++ b/docs/reference/sdk/functions/core.makeObjectSchema.md
@@ -15,6 +15,7 @@ at creation time, provide better TypeScript type inference, and can reduce
 boilerplate.
 
 **`Example`**
+
 ```
 coda.makeObjectSchema({
   id: "email",

--- a/docs/reference/sdk/functions/core.makeParameter.md
+++ b/docs/reference/sdk/functions/core.makeParameter.md
@@ -10,11 +10,13 @@ title: "makeParameter"
 Create a definition for a parameter for a formula or sync.
 
 **`Example`**
+
 ```
 makeParameter({type: ParameterType.String, name: 'myParam', description: 'My description'});
 ```
 
 **`Example`**
+
 ```
 makeParameter({type: ParameterType.StringArray, name: 'myArrayParam', description: 'My description'});
 ```

--- a/docs/reference/sdk/functions/core.makeSchema.md
+++ b/docs/reference/sdk/functions/core.makeSchema.md
@@ -21,6 +21,7 @@ At this time, this wrapper provides only better TypeScript type inference,
 but it may do validation in a future SDK version.
 
 **`Example`**
+
 ```
 coda.makeSchema({
   type: coda.ValueType.Array,

--- a/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
@@ -9,7 +9,7 @@ title: "makeSimpleAutocompleteMetadataFormula"
 
 **`Deprecated`**
 
- If you have a hardcoded array of autocomplete options, simply include that array
+If you have a hardcoded array of autocomplete options, simply include that array
 as the value of the `autocomplete` property in your parameter definition. There is no longer
 any needed to wrap a value with this formula.
 

--- a/docs/reference/sdk/functions/core.makeTranslateObjectFormula.md
+++ b/docs/reference/sdk/functions/core.makeTranslateObjectFormula.md
@@ -16,6 +16,7 @@ exactly that, but alternatively you could use `makeTranslateObjectFormula` and a
 `execute` implementation will be generated for you.
 
 **`Example`**
+
 ```
 makeTranslateObjectFormula({
   name: "Users",

--- a/docs/reference/sdk/functions/core.newPack.md
+++ b/docs/reference/sdk/functions/core.newPack.md
@@ -10,6 +10,7 @@ title: "newPack"
 Creates a new skeleton pack definition that can be added to.
 
 **`Example`**
+
 ```
 export const pack = newPack();
 pack.addFormula({resultType: ValueType.String, name: 'MyFormula', ...});

--- a/docs/reference/sdk/functions/core.simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/core.simpleAutocomplete.md
@@ -18,6 +18,7 @@ The primary use case here is fetching a list of all possible results from an API
 and then refining them using the user's current search string.
 
 **`Example`**
+
 ```
 autocomplete: async function(context, search) {
   const response = await context.fetcher.fetch({method: "GET", url: "/api/entities"});

--- a/docs/reference/sdk/functions/core.withQueryParams.md
+++ b/docs/reference/sdk/functions/core.withQueryParams.md
@@ -12,6 +12,7 @@ Helper to create a new URL by appending parameters to a base URL.
 The input URL may or may not having existing parameters.
 
 **`Example`**
+
 ```
 // Returns `"/someApi/someEndpoint?token=asdf&limit=5"`
 let url = withQueryParams("/someApi/someEndpoint", {token: "asdf", limit: 5});

--- a/docs/reference/sdk/interfaces/core.BaseFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.BaseFormulaDef.md
@@ -180,7 +180,7 @@ ___
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` instead
+use `isAction` and `connectionRequirement` instead
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.Continuation.md
+++ b/docs/reference/sdk/interfaces/core.Continuation.md
@@ -18,9 +18,11 @@ as an input to the subsequent invocation of the sync formula.
 The contents of this object are entirely up to the pack author.
 
 Examples:
+
 ```
 {nextPage: 3}
 ```
+
 ```
 {nextPageUrl: 'https://someapi.com/api/items?pageToken=asdf123'}
 ```

--- a/docs/reference/sdk/interfaces/core.CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CustomAuthentication.md
@@ -22,6 +22,7 @@ token is required for security reasons.
 {% endraw %}
 
 **`Example`**
+
 ```
 {% raw %}
 // Suppose you're using an API that requires a secret id in the request URL,

--- a/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
@@ -184,7 +184,7 @@ ___
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` instead
+use `isAction` and `connectionRequirement` instead
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.Format.md
+++ b/docs/reference/sdk/interfaces/core.Format.md
@@ -52,7 +52,7 @@ ___
 
 **`Deprecated`**
 
- Namespaces are being removed from the product.
+Namespaces are being removed from the product.
 
 #### Defined in
 
@@ -66,7 +66,7 @@ ___
 
 **`Deprecated`**
 
- No longer needed, will be inferred from the referenced formula.
+No longer needed, will be inferred from the referenced formula.
 
 #### Defined in
 
@@ -118,7 +118,7 @@ ___
 
 **`Deprecated`**
 
- Currently unused.
+Currently unused.
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.Identity.md
+++ b/docs/reference/sdk/interfaces/core.Identity.md
@@ -22,7 +22,7 @@ one isn't set by the maker.
 
 **`Deprecated`**
 
- See [attribution](core.ObjectSchemaDefinition.md#attribution)
+See [attribution](core.ObjectSchemaDefinition.md#attribution)
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/core.IdentityDefinition.md
@@ -31,7 +31,7 @@ table definition, so you needn't explicitly create on unless desired.
 
 **`Deprecated`**
 
- See [attribution](core.ObjectSchemaDefinition.md#attribution)
+See [attribution](core.ObjectSchemaDefinition.md#attribution)
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.ImageAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.ImageAttributionNode.md
@@ -11,6 +11,7 @@ This is often the logo of the data source along with a link back to the home pag
 of the data source or directly to the source data.
 
 **`Example`**
+
 ```
 coda.makeAttributionNode({
   type: coda.AttributionNodeType.Image,

--- a/docs/reference/sdk/interfaces/core.InvocationLocation.md
+++ b/docs/reference/sdk/interfaces/core.InvocationLocation.md
@@ -15,7 +15,7 @@ Information about the Coda environment and doc this formula was invoked from, fo
 
 **`Deprecated`**
 
- This will be removed in a future version of the SDK.
+This will be removed in a future version of the SDK.
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.LinkAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.LinkAttributionNode.md
@@ -11,6 +11,7 @@ This might be used to attribute the data source and link back to the home page
 of the data source or directly to the source data.
 
 **`Example`**
+
 ```
 coda.makeAttributionNode({
   type: coda.AttributionNodeType.Link,

--- a/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
@@ -41,6 +41,7 @@ to create a table. Selecting a result with `hasChildren: true` will invoke
 `listDynamicUrls` again with `value` as the second argument.
 
 That is, your dynamic sync table definition might include:
+
 ```
 listDynamicUrls: async function(context, parentValue) {
   ...

--- a/docs/reference/sdk/interfaces/core.Network.md
+++ b/docs/reference/sdk/interfaces/core.Network.md
@@ -7,7 +7,7 @@ title: "Network"
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` on the formula definition instead.
+use `isAction` and `connectionRequirement` on the formula definition instead.
 
 ## Properties
 

--- a/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
@@ -186,7 +186,7 @@ ___
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` instead
+use `isAction` and `connectionRequirement` instead
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.ObjectSchemaDefinition.md
+++ b/docs/reference/sdk/interfaces/core.ObjectSchemaDefinition.md
@@ -93,7 +93,7 @@ ___
 
 **`Deprecated`**
 
- Use [featuredProperties](core.ObjectSchemaDefinition.md#featuredproperties)
+Use [featuredProperties](core.ObjectSchemaDefinition.md#featuredproperties)
 
 #### Defined in
 
@@ -132,7 +132,7 @@ ___
 
 **`Deprecated`**
 
- Use [idProperty](core.ObjectSchemaDefinition.md#idproperty)
+Use [idProperty](core.ObjectSchemaDefinition.md#idproperty)
 
 #### Defined in
 
@@ -190,7 +190,7 @@ ___
 
 **`Deprecated`**
 
- Use [displayProperty](core.ObjectSchemaDefinition.md#displayproperty)
+Use [displayProperty](core.ObjectSchemaDefinition.md#displayproperty)
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.PackDefinition.md
+++ b/docs/reference/sdk/interfaces/core.PackDefinition.md
@@ -7,7 +7,7 @@ title: "PackDefinition"
 
 **`Deprecated`**
 
- use `#PackVersionDefinition`
+use `#PackVersionDefinition`
 
 The legacy complete definition of a Pack including un-versioned metadata.
 This should only be used by legacy Coda pack implementations.
@@ -97,8 +97,6 @@ ___
 • `Optional` **formulaNamespace**: `string`
 
 **`Deprecated`**
-
- 
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.PackFormulaDef.md
@@ -182,7 +182,7 @@ ___
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` instead
+use `isAction` and `connectionRequirement` instead
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/core.PackVersionDefinition.md
@@ -46,8 +46,6 @@ ___
 
 **`Deprecated`**
 
- 
-
 #### Defined in
 
 [types.ts:877](https://github.com/coda/packs-sdk/blob/main/types.ts#L877)

--- a/docs/reference/sdk/interfaces/core.ParamDef.md
+++ b/docs/reference/sdk/interfaces/core.ParamDef.md
@@ -40,7 +40,7 @@ ___
 
 **`Deprecated`**
 
- This will be removed in a future version of the SDK. Use [suggestedValue](core.ParamDef.md#suggestedvalue) instead.
+This will be removed in a future version of the SDK. Use [suggestedValue](core.ParamDef.md#suggestedvalue) instead.
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.RequestHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/core.RequestHandlerTemplate.md
@@ -9,6 +9,7 @@ Configuration for how to construct an HTTP request for a code-free formula defin
 created using [makeTranslateObjectFormula](../functions/core.makeTranslateObjectFormula.md).
 
 **`Example`**
+
 ```
 coda.makeTranslateObjectFormula({
   name: "FetchWidget",

--- a/docs/reference/sdk/interfaces/core.SetEndpoint.md
+++ b/docs/reference/sdk/interfaces/core.SetEndpoint.md
@@ -59,7 +59,7 @@ ___
 
 **`Deprecated`**
 
- Use [getOptions](core.SetEndpoint.md#getoptions)
+Use [getOptions](core.SetEndpoint.md#getoptions)
 
 #### Defined in
 

--- a/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
@@ -182,7 +182,7 @@ ___
 
 **`Deprecated`**
 
- use `isAction` and `connectionRequirement` instead
+use `isAction` and `connectionRequirement` instead
 
 #### Inherited from
 

--- a/docs/reference/sdk/interfaces/core.TextAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.TextAttributionNode.md
@@ -10,6 +10,7 @@ An attribution node that simply renders some text.
 This might be used to attribute the data source.
 
 **`Example`**
+
 ```
 coda.makeAttributionNode({
   type: coda.AttributionNodeType.Text,

--- a/docs/reference/sdk/modules/core.md
+++ b/docs/reference/sdk/modules/core.md
@@ -7,6 +7,7 @@ The core components of the Pack SDK. These functions and types are used to
 define your Pack, it's building blocks, and their logic.
 
 This module is imported using the following code:
+
 ```ts
 import * as coda from "@codahq/packs-sdk";
 ```

--- a/docs/reference/sdk/modules/testing.md
+++ b/docs/reference/sdk/modules/testing.md
@@ -7,6 +7,7 @@ Utilities that aid in writing unit tests and integration tests for Packs.
 They are only available when developing locally using the CLI.
 
 This module is imported using the following code:
+
 ```ts
 import * as testing from "@codahq/packs-sdk/dist/development";
 ```

--- a/docs/reference/sdk/types/core.PackId.md
+++ b/docs/reference/sdk/types/core.PackId.md
@@ -9,7 +9,7 @@ title: "PackId"
 
 **`Deprecated`**
 
- Use `number` in new code.
+Use `number` in new code.
 
 #### Defined in
 

--- a/documentation/typedoc_post_process.ts
+++ b/documentation/typedoc_post_process.ts
@@ -24,7 +24,6 @@ async function process(file: string) {
   let content = buf.toString();
 
   content = addFrontmatter(file, content);
-  content = fixCodeBlocks(file, content);
 
   return fs.promises.writeFile(file, content);
 }
@@ -46,13 +45,6 @@ function addFrontmatter(file: string, content: string): string {
   const title = match![1];
   const frontmatter = `---\ntitle: "${title}"\n---\n`;
   return frontmatter + content;
-}
-
-/**
- * Fix code blocks. See https://github.com/tgreyuk/typedoc-plugin-markdown/issues/324#issuecomment-1175320510
- */
- function fixCodeBlocks(file: string, content: string): string {
-  return content.replace(/^\s+```/gm, '```');
 }
 
 main().catch(print);

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ts-loader": "^9.3.1",
     "ts-node": "^10.8.1",
     "typedoc": "^0.23.2",
-    "typedoc-plugin-markdown": "^3.13.2"
+    "typedoc-plugin-markdown": "^3.13.3"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,14 +1294,6 @@
     "@typescript-eslint/typescript-estree" "5.30.3"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.29.0":
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz#2a6a32e3416cb133e9af8dcf54bf077a916aeed3"
-  integrity sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==
-  dependencies:
-    "@typescript-eslint/types" "5.29.0"
-    "@typescript-eslint/visitor-keys" "5.29.0"
-
 "@typescript-eslint/scope-manager@5.30.3":
   version "5.30.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.3.tgz#de7edb0b59efd71975a82cbf3f1b97c5c90769f0"
@@ -1319,28 +1311,10 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.29.0":
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.29.0.tgz#7861d3d288c031703b2d97bc113696b4d8c19aab"
-  integrity sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==
-
 "@typescript-eslint/types@5.30.3":
   version "5.30.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.3.tgz#8ef6313dcec2e297b167dd25ef363e36857c49ff"
   integrity sha512-vshU3pjSTgBPNgfd55JLYngHkXuwQP68fxYFUAg1Uq+JrR3xG/XjvL9Dmv28CpOERtqwkaR4QQ3mD0NLZcE2Xw==
-
-"@typescript-eslint/typescript-estree@5.29.0":
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz#e83d19aa7fd2e74616aab2f25dfbe4de4f0b5577"
-  integrity sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==
-  dependencies:
-    "@typescript-eslint/types" "5.29.0"
-    "@typescript-eslint/visitor-keys" "5.29.0"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.30.3":
   version "5.30.3"
@@ -1366,14 +1340,6 @@
     "@typescript-eslint/typescript-estree" "5.30.3"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
-
-"@typescript-eslint/visitor-keys@5.29.0":
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz#7a4749fa7ef5160c44a451bf060ac1dc6dfb77ee"
-  integrity sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==
-  dependencies:
-    "@typescript-eslint/types" "5.29.0"
-    eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.30.3":
   version "5.30.3"
@@ -6596,10 +6562,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-plugin-markdown@^3.13.2:
-  version "3.13.2"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.2.tgz#988846ab68365ef215fbae35a75745fa7641a8af"
-  integrity sha512-WpP+XW4TZ7yVIM9jSjTWUznZitXWY8OwSVRZAu65+lOI6tiIeUYEsgiFzIdGjNcWbwD6THNcJqATDoMVIp9RKw==
+typedoc-plugin-markdown@^3.13.3:
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.3.tgz#4a242b1927e5f06f3bacfd7d6e38204b1d2a13ac"
+  integrity sha512-KKvFkQphRcH26NoBCKjjZ7a3rkPBQAOuWg1F4s+snDSWXfTyGWO5isgoe19VUbG87W8X/0x3uc/O0Nj7Qle3TQ==
   dependencies:
     handlebars "^4.7.7"
 


### PR DESCRIPTION
In #2100 I added a workaround for a bug in the TypeDoc markdown plugin. It was [since fixed](https://github.com/tgreyuk/typedoc-plugin-markdown/issues/324#issuecomment-1175496977), and this PR updates the library version and removes the workaround.