### PR TITLE
Allow flexible yes/no responses in prompts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ compile-thunk:
 		--target=es2020;
 
 .PHONY: compile-ts
-compile-ts:	
+compile-ts:
 	${ROOTDIR}/node_modules/.bin/tsc
 
 	$(MAKE) compile-thunk
@@ -127,7 +127,7 @@ compile-ts:
 	# copy buffer.d.ts to be used by monaco browser.
 	cp ${ROOTDIR}/node_modules/buffer/index.d.ts ${ROOTDIR}/dist/buffer.d.ts
 
-	# This bundle is used by the Pack studio to compile the pack bundle in the browser. It will be loaded in both 
+	# This bundle is used by the Pack studio to compile the pack bundle in the browser. It will be loaded in both
 	# browser and isolated-vm. In the browser, the pack bundle is loaded in an iframe to extract pack metadata.
 	# In lambda, the pack bundle actually runs formulas.
 	#

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -35,7 +35,7 @@ export async function handleClone({packIdOrUrl, codaApiEndpoint}: ArgumentsCamel
   const codeAlreadyExists = fs.existsSync(path.join(manifestDir, 'pack.ts'));
   if (codeAlreadyExists) {
     const shouldOverwrite = promptForInput('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
-      options: ['yes', 'no'],
+      yesOrNo: true,
     });
     if (shouldOverwrite.toLocaleLowerCase() !== 'yes') {
       return printAndExit('Aborting');
@@ -68,9 +68,9 @@ export async function handleClone({packIdOrUrl, codaApiEndpoint}: ArgumentsCamel
 
     const shouldInitializeWithoutDownload = promptForInput(
       'Do you want to continue initializing with template starter code instead (y/N)?',
-      {options: ['y', 'n', 'N', '']},
+      {yesOrNo: true},
     );
-    if (shouldInitializeWithoutDownload !== 'y') {
+    if (shouldInitializeWithoutDownload !== 'yes') {
       return process.exit(1);
     }
 

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -58,9 +58,10 @@ export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl}: Ar
     }
 
     const input = promptForInput(
-      `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? Press "y" to overwrite or "n" to cancel: `,
+      `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `,
+      { yesOrNo: true }
     );
-    if (input.toLocaleLowerCase() !== 'y') {
+    if (input.toLocaleLowerCase() !== 'yes') {
       return process.exit(1);
     }
   }

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -18,8 +18,8 @@ export async function handleRegister({apiToken, codaApiEndpoint}: ArgumentsCamel
   if (!apiToken) {
     // TODO: deal with auto-open on devbox setups
     const shouldOpenBrowser = promptForInput(
-      'No API token provided. Do you want to visit Coda to create one (yes/no)? ',
-      {options: ['yes', 'no']},
+      'No API token provided. Do you want to visit Coda to create one (y/N)? ',
+      {yesOrNo: true},
     );
     if (shouldOpenBrowser !== 'yes') {
       return process.exit(1);

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -67,10 +67,10 @@ export async function handleRelease({
     const [latestPackVersionData] = versions;
     const {packVersion: latestPackVersion} = latestPackVersionData;
     const shouldReleaseLatestPackVersion = promptForInput(
-      `No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/n)\n`,
-      {options: ['y', 'n']},
+      `No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`,
+      {yesOrNo: true},
     );
-    if (shouldReleaseLatestPackVersion !== 'y') {
+    if (shouldReleaseLatestPackVersion !== 'yes') {
       return process.exit(1);
     }
     packVersion = latestPackVersion;

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -30,7 +30,7 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
     const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(manifestDir, 'pack.ts'));
     if (codeAlreadyExists) {
         const shouldOverwrite = (0, helpers_5.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
-            options: ['yes', 'no'],
+            yesOrNo: true,
         });
         if (shouldOverwrite.toLocaleLowerCase() !== 'yes') {
             return (0, helpers_4.printAndExit)('Aborting');
@@ -58,8 +58,8 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
     }
     if (!sourceCode) {
         (0, helpers_3.print)(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
-        const shouldInitializeWithoutDownload = (0, helpers_5.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?', { options: ['y', 'n', 'N', ''] });
-        if (shouldInitializeWithoutDownload !== 'y') {
+        const shouldInitializeWithoutDownload = (0, helpers_5.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?', { yesOrNo: true });
+        if (shouldInitializeWithoutDownload !== 'yes') {
             return process.exit(1);
         }
         await (0, init_1.handleInit)();

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -48,8 +48,8 @@ async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
         if (existingPackId === packId) {
             return (0, helpers_3.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
         }
-        const input = (0, helpers_4.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? Press "y" to overwrite or "n" to cancel: `);
-        if (input.toLocaleLowerCase() !== 'y') {
+        const input = (0, helpers_4.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `, { yesOrNo: true });
+        if (input.toLocaleLowerCase() !== 'yes') {
             return process.exit(1);
         }
     }

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -16,7 +16,7 @@ async function handleRegister({ apiToken, codaApiEndpoint }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     if (!apiToken) {
         // TODO: deal with auto-open on devbox setups
-        const shouldOpenBrowser = (0, helpers_4.promptForInput)('No API token provided. Do you want to visit Coda to create one (yes/no)? ', { options: ['yes', 'no'] });
+        const shouldOpenBrowser = (0, helpers_4.promptForInput)('No API token provided. Do you want to visit Coda to create one (y/N)? ', { yesOrNo: true });
         if (shouldOpenBrowser !== 'yes') {
             return process.exit(1);
         }

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -69,8 +69,8 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, c
         }
         const [latestPackVersionData] = versions;
         const { packVersion: latestPackVersion } = latestPackVersionData;
-        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/n)\n`, { options: ['y', 'n'] });
-        if (shouldReleaseLatestPackVersion !== 'y') {
+        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`, { yesOrNo: true });
+        if (shouldReleaseLatestPackVersion !== 'yes') {
             return process.exit(1);
         }
         packVersion = latestPackVersion;

--- a/dist/testing/auth.js
+++ b/dist/testing/auth.js
@@ -93,8 +93,9 @@ class CredentialHandler {
     checkForExistingCredential() {
         const existingCredentials = readCredentialsFile(this._manifestDir);
         if (existingCredentials) {
-            const input = (0, helpers_4.promptForInput)(`Credentials already exist for this Pack, press "y" to overwrite or "n" to cancel: `);
-            if (input.toLocaleLowerCase() !== 'y') {
+            const input = (0, helpers_4.promptForInput)(`Credentials already exist for this Pack, overwrite? (y/N): `, { yesOrNo: true });
+            if (input.toLocaleLowerCase() !== 'yes') {
+                throw new Error(`Input: ${input}`);
                 return process.exit(1);
             }
             return existingCredentials;

--- a/dist/testing/helpers.d.ts
+++ b/dist/testing/helpers.d.ts
@@ -16,9 +16,10 @@ export declare const printError: {
     (message?: any, ...optionalParams: any[]): void;
 };
 export declare function printAndExit(msg: string, exitCode?: number): never;
-export declare function promptForInput(prompt: string, { mask, options }?: {
+export declare function promptForInput(prompt: string, { mask, options, yesOrNo }?: {
     mask?: boolean;
     options?: string[];
+    yesOrNo?: boolean;
 }): string;
 export declare function readFile(fileName: string): Buffer | undefined;
 export declare function readJSONFile(fileName: string): any | undefined;

--- a/dist/testing/helpers.js
+++ b/dist/testing/helpers.js
@@ -34,6 +34,7 @@ const readlineSync = __importStar(require("readline-sync"));
 const source_map_1 = require("../runtime/common/source_map");
 const marshaling_1 = require("../runtime/common/marshaling");
 const marshaling_2 = require("../runtime/common/marshaling");
+const yn_1 = __importDefault(require("yn"));
 function getManifestFromModule(module) {
     if (!module.manifest && !module.pack) {
         printAndExit('Manifest file must export a variable called "manifest" that refers to a PackDefinition.');
@@ -52,10 +53,20 @@ function printAndExit(msg, exitCode = 1) {
     return process.exit(exitCode);
 }
 exports.printAndExit = printAndExit;
-function promptForInput(prompt, { mask, options } = {}) {
+function promptForInput(prompt, { mask, options, yesOrNo } = {}) {
     while (true) {
         const answer = readlineSync.question(prompt, { mask: mask ? '*' : undefined, hideEchoBack: mask });
-        if (!options || options.includes(answer)) {
+        if (yesOrNo) {
+            if (answer === '') {
+                return 'no';
+            }
+            const response = (0, yn_1.default)(answer, { default: null });
+            if (response === null) {
+                continue;
+            }
+            return (0, yn_1.default)(answer) ? 'yes' : 'no';
+        }
+        else if (!options || options.includes(answer)) {
             return answer;
         }
     }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/node": "^18.6.3",
     "@types/node-fetch": "^2.6.1",
     "@types/pascalcase": "^1.0.1",
+    "@types/proxyquire": "^1.3.28",
     "@types/qs": "^6.9.7",
     "@types/readline-sync": "1.4.4",
     "@types/request": "^2.48.8",
@@ -97,6 +98,7 @@
     "mime": "^3.0.0",
     "mocha": "^10.0.0",
     "mock-fs": "^5.1.2",
+    "proxyquire": "^2.1.3",
     "release-it": "^15.2.0",
     "remark-cli": "^11.0.0",
     "remark-lint-no-undefined-references": "^4.1.1",
@@ -106,7 +108,7 @@
     "typedoc-plugin-markdown": "^3.13.4"
   },
   "resolutions": {
-    "release-it/node-fetch": "^3.2.10", 
+    "release-it/node-fetch": "^3.2.10",
     "ansi-regex": "^5.0.1",
     "got": "^12.1.0",
     "jsprim": "^2.0.2",

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -1327,7 +1327,7 @@ describe('Auth', () => {
           clientSecret: 'existing-client-secret',
         });
 
-        setupReadline(['y', '', '']);
+        setupReadline(['yes', '', '']);
         doSetupAuth(pack);
 
         assertCredentialsFileExactly({

--- a/test/helpers_test.ts
+++ b/test/helpers_test.ts
@@ -1,0 +1,102 @@
+import proxyquire from 'proxyquire';
+
+function makeInputGenerator(input: string | string[]): () => string {
+  input = typeof input === 'string' ? [input] : input;
+  const values = input.values();
+  return () => {
+    const value = values.next();
+    if (value.done)
+      {throw new Error('No input left.')}
+    return value.value;
+  };
+}
+
+describe('Helpers', () => {
+  describe('promptForInput', () => {
+    let inputGenerator: () => string;
+
+    function setInput(input: string | string[]) {
+      inputGenerator = makeInputGenerator(input);
+    }
+
+    const readlineStub = {
+      question() {
+        return inputGenerator();
+      }
+    };
+
+    const helpers = proxyquire('../testing/helpers', {
+      'readline-sync': readlineStub,
+    });
+
+    it('Returns input', () => {
+      setInput('cat');
+      const result = helpers.promptForInput('Enter an animal');
+      assert.equal(result, 'cat');
+    });
+
+    it('Returns first valid options', () => {
+      setInput(['cat', 'dog']);
+      const result = helpers.promptForInput('Enter an animal', {
+        options: ['cat', 'dog'],
+      });
+      assert.equal(result, 'cat');
+    });
+
+    it('Retries invalid option', () => {
+      setInput(['mouse', 'cat']);
+      const result = helpers.promptForInput('Enter an animal', {
+        options: ['cat', 'dog'],
+      });
+      assert.equal(result, 'cat');
+    });
+
+    it('Returns first valid yes or no', () => {
+      setInput(['yes', 'no']);
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'yes');
+    });
+
+    it('Retries invalid yes or no', () => {
+      setInput(['cat', 'yes']);
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'yes');
+    });
+
+    it('Returns yes for y', () => {
+      setInput('y');
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'yes');
+    });
+
+    it('Returns no as is', () => {
+      setInput('no');
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'no');
+    });
+
+    it('Returns no for n', () => {
+      setInput('n');
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'no');
+    });
+
+    it('Returns no for empty string', () => {
+      setInput('');
+      const result = helpers.promptForInput('Feed animal?', {
+        yesOrNo: true,
+      });
+      assert.equal(result, 'no');
+    });
+  });
+});

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -106,9 +106,11 @@ class CredentialHandler {
     const existingCredentials = readCredentialsFile(this._manifestDir);
     if (existingCredentials) {
       const input = promptForInput(
-        `Credentials already exist for this Pack, press "y" to overwrite or "n" to cancel: `,
+        `Credentials already exist for this Pack, overwrite? (y/N): `,
+        {yesOrNo: true}
       );
-      if (input.toLocaleLowerCase() !== 'y') {
+      if (input.toLocaleLowerCase() !== 'yes') {
+        throw new Error(`Input: ${input}`);
         return process.exit(1);
       }
       return existingCredentials;

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -6,6 +6,7 @@ import * as readlineSync from 'readline-sync';
 import {translateErrorStackFromVM} from '../runtime/common/source_map';
 import {unwrapError} from '../runtime/common/marshaling';
 import {wrapError} from '../runtime/common/marshaling';
+import yn from 'yn';
 
 export function getManifestFromModule(module: any): PackVersionDefinition {
   if (!module.manifest && !module.pack) {
@@ -26,10 +27,20 @@ export function printAndExit(msg: string, exitCode: number = 1): never {
   return process.exit(exitCode);
 }
 
-export function promptForInput(prompt: string, {mask, options}: {mask?: boolean; options?: string[]} = {}): string {
+export function promptForInput(prompt: string, {mask, options, yesOrNo}:
+  {mask?: boolean; options?: string[], yesOrNo?: boolean} = {}): string {
   while (true) {
     const answer = readlineSync.question(prompt, {mask: mask ? '*' : undefined, hideEchoBack: mask});
-    if (!options || options.includes(answer)) {
+    if (yesOrNo) {
+      if (answer === '') {
+        return 'no';
+      }
+      const response = yn(answer, {default: null});
+      if (response === null) {
+        continue;
+      }
+      return yn(answer) ? 'yes' : 'no';
+    } else if (!options || options.includes(answer)) {
       return answer;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,11 @@
   resolved "https://registry.npmjs.org/@types/pascalcase/-/pascalcase-1.0.1.tgz"
   integrity sha512-JYPox1hbKw66Sv9HtvTp0r5jJkaz6k+V8XjEnZUb7B+4ffIoS+3sjiAtwkX6IMO68UQtQWe9QcAjugn9VR4GJg==
 
+"@types/proxyquire@^1.3.28":
+  version "1.3.28"
+  resolved "https://registry.yarnpkg.com/@types/proxyquire/-/proxyquire-1.3.28.tgz#05a647bb0d8fe48fc8edcc193e43cc79310faa7d"
+  integrity sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==
+
 "@types/qs@*", "@types/qs@^6.9.7":
   version "6.9.7"
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz"
@@ -3229,6 +3234,14 @@ file-uri-to-path@2:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
   integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
@@ -3992,6 +4005,13 @@ is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
+  dependencies:
+    has "^1.0.3"
+
 is-date-object@^1.0.1:
   version "1.0.4"
   resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz"
@@ -4076,6 +4096,11 @@ is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
+is-object@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
 is-path-inside@^3.0.2:
   version "3.0.3"
@@ -4585,7 +4610,7 @@ media-typer@0.3.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-merge-descriptors@1.0.1:
+merge-descriptors@1.0.1, merge-descriptors@~1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
@@ -4971,6 +4996,11 @@ module-deps@^6.2.3:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==
 
 mold-source-map@^0.4.0:
   version "0.4.0"
@@ -5526,6 +5556,15 @@ proxy-from-env@^1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+proxyquire@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz"
@@ -5906,6 +5945,15 @@ resolve@^1.1.6:
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.11.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
A developer noticed that [the documentation](https://coda.io/packs/build/latest/tutorials/get-started/cli/#register-an-api-token) said to enter `y` but that only `yes` was accepted. I noticed that the codebase was using a mix of `yes` and `y`, without the ability to convert between the two.

I updated the `promptForInput` helper function to include a special `yesOrNo` mode that used the `yn` NPM library to handle all the variations. I then updated the codebase to use the this new mode wherever a yes/no question was being asked.

I also added tests for this function, using the newly added `proxyquire` NPM library, as I couldn't get `sinon` to mock a lop-level export of a library.