### PR TITLE
Fix zod validation for slider min/max/step that are formulas.

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -498,11 +498,12 @@ const scalePropertySchema = zodCompleteStrictObject({
     icon: z.nativeEnum(schema_10.ScaleIconSet).optional(),
     ...basePropertyValidators,
 });
+const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
 const sliderPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_13.ValueType.Number),
     codaType: zodDiscriminant(schema_12.ValueHintType.Slider),
-    maximum: z.number().optional(),
-    minimum: z.number().optional(),
+    maximum: optionalStringOrNumber,
+    minimum: optionalStringOrNumber,
     step: z.number().optional(),
     showValue: z.boolean().optional(),
     ...basePropertyValidators,
@@ -510,8 +511,8 @@ const sliderPropertySchema = zodCompleteStrictObject({
 const progressBarPropertySchema = zodCompleteStrictObject({
     type: zodDiscriminant(schema_13.ValueType.Number),
     codaType: zodDiscriminant(schema_12.ValueHintType.ProgressBar),
-    maximum: z.number().optional(),
-    minimum: z.number().optional(),
+    maximum: optionalStringOrNumber,
+    minimum: optionalStringOrNumber,
     step: z.number().optional(),
     showValue: z.boolean().optional(),
     ...basePropertyValidators,

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -504,7 +504,7 @@ const sliderPropertySchema = zodCompleteStrictObject({
     codaType: zodDiscriminant(schema_12.ValueHintType.Slider),
     maximum: optionalStringOrNumber,
     minimum: optionalStringOrNumber,
-    step: z.number().optional(),
+    step: optionalStringOrNumber,
     showValue: z.boolean().optional(),
     ...basePropertyValidators,
 });
@@ -513,7 +513,7 @@ const progressBarPropertySchema = zodCompleteStrictObject({
     codaType: zodDiscriminant(schema_12.ValueHintType.ProgressBar),
     maximum: optionalStringOrNumber,
     minimum: optionalStringOrNumber,
-    step: z.number().optional(),
+    step: optionalStringOrNumber,
     showValue: z.boolean().optional(),
     ...basePropertyValidators,
 });

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1143,6 +1143,13 @@ describe('Pack metadata Validation', () => {
               Foo: {type: ValueType.Number, codaType: ValueHintType.Scale, maximum: 5, icon: ScaleIconSet.Star},
               Bar: {type: ValueType.String, codaType: ValueHintType.Date, format: 'MMM D, YYYY'},
               Slider: {type: ValueType.Number, codaType: ValueHintType.Slider, minimum: 1, maximum: 3, step: 1},
+              SliderWithFormulas: {
+                type: ValueType.Number,
+                codaType: ValueHintType.Slider,
+                minimum: '[Min]',
+                maximum: '[Max]',
+                step: '[Step]',
+              },
               Progress: {
                 type: ValueType.Number,
                 codaType: ValueHintType.ProgressBar,
@@ -1191,6 +1198,10 @@ describe('Pack metadata Validation', () => {
         assert.equal(schemaProperties.Slider.minimum, 1);
         assert.equal(schemaProperties.Slider.maximum, 3);
         assert.equal(schemaProperties.Slider.step, 1);
+
+        assert.equal(schemaProperties.SliderWithFormulas.minimum, '[Min]');
+        assert.equal(schemaProperties.SliderWithFormulas.maximum, '[Max]');
+        assert.equal(schemaProperties.SliderWithFormulas.step, '[Step]');
 
         assert.equal(schemaProperties.Currency.precision, 2);
         assert.equal(schemaProperties.Currency.currencyCode, 'EUR');

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -613,12 +613,14 @@ const scalePropertySchema = zodCompleteStrictObject<ScaleSchema & ObjectSchemaPr
   ...basePropertyValidators,
 });
 
+const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
+
 const sliderPropertySchema = zodCompleteStrictObject<SliderSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.Slider),
-  maximum: z.number().optional(),
-  minimum: z.number().optional(),
-  step: z.number().optional(),
+  maximum: optionalStringOrNumber,
+  minimum: optionalStringOrNumber,
+  step: optionalStringOrNumber,
   showValue: z.boolean().optional(),
   ...basePropertyValidators,
 });
@@ -626,9 +628,9 @@ const sliderPropertySchema = zodCompleteStrictObject<SliderSchema & ObjectSchema
 const progressBarPropertySchema = zodCompleteStrictObject<ProgressBarSchema & ObjectSchemaProperty>({
   type: zodDiscriminant(ValueType.Number),
   codaType: zodDiscriminant(ValueHintType.ProgressBar),
-  maximum: z.number().optional(),
-  minimum: z.number().optional(),
-  step: z.number().optional(),
+  maximum: optionalStringOrNumber,
+  minimum: optionalStringOrNumber,
+  step: optionalStringOrNumber,
   showValue: z.boolean().optional(),
   ...basePropertyValidators,
 });


### PR DESCRIPTION
Part of the fix for https://staging.coda.io/d/_d-GJF-DmEUK#Bugs_tuq-W/r25095&view=modal. Sliders schemas can have formulas for these attributes, our types already supported that but zod did not. So if you try to cross-doc a column that uses formulas for these, you'd hit a zod validation error in the cross-doc workflow.

I don't think we have any other examples of passing CFL in the SDK yet, so I don't think this is functionality we should advertise, but if we're just blindly passing through values from cross-doc, seems ok.

This doesn't fully fix the issue though, because there's a bug in the API, and the actual cell values for sliders that use formulas are structured values and the API is returning them as serialized JSON strings rather than numbers (and those JSON values don't even have the cell value! just the calculated min/max/step values) so these do not round-trip properly.