### PR TITLE
Validate the authorizationUrl and tokenUrl are actually URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 - Added `ImageSchema`, for use with images. Allows packs to set two flags on a formula returning an image: if the image should be rendered with or without an outline, and whether to turn off the rounded corners. If the outline flag `ImageOutline` is not set on a schema, the default is `Solid`, and the image will be rendered with an outline. If the corners flag `ImageCornerStyle` is not set, the default is `Rounded`, and the image will be rendered with rounded corners.
 - Added `NumericDurationSchema`, which will allow packs to return `ValueType.Number` values that are interpreted in Coda as a duration in seconds.
 - Added autocomplete support for `ParameterType.StringArray` and `ParameterType.SparseStringArray` parameters.
+- Changed OAuth2 validation to check that authorizationUrl and tokenUrl parse as URLs.
 
 ## [1.0.2] - 2022-07-14
 

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -300,8 +300,8 @@ const defaultAuthenticationValidators = {
     }),
     [types_1.AuthenticationType.OAuth2]: zodCompleteStrictObject({
         type: zodDiscriminant(types_1.AuthenticationType.OAuth2),
-        authorizationUrl: z.string(),
-        tokenUrl: z.string(),
+        authorizationUrl: z.string().url(),
+        tokenUrl: z.string().url(),
         scopes: z.array(z.string()).optional(),
         scopeDelimiter: z.enum([' ', ',', ';']).optional(),
         tokenPrefix: z.string().optional(),

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -2309,8 +2309,8 @@ describe('Pack metadata Validation', () => {
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2,
-          authorizationUrl: 'some-url',
-          tokenUrl: 'some-url',
+          authorizationUrl: 'https://example.com/authUrl',
+          tokenUrl: 'https://example.com/tokenUrl',
           scopes: ['scope 1', 'scope 2'],
           tokenPrefix: 'some-prefix',
           additionalParams: {foo: 'bar'},
@@ -2333,11 +2333,32 @@ describe('Pack metadata Validation', () => {
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2,
+          authorizationUrl: 'https://example.com/authUrl',
+          tokenUrl: 'https://example.com/tokenUrl',
+        },
+      });
+      await validateJson(metadata);
+    });
+
+    it('OAuth2, errors', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.OAuth2,
           authorizationUrl: 'some-url',
           tokenUrl: 'some-url',
         },
       });
-      await validateJson(metadata);
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'Invalid url',
+          path: 'defaultAuthentication.authorizationUrl',
+        },
+        {
+          message: 'Invalid url',
+          path: 'defaultAuthentication.tokenUrl',
+        },
+      ]);
     });
 
     it('WebBasic', async () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -380,8 +380,8 @@ const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> 
   }),
   [AuthenticationType.OAuth2]: zodCompleteStrictObject<OAuth2Authentication>({
     type: zodDiscriminant(AuthenticationType.OAuth2),
-    authorizationUrl: z.string(),
-    tokenUrl: z.string(),
+    authorizationUrl: z.string().url(),
+    tokenUrl: z.string().url(),
     scopes: z.array(z.string()).optional(),
     scopeDelimiter: z.enum([' ', ',', ';']).optional(),
     tokenPrefix: z.string().optional(),


### PR DESCRIPTION
This is just earlier feedback to a pack developer if there's something wrong with the provided authorizationUrl or tokenUrl

As a side benefit, once all packs are running at the next SDK release or higher we can simplify validation rules involving the domains of these URLs on the server side because parse errors could be server errors instead of a user-facing request error.