### PR TITLE
Fix small typo in schemas.md

### DIFF
--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -71,7 +71,7 @@ pack.addFormula({
   // ...
   resultType: coda.ValueType.Array,
   items: coda.makeSchema({
-    type: coda.ValeType.Number,
+    type: coda.ValueType.Number,
   }),
   // ...
 });


### PR DESCRIPTION
fix typo: coda.ValeType.Number -> coda.ValueType.Number