### PR TITLE
Create OAuth guide

### DIFF
--- a/docs/guides/advanced/.nav.yml
+++ b/docs/guides/advanced/.nav.yml
@@ -1,0 +1,3 @@
+nav:
+  - authentication
+  - ...

--- a/docs/guides/advanced/authentication/.nav.yml
+++ b/docs/guides/advanced/authentication/.nav.yml
@@ -1,0 +1,3 @@
+nav:
+  - Overview: index.md
+  - ...

--- a/docs/guides/advanced/authentication/index.md
+++ b/docs/guides/advanced/authentication/index.md
@@ -260,80 +260,9 @@ pack.setUserAuthentication({
     ```
 
 
-### OAuth 2.0
+### Token exchange
 
-[OAuth 2.0][oauth_definition] is a modern, more secure alternative to passing usernames and passwords that has been adopted by many APIs. The details of this protocol can get complicated, but when building a Pack you only need to specify some configuration options and Coda handles the token exchange, storage, refresh, etc.
-
-To configure [`OAuth2`][OAuth] authentication you must specify the authorization URL and the token URL. These URLs are found in the technical documentation of the API you are connecting to, and will be different for each API.
-
-```ts
-pack.setUserAuthentication({
-  type: coda.AuthenticationType.OAuth2,
-  // These URLs come from the API's developer documentation.
-  authorizationUrl: "https://example.com/authorize",
-  tokenUrl: "https://api.example.com/token",
-});
-```
-
-After adding the code, build a new version of your Pack and then navigate to the **Settings** tab. There you'll see an **Add OAuth Credentials** button you can use to set the Pack's credentials.
-
-<img src="../../../images/auth_oauth.png" srcset="../../../images/auth_oauth_2x.png 2x" class="screenshot" alt="Setting the OAuth client ID and secret">
-
-These credentials identify your application to the provider, and are the same for every user that uses your Pack. You need to obtain these credentials from the API provider, typically by registering your application in the provider's developer console or portal. These values are typically called the client ID and secret, but may in some cases be referred to using terms like "consumer" or "application".
-
-When registering you application in the API provider's console you will be asked to provide a redirect URL. This is where the provider should redirect the user to after they have signed in and approved access. When building a Pack this value should always be set to:
-
-```
-https://coda.io/packsAuth/oauth2
-```
-
-There are many subtle variations to the OAuth2 flow, and Coda can accommodate a variety of them. You can find the additional configuration options in the [`OAuth2Authentication`][OAuth2Authentication] documentation.
-
-However if the API provider deviates too far from the OAuth 2.0 specification it may not be possible to find a configuration that will work. Additionally, Coda currently only supports the [Authorization Code][oauth2_code] grant type, and others like [Client Credentials][oauth2_client] can't be used. If you get stuck please [contact support][support] to explore other options.
-
-[View Sample Code][sample_oauth2]{ .md-button }
-
-??? note "Flexible authentication during token exchange"
-    The OAuth2 specification doesn't require a specific authentication schema your app must use when exchanging tokens. Coda supports the two most popular variants:
-
-    1. Sending the `client_secret` in the JSON body
-    1. Sending an `Authorization: Basic` header using the client ID and secret.
-
-    No configuration is required, Coda will try them both to see what works.
-
-??? warning "OAuth 1.0a not supported"
-    Coda doesn't currently support the older 1.0 or 1.0a versions of the OAuth specification. If you would like to connect to an API that only supports these versions of the standard please [contact support][support] so that we can continue to gauge interest.
-
-
-#### Incremental OAuth
-
-As your pack grows you may find that you need to request more OAuth scopes than you initially did when your existing users connected. Coda allows new scopes to be added to Pack OAuth settings in a non-breaking way: we don't prompt the user to re-authorize until they try to use a Pack feature that fails. Once that happens, we notice that the connection the user was using was created with a stale list of OAuth scopes and we prompt them to re-authenticate it to get your new scopes.
-
-Even when you do know all of the scopes you need, you may not want to request them all at once. An approval screen with a long list of permissions can be intimidating to new users and some my choose to abandon your Pack. In these cases you may want to use incremental authorization, made possible in Packs by the formula field [`extraOAuthScopes`][extraOAuthScopes]. You can use it to specify additional scopes that are needed in order to run a specific formula.
-
-```ts
-pack.setUserAuthentication({
-  type: coda.AuthenticationType.OAuth2,
-  // ...
-  scopes: ["read"],
-});
-
-// ...
-
-pack.addFormula({
-  name: "UpdateItem",
-  // ...
-  isAction: true,
-  extraOAuthScopes: ["update"],
-  // ...
-});
-```
-
-When the Pack above is installed the user will only be required to grant access to the `read` scope. However, when they try to use the `UpdateItem` action formula and it fails they will then be prompted to grant additional access to the `write` scope. This prompt is displayed as a pop-up dialog at the bottom of the doc:
-
-<img src="../../../images/auth_oauth_incremental.png" srcset="../../../images/auth_oauth_incremental_2x.png 2x" class="screenshot" alt="Prompting the user for additional permissions">
-
-When the user signs in again they will be prompted to approve the additional scopes, after which they will be able to use the formula successfully.
+Some APIs use short-lived tokens which must be obtained through an credential exchange or approval process. The industry-wide standard for this is OAuth 2.0, which is supported in the Pack SDK. You can read more about it in the [OAuth guide][oauth_guide]. Other forms of token exchange are not currently supported.
 
 
 ## Requiring authentication
@@ -398,7 +327,7 @@ pack.setUserAuthentication({
 
 This function is run after the user has entered their credentials, and the credentials are automatically applied to the Fetcher request.
 
-[View Sample Code][sample_oauth2]{ .md-button }
+[View Sample Code][sample_connection_name]{ .md-button }
 
 !!! tip "Use detailed account names"
     If your service allows users to [connect to multiple endpoints](#endpoints), we recommend that you include the endpoint name as well. For example, a pattern like "User Name (Endpoint Name)".
@@ -527,34 +456,29 @@ Typically a Pack can only make HTTP requests to the [network domains][network_do
 There are services however where each account is associated with a distinct domain, instead of a sub-domain of a common root domain. This makes it impossible to declare them ahead of time as network domains. In these cases you can omit network domain declaration from your Pack, which will allow it to make requests to the account's endpoint URL (and only that URL) regardless of domain.
 
 
-[samples]: ../../samples/topic/authentication.md
-[sample_auth_header]: ../../samples/topic/authentication.md#authorization-header
-[sample_custom_header]: ../../samples/topic/authentication.md#custom-header
-[sample_query_param]: ../../samples/topic/authentication.md#query-parameter
-[sample_web_basic]: ../../samples/topic/authentication.md#username-and-password
-[sample_oauth2]: ../../samples/topic/authentication.md#oauth2
-[sample_manual_endpoint]: ../../samples/topic/authentication.md#manual-endpoint
-[sample_automatic_endpoint]: ../../samples/topic/authentication.md#automatic-endpoint
-[sample_selected_endpoint]: ../../samples/topic/authentication.md#selected-endpoint
+[samples]: ../../../samples/topic/authentication.md
+[sample_auth_header]: ../../../samples/topic/authentication.md#authorization-header
+[sample_custom_header]: ../../../samples/topic/authentication.md#custom-header
+[sample_query_param]: ../../../samples/topic/authentication.md#query-parameter
+[sample_web_basic]: ../../../samples/topic/authentication.md#username-and-password
+[sample_manual_endpoint]: ../../../samples/topic/authentication.md#manual-endpoint
+[sample_automatic_endpoint]: ../../../samples/topic/authentication.md#automatic-endpoint
+[sample_selected_endpoint]: ../../../samples/topic/authentication.md#selected-endpoint
+[sample_connection_name]: ../../../samples/topic/authentication.md#oauth2
 
 [hc_account_sharing]: https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs
 [account_settings]: https://coda.io/account
-[AuthenticationType]: ../../reference/sdk/enums/core.AuthenticationType.md
-[support]: ../../support/index.md
+[AuthenticationType]: ../../../reference/sdk/enums/core.AuthenticationType.md
+[support]: ../../../support/index.md
 [coda_api_auth]: https://coda.io/developers/apis/v1#section/Authentication
-[HeaderBearerToken]: ../../reference/sdk/enums/core.AuthenticationType.md#headerbearertoken
-[CustomHeaderToken]: ../../reference/sdk/enums/core.AuthenticationType.md#customheadertoken
-[QueryParamToken]: ../../reference/sdk/enums/core.AuthenticationType.md#queryparamtoken
-[QueryParamToken]: ../../reference/sdk/enums/core.AuthenticationType.md#custom
+[HeaderBearerToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#headerbearertoken
+[CustomHeaderToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#customheadertoken
+[QueryParamToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#queryparamtoken
+[QueryParamToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#custom
 [wikipedia_basic_auth]: https://en.wikipedia.org/wiki/Basic_access_authentication
-[WebBasic]: ../../reference/sdk/enums/core.AuthenticationType.md#webbasic
-[Custom]: ../../reference/sdk/enums/core.AuthenticationType.md#custom
-[oauth_definition]: https://oauth.net/2/
-[OAuth]: ../../reference/sdk/enums/core.AuthenticationType.md#oauth2
-[OAuth2Authentication]: ../../reference/sdk/interfaces/core.OAuth2Authentication.md
-[oauth2_code]: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
-[oauth2_client]: https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
-[getConnectionName]: ../../reference/sdk/interfaces/core.BaseAuthentication.md#getconnectionname
-[network_domains]: fetcher.md#network-domains
-[autocomplete_dynamic]: ../basics/parameters/autocomplete.md#dynamic-options
-[extraOAuthScopes]: ../../reference/sdk/interfaces/core.BaseFormulaDef.md#extraoauthscopes
+[WebBasic]: ../../../reference/sdk/enums/core.AuthenticationType.md#webbasic
+[Custom]: ../../../reference/sdk/enums/core.AuthenticationType.md#custom
+[getConnectionName]: ../../../reference/sdk/interfaces/core.BaseAuthentication.md#getconnectionname
+[network_domains]: ../fetcher.md#network-domains
+[autocomplete_dynamic]: ../../basics/parameters/autocomplete.md#dynamic-options
+[oauth_guide]: oauth2.md

--- a/docs/guides/advanced/authentication/oauth2.md
+++ b/docs/guides/advanced/authentication/oauth2.md
@@ -1,0 +1,168 @@
+---
+title: OAuth
+---
+
+# Authenticating using OAuth
+
+[OAuth 2.0][oauth_definition] is a modern, more secure alternative to passing usernames and passwords that has been adopted by many APIs. The details of this protocol can get complicated, but when building a Pack you only need to specify some configuration options and Coda handles the token exchange, storage, refresh, etc.
+
+Read the [Authentication guide][authentication] for more information about how to authenticate users in Packs.
+
+[Try Tutorial][tutorial_oauth2]{ .md-button .md-button--primary }
+[View Sample Code][sample_oauth2]{ .md-button }
+
+!!! warning "OAuth 1.0 not supported"
+    Coda doesn't currently support the older 1.0 or 1.0a versions of the OAuth specification. If you would like to connect to an API that only supports these versions of the standard please [contact support][support] so that we can continue to gauge interest.
+
+
+## Setup OAuth authentication
+
+To enable your Pack to authenticate users with OAuth you need to configure the OAuth flow and enter your developer credentials.
+
+
+### Add configuration code
+
+To configure [`OAuth2`][OAuth] authentication you must specify the authorization URL and the token URL. These URLs are found in the technical documentation of the API you are connecting to, and will be different for each API.
+
+```ts
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.OAuth2,
+  // These URLs come from the API's developer documentation.
+  authorizationUrl: "https://example.com/authorize",
+  tokenUrl: "https://api.example.com/token",
+});
+```
+
+Many APIs also support granular scopes, allowing you to request a limited set of permissions from the user. These can be speciefied as an array in the `scopes` field:
+
+```ts
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.OAuth2,
+  // These URLs come from the API's developer documentation.
+  authorizationUrl: "https://example.com/authorize",
+  tokenUrl: "https://api.example.com/token",
+  scopes: ["user", "projects", "tasks"],
+});
+```
+
+There are many subtle variations to the OAuth2 flow, and Coda can accommodate a variety of them. You can find the additional configuration options in the [`OAuth2Authentication`][OAuth2Authentication] documentation, as well as [sample code][sample_apis] showing how to setup OAuth for the most popular APIs.
+
+However if the API provider deviates too far from the OAuth 2.0 specification it may not be possible to find a configuration that will work. Additionally, Coda currently only supports the [Authorization Code][oauth2_code] grant type, and others like [Client Credentials][oauth2_client] can't be used. If you get stuck please [contact support][support] to explore other options.
+
+??? note "Flexible authentication during token exchange"
+    The OAuth2 specification doesn't require a specific authentication schema your app must use when exchanging tokens. Coda supports the two most popular variants:
+
+    1. Sending the `client_secret` in the JSON body
+    1. Sending an `Authorization: Basic` header using the client ID and secret.
+
+    No configuration is required, Coda will try them both to see what works.
+
+### Set developer credentials
+
+After you the add the configuration code, build a new version of your Pack and then navigate to the **Settings** tab. There you'll see an **Add OAuth Credentials** button you can use to set the Pack's credentials.
+
+<img src="../../../../images/auth_oauth.png" srcset="../../../../images/auth_oauth_2x.png 2x" class="screenshot" alt="Setting the OAuth client ID and secret">
+
+These credentials identify your application and are the same for every user that uses your Pack. You need to obtain these credentials from the API provider, typically by registering your application in the provider's developer console or portal. These values are typically called the client ID and secret, but may in some cases be referred to using terms like "consumer" or "application".
+
+
+#### Redirect URL
+
+When registering you application in the API provider's console you will be asked to provide a redirect URL. This is where the provider should redirect the user to after they have signed in and approved access. When building a Pack this value should always be set to:
+
+```
+https://coda.io/packsAuth/oauth2
+```
+
+
+## Token expiry and refresh
+
+Many APIs return short-lived access tokens which expire after a few hours. Coda doesn't track the expiration of these tokens, but instead waits for an API request using the token to fail before attempting to refresh it. Specifically, Coda only does a refresh when:
+
+- The Pack execution fails with a [`StatusCodeError`][statuscodeerror] with a 401 status (Unauthorized)
+- The OAuth provider returned a `refresh_token` during a previous token exchange
+
+If you have error handling in your Pack, make sure to re-throw these 401 errors so that the token refresh process takes place.
+
+```ts
+try {
+  let response = await context.fetcher.fetch({
+    // ...
+  });
+  // ...
+} catch (error) {
+  if (error.statusCode == 401) {
+    // Perhaps the token has expired, re-throw the error to attempt a refresh.
+    throw error;
+  }
+  // Else handle or throw the error as normal.
+}
+```
+
+
+## Additional scopes
+
+As your pack grows you may find that you need to request more OAuth scopes than you initially did when your existing users connected. Coda allows new scopes to be added to Pack OAuth settings in a non-breaking way: we don't prompt the user to re-authorize until they try to use a Pack feature that fails. Once that happens, we notice that the connection the user was using was created with a stale list of OAuth scopes and we prompt them to re-authenticate it to get your new scopes.
+
+
+### Triggering a prompt
+
+Normally the user will be prompted to approve new scopes if the Pack fails with a [`StatusCodeError`][statuscodeerror] with a 403 status (Forbidden). However some APIs may fail with different status codes, or only return partial information, if scopes are missing. In those cases you can detect the problem in your code and throw a [`MissingScopesError`][missingscopeserror] to trigger the prompt.
+
+```ts
+try {
+  let response = context.fetcher.fetch({
+    // ...
+  });
+} catch (error) {
+  // Determine if the error is due to missing scopes.
+  if (error.statusCode == 400 && error.body?.message.includes("permission")) {
+    throw new coda.MissingScopesError();
+  }
+  // Else handle or throw the error as normal.
+}
+```
+
+
+### Incremental authorization
+
+Even when you do know all of the scopes you need, you may not want to request them all at once. An approval screen with a long list of permissions can be intimidating to new users and some my choose to abandon your Pack. In these cases you may want to use incremental authorization, made possible in Packs by the formula field [`extraOAuthScopes`][extraOAuthScopes]. You can use it to specify additional scopes that are needed in order to run a specific formula.
+
+```ts
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.OAuth2,
+  // ...
+  scopes: ["read"],
+});
+
+// ...
+
+pack.addFormula({
+  name: "UpdateItem",
+  // ...
+  isAction: true,
+  extraOAuthScopes: ["update"],
+  // ...
+});
+```
+
+When the Pack above is installed the user will only be required to grant access to the `read` scope. However, when they try to use the `UpdateItem` action formula and it fails they will then be prompted to grant additional access to the `write` scope. This prompt is displayed as a pop-up dialog at the bottom of the doc:
+
+<img src="../../../../images/auth_oauth_incremental.png" srcset="../../../../images/auth_oauth_incremental_2x.png 2x" class="screenshot" alt="Prompting the user for additional permissions">
+
+When the user signs in again they will be prompted to approve the additional scopes, after which they will be able to use the formula successfully.
+
+
+[oauth_definition]: https://oauth.net/2/
+[authentication]: index.md
+[OAuth]: ../../../reference/sdk/enums/core.AuthenticationType.md#oauth2
+[OAuth2Authentication]: ../../../reference/sdk/interfaces/core.OAuth2Authentication.md
+[oauth2_code]: https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/
+[oauth2_client]: https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
+[extraOAuthScopes]: ../../../reference/sdk/interfaces/core.BaseFormulaDef.md#extraoauthscopes
+[support]: ../../../support/index.md
+[sample_oauth2]: ../../../samples/topic/authentication.md#oauth2
+[sample_apis]: ../../../samples/topic/apis.md
+[tutorial_oauth2]: ../../../tutorials/build/oauth.md
+[statuscodeerror]: ../../../reference/sdk/classes/core.StatusCodeError.md
+[missingscopeserror]: ../../../reference/sdk/classes/core.MissingScopesError.md

--- a/docs/guides/advanced/fetcher.md
+++ b/docs/guides/advanced/fetcher.md
@@ -415,8 +415,8 @@ dig +short egress.coda.io
 [stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [cacheTtlSecs]: ../../reference/sdk/interfaces/core.FetchRequest.md#cacheTtlSecs
 [formula_cache]: ../blocks/formulas.md#caching
-[authentication]: ../advanced/authentication.md
+[authentication]: ../advanced/authentication/index.md
 [spec_headers]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
 [baseauthentication_networkdomain]: ../../reference/sdk/interfaces/core.BaseAuthentication.md#networkdomain
-[auth_user]: ../advanced/authentication.md#user
+[auth_user]: ../advanced/authentication/index.md#user
 [temporaryblobstorage]: ../../reference/sdk/interfaces/core.TemporaryBlobStorage.md

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -72,4 +72,4 @@ While it's easy to get started building a Pack, there are lots of options to exp
 [promotion]: https://coda.io/@hector/promotion-best-practices
 [schemas_row_identifier]: advanced/schemas.md#row-identifier
 [schemas_featured_columns]: advanced/schemas.md#featured-columns
-[auth_name]: advanced/authentication.md#name
+[auth_name]: advanced/authentication/index.md#name

--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -170,7 +170,7 @@ examples: [
 [cacheTtlSecs]: ../../reference/sdk/interfaces/core.PackFormulaDef.md#cachettlsecs
 [fetcher_cache]: ../advanced/fetcher.md#caching
 [fetcher_rate_limits]: ../advanced/fetcher.md#ratelimits
-[authentication]: ../advanced/authentication.md
+[authentication]: ../advanced/authentication/index.md
 [system_auth]: ../../reference/sdk/classes/core.PackDefinitionBuilder.md#setsystemauthentication
 [user_auth]: ../../reference/sdk/classes/core.PackDefinitionBuilder.md#setuserauthentication
 [connectionRequirement]: ../../reference/sdk/interfaces/core.PackFormulaDef.md#connectionrequirement

--- a/docs/support/migration/v0.11.0.md
+++ b/docs/support/migration/v0.11.0.md
@@ -184,9 +184,9 @@ As of this SDK version the decompression will will be done automatically for you
 [baseauthentication_networkdomain]: ../../reference/sdk/interfaces/core.BaseAuthentication.md#networkdomain
 [schemas_object]: ../../guides/advanced/schemas.md#object
 [setendpoint]: ../../reference/sdk/interfaces/core.SetEndpoint.md
-[authentication_setendpoint]: ../../guides/advanced/authentication.md#setendpoint
+[authentication_setendpoint]: ../../guides/advanced/authentication/index.md#setendpoint
 [schemas_attribution]: ../../guides/advanced/schemas.md#attribution
 [parameters_suggested]: ../../guides/basics/parameters/index.md#suggested
 [sync_tables_identity]: ../../guides/blocks/sync-tables/index.md#identity
 [schemas_references]: ../../guides/advanced/schemas.md#references
-[auth_user]: ../../guides/advanced/authentication.md#user
+[auth_user]: ../../guides/advanced/authentication/index.md#user

--- a/docs/tutorials/build/oauth.md
+++ b/docs/tutorials/build/oauth.md
@@ -556,7 +556,8 @@ You'll notice that it takes in an account as a parameter, and it should auto-sel
 
 Now that you have an understanding of how to use OAuth2 in Packs, here are some more resources you can explore:
 
-- [Authentication guide][authentication] - More in-depth information about how to setup authentication in a Pack, including OAuth2.
+- [Authentication guide][authentication] - Information about how authentication works in Packs.
+- [OAuth guide][oauth_guide] - More in-depth information about how to setup OAuth authentication.
 - [Sample code][samples_apis] - A collection of sample Packs that use OAuth2 to connect to various popular APIs.
 
 
@@ -573,3 +574,4 @@ Now that you have an understanding of how to use OAuth2 in Packs, here are some 
 [todoist_tasks]: https://developer.todoist.com/rest/v1/#get-active-tasks
 [authentication]: ../../guides/advanced/authentication/index.md
 [samples_apis]: ../../samples/topic/apis.md
+[oauth_guide]: ../../guides/advanced/authentication/oauth2.md

--- a/docs/tutorials/build/oauth.md
+++ b/docs/tutorials/build/oauth.md
@@ -571,5 +571,5 @@ Now that you have an understanding of how to use OAuth2 in Packs, here are some 
 [todoist_console]: https://developer.todoist.com/appconsole.html
 [oauth_standard]: https://datatracker.ietf.org/doc/html/rfc6749
 [todoist_tasks]: https://developer.todoist.com/rest/v1/#get-active-tasks
-[authentication]: ../../guides/advanced/authentication.md
+[authentication]: ../../guides/advanced/authentication/index.md
 [samples_apis]: ../../samples/topic/apis.md


### PR DESCRIPTION
Wanted to add more information about OAuth token refreshes and incremental auth prompts, and it was becoming too much for the existing Authentication guide. Broke our OAuth into a separate page and added that new information.