### PR TITLE
Use nav title for listing pages

### DIFF
--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -21,7 +21,7 @@ No need to start from scratch; we've got dozens of sample Packs for your to brow
 {# Read the page's source, but don't output anything. This is required to populate the page title and metadata. #}
 {{ page.read_source(config) or "" }}
 
-### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{page.title}}
+### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{ page.meta.get("nav", page.title) }}
 
 {{page.meta.description}}
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -21,7 +21,7 @@ The tutorials below provide step-by-step instructions and sample code to help yo
 {# Read the page's source, but don't output anything. This is required to populate the page title and metadata. #}
 {{ page.read_source(config) or "" }}
 
-### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{page.title}}
+### {% if page.meta.icon %}:{{page.meta.icon|replace("/", "-")}}:{% endif %} {{ page.meta.get("nav", page.title) }}
 
 {% if page.meta.description %}{{page.meta.description}}{% endif %}
 


### PR DESCRIPTION
The Tutorials and Samples listing pages were using `page.title` to generate the card titles. However the changes in #2212 make that default to the H1 value, which can be a bit long and awkward in the card.

![image](https://user-images.githubusercontent.com/88106038/191842937-5f0509ba-d44d-4c07-87cc-3cd50a38aca8.png)

`mkdocs_hooks.py`, which corrects `page.title` using the `nav:` frontmatter field, runs after the `macros` plugin. Switching the order would introduce other potential problems, so instead adjusting the macro logic to use the `nav:` field as well. This reverts these pages back to how they were before #2212.

![image](https://user-images.githubusercontent.com/88106038/191844099-dcd0a1f8-f21c-45dc-b77f-46040983d241.png)
