### PR TITLE
params can be undefined

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -339,7 +339,7 @@ type TypeOfMap<T extends UnionType> = T extends Type
  * the parameter defintion for that formula.
  */
 export type ParamValues<ParamDefsT extends ParamDefs> = {
-  [K in keyof ParamDefsT]: ParamDefsT[K] extends ParamDef<infer T> ? TypeOfMap<T> : never;
+  [K in keyof ParamDefsT]: ParamDefsT[K] extends ParamDef<infer T> ? TypeOfMap<T> | undefined : never;
 } & any[]; // NOTE(oleg): we need this to avoid "must have a '[Symbol.iterator]()' method that returns an iterator."
 
 /**


### PR DESCRIPTION
Currently there is an edge case with `optional: true` paramaters where they can be undefined without typescript catching it.

This PR leans on the safer side and marks that all params can be undefined, which inspires pack authors to set default values to prevent undefined exceptions.

See discussion at: https://community.coda.io/t/incorrect-types-for-optional-array-params/33848/5?u=balupton