### PR TITLE
Small doc updates

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -607,8 +607,8 @@ export interface TemporaryBlobStorage {
    * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
    * Coda reserves the right to ignore long expirations.
    *
-   * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-   * disposition) that will be downloaded when accessed as the file name provided.
+   * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+   * be downloaded with the file name provided.
    */
   storeUrl(
     url: string,
@@ -622,8 +622,8 @@ export interface TemporaryBlobStorage {
    * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
    * Coda reserves the right to ignore long expirations.
    *
-   * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-   * disposition) that will be downloaded when accessed as the file name provided.
+   * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+   * be downloaded with the file name provided.
    */
   storeBlob(
     blobData: Buffer,

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -494,8 +494,8 @@ export interface TemporaryBlobStorage {
      * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
      * Coda reserves the right to ignore long expirations.
      *
-     * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-     * disposition) that will be downloaded when accessed as the file name provided.
+     * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+     * be downloaded with the file name provided.
      */
     storeUrl(url: string, opts?: {
         expiryMs?: number;
@@ -508,8 +508,8 @@ export interface TemporaryBlobStorage {
      * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
      * Coda reserves the right to ignore long expirations.
      *
-     * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-     * disposition) that will be downloaded when accessed as the file name provided.
+     * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+     * be downloaded with the file name provided.
      */
     storeBlob(blobData: Buffer, contentType: string, opts?: {
         expiryMs?: number;

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1601,8 +1601,8 @@ export interface TemporaryBlobStorage {
 	 * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
 	 * Coda reserves the right to ignore long expirations.
 	 *
-	 * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-	 * disposition) that will be downloaded when accessed as the file name provided.
+	 * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+	 * be downloaded with the file name provided.
 	 */
 	storeUrl(url: string, opts?: {
 		expiryMs?: number;
@@ -1615,8 +1615,8 @@ export interface TemporaryBlobStorage {
 	 * The URL expires after 15 minutes by default, but you may pass a custom expiry, however
 	 * Coda reserves the right to ignore long expirations.
 	 *
-	 * If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-	 * disposition) that will be downloaded when accessed as the file name provided.
+	 * If the `downloadFilename` parameter is specified, when opened in the browser the file will
+	 * be downloaded with the file name provided.
 	 */
 	storeBlob(blobData: Buffer, contentType: string, opts?: {
 		expiryMs?: number;

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -44,5 +44,5 @@ Coda supports both document- and page-level icons, from a library we source from
 [google_verification]: https://support.google.com/cloud/answer/9110914
 [google_verification_exceptions]: https://support.google.com/cloud/answer/9110914#exceptions-ver-reqts&zippy=%2Cexceptions-to-verification-requirements
 [google_verification_line]: https://support.google.com/cloud/answer/9110914?hl=en#zippy=%2Chow-can-i-make-sure-the-verification-process-is-as-streamlined-as-possible
-[oauth_redirect]: ./advanced/authentication/oauth2/#redirect-url
+[oauth_redirect]: basics/authentication/oauth2.md#redirect-url
 [packs_apps_script]: https://coda.io/packs/apps-script-14470

--- a/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
@@ -42,8 +42,8 @@ Returns a URL for the temporary file that you should return in your formula resp
 The URL expires after 15 minutes by default, but you may pass a custom expiry, however
 Coda reserves the right to ignore long expirations.
 
-If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-disposition) that will be downloaded when accessed as the file name provided.
+If the `downloadFilename` parameter is specified, when opened in the browser the file will
+be downloaded with the file name provided.
 
 #### Parameters
 
@@ -76,8 +76,8 @@ that you should return in your formula response.
 The URL expires after 15 minutes by default, but you may pass a custom expiry, however
 Coda reserves the right to ignore long expirations.
 
-If the `downloadFilename` parameter is specified, the data will be interpreted as a file (`attachment` content
-disposition) that will be downloaded when accessed as the file name provided.
+If the `downloadFilename` parameter is specified, when opened in the browser the file will
+be downloaded with the file name provided.
 
 #### Parameters
 


### PR DESCRIPTION
- Adjust language for temporary blob storage to reflect the fact that `downloadAs` doesn't change the content-disposition.
- Fix broken link in FAQ.