### PR TITLE
fix CLI compiler for using node modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog keeps track of all changes to the Packs SDK. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+- Fixed the CLI compiler throwing for using common node modules.
+
 ## [1.0.4] - 2022-08-04
 
 - Increased building block description limit to 1000.

--- a/dist/testing/compile.js
+++ b/dist/testing/compile.js
@@ -123,6 +123,9 @@ async function buildWithES({ lastBundleFilename, outputBundleFilename, options: 
         // - cjs bundles are adding exports to global.exports.
         // - if iife bundles add exports to global, require() doesn't work. only module.exports works. idk why.
         globalName: format === 'iife' ? 'module.exports' : undefined,
+        // Set target to 'node' to allow pack to use node utils. These node utils will however
+        // be later browserified.
+        platform: 'node',
         // isolated-vm environment is approximately es2020. It's known that es2021 will break because of
         // logical assignment
         target: 'ES2020',

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -1,4 +1,5 @@
 import * as coda from '../..';
+import path from 'path';
 
 export const pack = coda.newPack();
 
@@ -204,4 +205,21 @@ pack.addFormula({
       }
     }
   },
+});
+
+pack.addFormula({
+  name: 'NodeUtils',
+  description: '',
+  parameters: [
+    coda.makeParameter({
+      type: coda.ParameterType.String,
+      name: 'name',
+      description: '',
+    }),
+  ],
+  resultType: coda.ValueType.String,
+  execute: async ([name]) => {
+    return path.join('baseDir', name);
+  },
+  cacheTtlSecs: 0,
 });

--- a/testing/compile.ts
+++ b/testing/compile.ts
@@ -157,6 +157,10 @@ async function buildWithES({
     // - if iife bundles add exports to global, require() doesn't work. only module.exports works. idk why.
     globalName: format === 'iife' ? 'module.exports' : undefined,
 
+    // Set target to 'node' to allow pack to use node utils. These node utils will however
+    // be later browserified.
+    platform: 'node',
+
     // isolated-vm environment is approximately es2020. It's known that es2021 will break because of
     // logical assignment
     target: 'ES2020',


### PR DESCRIPTION
I realized that the platform='node' in the compiler only allows to use node modules. it will be browserified anyway later. 

maybe there's better way to make this work but let's unblock the sdk for now.

```
-> % npx ts-node cli/coda.ts build test/packs/fake_v2.ts            
Pack built successfully. Compiled output is in /var/folders/n1/7qfgvcqn04j0py98bvnsnd500000gp/T/coda-packs-114f3e2d-d4a2-4578-84f3-9f195b8924adwRX5AS/bundle.js
```