### PR TITLE
Update Google Verification FAQ

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -9,15 +9,29 @@ description: Answers to some of the most common questions about building Packs.
 
 To connect to a Google API from a Pack you need to use OAuth2 authentication. Many APIs require scopes that Google deems "sensitive", meaning that Google must approve your integration before other users can sign in. This approval process is known as [OAuth verification][google_verification], and involves many steps and checks.
 
-One of those checks is that Google must verify you own the domain name for all of the domains used by the integration. This includes the redirect URI that users are sent to after they complete the approval screen. For Coda Packs this redirect URL is always:
+!!! info "Exceptions"
+    There are some [exceptions to Google's verification requirement][google_verification_exceptions], for example an app only used internally within a single organization. Check this list first before beginning the verification process.
+
+One of the checks is that Google must verify you own the domain name for all of the domains used by the integration. This includes the redirect URI that users are sent to after they complete the approval screen. For Coda Packs this redirect URL is always:
 
 ```
 https://coda.io/packsAuth/oauth2
 ```
 
-To meet Google's verification requirements you would need to verify ownership of the `coda.io` domain, which isn't possible. While we hope to find a solution to this problem in the long run, at the moment it isn't possible to complete the verification process with Google.
+To meet Google's verification requirements you would need to verify ownership of the `coda.io` domain, which isn't possible. However [Google's FAQ][google_verification_line] includes this line:
 
-There are some [exceptions to Google's verification requirement][google_verification_exceptions], for example an app only used internally within a single organization. If you can adjust your Pack to meet one of these exceptions you can work around the problem.
+>  Note: If you are using a third party service provider and your domain is owned by them, then you need to provide a detailed justification for us to validate it.
+
+Although Google includes an exception for apps that don't own the domain of their redirect URL, it's outside the standard script the review team follows and may take some convincing. Here are some tips to help you get your integration approved:
+
+- Create a published doc for your Pack to act as the "home page". Ensure it, your Pack listing, and the Google consent screen branding all match (name, icon, etc).
+- Ensure you have a privacy policy published, even if it's just a minimal one. It can live in the published doc mentioned above.
+- Record a video showing the installation and usage of the Pack.
+- In the verification form there is a field that asks for a similar app that has been verified, and you can refer them to the previously approved [Apps Script Pack][packs_apps_script], with project number 367090187070.
+- If they insist on proof of ownership of `coda.io`, quote the clause from the FAQ and mention that Coda requires that everyone uses the same redirect URL. You can link them to [this section][oauth_redirect] of the OAuth documentation.
+- If they insist that a branded "Google Sign-in" button be used to start the OAuth flow, mention that the Coda platform controls these buttons and that you can't change them.
+
+With enough persistence you should be able to get your Pack verified. The process may take a week or more to complete, so plan accordingly.
 
 
 ## Can you add my company's icon as an option in Coda?
@@ -29,3 +43,6 @@ Coda supports both document- and page-level icons, from a library we source from
 
 [google_verification]: https://support.google.com/cloud/answer/9110914
 [google_verification_exceptions]: https://support.google.com/cloud/answer/9110914#exceptions-ver-reqts&zippy=%2Cexceptions-to-verification-requirements
+[google_verification_line]: https://support.google.com/cloud/answer/9110914?hl=en#zippy=%2Chow-can-i-make-sure-the-verification-process-is-as-streamlined-as-possible
+[oauth_redirect]: ./advanced/authentication/oauth2/#redirect-url
+[packs_apps_script]: https://coda.io/packs/apps-script-14470


### PR DESCRIPTION
Now that we have found a path to Google OAuth verification, update the FAQ accordingly.