### PR TITLE
Fix endless loop

### DIFF
--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -298,7 +298,7 @@ function newRealFetcherExecutionContext(packDef, manifestPath) {
 }
 exports.newRealFetcherExecutionContext = newRealFetcherExecutionContext;
 function newRealFetcherSyncExecutionContext(packDef, manifestPath) {
-    const context = newRealFetcherSyncExecutionContext(packDef, manifestPath);
+    const context = newRealFetcherExecutionContext(packDef, manifestPath);
     return { ...context, sync: {} };
 }
 exports.newRealFetcherSyncExecutionContext = newRealFetcherSyncExecutionContext;

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -472,6 +472,6 @@ export function newRealFetcherSyncExecutionContext(
   packDef: BasicPackDefinition,
   manifestPath: string,
 ): SyncExecutionContext {
-  const context = newRealFetcherSyncExecutionContext(packDef, manifestPath);
+  const context = newRealFetcherExecutionContext(packDef, manifestPath);
   return {...context, sync: {}};
 }


### PR DESCRIPTION
Identified when trying to help [a user in the community](https://community.coda.io/t/testing-dynamic-sync-formulas/32585), `newRealFetcherSyncExecutionContext` was calling itself instead of `newRealFetcherExecutionContext`, resulting in an endless loop.

