### PR TITLE
Add length validation to various fields that will be indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 - Added `NumericDurationSchema`, which will allow packs to return `ValueType.Number` values that are interpreted in Coda as a duration in seconds.
 - Added autocomplete support for `ParameterType.StringArray` and `ParameterType.SparseStringArray` parameters.
 - Changed OAuth2 validation to check that authorizationUrl and tokenUrl parse as URLs.
+- Limited number of formulas, column formats, and sync tables to 100 each. Added character limits to names and descriptions, and to length of column matchers and network domains.
 
 ## [1.0.2] - 2022-07-14
 

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -16,7 +16,7 @@ export declare const Limits: {
     BuildingBlockName: number;
     BuildingBlockDescription: number;
     ColumnMatcherRegex: number;
-    NumColumnMatchers: number;
+    NumColumnMatchersPerFormat: number;
     NetworkDomainUrl: number;
 };
 export declare class PackMetadataValidationError extends Error {

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -11,6 +11,11 @@ import * as z from 'zod';
  * a real RegExp object.
  */
 export declare const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX: RegExp;
+export declare const BUILDING_BLOCK_COUNT_LIMIT = 500;
+export declare const BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
+export declare const BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
+export declare const COLUMN_MATCHERS_COUNT_LIMIT = 10;
+export declare const NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
 export declare class PackMetadataValidationError extends Error {
     readonly originalError: Error | undefined;
     readonly validationErrors: ValidationError[] | undefined;

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -14,6 +14,7 @@ export declare const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX: RegExp;
 export declare const BUILDING_BLOCK_COUNT_LIMIT = 500;
 export declare const BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
 export declare const BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
+export declare const COLUMN_MATCHERS_CHARACTER_LIMIT = 100;
 export declare const COLUMN_MATCHERS_COUNT_LIMIT = 10;
 export declare const NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
 export declare class PackMetadataValidationError extends Error {

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -11,12 +11,14 @@ import * as z from 'zod';
  * a real RegExp object.
  */
 export declare const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX: RegExp;
-export declare const BUILDING_BLOCK_COUNT_LIMIT = 500;
-export declare const BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
-export declare const BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
-export declare const COLUMN_MATCHERS_CHARACTER_LIMIT = 100;
-export declare const COLUMN_MATCHERS_COUNT_LIMIT = 10;
-export declare const NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
+export declare const Limits: {
+    BuildingBlockCountPerType: number;
+    BuildingBlockName: number;
+    BuildingBlockDescription: number;
+    ColumnMatcherRegex: number;
+    NumColumnMatchers: number;
+    NetworkDomainUrl: number;
+};
 export declare class PackMetadataValidationError extends Error {
     readonly originalError: Error | undefined;
     readonly validationErrors: ValidationError[] | undefined;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -26,7 +26,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.zodErrorDetailToValidationError = exports.validateSyncTableSchema = exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = exports.NETWORK_DOMAIN_CHARACTER_LIMIT = exports.COLUMN_MATCHERS_COUNT_LIMIT = exports.BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = exports.BUILDING_BLOCK_NAME_CHARACTER_LIMIT = exports.BUILDING_BLOCK_COUNT_LIMIT = exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = void 0;
+exports.zodErrorDetailToValidationError = exports.validateSyncTableSchema = exports.validateVariousAuthenticationMetadata = exports.validatePackVersionMetadata = exports.PackMetadataValidationError = exports.NETWORK_DOMAIN_CHARACTER_LIMIT = exports.COLUMN_MATCHERS_COUNT_LIMIT = exports.COLUMN_MATCHERS_CHARACTER_LIMIT = exports.BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = exports.BUILDING_BLOCK_NAME_CHARACTER_LIMIT = exports.BUILDING_BLOCK_COUNT_LIMIT = exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = void 0;
 const schema_1 = require("../schema");
 const types_1 = require("../types");
 const schema_2 = require("../schema");
@@ -67,6 +67,7 @@ exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = /^\/(.*)\/([a-z]+)?$/;
 exports.BUILDING_BLOCK_COUNT_LIMIT = 500;
 exports.BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
 exports.BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
+exports.COLUMN_MATCHERS_CHARACTER_LIMIT = 100;
 exports.COLUMN_MATCHERS_COUNT_LIMIT = 10;
 exports.NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
 var CustomErrorCode;
@@ -908,7 +909,7 @@ const formatMetadataSchema = zodCompleteObject({
     hasNoConnection: z.boolean().optional(),
     instructions: z.string().optional(),
     placeholder: z.string().optional(),
-    matchers: z.array(z.string().refine(validateFormatMatcher)).max(exports.COLUMN_MATCHERS_COUNT_LIMIT),
+    matchers: z.array(z.string().max(exports.COLUMN_MATCHERS_CHARACTER_LIMIT).refine(validateFormatMatcher)).max(exports.COLUMN_MATCHERS_COUNT_LIMIT),
 });
 const syncFormulaSchema = zodCompleteObject({
     schema: arrayPropertySchema.optional(),

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -67,8 +67,8 @@ exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = /^\/(.*)\/([a-z]+)?$/;
 exports.Limits = {
     BuildingBlockCountPerType: 100,
     BuildingBlockName: 50,
-    BuildingBlockDescription: 100,
-    ColumnMatcherRegex: 100,
+    BuildingBlockDescription: 250,
+    ColumnMatcherRegex: 300,
     NumColumnMatchersPerFormat: 10,
     NetworkDomainUrl: 253,
 };

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -384,7 +384,7 @@ const variousSupportedAuthenticationValidators = Object.entries(defaultAuthentic
     .map(([_authType, schema]) => schema);
 const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
 const paramDefValidator = zodCompleteObject({
-    name: z.string(),
+    name: z.string().max(exports.Limits.BuildingBlockName),
     type: z
         .union([
         z.nativeEnum(api_types_3.Type),
@@ -398,7 +398,7 @@ const paramDefValidator = zodCompleteObject({
         !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === api_types_3.Type.object), {
         message: 'Object parameters are not currently supported.',
     }),
-    description: z.string(),
+    description: z.string().max(exports.Limits.BuildingBlockDescription),
     optional: z.boolean().optional(),
     autocomplete: z.unknown().optional(),
     defaultValue: z.unknown().optional(),
@@ -1071,13 +1071,13 @@ function validateFormulas(schema) {
         .superRefine((data, context) => {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j;
         const blockTypesOverLimit = [];
-        if ((_b = (_a = data.formulas) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0 > exports.Limits.BuildingBlockCountPerType) {
+        if (((_b = (_a = data.formulas) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0) > exports.Limits.BuildingBlockCountPerType) {
             blockTypesOverLimit.push(`${(_c = data.formulas) === null || _c === void 0 ? void 0 : _c.length} formulas`);
         }
-        if ((_e = (_d = data.formats) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 0 > exports.Limits.BuildingBlockCountPerType) {
+        if (((_e = (_d = data.formats) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 0) > exports.Limits.BuildingBlockCountPerType) {
             blockTypesOverLimit.push(`${(_f = data.formats) === null || _f === void 0 ? void 0 : _f.length} formats`);
         }
-        if ((_h = (_g = data.syncTables) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0 > exports.Limits.BuildingBlockCountPerType) {
+        if (((_h = (_g = data.syncTables) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0) > exports.Limits.BuildingBlockCountPerType) {
             blockTypesOverLimit.push(`${(_j = data.syncTables) === null || _j === void 0 ? void 0 : _j.length} sync tables`);
         }
         if (blockTypesOverLimit.length) {

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1402,8 +1402,7 @@ describe('Pack metadata Validation', () => {
           },
         ]);
       });
-    }
-    );
+    });
 
     it('duplicate sync table identity names', async () => {
       const syncTable1 = makeSyncTable({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -94,6 +94,7 @@ export const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = /^\/(.*)\/([a-z]+)?$/;
 export const BUILDING_BLOCK_COUNT_LIMIT = 500;
 export const BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
 export const BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
+export const COLUMN_MATCHERS_CHARACTER_LIMIT = 100;
 export const COLUMN_MATCHERS_COUNT_LIMIT = 10;
 export const NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
 
@@ -1087,7 +1088,8 @@ const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
   hasNoConnection: z.boolean().optional(),
   instructions: z.string().optional(),
   placeholder: z.string().optional(),
-  matchers: z.array(z.string().refine(validateFormatMatcher)).max(COLUMN_MATCHERS_COUNT_LIMIT),
+  matchers: z.array(
+    z.string().max(COLUMN_MATCHERS_CHARACTER_LIMIT).refine(validateFormatMatcher)).max(COLUMN_MATCHERS_COUNT_LIMIT),
 });
 
 const syncFormulaSchema = zodCompleteObject<Omit<SyncFormula<any, any, ParamDefs, ObjectSchema<any, any>>, 'execute'>>({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -91,12 +91,15 @@ import * as z from 'zod';
  * a real RegExp object.
  */
 export const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = /^\/(.*)\/([a-z]+)?$/;
-export const BUILDING_BLOCK_COUNT_LIMIT = 500;
-export const BUILDING_BLOCK_NAME_CHARACTER_LIMIT = 50;
-export const BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT = 500;
-export const COLUMN_MATCHERS_CHARACTER_LIMIT = 100;
-export const COLUMN_MATCHERS_COUNT_LIMIT = 10;
-export const NETWORK_DOMAIN_CHARACTER_LIMIT = 100;
+
+export const Limits = {
+  BuildingBlockCountPerType: 100,
+  BuildingBlockName: 50,
+  BuildingBlockDescription: 100,
+  ColumnMatcherRegex: 100,
+  NumColumnMatchers: 10,
+  NetworkDomainUrl: 253,
+}
 
 enum CustomErrorCode {
   NonMatchingDiscriminant = 'nonMatchingDiscriminant',
@@ -501,8 +504,8 @@ const commonPackFormulaSchema = {
   // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
   // whose getter names violate the validator, and those exemptions require the pack id, so this has to be
   // done as a superRefine on the top-level object that also contains the pack id.
-  name: z.string().max(BUILDING_BLOCK_NAME_CHARACTER_LIMIT),
-  description: z.string().max(BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT),
+  name: z.string().max(Limits.BuildingBlockName),
+  description: z.string().max(Limits.BuildingBlockDescription),
   examples: z
     .array(
       z.object({
@@ -1082,14 +1085,14 @@ const formulaMetadataSchema = z
   });
 
 const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
-  name: z.string().max(BUILDING_BLOCK_NAME_CHARACTER_LIMIT),
+  name: z.string().max(Limits.BuildingBlockName),
   formulaNamespace: z.string().optional(), // Will be removed once we deprecate namespace objects.
   formulaName: z.string(),
   hasNoConnection: z.boolean().optional(),
   instructions: z.string().optional(),
   placeholder: z.string().optional(),
   matchers: z.array(
-    z.string().max(COLUMN_MATCHERS_CHARACTER_LIMIT).refine(validateFormatMatcher)).max(COLUMN_MATCHERS_COUNT_LIMIT),
+    z.string().max(Limits.ColumnMatcherRegex).refine(validateFormatMatcher)).max(Limits.NumColumnMatchers),
 });
 
 const syncFormulaSchema = zodCompleteObject<Omit<SyncFormula<any, any, ParamDefs, ObjectSchema<any, any>>, 'execute'>>({
@@ -1100,8 +1103,8 @@ const syncFormulaSchema = zodCompleteObject<Omit<SyncFormula<any, any, ParamDefs
 });
 
 const baseSyncTableSchema = {
-  name: z.string().nonempty().max(BUILDING_BLOCK_NAME_CHARACTER_LIMIT),
-  description: z.string().max(BUILDING_BLOCK_DESCRIPTION_CHARACTER_LIMIT).optional(),
+  name: z.string().nonempty().max(Limits.BuildingBlockName),
+  description: z.string().max(Limits.BuildingBlockDescription).optional(),
   schema: genericObjectSchema,
   getter: syncFormulaSchema,
   entityName: z.string().optional(),
@@ -1110,7 +1113,7 @@ const baseSyncTableSchema = {
   identityName: z
     .string()
     .min(1)
-    .max(BUILDING_BLOCK_NAME_CHARACTER_LIMIT)
+    .max(Limits.BuildingBlockName)
     .optional()
     .refine(
       val => !val || !SystemColumnNames.includes(val),
@@ -1171,7 +1174,7 @@ const unrefinedPackVersionMetadataSchema = zodCompleteObject<PackVersionMetadata
     .array(
       z
         .string()
-        .max(NETWORK_DOMAIN_CHARACTER_LIMIT)
+        .max(Limits.NetworkDomainUrl)
         .refine(domain => !(domain.startsWith('http:') || domain.startsWith('https:') || domain.indexOf('/') >= 0), {
           message: 'Invalid network domain. Instead of "https://www.example.com", just specify "example.com".',
         }),
@@ -1279,12 +1282,24 @@ function validateFormulas(schema: z.ZodObject<any>) {
       },
     )
     .superRefine((data, context) => {
-      const buildingBlockCount = (data.syncTables?.length as number || 0) + (data.formulas?.length as number ?? 0) +
-        (data.formats?.length as number || 0);
-      if (buildingBlockCount > BUILDING_BLOCK_COUNT_LIMIT) {
+      const blockTypesOverLimit: string[] = [];
+      if (data.formulas?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+        blockTypesOverLimit.push(`${data.formulas?.length} formulas`);
+      }
+
+      if (data.formats?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+        blockTypesOverLimit.push(`${data.formats?.length} formats`);
+      }
+
+      if (data.syncTables?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+        blockTypesOverLimit.push(`${data.syncTables?.length} sync tables`);
+      }
+
+      if (blockTypesOverLimit.length) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Cannot have more than ${BUILDING_BLOCK_COUNT_LIMIT} formulas, sync tables, and column formats. Detected ${buildingBlockCount}.`,
+          message: `Cannot have more than ${Limits.BuildingBlockCountPerType} of each of formulas, sync tables, and column formats. ` +
+          `Detected ${blockTypesOverLimit.join(', ')}.`,
         })
       }
     })

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -475,7 +475,7 @@ const variousSupportedAuthenticationValidators = Object.entries(defaultAuthentic
 const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
 
 const paramDefValidator = zodCompleteObject<ParamDef<any>>({
-  name: z.string(),
+  name: z.string().max(Limits.BuildingBlockName),
   type: z
     .union([
       z.nativeEnum(Type),
@@ -493,7 +493,7 @@ const paramDefValidator = zodCompleteObject<ParamDef<any>>({
         message: 'Object parameters are not currently supported.',
       },
     ),
-  description: z.string(),
+  description: z.string().max(Limits.BuildingBlockDescription),
   optional: z.boolean().optional(),
   autocomplete: z.unknown().optional(),
   defaultValue: z.unknown().optional(),
@@ -1283,15 +1283,15 @@ function validateFormulas(schema: z.ZodObject<any>) {
     )
     .superRefine((data, context) => {
       const blockTypesOverLimit: string[] = [];
-      if (data.formulas?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+      if ((data.formulas?.length ?? 0) > Limits.BuildingBlockCountPerType) {
         blockTypesOverLimit.push(`${data.formulas?.length} formulas`);
       }
 
-      if (data.formats?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+      if ((data.formats?.length ?? 0) > Limits.BuildingBlockCountPerType) {
         blockTypesOverLimit.push(`${data.formats?.length} formats`);
       }
 
-      if (data.syncTables?.length ?? 0 > Limits.BuildingBlockCountPerType) {
+      if ((data.syncTables?.length ?? 0) > Limits.BuildingBlockCountPerType) {
         blockTypesOverLimit.push(`${data.syncTables?.length} sync tables`);
       }
 

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -95,8 +95,8 @@ export const PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX = /^\/(.*)\/([a-z]+)?$/;
 export const Limits = {
   BuildingBlockCountPerType: 100,
   BuildingBlockName: 50,
-  BuildingBlockDescription: 100,
-  ColumnMatcherRegex: 100,
+  BuildingBlockDescription: 250,
+  ColumnMatcherRegex: 300,
   NumColumnMatchersPerFormat: 10,
   NetworkDomainUrl: 253,
 }


### PR DESCRIPTION
Adds length validation to:
- Building block names and descriptions
- Total building block count
- Column format matchers length
- Network domain url length and column format matcher regex length
PTAL @gary-codaio @jonathan-codaio @huayang-codaio 