### PR TITLE
quick fix of security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "typedoc-plugin-markdown": "^3.13.4"
   },
   "resolutions": {
+    "release-it/node-fetch": "^3.2.10", 
     "ansi-regex": "^5.0.1",
     "got": "^12.1.0",
     "jsprim": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5060,10 +5060,10 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.9.tgz#3f6070bf854de20f21b9fe8479f823462e615d7d"
-  integrity sha512-/2lI+DBecVvVm9tDhjziTVjo2wmTsSxSk58saUYP0P/fRJ3xxtfMDY24+CKTkfm0Dlhyn3CSXNL0SoRiCZ8Rzg==
+node-fetch@3.2.9, node-fetch@^3.2.10:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.10.tgz#e8347f94b54ae18b57c9c049ef641cef398a85c8"
+  integrity sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==
   dependencies:
     data-uri-to-buffer "^4.0.0"
     fetch-blob "^3.1.4"


### PR DESCRIPTION
https://github.com/coda/packs-sdk/security/dependabot/19

not a big deal. we can't bump all node-fetch to 3+ because it isn't compatible with our API.