### PR TITLE
Add SDK support for string array autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 - Added `ImageSchema`, for use with images. Allows packs to set two flags on a formula returning an image: if the image should be rendered with or without an outline, and whether to turn off the rounded corners. If the outline flag `ImageOutline` is not set on a schema, the default is `Solid`, and the image will be rendered with an outline. If the corners flag `ImageCornerStyle` is not set, the default is `Rounded`, and the image will be rendered with rounded corners.
 - Added `NumericDurationSchema`, which will allow packs to return `ValueType.Number` values that are interpreted in Coda as a duration in seconds.
+- Added autocomplete support for `ParameterType.StringArray` and `ParameterType.SparseStringArray` parameters.
 
 ## [1.0.2] - 2022-07-14
 

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -230,10 +230,24 @@ export declare function isUserVisibleError(error: Error): error is UserVisibleEr
 export declare function isDynamicSyncTable(syncTable: SyncTable): syncTable is GenericDynamicSyncTable;
 export declare function wrapMetadataFunction(fnOrFormula: MetadataFormula | MetadataFunction | undefined): MetadataFormula | undefined;
 export declare function wrapGetSchema(getSchema: MetadataFormula | undefined): MetadataFormula | undefined;
+/**
+ * List of ParameterTypes that support autocomplete.
+ */
+export declare type AutocompleteParameterTypes = ParameterType.Number | ParameterType.String | ParameterType.StringArray | ParameterType.SparseStringArray;
+/**
+ * Mapping of autocomplete-enabled ParameterTypes to the underlying Type that should be returned
+ * by the autocomplete parameter.
+ */
+export interface AutocompleteParameterTypeMapping {
+    [ParameterType.Number]: Type.number;
+    [ParameterType.String]: Type.string;
+    [ParameterType.StringArray]: Type.string;
+    [ParameterType.SparseStringArray]: Type.string;
+}
 /** Options you can specify when defining a parameter using {@link makeParameter}. */
 export declare type ParameterOptions<T extends ParameterType> = Omit<ParamDef<ParameterTypeMap[T]>, 'type' | 'autocomplete'> & {
     type: T;
-    autocomplete?: T extends ParameterType.Number | ParameterType.String ? MetadataFormulaDef | Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>> : undefined;
+    autocomplete?: T extends AutocompleteParameterTypes ? MetadataFormulaDef | Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>> : undefined;
 };
 /**
  * Create a definition for a parameter for a formula or sync.
@@ -655,11 +669,11 @@ export declare function makeMetadataFormula(execute: MetadataFunction, options?:
  * A result from a parameter autocomplete function that pairs a UI display value with
  * the underlying option that will be used in the formula when selected.
  */
-export interface SimpleAutocompleteOption<T extends ParameterType.Number | ParameterType.String> {
+export interface SimpleAutocompleteOption<T extends AutocompleteParameterTypes> {
     /** Text that will be displayed to the user in UI for this option. */
     display: string;
     /** The actual value that will get used in the formula if this option is selected. */
-    value: TypeMap[ParameterTypeMap[T]];
+    value: TypeMap[AutocompleteParameterTypeMapping[T]];
 }
 /**
  * Utility to search over an array of autocomplete results and return only those that
@@ -681,7 +695,7 @@ export interface SimpleAutocompleteOption<T extends ParameterType.Number | Param
  * }
  * ```
  */
-export declare function simpleAutocomplete<T extends ParameterType.Number | ParameterType.String>(search: string | undefined, options: Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>>): Promise<MetadataFormulaObjectResultType[]>;
+export declare function simpleAutocomplete<T extends AutocompleteParameterTypes>(search: string | undefined, options: Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>>): Promise<MetadataFormulaObjectResultType[]>;
 /**
  * A helper to search over a list of objects representing candidate search results,
  * filtering to only those that match a search string, and converting the matching
@@ -719,7 +733,7 @@ export declare function autocompleteSearchObjects<T>(search: string, objs: T[], 
  * as the value of the `autocomplete` property in your parameter definition. There is no longer
  * any needed to wrap a value with this formula.
  */
-export declare function makeSimpleAutocompleteMetadataFormula<T extends ParameterType.Number | ParameterType.String>(options: Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>>): MetadataFormula;
+export declare function makeSimpleAutocompleteMetadataFormula<T extends AutocompleteParameterTypes>(options: Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>>): MetadataFormula;
 /** @deprecated */
 export declare function makeObjectFormula<ParamDefsT extends ParamDefs, SchemaT extends Schema>({ response, ...definition }: ObjectResultFormulaDef<ParamDefsT, SchemaT>): ObjectPackFormula<ParamDefsT, SchemaT>;
 /**

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2055,10 +2055,24 @@ export declare type GenericDynamicSyncTable = DynamicSyncTableDef<any, any, Para
  * for defining a sync table.
  */
 export declare type SyncTable = GenericSyncTable | GenericDynamicSyncTable;
+/**
+ * List of ParameterTypes that support autocomplete.
+ */
+export declare type AutocompleteParameterTypes = ParameterType.Number | ParameterType.String | ParameterType.StringArray | ParameterType.SparseStringArray;
+/**
+ * Mapping of autocomplete-enabled ParameterTypes to the underlying Type that should be returned
+ * by the autocomplete parameter.
+ */
+export interface AutocompleteParameterTypeMapping {
+	[ParameterType.Number]: Type.number;
+	[ParameterType.String]: Type.string;
+	[ParameterType.StringArray]: Type.string;
+	[ParameterType.SparseStringArray]: Type.string;
+}
 /** Options you can specify when defining a parameter using {@link makeParameter}. */
 export declare type ParameterOptions<T extends ParameterType> = Omit<ParamDef<ParameterTypeMap[T]>, "type" | "autocomplete"> & {
 	type: T;
-	autocomplete?: T extends ParameterType.Number | ParameterType.String ? MetadataFormulaDef | Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>> : undefined;
+	autocomplete?: T extends AutocompleteParameterTypes ? MetadataFormulaDef | Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>> : undefined;
 };
 /**
  * Create a definition for a parameter for a formula or sync.
@@ -2420,11 +2434,11 @@ export declare function makeMetadataFormula(execute: MetadataFunction, options?:
  * A result from a parameter autocomplete function that pairs a UI display value with
  * the underlying option that will be used in the formula when selected.
  */
-export interface SimpleAutocompleteOption<T extends ParameterType.Number | ParameterType.String> {
+export interface SimpleAutocompleteOption<T extends AutocompleteParameterTypes> {
 	/** Text that will be displayed to the user in UI for this option. */
 	display: string;
 	/** The actual value that will get used in the formula if this option is selected. */
-	value: TypeMap[ParameterTypeMap[T]];
+	value: TypeMap[AutocompleteParameterTypeMapping[T]];
 }
 /**
  * Utility to search over an array of autocomplete results and return only those that
@@ -2446,7 +2460,7 @@ export interface SimpleAutocompleteOption<T extends ParameterType.Number | Param
  * }
  * ```
  */
-export declare function simpleAutocomplete<T extends ParameterType.Number | ParameterType.String>(search: string | undefined, options: Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>>): Promise<MetadataFormulaObjectResultType[]>;
+export declare function simpleAutocomplete<T extends AutocompleteParameterTypes>(search: string | undefined, options: Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>>): Promise<MetadataFormulaObjectResultType[]>;
 /**
  * A helper to search over a list of objects representing candidate search results,
  * filtering to only those that match a search string, and converting the matching
@@ -2484,7 +2498,7 @@ export declare function autocompleteSearchObjects<T>(search: string, objs: T[], 
  * as the value of the `autocomplete` property in your parameter definition. There is no longer
  * any needed to wrap a value with this formula.
  */
-export declare function makeSimpleAutocompleteMetadataFormula<T extends ParameterType.Number | ParameterType.String>(options: Array<TypeMap[ParameterTypeMap[T]] | SimpleAutocompleteOption<T>>): MetadataFormula;
+export declare function makeSimpleAutocompleteMetadataFormula<T extends AutocompleteParameterTypes>(options: Array<TypeMap[AutocompleteParameterTypeMapping[T]] | SimpleAutocompleteOption<T>>): MetadataFormula;
 /**
  * A set of options used internally by {@link makeDynamicSyncTable}, or for static
  * sync tables that have a dynamic schema.

--- a/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
@@ -17,13 +17,13 @@ any needed to wrap a value with this formula.
 
 | Name | Type |
 | :------ | :------ |
-| `T` | extends [`String`](../enums/core.ParameterType.md#string) \| [`Number`](../enums/core.ParameterType.md#number) |
+| `T` | extends `AutocompleteParameterTypes` |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `options` | (`TypeMap`[`ParameterTypeMap`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] |
+| `options` | (`TypeMap`[`AutocompleteParameterTypeMapping`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] |
 
 #### Returns
 

--- a/docs/reference/sdk/functions/core.simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/core.simpleAutocomplete.md
@@ -31,14 +31,14 @@ autocomplete: async function(context, search) {
 
 | Name | Type |
 | :------ | :------ |
-| `T` | extends [`String`](../enums/core.ParameterType.md#string) \| [`Number`](../enums/core.ParameterType.md#number) |
+| `T` | extends `AutocompleteParameterTypes` |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `search` | `undefined` \| `string` |
-| `options` | (`TypeMap`[`ParameterTypeMap`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] |
+| `options` | (`TypeMap`[`AutocompleteParameterTypeMapping`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] |
 
 #### Returns
 

--- a/docs/reference/sdk/interfaces/core.DynamicOptions.md
+++ b/docs/reference/sdk/interfaces/core.DynamicOptions.md
@@ -18,7 +18,7 @@ See [defaultAddDynamicColumns](core.DynamicSyncTableOptions.md#defaultadddynamic
 
 #### Defined in
 
-[api.ts:1307](https://github.com/coda/packs-sdk/blob/main/api.ts#L1307)
+[api.ts:1328](https://github.com/coda/packs-sdk/blob/main/api.ts#L1328)
 
 ___
 
@@ -30,7 +30,7 @@ See [entityName](core.DynamicSyncTableOptions.md#entityname)
 
 #### Defined in
 
-[api.ts:1305](https://github.com/coda/packs-sdk/blob/main/api.ts#L1305)
+[api.ts:1326](https://github.com/coda/packs-sdk/blob/main/api.ts#L1326)
 
 ___
 
@@ -47,4 +47,4 @@ does not require a [dynamicUrl](core.Sync.md#dynamicurl).
 
 #### Defined in
 
-[api.ts:1303](https://github.com/coda/packs-sdk/blob/main/api.ts#L1303)
+[api.ts:1324](https://github.com/coda/packs-sdk/blob/main/api.ts#L1324)

--- a/docs/reference/sdk/interfaces/core.DynamicSyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/core.DynamicSyncTableOptions.md
@@ -27,7 +27,7 @@ this sync table (including autocomplete formulas).
 
 #### Defined in
 
-[api.ts:1437](https://github.com/coda/packs-sdk/blob/main/api.ts#L1437)
+[api.ts:1458](https://github.com/coda/packs-sdk/blob/main/api.ts#L1458)
 
 ___
 
@@ -51,7 +51,7 @@ into the hands of the user.
 
 #### Defined in
 
-[api.ts:1453](https://github.com/coda/packs-sdk/blob/main/api.ts#L1453)
+[api.ts:1474](https://github.com/coda/packs-sdk/blob/main/api.ts#L1474)
 
 ___
 
@@ -65,7 +65,7 @@ This should describe what the dynamic sync table does in a more detailed languag
 
 #### Defined in
 
-[api.ts:1391](https://github.com/coda/packs-sdk/blob/main/api.ts#L1391)
+[api.ts:1412](https://github.com/coda/packs-sdk/blob/main/api.ts#L1412)
 
 ___
 
@@ -79,7 +79,7 @@ of `identity.name` from your schema will be used instead, so in most cases you d
 
 #### Defined in
 
-[api.ts:1432](https://github.com/coda/packs-sdk/blob/main/api.ts#L1432)
+[api.ts:1453](https://github.com/coda/packs-sdk/blob/main/api.ts#L1453)
 
 ___
 
@@ -94,7 +94,7 @@ These will eventually be consolidated.)
 
 #### Defined in
 
-[api.ts:1426](https://github.com/coda/packs-sdk/blob/main/api.ts#L1426)
+[api.ts:1447](https://github.com/coda/packs-sdk/blob/main/api.ts#L1447)
 
 ___
 
@@ -109,7 +109,7 @@ of the table data. This is typically a browser-friendly form of the
 
 #### Defined in
 
-[api.ts:1414](https://github.com/coda/packs-sdk/blob/main/api.ts#L1414)
+[api.ts:1435](https://github.com/coda/packs-sdk/blob/main/api.ts#L1435)
 
 ___
 
@@ -121,7 +121,7 @@ A formula that returns the name of this table.
 
 #### Defined in
 
-[api.ts:1395](https://github.com/coda/packs-sdk/blob/main/api.ts#L1395)
+[api.ts:1416](https://github.com/coda/packs-sdk/blob/main/api.ts#L1416)
 
 ___
 
@@ -133,7 +133,7 @@ A formula that returns the schema for this table.
 
 #### Defined in
 
-[api.ts:1407](https://github.com/coda/packs-sdk/blob/main/api.ts#L1407)
+[api.ts:1428](https://github.com/coda/packs-sdk/blob/main/api.ts#L1428)
 
 ___
 
@@ -149,7 +149,7 @@ differentiate which exact table to use.
 
 #### Defined in
 
-[api.ts:1403](https://github.com/coda/packs-sdk/blob/main/api.ts#L1403)
+[api.ts:1424](https://github.com/coda/packs-sdk/blob/main/api.ts#L1424)
 
 ___
 
@@ -162,7 +162,7 @@ used to create an instance of this dynamic sync table.
 
 #### Defined in
 
-[api.ts:1419](https://github.com/coda/packs-sdk/blob/main/api.ts#L1419)
+[api.ts:1440](https://github.com/coda/packs-sdk/blob/main/api.ts#L1440)
 
 ___
 
@@ -178,7 +178,7 @@ is returned by the `getName` formula.
 
 #### Defined in
 
-[api.ts:1385](https://github.com/coda/packs-sdk/blob/main/api.ts#L1385)
+[api.ts:1406](https://github.com/coda/packs-sdk/blob/main/api.ts#L1406)
 
 ___
 
@@ -193,4 +193,4 @@ in placeholderSchema will be rendered by default after the sync.
 
 #### Defined in
 
-[api.ts:1460](https://github.com/coda/packs-sdk/blob/main/api.ts#L1460)
+[api.ts:1481](https://github.com/coda/packs-sdk/blob/main/api.ts#L1481)

--- a/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
@@ -220,7 +220,7 @@ A definition of the request and any parameter transformations to make in order t
 
 #### Defined in
 
-[api.ts:564](https://github.com/coda/packs-sdk/blob/main/api.ts#L564)
+[api.ts:585](https://github.com/coda/packs-sdk/blob/main/api.ts#L585)
 
 ___
 

--- a/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
@@ -18,7 +18,7 @@ The value displayed to the user in the UI.
 
 #### Defined in
 
-[api.ts:974](https://github.com/coda/packs-sdk/blob/main/api.ts#L974)
+[api.ts:995](https://github.com/coda/packs-sdk/blob/main/api.ts#L995)
 
 ___
 
@@ -55,7 +55,7 @@ as the `value` of the result that was clicked on.
 
 #### Defined in
 
-[api.ts:1005](https://github.com/coda/packs-sdk/blob/main/api.ts#L1005)
+[api.ts:1026](https://github.com/coda/packs-sdk/blob/main/api.ts#L1026)
 
 ___
 
@@ -67,4 +67,4 @@ The value used for the formula argument when the user selects this option.
 
 #### Defined in
 
-[api.ts:976](https://github.com/coda/packs-sdk/blob/main/api.ts#L976)
+[api.ts:997](https://github.com/coda/packs-sdk/blob/main/api.ts#L997)

--- a/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
@@ -222,7 +222,7 @@ A definition of the request and any parameter transformations to make in order t
 
 #### Defined in
 
-[api.ts:549](https://github.com/coda/packs-sdk/blob/main/api.ts#L549)
+[api.ts:570](https://github.com/coda/packs-sdk/blob/main/api.ts#L570)
 
 ___
 
@@ -234,7 +234,7 @@ A definition of the schema for the object list returned by this function.
 
 #### Defined in
 
-[api.ts:551](https://github.com/coda/packs-sdk/blob/main/api.ts#L551)
+[api.ts:572](https://github.com/coda/packs-sdk/blob/main/api.ts#L572)
 
 ___
 

--- a/docs/reference/sdk/interfaces/core.SimpleAutocompleteOption.md
+++ b/docs/reference/sdk/interfaces/core.SimpleAutocompleteOption.md
@@ -12,7 +12,7 @@ the underlying option that will be used in the formula when selected.
 
 | Name | Type |
 | :------ | :------ |
-| `T` | extends [`Number`](../enums/core.ParameterType.md#number) \| [`String`](../enums/core.ParameterType.md#string) |
+| `T` | extends `AutocompleteParameterTypes` |
 
 ## Properties
 
@@ -24,16 +24,16 @@ Text that will be displayed to the user in UI for this option.
 
 #### Defined in
 
-[api.ts:1116](https://github.com/coda/packs-sdk/blob/main/api.ts#L1116)
+[api.ts:1137](https://github.com/coda/packs-sdk/blob/main/api.ts#L1137)
 
 ___
 
 ### value
 
-• **value**: `TypeMap`[`ParameterTypeMap`[`T`]]
+• **value**: `TypeMap`[`AutocompleteParameterTypeMapping`[`T`]]
 
 The actual value that will get used in the formula if this option is selected.
 
 #### Defined in
 
-[api.ts:1118](https://github.com/coda/packs-sdk/blob/main/api.ts#L1118)
+[api.ts:1139](https://github.com/coda/packs-sdk/blob/main/api.ts#L1139)

--- a/docs/reference/sdk/interfaces/core.SyncFormulaResult.md
+++ b/docs/reference/sdk/interfaces/core.SyncFormulaResult.md
@@ -30,7 +30,7 @@ until there is no continuation returned.
 
 #### Defined in
 
-[api.ts:671](https://github.com/coda/packs-sdk/blob/main/api.ts#L671)
+[api.ts:692](https://github.com/coda/packs-sdk/blob/main/api.ts#L692)
 
 ___
 
@@ -42,4 +42,4 @@ The list of results from this page.
 
 #### Defined in
 
-[api.ts:665](https://github.com/coda/packs-sdk/blob/main/api.ts#L665)
+[api.ts:686](https://github.com/coda/packs-sdk/blob/main/api.ts#L686)

--- a/docs/reference/sdk/interfaces/core.SyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/core.SyncTableOptions.md
@@ -27,7 +27,7 @@ this sync table (including autocomplete formulas).
 
 #### Defined in
 
-[api.ts:1361](https://github.com/coda/packs-sdk/blob/main/api.ts#L1361)
+[api.ts:1382](https://github.com/coda/packs-sdk/blob/main/api.ts#L1382)
 
 ___
 
@@ -41,7 +41,7 @@ description for a 'Products' sync table could be: 'Returns products from the e-c
 
 #### Defined in
 
-[api.ts:1330](https://github.com/coda/packs-sdk/blob/main/api.ts#L1330)
+[api.ts:1351](https://github.com/coda/packs-sdk/blob/main/api.ts#L1351)
 
 ___
 
@@ -54,7 +54,7 @@ sync tables that have a dynamic schema.
 
 #### Defined in
 
-[api.ts:1366](https://github.com/coda/packs-sdk/blob/main/api.ts#L1366)
+[api.ts:1387](https://github.com/coda/packs-sdk/blob/main/api.ts#L1387)
 
 ___
 
@@ -69,7 +69,7 @@ These will eventually be consolidated.)
 
 #### Defined in
 
-[api.ts:1356](https://github.com/coda/packs-sdk/blob/main/api.ts#L1356)
+[api.ts:1377](https://github.com/coda/packs-sdk/blob/main/api.ts#L1377)
 
 ___
 
@@ -91,7 +91,7 @@ of the object, and the schema is declared as `{identity: {name: 'Products'}}`.
 
 #### Defined in
 
-[api.ts:1344](https://github.com/coda/packs-sdk/blob/main/api.ts#L1344)
+[api.ts:1365](https://github.com/coda/packs-sdk/blob/main/api.ts#L1365)
 
 ___
 
@@ -105,7 +105,7 @@ from an e-commerce platform should be called 'Products'. This name must not cont
 
 #### Defined in
 
-[api.ts:1324](https://github.com/coda/packs-sdk/blob/main/api.ts#L1324)
+[api.ts:1345](https://github.com/coda/packs-sdk/blob/main/api.ts#L1345)
 
 ___
 
@@ -118,4 +118,4 @@ schema for a single product. The sync formula will return an array of objects th
 
 #### Defined in
 
-[api.ts:1349](https://github.com/coda/packs-sdk/blob/main/api.ts#L1349)
+[api.ts:1370](https://github.com/coda/packs-sdk/blob/main/api.ts#L1370)

--- a/docs/reference/sdk/types/core.ArrayFormulaDef.md
+++ b/docs/reference/sdk/types/core.ArrayFormulaDef.md
@@ -18,4 +18,4 @@ A definition accepted by [makeFormula](../functions/core.makeFormula.md) for a f
 
 #### Defined in
 
-[api.ts:931](https://github.com/coda/packs-sdk/blob/main/api.ts#L931)
+[api.ts:952](https://github.com/coda/packs-sdk/blob/main/api.ts#L952)

--- a/docs/reference/sdk/types/core.BaseFormula.md
+++ b/docs/reference/sdk/types/core.BaseFormula.md
@@ -18,4 +18,4 @@ The base class for pack formula descriptors. Subclasses vary based on the return
 
 #### Defined in
 
-[api.ts:568](https://github.com/coda/packs-sdk/blob/main/api.ts#L568)
+[api.ts:589](https://github.com/coda/packs-sdk/blob/main/api.ts#L589)

--- a/docs/reference/sdk/types/core.BooleanFormulaDef.md
+++ b/docs/reference/sdk/types/core.BooleanFormulaDef.md
@@ -17,4 +17,4 @@ A definition accepted by [makeFormula](../functions/core.makeFormula.md) for a f
 
 #### Defined in
 
-[api.ts:923](https://github.com/coda/packs-sdk/blob/main/api.ts#L923)
+[api.ts:944](https://github.com/coda/packs-sdk/blob/main/api.ts#L944)

--- a/docs/reference/sdk/types/core.BooleanPackFormula.md
+++ b/docs/reference/sdk/types/core.BooleanPackFormula.md
@@ -17,4 +17,4 @@ A pack formula that returns a boolean.
 
 #### Defined in
 
-[api.ts:581](https://github.com/coda/packs-sdk/blob/main/api.ts#L581)
+[api.ts:602](https://github.com/coda/packs-sdk/blob/main/api.ts#L602)

--- a/docs/reference/sdk/types/core.Formula.md
+++ b/docs/reference/sdk/types/core.Formula.md
@@ -23,4 +23,4 @@ pack, like an autocomplete metadata formula or a sync getter formula.
 
 #### Defined in
 
-[api.ts:609](https://github.com/coda/packs-sdk/blob/main/api.ts#L609)
+[api.ts:630](https://github.com/coda/packs-sdk/blob/main/api.ts#L630)

--- a/docs/reference/sdk/types/core.FormulaDefinition.md
+++ b/docs/reference/sdk/types/core.FormulaDefinition.md
@@ -19,4 +19,4 @@ A formula definition accepted by [makeFormula](../functions/core.makeFormula.md)
 
 #### Defined in
 
-[api.ts:954](https://github.com/coda/packs-sdk/blob/main/api.ts#L954)
+[api.ts:975](https://github.com/coda/packs-sdk/blob/main/api.ts#L975)

--- a/docs/reference/sdk/types/core.MetadataContext.md
+++ b/docs/reference/sdk/types/core.MetadataContext.md
@@ -14,4 +14,4 @@ values are provided in this context object.
 
 #### Defined in
 
-[api.ts:1014](https://github.com/coda/packs-sdk/blob/main/api.ts#L1014)
+[api.ts:1035](https://github.com/coda/packs-sdk/blob/main/api.ts#L1035)

--- a/docs/reference/sdk/types/core.MetadataFormula.md
+++ b/docs/reference/sdk/types/core.MetadataFormula.md
@@ -37,4 +37,4 @@ current value.
 
 #### Defined in
 
-[api.ts:1049](https://github.com/coda/packs-sdk/blob/main/api.ts#L1049)
+[api.ts:1070](https://github.com/coda/packs-sdk/blob/main/api.ts#L1070)

--- a/docs/reference/sdk/types/core.MetadataFormulaDef.md
+++ b/docs/reference/sdk/types/core.MetadataFormulaDef.md
@@ -13,4 +13,4 @@ or a full metadata formula definition (mostly supported for legacy code).
 
 #### Defined in
 
-[api.ts:1069](https://github.com/coda/packs-sdk/blob/main/api.ts#L1069)
+[api.ts:1090](https://github.com/coda/packs-sdk/blob/main/api.ts#L1090)

--- a/docs/reference/sdk/types/core.MetadataFormulaResultType.md
+++ b/docs/reference/sdk/types/core.MetadataFormulaResultType.md
@@ -11,4 +11,4 @@ The type of values that can be returned from a [MetadataFormula](core.MetadataFo
 
 #### Defined in
 
-[api.ts:1019](https://github.com/coda/packs-sdk/blob/main/api.ts#L1019)
+[api.ts:1040](https://github.com/coda/packs-sdk/blob/main/api.ts#L1040)

--- a/docs/reference/sdk/types/core.MetadataFunction.md
+++ b/docs/reference/sdk/types/core.MetadataFunction.md
@@ -27,4 +27,4 @@ A JavaScript function that can implement a [MetadataFormulaDef](core.MetadataFor
 
 #### Defined in
 
-[api.ts:1058](https://github.com/coda/packs-sdk/blob/main/api.ts#L1058)
+[api.ts:1079](https://github.com/coda/packs-sdk/blob/main/api.ts#L1079)

--- a/docs/reference/sdk/types/core.NumericFormulaDef.md
+++ b/docs/reference/sdk/types/core.NumericFormulaDef.md
@@ -17,4 +17,4 @@ A definition accepted by [makeFormula](../functions/core.makeFormula.md) for a f
 
 #### Defined in
 
-[api.ts:915](https://github.com/coda/packs-sdk/blob/main/api.ts#L915)
+[api.ts:936](https://github.com/coda/packs-sdk/blob/main/api.ts#L936)

--- a/docs/reference/sdk/types/core.NumericPackFormula.md
+++ b/docs/reference/sdk/types/core.NumericPackFormula.md
@@ -17,4 +17,4 @@ A pack formula that returns a number.
 
 #### Defined in
 
-[api.ts:576](https://github.com/coda/packs-sdk/blob/main/api.ts#L576)
+[api.ts:597](https://github.com/coda/packs-sdk/blob/main/api.ts#L597)

--- a/docs/reference/sdk/types/core.ObjectFormulaDef.md
+++ b/docs/reference/sdk/types/core.ObjectFormulaDef.md
@@ -18,4 +18,4 @@ A definition accepted by [makeFormula](../functions/core.makeFormula.md) for a f
 
 #### Defined in
 
-[api.ts:942](https://github.com/coda/packs-sdk/blob/main/api.ts#L942)
+[api.ts:963](https://github.com/coda/packs-sdk/blob/main/api.ts#L963)

--- a/docs/reference/sdk/types/core.ObjectPackFormula.md
+++ b/docs/reference/sdk/types/core.ObjectPackFormula.md
@@ -18,4 +18,4 @@ A pack formula that returns a JavaScript object.
 
 #### Defined in
 
-[api.ts:591](https://github.com/coda/packs-sdk/blob/main/api.ts#L591)
+[api.ts:612](https://github.com/coda/packs-sdk/blob/main/api.ts#L612)

--- a/docs/reference/sdk/types/core.ParameterOptions.md
+++ b/docs/reference/sdk/types/core.ParameterOptions.md
@@ -5,7 +5,7 @@ title: "ParameterOptions"
 
 [core](../modules/core.md).ParameterOptions
 
-Ƭ **ParameterOptions**<`T`\>: `Omit`<[`ParamDef`](../interfaces/core.ParamDef.md)<`ParameterTypeMap`[`T`]\>, ``"type"`` \| ``"autocomplete"``\> & { `autocomplete?`: `T` extends [`Number`](../enums/core.ParameterType.md#number) \| [`String`](../enums/core.ParameterType.md#string) ? [`MetadataFormulaDef`](core.MetadataFormulaDef.md) \| (`TypeMap`[`ParameterTypeMap`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] : `undefined` ; `type`: `T`  }
+Ƭ **ParameterOptions**<`T`\>: `Omit`<[`ParamDef`](../interfaces/core.ParamDef.md)<`ParameterTypeMap`[`T`]\>, ``"type"`` \| ``"autocomplete"``\> & { `autocomplete?`: `T` extends `AutocompleteParameterTypes` ? [`MetadataFormulaDef`](core.MetadataFormulaDef.md) \| (`TypeMap`[`AutocompleteParameterTypeMapping`[`T`]] \| [`SimpleAutocompleteOption`](../interfaces/core.SimpleAutocompleteOption.md)<`T`\>)[] : `undefined` ; `type`: `T`  }
 
 Options you can specify when defining a parameter using [makeParameter](../functions/core.makeParameter.md).
 
@@ -17,4 +17,4 @@ Options you can specify when defining a parameter using [makeParameter](../funct
 
 #### Defined in
 
-[api.ts:338](https://github.com/coda/packs-sdk/blob/main/api.ts#L338)
+[api.ts:359](https://github.com/coda/packs-sdk/blob/main/api.ts#L359)

--- a/docs/reference/sdk/types/core.StringFormulaDef.md
+++ b/docs/reference/sdk/types/core.StringFormulaDef.md
@@ -17,4 +17,4 @@ A definition accepted by [makeFormula](../functions/core.makeFormula.md) for a f
 
 #### Defined in
 
-[api.ts:907](https://github.com/coda/packs-sdk/blob/main/api.ts#L907)
+[api.ts:928](https://github.com/coda/packs-sdk/blob/main/api.ts#L928)

--- a/docs/reference/sdk/types/core.StringPackFormula.md
+++ b/docs/reference/sdk/types/core.StringPackFormula.md
@@ -17,4 +17,4 @@ A pack formula that returns a string.
 
 #### Defined in
 
-[api.ts:586](https://github.com/coda/packs-sdk/blob/main/api.ts#L586)
+[api.ts:607](https://github.com/coda/packs-sdk/blob/main/api.ts#L607)

--- a/docs/reference/sdk/types/core.SyncFormula.md
+++ b/docs/reference/sdk/types/core.SyncFormula.md
@@ -23,4 +23,4 @@ input to [makeSyncTable](../functions/core.makeSyncTable.md) which outputs defin
 
 #### Defined in
 
-[api.ts:699](https://github.com/coda/packs-sdk/blob/main/api.ts#L699)
+[api.ts:720](https://github.com/coda/packs-sdk/blob/main/api.ts#L720)

--- a/docs/reference/sdk/types/core.TypedPackFormula.md
+++ b/docs/reference/sdk/types/core.TypedPackFormula.md
@@ -15,4 +15,4 @@ contents of a pack for for Coda internal use.
 
 #### Defined in
 
-[api.ts:637](https://github.com/coda/packs-sdk/blob/main/api.ts#L637)
+[api.ts:658](https://github.com/coda/packs-sdk/blob/main/api.ts#L658)

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -280,12 +280,42 @@ describe('API test', () => {
       });
     });
 
+    it('autocomplete works for array param', () => {
+      makeFormula({
+        resultType: ValueType.String,
+        name: 'Test',
+        description: '',
+        parameters: [makeParameter({
+          type: ParameterType.StringArray, 
+          name: 'myParam', 
+          description: '',
+          autocomplete: ['Foo', 'Bar', 'Baz'],
+        })],
+        execute: ([param]) => param[0],
+      });
+    });
+
     it('sparse array inferred from makeParameter with array param', () => {
       makeFormula({
         resultType: ValueType.String,
         name: 'Test',
         description: '',
         parameters: [makeParameter({type: ParameterType.SparseStringArray, name: 'myParam', description: ''})],
+        execute: ([param]) => param[0] ?? 'undefined',
+      });
+    });
+
+    it('autocomplete works for array param', () => {
+      makeFormula({
+        resultType: ValueType.String,
+        name: 'Test',
+        description: '',
+        parameters: [makeParameter({
+          type: ParameterType.SparseStringArray, 
+          name: 'myParam', 
+          description: '',
+          autocomplete: ['Foo', 'Bar', 'Baz'],
+        })],
         execute: ([param]) => param[0] ?? 'undefined',
       });
     });

--- a/typedoc.js
+++ b/typedoc.js
@@ -19,6 +19,8 @@ module.exports = {
     // Internal intermediate or helper types that we probably don't care to export or document.
     '$Values',
     'AsAuthDef',
+    'AutocompleteParameterTypeMapping',
+    'AutocompleteParameterTypes',
     'BooleanHintValueTypes',
     'GenericObjectSchema',
     'NumberHintValueTypes',
@@ -26,7 +28,7 @@ module.exports = {
     'ObjectSchema',
     'ObjectSchemaDefinitionType',
     'ObjectSchemaType',
-    'ParameterTypeMap',
+    'ParameterTypeMap',    
     'SimpleStringHintTypes',
     'StringHintTypeToSchemaType',
     'StringHintValueTypes',


### PR DESCRIPTION
@jonathan-codaio @huayang-codaio @coda/packs PTAL

Coda UX now supports ability to autocomplete string arrays; should be able to turn this on.