### PR TITLE
Add meta title and descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,12 @@ docs: typedoc generated-documentation build-mkdocs
 
 .PHONY: view-docs
 view-docs:
+	# By default don't generate social cards when previewing, for performance.
+	MK_DOCS_GENERATE_CARDS=${MK_DOCS_GENERATE_CARDS:-false}
 	if command -v expect &> /dev/null; then \
-		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk MK_DOCS_GENERATE_CARDS=false expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'; \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'; \
 	else \
-		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk MK_DOCS_GENERATE_CARDS=false pipenv run mkdocs serve; \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk pipenv run mkdocs serve; \
 	fi
 
 ###############################################################################

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ mkdocs-material = "*"
 mkdocs-awesome-pages-plugin = "*"
 mkdocs-macros-plugin = "*"
 mkdocs-redirects = "*"
+mkdocs-simple-hooks = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "11ea9c7c0e29331536dc087b4405abf59d7f48d1c7c7efe9b34465be1484cb48"
+            "sha256": "1852888b3905a79144ae94bfd2576f397dcd11a00ff3caec77b59b7bc111035c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,21 +24,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.3.post1"
         },
-        "cairocffi": {
-            "hashes": [
-                "sha256:108a3a7cb09e203bdd8501d9baad91d786d204561bd71e9364e8b34897c47b91"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.3.0"
-        },
-        "cairosvg": {
-            "hashes": [
-                "sha256:98c276b7e4f0caf01e5c7176765c104ffa1aa1461d63b2053b04ab663cf7052b",
-                "sha256:b0b9929cf5dba005178d746a8036fcf0025550f498ca54db61873322384783bc"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.5.2"
-        },
         "certifi": {
             "hashes": [
                 "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
@@ -46,75 +31,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2022.9.14"
-        },
-        "cffi": {
-            "hashes": [
-                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
-                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
-                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
-                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
-                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
-                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
-                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
-                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
-                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
-                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
-                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
-                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
-                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
-                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
-                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
-                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
-                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
-                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
-                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
-                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
-                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
-                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
-                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
-                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
-                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
-                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
-                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
-                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
-                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
-                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
-                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
-                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
-                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
-                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
-                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
-                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
-                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
-                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
-                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
-                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
-                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
-                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
-                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
-                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
-                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
-                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
-                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
-                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
-                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
-                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
-                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
-                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
-                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
-                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
-                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
-                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
-                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
-                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
-                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
-                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
-                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
-                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
-                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
-                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
-            ],
-            "version": "==1.15.1"
         },
         "charset-normalizer": {
             "hashes": [
@@ -131,22 +47,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
-        },
-        "cssselect2": {
-            "hashes": [
-                "sha256:3a83b2a68370c69c9cd3fcb88bbfaebe9d22edeef2c22d1ff3e1ed9c7fa45ed8",
-                "sha256:5b5d6dea81a5eb0c9ca39f116c8578dd413778060c94c1f51196371618909325"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.6.0"
-        },
-        "defusedxml": {
-            "hashes": [
-                "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
-                "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.7.1"
         },
         "ghp-import": {
             "hashes": [
@@ -267,11 +167,11 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:1b9e03b93c26db7c1b520480978024916eda73b49eb5818820cc10f4665f00fc",
-                "sha256:1bfd05e6e159db2c5f95821dc3c7afdc7a5a3a7acc544c3102f7acb28691f407"
+                "sha256:2daf604d00d554d5496c02b4c4d14dfa57dd689c90f639da5020601baef4b235",
+                "sha256:79e9b65e481edb539eda6a3a939a0e02609a5c54afc315c3b05f57ff40db3188"
             ],
             "index": "pypi",
-            "version": "==8.5.0"
+            "version": "==8.5.1"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -288,6 +188,14 @@
             "index": "pypi",
             "version": "==1.1.0"
         },
+        "mkdocs-simple-hooks": {
+            "hashes": [
+                "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c",
+                "sha256:efeabdbb98b0850a909adee285f3404535117159d5cb3a34f541d6eaa644d50a"
+            ],
+            "index": "pypi",
+            "version": "==0.1.5"
+        },
         "natsort": {
             "hashes": [
                 "sha256:04fe18fdd2b9e5957f19f687eb117f102ef8dde6b574764e536e91194bed4f5f",
@@ -303,77 +211,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==21.3"
-        },
-        "pillow": {
-            "hashes": [
-                "sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927",
-                "sha256:030e3460861488e249731c3e7ab59b07c7853838ff3b8e16aac9561bb345da14",
-                "sha256:0ed2c4ef2451de908c90436d6e8092e13a43992f1860275b4d8082667fbb2ffc",
-                "sha256:136659638f61a251e8ed3b331fc6ccd124590eeff539de57c5f80ef3a9594e58",
-                "sha256:13b725463f32df1bfeacbf3dd197fb358ae8ebcd8c5548faa75126ea425ccb60",
-                "sha256:1536ad017a9f789430fb6b8be8bf99d2f214c76502becc196c6f2d9a75b01b76",
-                "sha256:15928f824870535c85dbf949c09d6ae7d3d6ac2d6efec80f3227f73eefba741c",
-                "sha256:17d4cafe22f050b46d983b71c707162d63d796a1235cdf8b9d7a112e97b15bac",
-                "sha256:1802f34298f5ba11d55e5bb09c31997dc0c6aed919658dfdf0198a2fe75d5490",
-                "sha256:1cc1d2451e8a3b4bfdb9caf745b58e6c7a77d2e469159b0d527a4554d73694d1",
-                "sha256:1fd6f5e3c0e4697fa7eb45b6e93996299f3feee73a3175fa451f49a74d092b9f",
-                "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d",
-                "sha256:2ad0d4df0f5ef2247e27fc790d5c9b5a0af8ade9ba340db4a73bb1a4a3e5fb4f",
-                "sha256:2c58b24e3a63efd22554c676d81b0e57f80e0a7d3a5874a7e14ce90ec40d3069",
-                "sha256:2d33a11f601213dcd5718109c09a52c2a1c893e7461f0be2d6febc2879ec2402",
-                "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437",
-                "sha256:337a74fd2f291c607d220c793a8135273c4c2ab001b03e601c36766005f36885",
-                "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e",
-                "sha256:3d1f14f5f691f55e1b47f824ca4fdcb4b19b4323fe43cc7bb105988cad7496be",
-                "sha256:4134d3f1ba5f15027ff5c04296f13328fecd46921424084516bdb1b2548e66ff",
-                "sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da",
-                "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004",
-                "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f",
-                "sha256:5aed7dde98403cd91d86a1115c78d8145c83078e864c1de1064f52e6feb61b20",
-                "sha256:69bd1a15d7ba3694631e00df8de65a8cb031911ca11f44929c97fe05eb9b6c1d",
-                "sha256:6bf088c1ce160f50ea40764f825ec9b72ed9da25346216b91361eef8ad1b8f8c",
-                "sha256:6e8c66f70fb539301e064f6478d7453e820d8a2c631da948a23384865cd95544",
-                "sha256:74a04183e6e64930b667d321524e3c5361094bb4af9083db5c301db64cd341f3",
-                "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04",
-                "sha256:7761afe0126d046974a01e030ae7529ed0ca6a196de3ec6937c11df0df1bc91c",
-                "sha256:7888310f6214f19ab2b6df90f3f06afa3df7ef7355fc025e78a3044737fab1f5",
-                "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4",
-                "sha256:7c7b502bc34f6e32ba022b4a209638f9e097d7a9098104ae420eb8186217ebbb",
-                "sha256:808add66ea764ed97d44dda1ac4f2cfec4c1867d9efb16a33d158be79f32b8a4",
-                "sha256:831e648102c82f152e14c1a0938689dbb22480c548c8d4b8b248b3e50967b88c",
-                "sha256:93689632949aff41199090eff5474f3990b6823404e45d66a5d44304e9cdc467",
-                "sha256:96b5e6874431df16aee0c1ba237574cb6dff1dcb173798faa6a9d8b399a05d0e",
-                "sha256:9a54614049a18a2d6fe156e68e188da02a046a4a93cf24f373bffd977e943421",
-                "sha256:a138441e95562b3c078746a22f8fca8ff1c22c014f856278bdbdd89ca36cff1b",
-                "sha256:a647c0d4478b995c5e54615a2e5360ccedd2f85e70ab57fbe817ca613d5e63b8",
-                "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb",
-                "sha256:ad2277b185ebce47a63f4dc6302e30f05762b688f8dc3de55dbae4651872cdf3",
-                "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc",
-                "sha256:b6d5e92df2b77665e07ddb2e4dbd6d644b78e4c0d2e9272a852627cdba0d75cf",
-                "sha256:bc431b065722a5ad1dfb4df354fb9333b7a582a5ee39a90e6ffff688d72f27a1",
-                "sha256:bdd0de2d64688ecae88dd8935012c4a72681e5df632af903a1dca8c5e7aa871a",
-                "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28",
-                "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0",
-                "sha256:d5b87da55a08acb586bad5c3aa3b86505f559b84f39035b233d5bf844b0834b1",
-                "sha256:dcd7b9c7139dc8258d164b55696ecd16c04607f1cc33ba7af86613881ffe4ac8",
-                "sha256:dfe4c1fedfde4e2fbc009d5ad420647f7730d719786388b7de0999bf32c0d9fd",
-                "sha256:ea98f633d45f7e815db648fd7ff0f19e328302ac36427343e4432c84432e7ff4",
-                "sha256:ec52c351b35ca269cb1f8069d610fc45c5bd38c3e91f9ab4cbbf0aebc136d9c8",
-                "sha256:eef7592281f7c174d3d6cbfbb7ee5984a671fcd77e3fc78e973d492e9bf0eb3f",
-                "sha256:f07f1f00e22b231dd3d9b9208692042e29792d6bd4f6639415d2f23158a80013",
-                "sha256:f3fac744f9b540148fa7715a435d2283b71f68bfb6d4aae24482a890aed18b59",
-                "sha256:fa768eff5f9f958270b081bb33581b4b569faabf8774726b283edb06617101dc",
-                "sha256:fac2d65901fb0fdf20363fbd345c01958a742f2dc62a8dd4495af66e3ff502a4"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==9.2.0"
-        },
-        "pycparser": {
-            "hashes": [
-                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
-            ],
-            "version": "==2.21"
         },
         "pygments": {
             "hashes": [
@@ -485,14 +322,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
-        "tinycss2": {
-            "hashes": [
-                "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf",
-                "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.1.1"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
@@ -539,13 +368,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.4"
-        },
-        "webencodings": {
-            "hashes": [
-                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
-                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
-            ],
-            "version": "==0.5.1"
         },
         "zipp": {
             "hashes": [

--- a/docs/guides/.nav.yml
+++ b/docs/guides/.nav.yml
@@ -1,6 +1,6 @@
 nav:
   - overview.md
-  - Building blocks: blocks
+  - blocks
   - basics
   - advanced
   - development

--- a/docs/guides/advanced/caching.md
+++ b/docs/guides/advanced/caching.md
@@ -1,5 +1,6 @@
 ---
-title: Caching
+nav: Caching
+description: The various caching layers and how to configure them.
 ---
 
 # Caching formula and fetcher results
@@ -31,7 +32,7 @@ When making an HTTP request with the [fetcher][fetcher], the Packs runtime first
 
 <img src="../../../images/cache_fetcher_logs.png" srcset="../../../images/cache_fetcher_logs_2x.png 2x" class="screenshot" alt="Cached fetcher requests in the logs">
 
-By default the Packs runtime caches the HTTP responses for all `GET` requests, meaning that your code may not always be getting the latest response from the server. You can adjust this behavior by setting the [`cacheTtlSecs`][fetcher_cacheTtlSecs] field in the fetch request, which specifies for how many seconds the response should be cached. To disable caching for a request set that value to zero. 
+By default the Packs runtime caches the HTTP responses for all `GET` requests, meaning that your code may not always be getting the latest response from the server. You can adjust this behavior by setting the [`cacheTtlSecs`][fetcher_cacheTtlSecs] field in the fetch request, which specifies for how many seconds the response should be cached. To disable caching for a request set that value to zero.
 
 The following types of requests are never cached:
 

--- a/docs/guides/advanced/embeds.md
+++ b/docs/guides/advanced/embeds.md
@@ -1,3 +1,7 @@
+---
+description: Embed external content using Packs and optimize your app for embedding.
+---
+
 # Embedding content
 
 Packs typically operate purely on data and actions, leaving the display up to the document. However there are times in which you may want to provide a richer experience, which can be accomplished by embedding a portion of an application directly within the doc.

--- a/docs/guides/advanced/images.md
+++ b/docs/guides/advanced/images.md
@@ -1,5 +1,6 @@
 ---
-title: Images & files
+nav: Images & files
+description: Use images and files as parameters and return types.
 ---
 
 # Working with images and files

--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -1,5 +1,6 @@
 ---
-title: Schemas
+nav: Schemas
+description: Design schemas to represent rich data, for use in formulas and sync tables.
 ---
 
 # Structuring data with schemas

--- a/docs/guides/advanced/timezones.md
+++ b/docs/guides/advanced/timezones.md
@@ -1,5 +1,6 @@
 ---
-title: Timezones
+nav: Timezones
+description: Work with dates and times across the various timezone contexts in a Pack.
 ---
 
 # Timezones in Coda

--- a/docs/guides/advanced/two-way-sync.md
+++ b/docs/guides/advanced/two-way-sync.md
@@ -1,5 +1,6 @@
 ---
-title: Two-way sync
+nav: Two-way sync
+description: Use actions to update records and reflect those updates in a sync table.
 ---
 
 # Approximating two-way sync

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -1,5 +1,6 @@
 ---
-title: Authentication
+nav: Authentication
+description: Configure your Pack to request credentials from the user and pass them along with your fetcher requests.
 ---
 
 # Authenticating with other services

--- a/docs/guides/basics/authentication/oauth2.md
+++ b/docs/guides/basics/authentication/oauth2.md
@@ -1,5 +1,6 @@
 ---
-title: OAuth
+nav: OAuth
+description: Configure authentication for an API that uses OAuth2.
 ---
 
 # Authenticating using OAuth

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -1,5 +1,6 @@
 ---
-title: Data types
+nav: Data types
+description: Use semantic types to accurately represent data in the document.
 ---
 
 # Return data with meaningful types

--- a/docs/guides/basics/fetcher.md
+++ b/docs/guides/basics/fetcher.md
@@ -1,3 +1,7 @@
+---
+description: Make HTTP requests to external APIs and services using the custom Fetcher interface.
+---
+
 # Fetching remote data
 
 Many Packs use cases require fetching data from an outside source such as an API, which is done using the custom [`Fetcher`][Fetcher] interface. Other methods for making network requests in JavaScript (such as `XMLHttpRequest` or libraries like `axios` or `jQuery`) are not supported.

--- a/docs/guides/basics/parameters/autocomplete.md
+++ b/docs/guides/basics/parameters/autocomplete.md
@@ -1,5 +1,6 @@
 ---
-title: Autocomplete
+nav: Autocomplete
+description: Simplify entering parameters by providing choices users can select from.
 ---
 
 # Autocomplete parameter options

--- a/docs/guides/basics/parameters/index.md
+++ b/docs/guides/basics/parameters/index.md
@@ -1,5 +1,6 @@
 ---
-title: Parameters
+nav: Parameters
+description: Define parameters on formulas and sync tables to accept values from the user.
 ---
 
 # Accept input with parameters

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -1,3 +1,7 @@
+---
+description: Tips and checklists on how to create high quality Packs.
+---
+
 # Best practices
 
 While it's easy to get started building a Pack, there are lots of options to explore and decisions to make as you go. This page includes some best practices we've learned through developing our own Packs that we encourage you to consider.

--- a/docs/guides/blocks/.nav.yml
+++ b/docs/guides/blocks/.nav.yml
@@ -1,3 +1,4 @@
+title: Building blocks
 nav:
   - formulas.md
   - actions.md

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -1,5 +1,6 @@
 ---
-title: Actions
+nav: Actions
+description: Use actions to create, update, or delete records in APIs and external data sources.
 ---
 
 # Add custom actions for buttons and automations

--- a/docs/guides/blocks/column-formats.md
+++ b/docs/guides/blocks/column-formats.md
@@ -1,5 +1,6 @@
 ---
-title: Column Formats
+nav: Column formats
+description: Automatically apply a formula to a user's input to display it in a different format.
 ---
 
 # Add custom column formats

--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -1,6 +1,6 @@
 ---
-title: Formulas
-description: "Formulas are one of the most basic building blocks in Coda, and using Packs you can add your own custom ones."
+nav: Formulas
+description: Formulas are one of the most basic building blocks in Coda, and using Packs you can add your own custom ones.
 ---
 
 # Add custom formulas

--- a/docs/guides/blocks/sync-tables/dynamic.md
+++ b/docs/guides/blocks/sync-tables/dynamic.md
@@ -1,5 +1,6 @@
 ---
-title: Dynamic sync tables
+nav: Dynamic sync tables
+description: Build advanced sync tables that adapt to dynamic data sources.
 ---
 
 # Creating sync tables with dynamic schemas

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -1,5 +1,6 @@
 ---
-title: Sync tables
+nav: Sync tables
+description: Create tables of data that automatically sync in records from an external data source.
 ---
 
 # Add sync tables

--- a/docs/guides/development/cli.md
+++ b/docs/guides/development/cli.md
@@ -1,5 +1,6 @@
 ---
-title: Using the CLI
+nav: Using the CLI
+description: The CLI allows for local development, using libraries, and more.
 ---
 
 # Using the command line interface

--- a/docs/guides/development/libraries.md
+++ b/docs/guides/development/libraries.md
@@ -1,3 +1,7 @@
+---
+description: Add JavaScript libraries from NPM to enhance your Packs.
+---
+
 # Using libraries
 
 JavaScript has a rich and diverse set of libraries available, making it easy to re-use the work of others and more quickly develop an application. You can utilize many of these libraries when building Packs, but there are some important limitations to be aware of.

--- a/docs/guides/development/pack-maker-tools.md
+++ b/docs/guides/development/pack-maker-tools.md
@@ -1,3 +1,7 @@
+---
+description: Utilities for Pack makers to helper them build and troubleshoot their Packs.
+---
+
 # Pack maker tools
 
 While the Pack Studio and Pack CLI are used to develop a Pack, the primary way to monitor and interact with a Pack once it is installed in a document is via the Pack maker tools. It is a pane along the bottom of a Coda document that provides information about the Packs installed in the doc that you have edit access to.

--- a/docs/guides/development/testing.md
+++ b/docs/guides/development/testing.md
@@ -1,5 +1,6 @@
 ---
-title: Testing
+nav: Testing
+description: Make sure your Pack is working correctly by testing it in a doc or locally.
 ---
 
 # Testing your code

--- a/docs/guides/development/troubleshooting.md
+++ b/docs/guides/development/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
-title: Troubleshooting
+nav: Troubleshooting
+description: Tools and tips for how to find and fix problems in your Pack.
 ---
 
 # How to troubleshoot your code

--- a/docs/guides/development/versions.md
+++ b/docs/guides/development/versions.md
@@ -1,5 +1,6 @@
 ---
-title: Versions & releases
+nav: Versions & releases
+description: Create new builds of your Pack and release them to users.
 ---
 
 # Managing versions and releases

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,5 +1,6 @@
 ---
-title: FAQ
+nav: FAQ
+description: Answers to some of the most common questions about building Packs.
 ---
 
 # Frequently asked questions

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -1,5 +1,6 @@
 ---
-title: Overview
+nav: Overview
+description: A quick introduction to what Packs are and how they work.
 ---
 
 # What are Packs?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
-title: Home
+nav: Home
+description: A Pack is an extension that adds new powers to your doc. With a little JavaScript, anyone can create and publish a Pack to the Gallery.
 hide:
   - navigation
   - toc

--- a/docs/reference/sdk/classes/core.MissingScopesError.md
+++ b/docs/reference/sdk/classes/core.MissingScopesError.md
@@ -1,5 +1,5 @@
 ---
-title: "MissingScopesError"
+nav: "MissingScopesError"
 ---
 # Class: MissingScopesError
 

--- a/docs/reference/sdk/classes/core.PackDefinitionBuilder.md
+++ b/docs/reference/sdk/classes/core.PackDefinitionBuilder.md
@@ -1,5 +1,5 @@
 ---
-title: "PackDefinitionBuilder"
+nav: "PackDefinitionBuilder"
 ---
 # Class: PackDefinitionBuilder
 

--- a/docs/reference/sdk/classes/core.StatusCodeError.md
+++ b/docs/reference/sdk/classes/core.StatusCodeError.md
@@ -1,5 +1,5 @@
 ---
-title: "StatusCodeError"
+nav: "StatusCodeError"
 ---
 # Class: StatusCodeError
 

--- a/docs/reference/sdk/classes/core.UserVisibleError.md
+++ b/docs/reference/sdk/classes/core.UserVisibleError.md
@@ -1,5 +1,5 @@
 ---
-title: "UserVisibleError"
+nav: "UserVisibleError"
 ---
 # Class: UserVisibleError
 

--- a/docs/reference/sdk/enums/core.AttributionNodeType.md
+++ b/docs/reference/sdk/enums/core.AttributionNodeType.md
@@ -1,5 +1,5 @@
 ---
-title: "AttributionNodeType"
+nav: "AttributionNodeType"
 ---
 # Enumeration: AttributionNodeType
 

--- a/docs/reference/sdk/enums/core.AuthenticationType.md
+++ b/docs/reference/sdk/enums/core.AuthenticationType.md
@@ -1,5 +1,5 @@
 ---
-title: "AuthenticationType"
+nav: "AuthenticationType"
 ---
 # Enumeration: AuthenticationType
 

--- a/docs/reference/sdk/enums/core.ConnectionRequirement.md
+++ b/docs/reference/sdk/enums/core.ConnectionRequirement.md
@@ -1,5 +1,5 @@
 ---
-title: "ConnectionRequirement"
+nav: "ConnectionRequirement"
 ---
 # Enumeration: ConnectionRequirement
 

--- a/docs/reference/sdk/enums/core.CurrencyFormat.md
+++ b/docs/reference/sdk/enums/core.CurrencyFormat.md
@@ -1,5 +1,5 @@
 ---
-title: "CurrencyFormat"
+nav: "CurrencyFormat"
 ---
 # Enumeration: CurrencyFormat
 

--- a/docs/reference/sdk/enums/core.DurationUnit.md
+++ b/docs/reference/sdk/enums/core.DurationUnit.md
@@ -1,5 +1,5 @@
 ---
-title: "DurationUnit"
+nav: "DurationUnit"
 ---
 # Enumeration: DurationUnit
 

--- a/docs/reference/sdk/enums/core.EmailDisplayType.md
+++ b/docs/reference/sdk/enums/core.EmailDisplayType.md
@@ -1,5 +1,5 @@
 ---
-title: "EmailDisplayType"
+nav: "EmailDisplayType"
 ---
 # Enumeration: EmailDisplayType
 

--- a/docs/reference/sdk/enums/core.ImageCornerStyle.md
+++ b/docs/reference/sdk/enums/core.ImageCornerStyle.md
@@ -1,5 +1,5 @@
 ---
-title: "ImageCornerStyle"
+nav: "ImageCornerStyle"
 ---
 # Enumeration: ImageCornerStyle
 

--- a/docs/reference/sdk/enums/core.ImageOutline.md
+++ b/docs/reference/sdk/enums/core.ImageOutline.md
@@ -1,5 +1,5 @@
 ---
-title: "ImageOutline"
+nav: "ImageOutline"
 ---
 # Enumeration: ImageOutline
 

--- a/docs/reference/sdk/enums/core.LinkDisplayType.md
+++ b/docs/reference/sdk/enums/core.LinkDisplayType.md
@@ -1,5 +1,5 @@
 ---
-title: "LinkDisplayType"
+nav: "LinkDisplayType"
 ---
 # Enumeration: LinkDisplayType
 

--- a/docs/reference/sdk/enums/core.NetworkConnection.md
+++ b/docs/reference/sdk/enums/core.NetworkConnection.md
@@ -1,5 +1,5 @@
 ---
-title: "NetworkConnection"
+nav: "NetworkConnection"
 ---
 # Enumeration: NetworkConnection
 

--- a/docs/reference/sdk/enums/core.ParameterType.md
+++ b/docs/reference/sdk/enums/core.ParameterType.md
@@ -1,5 +1,5 @@
 ---
-title: "ParameterType"
+nav: "ParameterType"
 ---
 # Enumeration: ParameterType
 

--- a/docs/reference/sdk/enums/core.PostSetupType.md
+++ b/docs/reference/sdk/enums/core.PostSetupType.md
@@ -1,5 +1,5 @@
 ---
-title: "PostSetupType"
+nav: "PostSetupType"
 ---
 # Enumeration: PostSetupType
 

--- a/docs/reference/sdk/enums/core.PrecannedDateRange.md
+++ b/docs/reference/sdk/enums/core.PrecannedDateRange.md
@@ -1,5 +1,5 @@
 ---
-title: "PrecannedDateRange"
+nav: "PrecannedDateRange"
 ---
 # Enumeration: PrecannedDateRange
 

--- a/docs/reference/sdk/enums/core.ScaleIconSet.md
+++ b/docs/reference/sdk/enums/core.ScaleIconSet.md
@@ -1,5 +1,5 @@
 ---
-title: "ScaleIconSet"
+nav: "ScaleIconSet"
 ---
 # Enumeration: ScaleIconSet
 

--- a/docs/reference/sdk/enums/core.Type.md
+++ b/docs/reference/sdk/enums/core.Type.md
@@ -1,5 +1,5 @@
 ---
-title: "Type"
+nav: "Type"
 ---
 # Enumeration: Type
 

--- a/docs/reference/sdk/enums/core.ValueHintType.md
+++ b/docs/reference/sdk/enums/core.ValueHintType.md
@@ -1,5 +1,5 @@
 ---
-title: "ValueHintType"
+nav: "ValueHintType"
 ---
 # Enumeration: ValueHintType
 

--- a/docs/reference/sdk/enums/core.ValueType.md
+++ b/docs/reference/sdk/enums/core.ValueType.md
@@ -1,5 +1,5 @@
 ---
-title: "ValueType"
+nav: "ValueType"
 ---
 # Enumeration: ValueType
 

--- a/docs/reference/sdk/functions/core.assertCondition.md
+++ b/docs/reference/sdk/functions/core.assertCondition.md
@@ -1,5 +1,5 @@
 ---
-title: "assertCondition"
+nav: "assertCondition"
 ---
 # Function: assertCondition
 

--- a/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
@@ -1,5 +1,5 @@
 ---
-title: "autocompleteSearchObjects"
+nav: "autocompleteSearchObjects"
 ---
 # Function: autocompleteSearchObjects
 

--- a/docs/reference/sdk/functions/core.ensureExists.md
+++ b/docs/reference/sdk/functions/core.ensureExists.md
@@ -1,5 +1,5 @@
 ---
-title: "ensureExists"
+nav: "ensureExists"
 ---
 # Function: ensureExists
 

--- a/docs/reference/sdk/functions/core.ensureNonEmptyString.md
+++ b/docs/reference/sdk/functions/core.ensureNonEmptyString.md
@@ -1,5 +1,5 @@
 ---
-title: "ensureNonEmptyString"
+nav: "ensureNonEmptyString"
 ---
 # Function: ensureNonEmptyString
 

--- a/docs/reference/sdk/functions/core.ensureUnreachable.md
+++ b/docs/reference/sdk/functions/core.ensureUnreachable.md
@@ -1,5 +1,5 @@
 ---
-title: "ensureUnreachable"
+nav: "ensureUnreachable"
 ---
 # Function: ensureUnreachable
 

--- a/docs/reference/sdk/functions/core.generateSchema.md
+++ b/docs/reference/sdk/functions/core.generateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "generateSchema"
+nav: "generateSchema"
 ---
 # Function: generateSchema
 

--- a/docs/reference/sdk/functions/core.getQueryParams.md
+++ b/docs/reference/sdk/functions/core.getQueryParams.md
@@ -1,5 +1,5 @@
 ---
-title: "getQueryParams"
+nav: "getQueryParams"
 ---
 # Function: getQueryParams
 

--- a/docs/reference/sdk/functions/core.joinUrl.md
+++ b/docs/reference/sdk/functions/core.joinUrl.md
@@ -1,5 +1,5 @@
 ---
-title: "joinUrl"
+nav: "joinUrl"
 ---
 # Function: joinUrl
 

--- a/docs/reference/sdk/functions/core.makeAttributionNode.md
+++ b/docs/reference/sdk/functions/core.makeAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: "makeAttributionNode"
+nav: "makeAttributionNode"
 ---
 # Function: makeAttributionNode
 

--- a/docs/reference/sdk/functions/core.makeDynamicSyncTable.md
+++ b/docs/reference/sdk/functions/core.makeDynamicSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: "makeDynamicSyncTable"
+nav: "makeDynamicSyncTable"
 ---
 # Function: makeDynamicSyncTable
 

--- a/docs/reference/sdk/functions/core.makeEmptyFormula.md
+++ b/docs/reference/sdk/functions/core.makeEmptyFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "makeEmptyFormula"
+nav: "makeEmptyFormula"
 ---
 # Function: makeEmptyFormula
 

--- a/docs/reference/sdk/functions/core.makeFormula.md
+++ b/docs/reference/sdk/functions/core.makeFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "makeFormula"
+nav: "makeFormula"
 ---
 # Function: makeFormula
 

--- a/docs/reference/sdk/functions/core.makeMetadataFormula.md
+++ b/docs/reference/sdk/functions/core.makeMetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "makeMetadataFormula"
+nav: "makeMetadataFormula"
 ---
 # Function: makeMetadataFormula
 

--- a/docs/reference/sdk/functions/core.makeObjectSchema.md
+++ b/docs/reference/sdk/functions/core.makeObjectSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "makeObjectSchema"
+nav: "makeObjectSchema"
 ---
 # Function: makeObjectSchema
 

--- a/docs/reference/sdk/functions/core.makeParameter.md
+++ b/docs/reference/sdk/functions/core.makeParameter.md
@@ -1,5 +1,5 @@
 ---
-title: "makeParameter"
+nav: "makeParameter"
 ---
 # Function: makeParameter
 

--- a/docs/reference/sdk/functions/core.makeReferenceSchemaFromObjectSchema.md
+++ b/docs/reference/sdk/functions/core.makeReferenceSchemaFromObjectSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "makeReferenceSchemaFromObjectSchema"
+nav: "makeReferenceSchemaFromObjectSchema"
 ---
 # Function: makeReferenceSchemaFromObjectSchema
 

--- a/docs/reference/sdk/functions/core.makeSchema.md
+++ b/docs/reference/sdk/functions/core.makeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "makeSchema"
+nav: "makeSchema"
 ---
 # Function: makeSchema
 

--- a/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
+++ b/docs/reference/sdk/functions/core.makeSimpleAutocompleteMetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "makeSimpleAutocompleteMetadataFormula"
+nav: "makeSimpleAutocompleteMetadataFormula"
 ---
 # Function: makeSimpleAutocompleteMetadataFormula
 

--- a/docs/reference/sdk/functions/core.makeSyncTable.md
+++ b/docs/reference/sdk/functions/core.makeSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: "makeSyncTable"
+nav: "makeSyncTable"
 ---
 # Function: makeSyncTable
 

--- a/docs/reference/sdk/functions/core.makeTranslateObjectFormula.md
+++ b/docs/reference/sdk/functions/core.makeTranslateObjectFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "makeTranslateObjectFormula"
+nav: "makeTranslateObjectFormula"
 ---
 # Function: makeTranslateObjectFormula
 

--- a/docs/reference/sdk/functions/core.newPack.md
+++ b/docs/reference/sdk/functions/core.newPack.md
@@ -1,5 +1,5 @@
 ---
-title: "newPack"
+nav: "newPack"
 ---
 # Function: newPack
 

--- a/docs/reference/sdk/functions/core.simpleAutocomplete.md
+++ b/docs/reference/sdk/functions/core.simpleAutocomplete.md
@@ -1,5 +1,5 @@
 ---
-title: "simpleAutocomplete"
+nav: "simpleAutocomplete"
 ---
 # Function: simpleAutocomplete
 

--- a/docs/reference/sdk/functions/core.withIdentity.md
+++ b/docs/reference/sdk/functions/core.withIdentity.md
@@ -1,5 +1,5 @@
 ---
-title: "withIdentity"
+nav: "withIdentity"
 ---
 # Function: withIdentity
 

--- a/docs/reference/sdk/functions/core.withQueryParams.md
+++ b/docs/reference/sdk/functions/core.withQueryParams.md
@@ -1,5 +1,5 @@
 ---
-title: "withQueryParams"
+nav: "withQueryParams"
 ---
 # Function: withQueryParams
 

--- a/docs/reference/sdk/functions/testing.executeFormulaFromPackDef.md
+++ b/docs/reference/sdk/functions/testing.executeFormulaFromPackDef.md
@@ -1,5 +1,5 @@
 ---
-title: "executeFormulaFromPackDef"
+nav: "executeFormulaFromPackDef"
 ---
 # Function: executeFormulaFromPackDef
 

--- a/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
+++ b/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
@@ -1,5 +1,5 @@
 ---
-title: "executeFormulaOrSyncWithVM"
+nav: "executeFormulaOrSyncWithVM"
 ---
 # Function: executeFormulaOrSyncWithVM
 

--- a/docs/reference/sdk/functions/testing.executeMetadataFormula.md
+++ b/docs/reference/sdk/functions/testing.executeMetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "executeMetadataFormula"
+nav: "executeMetadataFormula"
 ---
 # Function: executeMetadataFormula
 

--- a/docs/reference/sdk/functions/testing.executeSyncFormulaFromPackDef.md
+++ b/docs/reference/sdk/functions/testing.executeSyncFormulaFromPackDef.md
@@ -1,5 +1,5 @@
 ---
-title: "executeSyncFormulaFromPackDef"
+nav: "executeSyncFormulaFromPackDef"
 ---
 # Function: executeSyncFormulaFromPackDef
 

--- a/docs/reference/sdk/functions/testing.executeSyncFormulaFromPackDefSingleIteration.md
+++ b/docs/reference/sdk/functions/testing.executeSyncFormulaFromPackDefSingleIteration.md
@@ -1,5 +1,5 @@
 ---
-title: "executeSyncFormulaFromPackDefSingleIteration"
+nav: "executeSyncFormulaFromPackDefSingleIteration"
 ---
 # Function: executeSyncFormulaFromPackDefSingleIteration
 

--- a/docs/reference/sdk/functions/testing.newJsonFetchResponse.md
+++ b/docs/reference/sdk/functions/testing.newJsonFetchResponse.md
@@ -1,5 +1,5 @@
 ---
-title: "newJsonFetchResponse"
+nav: "newJsonFetchResponse"
 ---
 # Function: newJsonFetchResponse
 

--- a/docs/reference/sdk/functions/testing.newMockExecutionContext.md
+++ b/docs/reference/sdk/functions/testing.newMockExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "newMockExecutionContext"
+nav: "newMockExecutionContext"
 ---
 # Function: newMockExecutionContext
 

--- a/docs/reference/sdk/functions/testing.newMockSyncExecutionContext.md
+++ b/docs/reference/sdk/functions/testing.newMockSyncExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "newMockSyncExecutionContext"
+nav: "newMockSyncExecutionContext"
 ---
 # Function: newMockSyncExecutionContext
 

--- a/docs/reference/sdk/functions/testing.newRealFetcherExecutionContext.md
+++ b/docs/reference/sdk/functions/testing.newRealFetcherExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "newRealFetcherExecutionContext"
+nav: "newRealFetcherExecutionContext"
 ---
 # Function: newRealFetcherExecutionContext
 

--- a/docs/reference/sdk/functions/testing.newRealFetcherSyncExecutionContext.md
+++ b/docs/reference/sdk/functions/testing.newRealFetcherSyncExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "newRealFetcherSyncExecutionContext"
+nav: "newRealFetcherSyncExecutionContext"
 ---
 # Function: newRealFetcherSyncExecutionContext
 

--- a/docs/reference/sdk/interfaces/core.AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.AWSAccessKeyAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "AWSAccessKeyAuthentication"
+nav: "AWSAccessKeyAuthentication"
 ---
 # Interface: AWSAccessKeyAuthentication
 

--- a/docs/reference/sdk/interfaces/core.AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.AWSAssumeRoleAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "AWSAssumeRoleAuthentication"
+nav: "AWSAssumeRoleAuthentication"
 ---
 # Interface: AWSAssumeRoleAuthentication
 

--- a/docs/reference/sdk/interfaces/core.ArraySchema.md
+++ b/docs/reference/sdk/interfaces/core.ArraySchema.md
@@ -1,5 +1,5 @@
 ---
-title: "ArraySchema"
+nav: "ArraySchema"
 ---
 # Interface: ArraySchema<T\>
 

--- a/docs/reference/sdk/interfaces/core.ArrayType.md
+++ b/docs/reference/sdk/interfaces/core.ArrayType.md
@@ -1,5 +1,5 @@
 ---
-title: "ArrayType"
+nav: "ArrayType"
 ---
 # Interface: ArrayType<T\>
 

--- a/docs/reference/sdk/interfaces/core.BaseAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.BaseAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "BaseAuthentication"
+nav: "BaseAuthentication"
 ---
 # Interface: BaseAuthentication
 

--- a/docs/reference/sdk/interfaces/core.BaseFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.BaseFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "BaseFormulaDef"
+nav: "BaseFormulaDef"
 ---
 # Interface: BaseFormulaDef<ParamDefsT, ResultT\>
 

--- a/docs/reference/sdk/interfaces/core.BooleanSchema.md
+++ b/docs/reference/sdk/interfaces/core.BooleanSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "BooleanSchema"
+nav: "BooleanSchema"
 ---
 # Interface: BooleanSchema
 

--- a/docs/reference/sdk/interfaces/core.CodaApiBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CodaApiBearerTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "CodaApiBearerTokenAuthentication"
+nav: "CodaApiBearerTokenAuthentication"
 ---
 # Interface: CodaApiBearerTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/core.Continuation.md
+++ b/docs/reference/sdk/interfaces/core.Continuation.md
@@ -1,5 +1,5 @@
 ---
-title: "Continuation"
+nav: "Continuation"
 ---
 # Interface: Continuation
 

--- a/docs/reference/sdk/interfaces/core.CurrencySchema.md
+++ b/docs/reference/sdk/interfaces/core.CurrencySchema.md
@@ -1,5 +1,5 @@
 ---
-title: "CurrencySchema"
+nav: "CurrencySchema"
 ---
 # Interface: CurrencySchema
 

--- a/docs/reference/sdk/interfaces/core.CustomAuthParameter.md
+++ b/docs/reference/sdk/interfaces/core.CustomAuthParameter.md
@@ -1,5 +1,5 @@
 ---
-title: "CustomAuthParameter"
+nav: "CustomAuthParameter"
 ---
 # Interface: CustomAuthParameter
 

--- a/docs/reference/sdk/interfaces/core.CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CustomAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "CustomAuthentication"
+nav: "CustomAuthentication"
 ---
 # Interface: CustomAuthentication
 

--- a/docs/reference/sdk/interfaces/core.CustomHeaderTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CustomHeaderTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "CustomHeaderTokenAuthentication"
+nav: "CustomHeaderTokenAuthentication"
 ---
 # Interface: CustomHeaderTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/core.DurationSchema.md
+++ b/docs/reference/sdk/interfaces/core.DurationSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "DurationSchema"
+nav: "DurationSchema"
 ---
 # Interface: DurationSchema
 

--- a/docs/reference/sdk/interfaces/core.DynamicOptions.md
+++ b/docs/reference/sdk/interfaces/core.DynamicOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "DynamicOptions"
+nav: "DynamicOptions"
 ---
 # Interface: DynamicOptions
 

--- a/docs/reference/sdk/interfaces/core.DynamicSyncTableDef.md
+++ b/docs/reference/sdk/interfaces/core.DynamicSyncTableDef.md
@@ -1,5 +1,5 @@
 ---
-title: "DynamicSyncTableDef"
+nav: "DynamicSyncTableDef"
 ---
 # Interface: DynamicSyncTableDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.DynamicSyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/core.DynamicSyncTableOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "DynamicSyncTableOptions"
+nav: "DynamicSyncTableOptions"
 ---
 # Interface: DynamicSyncTableOptions<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.EmailSchema.md
+++ b/docs/reference/sdk/interfaces/core.EmailSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "EmailSchema"
+nav: "EmailSchema"
 ---
 # Interface: EmailSchema
 

--- a/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.EmptyFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "EmptyFormulaDef"
+nav: "EmptyFormulaDef"
 ---
 # Interface: EmptyFormulaDef<ParamsT\>
 

--- a/docs/reference/sdk/interfaces/core.ExecutionContext.md
+++ b/docs/reference/sdk/interfaces/core.ExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "ExecutionContext"
+nav: "ExecutionContext"
 ---
 # Interface: ExecutionContext
 

--- a/docs/reference/sdk/interfaces/core.FetchRequest.md
+++ b/docs/reference/sdk/interfaces/core.FetchRequest.md
@@ -1,5 +1,5 @@
 ---
-title: "FetchRequest"
+nav: "FetchRequest"
 ---
 # Interface: FetchRequest
 

--- a/docs/reference/sdk/interfaces/core.FetchResponse.md
+++ b/docs/reference/sdk/interfaces/core.FetchResponse.md
@@ -1,5 +1,5 @@
 ---
-title: "FetchResponse"
+nav: "FetchResponse"
 ---
 # Interface: FetchResponse<T\>
 

--- a/docs/reference/sdk/interfaces/core.Fetcher.md
+++ b/docs/reference/sdk/interfaces/core.Fetcher.md
@@ -1,5 +1,5 @@
 ---
-title: "Fetcher"
+nav: "Fetcher"
 ---
 # Interface: Fetcher
 

--- a/docs/reference/sdk/interfaces/core.Format.md
+++ b/docs/reference/sdk/interfaces/core.Format.md
@@ -1,5 +1,5 @@
 ---
-title: "Format"
+nav: "Format"
 ---
 # Interface: Format
 

--- a/docs/reference/sdk/interfaces/core.HeaderBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.HeaderBearerTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "HeaderBearerTokenAuthentication"
+nav: "HeaderBearerTokenAuthentication"
 ---
 # Interface: HeaderBearerTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/core.Identity.md
+++ b/docs/reference/sdk/interfaces/core.Identity.md
@@ -1,5 +1,5 @@
 ---
-title: "Identity"
+nav: "Identity"
 ---
 # Interface: Identity
 

--- a/docs/reference/sdk/interfaces/core.IdentityDefinition.md
+++ b/docs/reference/sdk/interfaces/core.IdentityDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "IdentityDefinition"
+nav: "IdentityDefinition"
 ---
 # Interface: IdentityDefinition
 

--- a/docs/reference/sdk/interfaces/core.ImageAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.ImageAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: "ImageAttributionNode"
+nav: "ImageAttributionNode"
 ---
 # Interface: ImageAttributionNode
 

--- a/docs/reference/sdk/interfaces/core.ImageSchema.md
+++ b/docs/reference/sdk/interfaces/core.ImageSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "ImageSchema"
+nav: "ImageSchema"
 ---
 # Interface: ImageSchema
 

--- a/docs/reference/sdk/interfaces/core.InvocationLocation.md
+++ b/docs/reference/sdk/interfaces/core.InvocationLocation.md
@@ -1,5 +1,5 @@
 ---
-title: "InvocationLocation"
+nav: "InvocationLocation"
 ---
 # Interface: InvocationLocation
 

--- a/docs/reference/sdk/interfaces/core.LinkAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.LinkAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: "LinkAttributionNode"
+nav: "LinkAttributionNode"
 ---
 # Interface: LinkAttributionNode
 

--- a/docs/reference/sdk/interfaces/core.LinkSchema.md
+++ b/docs/reference/sdk/interfaces/core.LinkSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "LinkSchema"
+nav: "LinkSchema"
 ---
 # Interface: LinkSchema
 

--- a/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
+++ b/docs/reference/sdk/interfaces/core.MetadataFormulaObjectResultType.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataFormulaObjectResultType"
+nav: "MetadataFormulaObjectResultType"
 ---
 # Interface: MetadataFormulaObjectResultType
 

--- a/docs/reference/sdk/interfaces/core.MultiQueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.MultiQueryParamTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "MultiQueryParamTokenAuthentication"
+nav: "MultiQueryParamTokenAuthentication"
 ---
 # Interface: MultiQueryParamTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/core.Network.md
+++ b/docs/reference/sdk/interfaces/core.Network.md
@@ -1,5 +1,5 @@
 ---
-title: "Network"
+nav: "Network"
 ---
 # Interface: Network
 

--- a/docs/reference/sdk/interfaces/core.NoAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.NoAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "NoAuthentication"
+nav: "NoAuthentication"
 ---
 # Interface: NoAuthentication
 

--- a/docs/reference/sdk/interfaces/core.NumericDateSchema.md
+++ b/docs/reference/sdk/interfaces/core.NumericDateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericDateSchema"
+nav: "NumericDateSchema"
 ---
 # Interface: NumericDateSchema
 

--- a/docs/reference/sdk/interfaces/core.NumericDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/core.NumericDateTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericDateTimeSchema"
+nav: "NumericDateTimeSchema"
 ---
 # Interface: NumericDateTimeSchema
 

--- a/docs/reference/sdk/interfaces/core.NumericDurationSchema.md
+++ b/docs/reference/sdk/interfaces/core.NumericDurationSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericDurationSchema"
+nav: "NumericDurationSchema"
 ---
 # Interface: NumericDurationSchema
 

--- a/docs/reference/sdk/interfaces/core.NumericSchema.md
+++ b/docs/reference/sdk/interfaces/core.NumericSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericSchema"
+nav: "NumericSchema"
 ---
 # Interface: NumericSchema
 

--- a/docs/reference/sdk/interfaces/core.NumericTimeSchema.md
+++ b/docs/reference/sdk/interfaces/core.NumericTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericTimeSchema"
+nav: "NumericTimeSchema"
 ---
 # Interface: NumericTimeSchema
 

--- a/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "OAuth2Authentication"
+nav: "OAuth2Authentication"
 ---
 # Interface: OAuth2Authentication
 

--- a/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.ObjectArrayFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectArrayFormulaDef"
+nav: "ObjectArrayFormulaDef"
 ---
 # Interface: ObjectArrayFormulaDef<ParamsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.ObjectSchemaDefinition.md
+++ b/docs/reference/sdk/interfaces/core.ObjectSchemaDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectSchemaDefinition"
+nav: "ObjectSchemaDefinition"
 ---
 # Interface: ObjectSchemaDefinition<K, L\>
 

--- a/docs/reference/sdk/interfaces/core.ObjectSchemaProperty.md
+++ b/docs/reference/sdk/interfaces/core.ObjectSchemaProperty.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectSchemaProperty"
+nav: "ObjectSchemaProperty"
 ---
 # Interface: ObjectSchemaProperty
 

--- a/docs/reference/sdk/interfaces/core.PackDefinition.md
+++ b/docs/reference/sdk/interfaces/core.PackDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "PackDefinition"
+nav: "PackDefinition"
 ---
 # Interface: PackDefinition
 

--- a/docs/reference/sdk/interfaces/core.PackFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.PackFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "PackFormulaDef"
+nav: "PackFormulaDef"
 ---
 # Interface: PackFormulaDef<ParamsT, ResultT\>
 

--- a/docs/reference/sdk/interfaces/core.PackVersionDefinition.md
+++ b/docs/reference/sdk/interfaces/core.PackVersionDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "PackVersionDefinition"
+nav: "PackVersionDefinition"
 ---
 # Interface: PackVersionDefinition
 

--- a/docs/reference/sdk/interfaces/core.ParamDef.md
+++ b/docs/reference/sdk/interfaces/core.ParamDef.md
@@ -1,5 +1,5 @@
 ---
-title: "ParamDef"
+nav: "ParamDef"
 ---
 # Interface: ParamDef<T\>
 

--- a/docs/reference/sdk/interfaces/core.ProgressBarSchema.md
+++ b/docs/reference/sdk/interfaces/core.ProgressBarSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "ProgressBarSchema"
+nav: "ProgressBarSchema"
 ---
 # Interface: ProgressBarSchema
 

--- a/docs/reference/sdk/interfaces/core.QueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.QueryParamTokenAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "QueryParamTokenAuthentication"
+nav: "QueryParamTokenAuthentication"
 ---
 # Interface: QueryParamTokenAuthentication
 

--- a/docs/reference/sdk/interfaces/core.RequestHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/core.RequestHandlerTemplate.md
@@ -1,5 +1,5 @@
 ---
-title: "RequestHandlerTemplate"
+nav: "RequestHandlerTemplate"
 ---
 # Interface: RequestHandlerTemplate
 

--- a/docs/reference/sdk/interfaces/core.ResponseHandlerTemplate.md
+++ b/docs/reference/sdk/interfaces/core.ResponseHandlerTemplate.md
@@ -1,5 +1,5 @@
 ---
-title: "ResponseHandlerTemplate"
+nav: "ResponseHandlerTemplate"
 ---
 # Interface: ResponseHandlerTemplate<T\>
 

--- a/docs/reference/sdk/interfaces/core.ScaleSchema.md
+++ b/docs/reference/sdk/interfaces/core.ScaleSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "ScaleSchema"
+nav: "ScaleSchema"
 ---
 # Interface: ScaleSchema
 

--- a/docs/reference/sdk/interfaces/core.SetEndpoint.md
+++ b/docs/reference/sdk/interfaces/core.SetEndpoint.md
@@ -1,5 +1,5 @@
 ---
-title: "SetEndpoint"
+nav: "SetEndpoint"
 ---
 # Interface: SetEndpoint
 

--- a/docs/reference/sdk/interfaces/core.SimpleAutocompleteOption.md
+++ b/docs/reference/sdk/interfaces/core.SimpleAutocompleteOption.md
@@ -1,5 +1,5 @@
 ---
-title: "SimpleAutocompleteOption"
+nav: "SimpleAutocompleteOption"
 ---
 # Interface: SimpleAutocompleteOption<T\>
 

--- a/docs/reference/sdk/interfaces/core.SimpleStringSchema.md
+++ b/docs/reference/sdk/interfaces/core.SimpleStringSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "SimpleStringSchema"
+nav: "SimpleStringSchema"
 ---
 # Interface: SimpleStringSchema<T\>
 

--- a/docs/reference/sdk/interfaces/core.SliderSchema.md
+++ b/docs/reference/sdk/interfaces/core.SliderSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "SliderSchema"
+nav: "SliderSchema"
 ---
 # Interface: SliderSchema
 

--- a/docs/reference/sdk/interfaces/core.StatusCodeErrorResponse.md
+++ b/docs/reference/sdk/interfaces/core.StatusCodeErrorResponse.md
@@ -1,5 +1,5 @@
 ---
-title: "StatusCodeErrorResponse"
+nav: "StatusCodeErrorResponse"
 ---
 # Interface: StatusCodeErrorResponse
 

--- a/docs/reference/sdk/interfaces/core.StringDateSchema.md
+++ b/docs/reference/sdk/interfaces/core.StringDateSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "StringDateSchema"
+nav: "StringDateSchema"
 ---
 # Interface: StringDateSchema
 

--- a/docs/reference/sdk/interfaces/core.StringDateTimeSchema.md
+++ b/docs/reference/sdk/interfaces/core.StringDateTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "StringDateTimeSchema"
+nav: "StringDateTimeSchema"
 ---
 # Interface: StringDateTimeSchema
 

--- a/docs/reference/sdk/interfaces/core.StringEmbedSchema.md
+++ b/docs/reference/sdk/interfaces/core.StringEmbedSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "StringEmbedSchema"
+nav: "StringEmbedSchema"
 ---
 # Interface: StringEmbedSchema
 

--- a/docs/reference/sdk/interfaces/core.StringTimeSchema.md
+++ b/docs/reference/sdk/interfaces/core.StringTimeSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "StringTimeSchema"
+nav: "StringTimeSchema"
 ---
 # Interface: StringTimeSchema
 

--- a/docs/reference/sdk/interfaces/core.Sync.md
+++ b/docs/reference/sdk/interfaces/core.Sync.md
@@ -1,5 +1,5 @@
 ---
-title: "Sync"
+nav: "Sync"
 ---
 # Interface: Sync
 

--- a/docs/reference/sdk/interfaces/core.SyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/core.SyncExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncExecutionContext"
+nav: "SyncExecutionContext"
 ---
 # Interface: SyncExecutionContext
 

--- a/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncFormulaDef"
+nav: "SyncFormulaDef"
 ---
 # Interface: SyncFormulaDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.SyncFormulaResult.md
+++ b/docs/reference/sdk/interfaces/core.SyncFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncFormulaResult"
+nav: "SyncFormulaResult"
 ---
 # Interface: SyncFormulaResult<K, L, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.SyncTableDef.md
+++ b/docs/reference/sdk/interfaces/core.SyncTableDef.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncTableDef"
+nav: "SyncTableDef"
 ---
 # Interface: SyncTableDef<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.SyncTableOptions.md
+++ b/docs/reference/sdk/interfaces/core.SyncTableOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncTableOptions"
+nav: "SyncTableOptions"
 ---
 # Interface: SyncTableOptions<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
@@ -1,5 +1,5 @@
 ---
-title: "TemporaryBlobStorage"
+nav: "TemporaryBlobStorage"
 ---
 # Interface: TemporaryBlobStorage
 

--- a/docs/reference/sdk/interfaces/core.TextAttributionNode.md
+++ b/docs/reference/sdk/interfaces/core.TextAttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: "TextAttributionNode"
+nav: "TextAttributionNode"
 ---
 # Interface: TextAttributionNode
 

--- a/docs/reference/sdk/interfaces/core.VariousAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.VariousAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "VariousAuthentication"
+nav: "VariousAuthentication"
 ---
 # Interface: VariousAuthentication
 

--- a/docs/reference/sdk/interfaces/core.WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.WebBasicAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "WebBasicAuthentication"
+nav: "WebBasicAuthentication"
 ---
 # Interface: WebBasicAuthentication
 

--- a/docs/reference/sdk/interfaces/testing.ContextOptions.md
+++ b/docs/reference/sdk/interfaces/testing.ContextOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "ContextOptions"
+nav: "ContextOptions"
 ---
 # Interface: ContextOptions
 

--- a/docs/reference/sdk/interfaces/testing.ExecuteOptions.md
+++ b/docs/reference/sdk/interfaces/testing.ExecuteOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "ExecuteOptions"
+nav: "ExecuteOptions"
 ---
 # Interface: ExecuteOptions
 

--- a/docs/reference/sdk/interfaces/testing.MockExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "MockExecutionContext"
+nav: "MockExecutionContext"
 ---
 # Interface: MockExecutionContext
 

--- a/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
@@ -1,5 +1,5 @@
 ---
-title: "MockSyncExecutionContext"
+nav: "MockSyncExecutionContext"
 ---
 # Interface: MockSyncExecutionContext
 

--- a/docs/reference/sdk/modules.md
+++ b/docs/reference/sdk/modules.md
@@ -1,5 +1,5 @@
 ---
-title: "Modules"
+nav: "Modules"
 ---
 # Modules
 

--- a/docs/reference/sdk/modules/core.SvgConstants.md
+++ b/docs/reference/sdk/modules/core.SvgConstants.md
@@ -1,5 +1,5 @@
 ---
-title: "SvgConstants"
+nav: "SvgConstants"
 ---
 # Namespace: SvgConstants
 

--- a/docs/reference/sdk/modules/core.md
+++ b/docs/reference/sdk/modules/core.md
@@ -1,5 +1,5 @@
 ---
-title: "core"
+nav: "core"
 ---
 # Module: core
 

--- a/docs/reference/sdk/modules/testing.md
+++ b/docs/reference/sdk/modules/testing.md
@@ -1,5 +1,5 @@
 ---
-title: "testing"
+nav: "testing"
 ---
 # Module: testing
 

--- a/docs/reference/sdk/types/core.ArrayFormulaDef.md
+++ b/docs/reference/sdk/types/core.ArrayFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "ArrayFormulaDef"
+nav: "ArrayFormulaDef"
 ---
 # Type alias: ArrayFormulaDef<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.AttributionNode.md
+++ b/docs/reference/sdk/types/core.AttributionNode.md
@@ -1,5 +1,5 @@
 ---
-title: "AttributionNode"
+nav: "AttributionNode"
 ---
 # Type alias: AttributionNode
 

--- a/docs/reference/sdk/types/core.Authentication.md
+++ b/docs/reference/sdk/types/core.Authentication.md
@@ -1,5 +1,5 @@
 ---
-title: "Authentication"
+nav: "Authentication"
 ---
 # Type alias: Authentication
 

--- a/docs/reference/sdk/types/core.BaseFormula.md
+++ b/docs/reference/sdk/types/core.BaseFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "BaseFormula"
+nav: "BaseFormula"
 ---
 # Type alias: BaseFormula<ParamDefsT, ResultT\>
 

--- a/docs/reference/sdk/types/core.BasicPackDefinition.md
+++ b/docs/reference/sdk/types/core.BasicPackDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "BasicPackDefinition"
+nav: "BasicPackDefinition"
 ---
 # Type alias: BasicPackDefinition
 

--- a/docs/reference/sdk/types/core.BooleanFormulaDef.md
+++ b/docs/reference/sdk/types/core.BooleanFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "BooleanFormulaDef"
+nav: "BooleanFormulaDef"
 ---
 # Type alias: BooleanFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.BooleanHintTypes.md
+++ b/docs/reference/sdk/types/core.BooleanHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: "BooleanHintTypes"
+nav: "BooleanHintTypes"
 ---
 # Type alias: BooleanHintTypes
 

--- a/docs/reference/sdk/types/core.BooleanPackFormula.md
+++ b/docs/reference/sdk/types/core.BooleanPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "BooleanPackFormula"
+nav: "BooleanPackFormula"
 ---
 # Type alias: BooleanPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.FetchMethodType.md
+++ b/docs/reference/sdk/types/core.FetchMethodType.md
@@ -1,5 +1,5 @@
 ---
-title: "FetchMethodType"
+nav: "FetchMethodType"
 ---
 # Type alias: FetchMethodType
 

--- a/docs/reference/sdk/types/core.Formula.md
+++ b/docs/reference/sdk/types/core.Formula.md
@@ -1,5 +1,5 @@
 ---
-title: "Formula"
+nav: "Formula"
 ---
 # Type alias: Formula<ParamDefsT, ResultT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.FormulaDefinition.md
+++ b/docs/reference/sdk/types/core.FormulaDefinition.md
@@ -1,5 +1,5 @@
 ---
-title: "FormulaDefinition"
+nav: "FormulaDefinition"
 ---
 # Type alias: FormulaDefinition<ParamDefsT, ResultT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.GenericDynamicSyncTable.md
+++ b/docs/reference/sdk/types/core.GenericDynamicSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: "GenericDynamicSyncTable"
+nav: "GenericDynamicSyncTable"
 ---
 # Type alias: GenericDynamicSyncTable
 

--- a/docs/reference/sdk/types/core.GenericSyncFormula.md
+++ b/docs/reference/sdk/types/core.GenericSyncFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "GenericSyncFormula"
+nav: "GenericSyncFormula"
 ---
 # Type alias: GenericSyncFormula
 

--- a/docs/reference/sdk/types/core.GenericSyncFormulaResult.md
+++ b/docs/reference/sdk/types/core.GenericSyncFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: "GenericSyncFormulaResult"
+nav: "GenericSyncFormulaResult"
 ---
 # Type alias: GenericSyncFormulaResult
 

--- a/docs/reference/sdk/types/core.GenericSyncTable.md
+++ b/docs/reference/sdk/types/core.GenericSyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: "GenericSyncTable"
+nav: "GenericSyncTable"
 ---
 # Type alias: GenericSyncTable
 

--- a/docs/reference/sdk/types/core.InferrableTypes.md
+++ b/docs/reference/sdk/types/core.InferrableTypes.md
@@ -1,5 +1,5 @@
 ---
-title: "InferrableTypes"
+nav: "InferrableTypes"
 ---
 # Type alias: InferrableTypes
 

--- a/docs/reference/sdk/types/core.MetadataContext.md
+++ b/docs/reference/sdk/types/core.MetadataContext.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataContext"
+nav: "MetadataContext"
 ---
 # Type alias: MetadataContext
 

--- a/docs/reference/sdk/types/core.MetadataFormula.md
+++ b/docs/reference/sdk/types/core.MetadataFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataFormula"
+nav: "MetadataFormula"
 ---
 # Type alias: MetadataFormula
 

--- a/docs/reference/sdk/types/core.MetadataFormulaDef.md
+++ b/docs/reference/sdk/types/core.MetadataFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataFormulaDef"
+nav: "MetadataFormulaDef"
 ---
 # Type alias: MetadataFormulaDef
 

--- a/docs/reference/sdk/types/core.MetadataFormulaResultType.md
+++ b/docs/reference/sdk/types/core.MetadataFormulaResultType.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataFormulaResultType"
+nav: "MetadataFormulaResultType"
 ---
 # Type alias: MetadataFormulaResultType
 

--- a/docs/reference/sdk/types/core.MetadataFunction.md
+++ b/docs/reference/sdk/types/core.MetadataFunction.md
@@ -1,5 +1,5 @@
 ---
-title: "MetadataFunction"
+nav: "MetadataFunction"
 ---
 # Type alias: MetadataFunction
 

--- a/docs/reference/sdk/types/core.NumberHintTypes.md
+++ b/docs/reference/sdk/types/core.NumberHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: "NumberHintTypes"
+nav: "NumberHintTypes"
 ---
 # Type alias: NumberHintTypes
 

--- a/docs/reference/sdk/types/core.NumberSchema.md
+++ b/docs/reference/sdk/types/core.NumberSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "NumberSchema"
+nav: "NumberSchema"
 ---
 # Type alias: NumberSchema
 

--- a/docs/reference/sdk/types/core.NumericFormulaDef.md
+++ b/docs/reference/sdk/types/core.NumericFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericFormulaDef"
+nav: "NumericFormulaDef"
 ---
 # Type alias: NumericFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.NumericPackFormula.md
+++ b/docs/reference/sdk/types/core.NumericPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "NumericPackFormula"
+nav: "NumericPackFormula"
 ---
 # Type alias: NumericPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.ObjectFormulaDef.md
+++ b/docs/reference/sdk/types/core.ObjectFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectFormulaDef"
+nav: "ObjectFormulaDef"
 ---
 # Type alias: ObjectFormulaDef<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.ObjectHintTypes.md
+++ b/docs/reference/sdk/types/core.ObjectHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectHintTypes"
+nav: "ObjectHintTypes"
 ---
 # Type alias: ObjectHintTypes
 

--- a/docs/reference/sdk/types/core.ObjectPackFormula.md
+++ b/docs/reference/sdk/types/core.ObjectPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectPackFormula"
+nav: "ObjectPackFormula"
 ---
 # Type alias: ObjectPackFormula<ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.ObjectSchemaProperties.md
+++ b/docs/reference/sdk/types/core.ObjectSchemaProperties.md
@@ -1,5 +1,5 @@
 ---
-title: "ObjectSchemaProperties"
+nav: "ObjectSchemaProperties"
 ---
 # Type alias: ObjectSchemaProperties<K\>
 

--- a/docs/reference/sdk/types/core.PackFormulaResult.md
+++ b/docs/reference/sdk/types/core.PackFormulaResult.md
@@ -1,5 +1,5 @@
 ---
-title: "PackFormulaResult"
+nav: "PackFormulaResult"
 ---
 # Type alias: PackFormulaResult
 

--- a/docs/reference/sdk/types/core.PackFormulaValue.md
+++ b/docs/reference/sdk/types/core.PackFormulaValue.md
@@ -1,5 +1,5 @@
 ---
-title: "PackFormulaValue"
+nav: "PackFormulaValue"
 ---
 # Type alias: PackFormulaValue
 

--- a/docs/reference/sdk/types/core.PackId.md
+++ b/docs/reference/sdk/types/core.PackId.md
@@ -1,5 +1,5 @@
 ---
-title: "PackId"
+nav: "PackId"
 ---
 # Type alias: PackId
 

--- a/docs/reference/sdk/types/core.ParamDefs.md
+++ b/docs/reference/sdk/types/core.ParamDefs.md
@@ -1,5 +1,5 @@
 ---
-title: "ParamDefs"
+nav: "ParamDefs"
 ---
 # Type alias: ParamDefs
 

--- a/docs/reference/sdk/types/core.ParamValues.md
+++ b/docs/reference/sdk/types/core.ParamValues.md
@@ -1,5 +1,5 @@
 ---
-title: "ParamValues"
+nav: "ParamValues"
 ---
 # Type alias: ParamValues<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.ParameterOptions.md
+++ b/docs/reference/sdk/types/core.ParameterOptions.md
@@ -1,5 +1,5 @@
 ---
-title: "ParameterOptions"
+nav: "ParameterOptions"
 ---
 # Type alias: ParameterOptions<T\>
 

--- a/docs/reference/sdk/types/core.PostSetup.md
+++ b/docs/reference/sdk/types/core.PostSetup.md
@@ -1,5 +1,5 @@
 ---
-title: "PostSetup"
+nav: "PostSetup"
 ---
 # Type alias: PostSetup
 

--- a/docs/reference/sdk/types/core.PostSetupDef.md
+++ b/docs/reference/sdk/types/core.PostSetupDef.md
@@ -1,5 +1,5 @@
 ---
-title: "PostSetupDef"
+nav: "PostSetupDef"
 ---
 # Type alias: PostSetupDef
 

--- a/docs/reference/sdk/types/core.Schema.md
+++ b/docs/reference/sdk/types/core.Schema.md
@@ -1,5 +1,5 @@
 ---
-title: "Schema"
+nav: "Schema"
 ---
 # Type alias: Schema
 

--- a/docs/reference/sdk/types/core.SchemaType.md
+++ b/docs/reference/sdk/types/core.SchemaType.md
@@ -1,5 +1,5 @@
 ---
-title: "SchemaType"
+nav: "SchemaType"
 ---
 # Type alias: SchemaType<T\>
 

--- a/docs/reference/sdk/types/core.SetEndpointDef.md
+++ b/docs/reference/sdk/types/core.SetEndpointDef.md
@@ -1,5 +1,5 @@
 ---
-title: "SetEndpointDef"
+nav: "SetEndpointDef"
 ---
 # Type alias: SetEndpointDef
 

--- a/docs/reference/sdk/types/core.StringFormulaDef.md
+++ b/docs/reference/sdk/types/core.StringFormulaDef.md
@@ -1,5 +1,5 @@
 ---
-title: "StringFormulaDef"
+nav: "StringFormulaDef"
 ---
 # Type alias: StringFormulaDef<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.StringHintTypes.md
+++ b/docs/reference/sdk/types/core.StringHintTypes.md
@@ -1,5 +1,5 @@
 ---
-title: "StringHintTypes"
+nav: "StringHintTypes"
 ---
 # Type alias: StringHintTypes
 

--- a/docs/reference/sdk/types/core.StringPackFormula.md
+++ b/docs/reference/sdk/types/core.StringPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "StringPackFormula"
+nav: "StringPackFormula"
 ---
 # Type alias: StringPackFormula<ParamDefsT\>
 

--- a/docs/reference/sdk/types/core.StringSchema.md
+++ b/docs/reference/sdk/types/core.StringSchema.md
@@ -1,5 +1,5 @@
 ---
-title: "StringSchema"
+nav: "StringSchema"
 ---
 # Type alias: StringSchema
 

--- a/docs/reference/sdk/types/core.SuggestedValueType.md
+++ b/docs/reference/sdk/types/core.SuggestedValueType.md
@@ -1,5 +1,5 @@
 ---
-title: "SuggestedValueType"
+nav: "SuggestedValueType"
 ---
 # Type alias: SuggestedValueType<T\>
 

--- a/docs/reference/sdk/types/core.SyncFormula.md
+++ b/docs/reference/sdk/types/core.SyncFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncFormula"
+nav: "SyncFormula"
 ---
 # Type alias: SyncFormula<K, L, ParamDefsT, SchemaT\>
 

--- a/docs/reference/sdk/types/core.SyncTable.md
+++ b/docs/reference/sdk/types/core.SyncTable.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncTable"
+nav: "SyncTable"
 ---
 # Type alias: SyncTable
 

--- a/docs/reference/sdk/types/core.SystemAuthentication.md
+++ b/docs/reference/sdk/types/core.SystemAuthentication.md
@@ -1,5 +1,5 @@
 ---
-title: "SystemAuthentication"
+nav: "SystemAuthentication"
 ---
 # Type alias: SystemAuthentication
 

--- a/docs/reference/sdk/types/core.SystemAuthenticationDef.md
+++ b/docs/reference/sdk/types/core.SystemAuthenticationDef.md
@@ -1,5 +1,5 @@
 ---
-title: "SystemAuthenticationDef"
+nav: "SystemAuthenticationDef"
 ---
 # Type alias: SystemAuthenticationDef
 

--- a/docs/reference/sdk/types/core.TypedPackFormula.md
+++ b/docs/reference/sdk/types/core.TypedPackFormula.md
@@ -1,5 +1,5 @@
 ---
-title: "TypedPackFormula"
+nav: "TypedPackFormula"
 ---
 # Type alias: TypedPackFormula
 

--- a/docs/reference/sdk/variables/core.SvgConstants.DarkModeFragmentId.md
+++ b/docs/reference/sdk/variables/core.SvgConstants.DarkModeFragmentId.md
@@ -1,5 +1,5 @@
 ---
-title: "DarkModeFragmentId"
+nav: "DarkModeFragmentId"
 ---
 # Variable: DarkModeFragmentId
 

--- a/docs/reference/sdk/variables/core.SvgConstants.DataUrlPrefix.md
+++ b/docs/reference/sdk/variables/core.SvgConstants.DataUrlPrefix.md
@@ -1,5 +1,5 @@
 ---
-title: "DataUrlPrefix"
+nav: "DataUrlPrefix"
 ---
 # Variable: DataUrlPrefix
 

--- a/docs/reference/sdk/variables/core.SvgConstants.DataUrlPrefixWithDarkModeSupport.md
+++ b/docs/reference/sdk/variables/core.SvgConstants.DataUrlPrefixWithDarkModeSupport.md
@@ -1,5 +1,5 @@
 ---
-title: "DataUrlPrefixWithDarkModeSupport"
+nav: "DataUrlPrefixWithDarkModeSupport"
 ---
 # Variable: DataUrlPrefixWithDarkModeSupport
 

--- a/docs/reference/sdk/variables/core.ValidFetchMethods.md
+++ b/docs/reference/sdk/variables/core.ValidFetchMethods.md
@@ -1,5 +1,5 @@
 ---
-title: "ValidFetchMethods"
+nav: "ValidFetchMethods"
 ---
 # Variable: ValidFetchMethods
 

--- a/docs/samples/.nav.yml
+++ b/docs/samples/.nav.yml
@@ -1,5 +1,5 @@
 nav:
-  - Overview: index.md
+  - index.md
   - By topic: topic
   - full
   - CLI examples on GitHub: https://github.com/coda/packs-examples

--- a/docs/samples/full/cats.md
+++ b/docs/samples/full/cats.md
@@ -1,5 +1,5 @@
 ---
-title: Cats
+nav: Cats
 description: A Pack that generates images of cats.
 icon: fontawesome/solid/cat
 ---

--- a/docs/samples/full/daylight.md
+++ b/docs/samples/full/daylight.md
@@ -1,5 +1,5 @@
 ---
-title: Daylight
+nav: Daylight
 description: A Pack that fetches data about the expected hours of daylight at a location.
 icon: fontawesome/regular/sun
 ---

--- a/docs/samples/full/dnd.md
+++ b/docs/samples/full/dnd.md
@@ -1,5 +1,5 @@
 ---
-title: Dungeons &amp; Dragons
+nav: Dungeons &amp; Dragons
 description: A Pack that uses an API to retrieve information about the game Dungeons &amp; Dragons.
 icon: fontawesome/solid/dragon
 ---

--- a/docs/samples/full/github.md
+++ b/docs/samples/full/github.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub
+nav: GitHub
 description: A Pack that integrates with GitHub.
 icon: fontawesome/brands/github
 ---

--- a/docs/samples/full/hello-world.md
+++ b/docs/samples/full/hello-world.md
@@ -1,5 +1,5 @@
 ---
-title: Hello World
+nav: Hello World
 description: A simple &quot;Hello World&quot; Pack.
 icon: material/hand-wave-outline
 ---

--- a/docs/samples/full/math.md
+++ b/docs/samples/full/math.md
@@ -1,5 +1,5 @@
 ---
-title: Math
+nav: Math
 description: A Pack that provides various math operations.
 icon: material/calculator-variant
 ---

--- a/docs/samples/full/todoist.md
+++ b/docs/samples/full/todoist.md
@@ -1,5 +1,5 @@
 ---
-title: Todoist
+nav: Todoist
 description: A Pack that integrates with the application Todoist.
 icon: octicons/tasklist-16
 ---

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -1,5 +1,6 @@
 ---
-title: Samples
+nav: Samples
+description: An index of code examples to browse through.
 hide:
 - toc
 ---

--- a/docs/samples/topic/action.md
+++ b/docs/samples/topic/action.md
@@ -1,5 +1,5 @@
 ---
-title: Actions
+nav: Actions
 description: Samples that show how to create an action formula, for use in a button or automation.
 icon: material/cursor-default-click-outline
 ---

--- a/docs/samples/topic/apis.md
+++ b/docs/samples/topic/apis.md
@@ -1,5 +1,5 @@
 ---
-title: API setup
+nav: API setup
 description: Samples that show how to configure a Pack to connect to various popular APIs.
 icon: material/api
 ---

--- a/docs/samples/topic/authentication.md
+++ b/docs/samples/topic/authentication.md
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+nav: Authentication
 description: Samples that show how to authenticate with an API.
 icon: material/account-key
 ---

--- a/docs/samples/topic/autocomplete.md
+++ b/docs/samples/topic/autocomplete.md
@@ -1,5 +1,5 @@
 ---
-title: Autocomplete
+nav: Autocomplete
 description: Samples that show how to provide autocomplete options for a parameter.
 icon: material/form-dropdown
 ---

--- a/docs/samples/topic/column-format.md
+++ b/docs/samples/topic/column-format.md
@@ -1,5 +1,5 @@
 ---
-title: Column formats
+nav: Column formats
 description: Samples that show how to create a column format.
 icon: material/table-column
 ---

--- a/docs/samples/topic/data-type.md
+++ b/docs/samples/topic/data-type.md
@@ -1,5 +1,5 @@
 ---
-title: Data types
+nav: Data types
 description: Samples that show how to return values of various data types.
 icon: material/order-alphabetical-ascending
 ---

--- a/docs/samples/topic/dates.md
+++ b/docs/samples/topic/dates.md
@@ -1,5 +1,5 @@
 ---
-title: Dates and times
+nav: Dates and times
 description: Samples that show how to work with dates and times.
 icon: material/calendar-clock
 ---

--- a/docs/samples/topic/dynamic-sync-table.md
+++ b/docs/samples/topic/dynamic-sync-table.md
@@ -1,5 +1,5 @@
 ---
-title: Dynamic sync tables
+nav: Dynamic sync tables
 description: Samples that show how to create a dynamic sync table.
 icon: material/cloud-sync-outline
 ---

--- a/docs/samples/topic/fetcher.md
+++ b/docs/samples/topic/fetcher.md
@@ -1,5 +1,5 @@
 ---
-title: Fetcher
+nav: Fetcher
 description: Samples that show how to fetch data from an external source.
 icon: fontawesome/solid/cloud-arrow-down
 ---

--- a/docs/samples/topic/formula.md
+++ b/docs/samples/topic/formula.md
@@ -1,5 +1,5 @@
 ---
-title: Formulas
+nav: Formulas
 description: Samples that show how to create a formula.
 icon: material/function
 ---

--- a/docs/samples/topic/image.md
+++ b/docs/samples/topic/image.md
@@ -1,5 +1,5 @@
 ---
-title: Images
+nav: Images
 description: Samples that show how to work with images.
 icon: material/image
 ---

--- a/docs/samples/topic/parameter.md
+++ b/docs/samples/topic/parameter.md
@@ -1,5 +1,5 @@
 ---
-title: Parameters
+nav: Parameters
 description: Samples that show how to accept parameters from the user.
 icon: material/format-textbox
 ---

--- a/docs/samples/topic/schema.md
+++ b/docs/samples/topic/schema.md
@@ -1,5 +1,5 @@
 ---
-title: Schemas
+nav: Schemas
 description: Samples that show how to define a schema, to represent rich objects.
 icon: material/format-list-group
 ---

--- a/docs/samples/topic/sync-table.md
+++ b/docs/samples/topic/sync-table.md
@@ -1,5 +1,5 @@
 ---
-title: Sync tables
+nav: Sync tables
 description: Samples that show how to create a sync table.
 icon: material/table-sync
 ---

--- a/docs/support/.nav.yml
+++ b/docs/support/.nav.yml
@@ -1,5 +1,5 @@
 nav:
-  - Overview: index.md
+  - index.md
   - migration
   - contributing
   - ...

--- a/docs/support/contributing/.nav.yml
+++ b/docs/support/contributing/.nav.yml
@@ -1,3 +1,3 @@
 nav:
-  - Overview: index.md
+  - index.md
   - ...

--- a/docs/support/contributing/index.md
+++ b/docs/support/contributing/index.md
@@ -1,5 +1,7 @@
 ---
-title: Contributing
+nav: Contributing
+title: Contributing to the Coda Pack SDK
+description: Tips and policies for how to contribute to the SDK.
 ---
 
 --8<-- "CONTRIBUTING.md"

--- a/docs/support/contributing/style.md
+++ b/docs/support/contributing/style.md
@@ -1,5 +1,6 @@
 ---
-title: Style guide
+nav: Style guide
+description: Rules and guidelines to be followed when writing documentation for the SDK.
 ---
 
 # Documentation Style Guide

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -1,5 +1,6 @@
 ---
-title: Support
+nav: Support
+description: The support channels that exist for the Pack SDK.
 ---
 
 # How to get help

--- a/docs/support/migration/index.md
+++ b/docs/support/migration/index.md
@@ -1,5 +1,6 @@
 ---
-title: Migration
+nav: Migration
+description: How to upgrade to a new SDK version and what to look out for.
 ---
 
 # Migrating between SDK versions

--- a/docs/support/migration/v0.11.0.md
+++ b/docs/support/migration/v0.11.0.md
@@ -1,5 +1,6 @@
 ---
-title: Version 0.11.0
+nav: Version 0.11.0
+description: What changed and how to migrate to version 0.11.0.
 ---
 
 # Migrating to version 0.11.0

--- a/docs/tutorials/.nav.yml
+++ b/docs/tutorials/.nav.yml
@@ -1,5 +1,5 @@
 nav:
-  - Overview: index.md
+  - index.md
   - get-started
-  - Learn to build: build
+  - build
   - ...

--- a/docs/tutorials/build/.nav.yml
+++ b/docs/tutorials/build/.nav.yml
@@ -1,3 +1,4 @@
+title: Learn to build
 nav:
   - formula.md
   - fetcher.md

--- a/docs/tutorials/build/fetcher.md
+++ b/docs/tutorials/build/fetcher.md
@@ -1,5 +1,5 @@
 ---
-title: Call an API
+nav: Call an API
 description: Learn how to call an external API from within a Pack.
 icon: material/api
 hide:

--- a/docs/tutorials/build/formula.md
+++ b/docs/tutorials/build/formula.md
@@ -1,5 +1,5 @@
 ---
-title: Basic formula
+nav: Basic formula
 description: Learn how to build a basic formula from scratch.
 icon: material/function
 hide:

--- a/docs/tutorials/build/oauth.md
+++ b/docs/tutorials/build/oauth.md
@@ -1,5 +1,5 @@
 ---
-title: Using OAuth2
+nav: Using OAuth2
 description: Learn how to access private data in an API using OAuth2.
 icon: material/shield-key
 hide:

--- a/docs/tutorials/build/sync-table.md
+++ b/docs/tutorials/build/sync-table.md
@@ -1,5 +1,5 @@
 ---
-title: Sync table
+nav: Sync table
 description: Learn how to build a sync table of external data.
 icon: material/table-sync
 hide:

--- a/docs/tutorials/get-started/cli.md
+++ b/docs/tutorials/get-started/cli.md
@@ -1,5 +1,5 @@
 ---
-title: On your local machine
+nav: On your local machine
 description: Build your first Pack on your local machine using the CLI.
 icon: octicons/terminal-16
 ---

--- a/docs/tutorials/get-started/web.md
+++ b/docs/tutorials/get-started/web.md
@@ -1,5 +1,5 @@
 ---
-title: In the browser
+nav: In the browser
 description: Build your first Pack in minutes using the Pack Studio web editor.
 icon: octicons/browser-16
 ---

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,5 +1,6 @@
 ---
-title: Tutorials
+nav: Tutorials
+description: An index of guided lessons to help you learn various aspects of the SDK.
 hide:
 - toc
 ---

--- a/documentation/example_page_template.md
+++ b/documentation/example_page_template.md
@@ -1,5 +1,5 @@
 ---
-title: {{name}}
+nav: {{name}}
 description: {{description}}
 {{#if icon}}icon: {{icon}}{{/if}}
 ---

--- a/documentation/scripts/mkdocs_hooks.py
+++ b/documentation/scripts/mkdocs_hooks.py
@@ -1,0 +1,16 @@
+
+from mkdocs.utils import get_markdown_title
+
+# Adjust the nav once the markdown is read.
+def on_page_markdown(markdown, page, **kwargs):
+  # Set the meta title to the page's H1 title, if not already specified.
+  meta_title = get_markdown_title(markdown)
+  if 'title' not in page.meta and meta_title is not None:
+    page.meta['title'] = get_markdown_title(markdown)
+  # If the meta tags include a "nav" element, use that value as the nav entry
+  # for the page and remove it from the meta.
+  if 'nav' in page.meta:
+    page.title = page.meta['nav']
+    del page.meta['nav']
+  return markdown
+

--- a/documentation/typedoc_post_process.ts
+++ b/documentation/typedoc_post_process.ts
@@ -29,8 +29,8 @@ async function process(file: string) {
 }
 
 /**
- * Adds frontmatter to generated markdown files, setting a simplified title. The
- * frontmatter title is used in the nav.
+ * Adds frontmatter to generated markdown files, setting a simplified title to
+ * use in the navigation. The frontmatter nav title is used in the nav.
  */
 function addFrontmatter(file: string, content: string): string {
   if (content.startsWith('---\n')) {
@@ -43,7 +43,7 @@ function addFrontmatter(file: string, content: string): string {
     return content;
   }
   const title = match![1];
-  const frontmatter = `---\ntitle: "${title}"\n---\n`;
+  const frontmatter = `---\nnav: "${title}"\n---\n`;
   return frontmatter + content;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,9 @@ plugins:
           "guides/advanced/fetcher.md": "guides/basics/fetcher.md"
           # 2022-09-14: Move Overview page.
           "guides/index.md": "guides/overview.md"
-
+    - mkdocs-simple-hooks:
+        hooks:
+          on_page_markdown: "documentation.scripts.mkdocs_hooks:on_page_markdown"
     # Generate card images for social sharing.
     - social:
         cards: !ENV [MK_DOCS_GENERATE_CARDS, true]


### PR DESCRIPTION
Previously, many pages specified a `title:` tag in the frontmatter to set a shorter page title in the navigation. For example, "Caching" instead of "Caching formula and fetcher results". The problem was this same shorter title was used in the title tag of the page, the social sharing titles, and the generated social images.

![image](https://user-images.githubusercontent.com/88106038/191165707-8949e823-6fb1-4322-b7a5-80dcbe1db217.png)

In this PR, I move the navigation title to a new `nav:` tag in the frontmatter, which is later used to set `page.title` (which is what the nav shows). I also automatically generate the `title` meta tag from the first H1 (if not otherwise specified), which is used in the meta tags and social image. This allows for the same short names in the nav, but long names in the meta and social images.

![image](https://user-images.githubusercontent.com/88106038/191166075-3ae64434-9d2a-4511-b88a-9458477d7634.png)

This PR also:

- Adds a meta description for all pages.
- Allows overriding whether social cards are generated when previewing.