### PR TITLE
Create contributing and style guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ export PATH=$HOME/.local/bin:$PATH
 You can then install the other dependencies using the Makefile using the bootstrap script:
 
 ```sh
-make bs
+make bootstrap
 ```
 
 
@@ -81,7 +81,7 @@ The following section includes information about how to contribute to the SDK it
 
 ### Publishing Changes Process
 
-Adjustments to the `CHANGELOG.md` file should be marked under `### Unreleased` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`.
+Adjustments to the `CHANGELOG.md` file should be marked under `### Not yet released` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`.
 
 Our `CHANGELOG.md` follows the [Keep a Changelog][keepachangelog] standards, where there is a “Unreleased” section at the top for any unreleased changes. Upon release, it is named according to a semantic versioning system and dated.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to the Coda Pack SDK
+
+👍🎉 First off, thanks for taking the time to contribute! 🎉👍
+
+Changes to the core SDK itself can only be made by Coda engineers, and they must be coordinated with changes to the core Coda product. We do however welcome contributions to the [SDK documentation][docs], which can be done without access to or knowledge of the private codebase.
+
+
+## Contributing to the documentation
+
+For small contributions, such fixing a typo or adding a clarifying sentence, you can directly submit a pull request to this repo. For larger changes, such as adding a new page or code sample, first make a post to the [Coda Community][community] with your intentions to get feedback from a Codan. This helps ensure that you don't waste effort for a change which may not be approved.
+
+
+### Style guide
+
+When contributing to the documentation, please ensure your changes comply with the [style guide][style_guide]. Some elements of the style guide are enforced automatically using lint rules, but many others must be caught manually.
+
+
+### Environment setup
+
+While some documentation changes require only a single edit, others require building or validating your changes using the scripts in this repo's `Makefile`. This build system is designed to work on Unix-like command lines (Linux, Mac OSX, etc) and has a lot of dependencies.
+
+An easy way to get setup is to use [Google Cloud Shell][cloud_shell], an hosted command-line environment and web IDE that comes with most of the dependencies already installed. You can launch Google Cloud Shell and clone this repo using the button below:
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/coda/packs-sdk.git&cloudshell_workspace=.&cloudshell_open_in_editor=docs/index.md)
+
+The only dependency that needs to be installed manually in Google Cloud Shell is `pipenv`:
+
+```sh
+pip install --user pipenv
+export PATH=$HOME/.local/bin:$PATH
+```
+
+You can then install the other dependencies using the Makefile using the bootstrap script:
+
+```sh
+make bs
+```
+
+
+### Preview documentation
+
+You can preview your changes to the documentation locally by running the MkDocs preview server:
+
+```sh
+make view-docs
+```
+
+This will serve the documentation on localhost:8000. If you are using Google Cloud Shell, use the **Web Preview** icon at the top, changing the port to "8000", to view the documentation.
+
+
+### Changes to reference docs
+
+The reference documentation (under `docs/reference/sdk`) is automatically generated from the TypeScript definitions. Don't edit these markdown files directly, but instead make the change to the comment in the corresponding TypeScript file. Then to rebuild the markdown files run:
+
+```sh
+make docs
+```
+
+
+### Validating your changes
+
+Before opening a pull request we recommend that you first do a full build of the SDK. This will ensure that none of your changes break the core functionality of the SDK.
+
+```sh
+make build
+```
+
+That should succeed, and any changed files that result from it (usually in the `dist` directory) should be added to your PR.
+
+Additionally, you should run the `lint` check to ensure that all of your changes meet our style rules:
+
+```sh
+make lint
+```
+
+
+[docs]: https://coda.io/packs/build
+[community]: https://community.coda.io/c/developers-central/making-packs/15
+[cloud_shell]: https://cloud.google.com/shell
+[style_guide]: https://coda.io/packs/build/latest/support/contributing/style/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Changes to the core SDK itself can only be made by Coda engineers, and they must be coordinated with changes to the core Coda product. We do however welcome contributions to the [SDK documentation][docs], which can be done without access to or knowledge of the private codebase.
 
 
-## Contributing to the documentation
+## Documentation changes
 
 For small contributions, such fixing a typo or adding a clarifying sentence, you can directly submit a pull request to this repo. For larger changes, such as adding a new page or code sample, first make a post to the [Coda Community][community] with your intentions to get feedback from a Codan. This helps ensure that you don't waste effort for a change which may not be approved.
 
@@ -74,7 +74,20 @@ make lint
 ```
 
 
+## SDK changes
+
+The following section includes information about how to contribute to the SDK itself, which is only done by Coda engineers.
+
+
+### Publishing Changes Process
+
+Adjustments to the `CHANGELOG.md` file should be marked under `### Unreleased` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`.
+
+Our `CHANGELOG.md` follows the [Keep a Changelog][keepachangelog] standards, where there is a “Unreleased” section at the top for any unreleased changes. Upon release, it is named according to a semantic versioning system and dated.
+
+
 [docs]: https://coda.io/packs/build
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [cloud_shell]: https://cloud.google.com/shell
 [style_guide]: https://coda.io/packs/build/latest/support/contributing/style/
+[keepachangelog]: https://keepachangelog.com/en/1.0.0/

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,11 @@ docs: typedoc generated-documentation build-mkdocs
 
 .PHONY: view-docs
 view-docs:
-	PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'
+	if command -v expect &> /dev/null; then \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'; \
+	else \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk pipenv run mkdocs serve; \
+	fi
 
 ###############################################################################
 ### Deployment of documentation ###

--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ Coda Packs allow you to extend Coda by building new building blocks that can ope
 
 To learn more, see [our SDK documentation](https://coda.io/packs/build).
 
-## Contribution Guide
+## Contributing
 
-### Updating docs, site, and generated code
-
-Run `make build`
-
-### Publishing Changes Process
-
-Adjustments to the `CHANGELOG.md` file should be marked under `### Unreleased` until a release commit is made that updates `package.json` and `CHANGELOG.md` file with a new, later version, and publishes the new version to NPM using `make release`.
-
-#### CHANGELOG
-
-Our `CHANGELOG.md` follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) standards, where there is a “Unreleased” section at the top for any unreleased changes. Upon release, it is named according to a semantic versioning system and dated.
+See our [Contributing guide](CONTRIBUTING.md) for more information on how to contribute to this project.

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -42,6 +42,14 @@ li.no {
   list-style-type: "❌";
 }
 
+div.yes pre code {
+  background-color: #f1f9f1;
+}
+
+div.no pre code {
+  background-color: #f9f1f1;
+}
+
 /* Add an icon next to external links in the nav. */
 .md-sidebar a[href]:where(
   [href^="https://"],

--- a/docs/support/contributing/.nav.yml
+++ b/docs/support/contributing/.nav.yml
@@ -1,5 +1,3 @@
 nav:
   - Overview: index.md
-  - migration
-  - contributing
   - ...

--- a/docs/support/contributing/index.md
+++ b/docs/support/contributing/index.md
@@ -1,0 +1,5 @@
+---
+title: Contributing
+---
+
+--8<-- "CONTRIBUTING.md"

--- a/docs/support/contributing/style.md
+++ b/docs/support/contributing/style.md
@@ -11,6 +11,8 @@ This documentation aims to follow the [Google Developer Documentation Style Guid
 
 To ensure a consistent experience for readers, the following style rules should be followed when writing sample code. Many of these rules are enforced automatically by the linter for samples in the `documentation` directory, but small snippets of code inline in markdown files must be checked manually.
 
+These style rules have been written to optimize the experience for novice developers and those new to JavaScript. The language has many advanced features and alternative syntaxes, but they often sacrifice readability for compactness. The decisions in this style guide will therefore differ from what's traditionally selected by engineering teams.
+
 
 ### Use a single SDK import
 

--- a/docs/support/contributing/style.md
+++ b/docs/support/contributing/style.md
@@ -1,0 +1,328 @@
+---
+title: Style guide
+---
+
+# Documentation Style Guide
+
+This documentation aims to follow the [Google Developer Documentation Style Guide][google_style]. This style is not strictly enforced, but should be deferred to when options are being debated.
+
+
+## Sample code
+
+To ensure a consistent experience for readers, the following style rules should be followed when writing sample code. Many of these rules are enforced automatically by the linter for samples in the `documentation` directory, but small snippets of code inline in markdown files must be checked manually.
+
+
+### Use a single SDK import
+
+Import the entire SDK into a single variable named coda instead of using multiple, narrow imports.
+
+```{.ts .yes}
+// Yes
+import * as coda from "@codahq/packs-sdk";
+```
+
+```{.ts .no}
+// No
+import {makeFormula} from '@codahq/packs-sdk';
+import {makeParameter} from '@codahq/packs-sdk';
+```
+
+Having all usages of the SDK prefixed with coda.{something} makes it easier to distinguish what’s part of the SDK and what’s not. It also makes it easier to copy and paste code from other places without having to worry about adding imports.
+
+
+### Use double quotes
+
+Use double quotes whenever possible.
+
+```{.ts .yes}
+// Yes
+description: "A Hello World example.",
+```
+
+```{.ts .no}
+// No
+description: 'A Hello World example.',
+description: `A Hello World example.`,
+```
+
+Double quotes are required for JSON and often shown in example responses, and so it makes sense to standardize on them.
+
+
+### Prefer string concatenation
+
+Prefer string concatenation over template strings for simple cases.
+
+```{.ts .yes}
+// Yes
+let url = "http://example.com/thing/" + thingId;
+```
+
+```{.ts .no}
+// No
+let url = `http://example.com/thing/${thingId}`;
+```
+
+String concatenation is often easier to read and understand, and doesn’t introduce an additional string delimiter. Template strings can be used if multiple variables are being inserted.
+
+
+### Use `let` for variable declaration
+
+Prefer `let` over `const`, even in cases where the value is never re-assigned.
+
+```{.ts .yes}
+// Yes
+let url = "http://example.com";
+```
+
+```{.ts .no}
+// No
+const url = "http://example.com";
+```
+
+The distinction between `let` and `const` isn’t always clear to newer coders, and the inflexibility of `const` can lead to more errors as users are playing around with code they copy and pasted.
+
+!!! note "Exception: File-level constants"
+    File-level constants such as enums and schemas, should use const.
+    ```ts
+    const MaxItems = 100;
+    const MySchema = coda.makeObjectSchema(...);
+    ```
+
+
+### Avoid the ternary operator
+
+Use conditional blocks instead.
+
+```{.ts .yes}
+// Yes
+let foo = "bar";
+if (isThing) {
+  foo = "baz";
+}
+```
+
+```{.ts .no}
+// No
+let foo = isThing ? "bar" : "baz";
+```
+
+The ternary operator isn’t widely known among newer coders, and the syntax is very opaque if you haven’t see it before.
+
+
+### Avoid the spread operator
+
+Prefer a more concrete manipulation of objects, when feasible.
+
+```{.ts .yes}
+// Yes
+let result = response.body;
+result.foo = "bar";
+return result;
+```
+
+```{.ts .no}
+// No
+return {
+  ...response.body,
+  foo: 'bar',
+}
+```
+
+The syntax may not be familiar to newer coders, and more explicit assignments can make it clearer what’s going on.
+
+
+### Always set the key and value
+
+Even when the key and value are the same, always set both explicitly.
+
+```{.ts .yes}
+// Yes
+context.fetcher.fetch({
+  method: "GET",
+  url: url,
+});
+```
+
+```{.ts .no}
+// No
+context.fetcher.fetch({
+  method: "GET",
+  url,
+});
+```
+
+The shorthand notation that allows you to omit the value can be confusing to newer coders, especially when they need to adapt the code to work with different variable names.
+
+
+### Avoid destructuring
+
+Prefer to pull values out of objects and arrays more explicitly.
+
+```{.ts .yes}
+// Yes
+let items = response.body.items;
+let pageToken = response.body.pageToken;
+```
+
+```{.ts .no}
+// No
+let {items, pageToken} = response.body;
+```
+
+The destructuring syntax may not be familiar to newer coders, and it can easily be confused with creating an object or array.
+
+!!! note "Exception: Parameters values"
+    Destructuring can be used to separate out the parameters of a formula, such as in the `execute` function.
+    ```ts
+    execute: async function([width, height], context) {
+      // ...
+    }
+    ```
+
+
+### Always include `async` and `context` in formula execute methods
+
+Even when a formula doesn’t require them, always declare the `execute` function as `async` and add `context` parameter.
+
+```{.ts .yes}
+// Yes
+execute: async ([param], context) => {
+  return "Hello World!";
+},
+```
+
+```{.ts .no}
+// No
+execute: ([param]) => {
+  return "Hello World!";
+},
+```
+
+This makes it easier to add in `fetcher` calls later without needing to understand asynchronous programming. While there is a slight performance impact to making a function `async` unnecessarily, and unused variables are discouraged, the benefits outweigh the costs for new users.
+
+
+### Don’t declare schemas inline
+
+Even if a schema is only used in one formula, declare it separately.
+
+```{.ts .yes}
+// Yes
+const MySchema = coda.makeObjectSchema({ ... });
+pack.addFormula({
+  // ...
+  schema: MySchema,
+});
+```
+
+```{.ts .no}
+// No
+pack.addFormula({
+  // ...
+  schema: coda.makeObjectSchema({ ... });
+});
+```
+
+A formula definition can already be quite long, and adding a schema can make it even harder to parse. Additionally, schemas are often reused in a pack (a formula and a sync table, for instance) so it is a best practice to separate them earlier.
+
+
+### Use UpperCamelCase for schema variables
+
+Name schema constants using UpperCamelCase, like you would for a class.
+
+```{.ts .yes}
+// Yes
+const MySchema = coda.makeObjectSchema({ ... });
+```
+
+```{.ts .no}
+// No
+const mySchema = coda.makeObjectSchema({ ... });
+```
+
+Although not technically a class, schemas are similar enough and should be treated similarly.
+
+
+### Use the `function` keyword for most functions
+
+Define functions using the `function` keyword in most cases.
+
+```{.ts .yes}
+// Yes
+pack.addFormula({
+  // ...
+  execute: function([a, b], context) {
+    // ...
+  },
+});
+```
+
+```{.ts .no}
+// No
+pack.addFormula({
+  // ...
+  execute: ([a, b], context) => {
+    // ...
+  },
+});
+
+// Also no
+pack.addFormula({
+  // ...
+  execute([a, b], context) {
+    // ...
+  },
+});
+```
+
+The `function` keyword makes it very clear to readers that you are defining a function. The arrow function syntax is not as obvious for newer coders, and the latter syntax is another form of object shorthand notation which is discouraged.
+
+!!! note "Exception: Function as parameters"
+    Arrow functions are allowed for anonymous functions used as parameters, like those used in `Array.filter()`, etc.
+    ```ts
+    let completed = items.filter(item => item.isComplete);
+    ```
+
+
+### Formula key order
+
+The order of keys in the formula declaration should be:
+
+```ts
+pack.addFormula({
+  name: ...,
+  description: ...,
+  parameters: ...,
+  resultType: ...,
+  // If required.
+  schema: ...,
+  items: ...,
+  isAction: ...,
+  // Anything else.
+  execute: ...,
+});
+```
+
+
+### Object schema key order
+
+The order of keys in an object schema declaration should be:
+
+```
+const MySchema = coda.makeObjectSchema({
+  properties: ...,
+  displayProperty: ...,
+  idProperty: ...,
+  featuredProperties: ...,
+  // If required.
+  identity: ...,
+  // Anything else.
+});
+```
+
+
+### 80 character max line length
+
+Limit lines to 80 characters. Horizontal space is limited in the Packs Editor side panel and in the Documentation, and lines more than 80 characters can lead to scroll or wrapping that makes it harder to read.
+
+
+[google_style]: https://developers.google.com/style


### PR DESCRIPTION
Added a GitHub-standard `CONTRIBUTING.md` file with basic guidelines for contributing documentation changes. Also relocated some contributing information from the `README.md` to this new page.

Copied over the content from the original [sample code style guide](https://staging.coda.io/d/_d0_QypZAlFU/9-28-Sample-Code-Style-Guide_suCJo) into a page in the documentation, and referenced it in the contributing guide.

Staged:
- https://coda-packs-sdk--2117.com.readthedocs.build/en/2117/support/contributing/
- https://coda-packs-sdk--2117.com.readthedocs.build/en/2117/support/contributing/style/