### PR TITLE
Exit with a helpful warning if coda init cannot be completed because git is not installed.

### DIFF
--- a/cli/init.ts
+++ b/cli/init.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import {printAndExit} from '../testing/helpers';
 import {spawnProcess} from './helpers';
 
 const PacksExamplesDirectory = 'node_modules/@codahq/packs-examples';
@@ -24,6 +25,10 @@ function addPatches() {
   spawnProcess(`npx patch-package --exclude 'nothing' mold-source-map`);
 }
 
+function isGitAvailable(): boolean {
+  return spawnProcess('git --version').status === 0;
+}
+
 // By no means comprehensive, just an attempt to cover characters that can appear in a package.json declaration.
 function escapeShellCmd(cmd: string): string {
   return cmd.replace('>', '\\>').replace('<', '\\<');
@@ -46,6 +51,12 @@ export async function handleInit() {
   }
 
   if (!isPacksExamplesInstalled) {
+    if (!isGitAvailable()) {
+      return printAndExit(
+        'The coda init command requires git to be installed and available in your path. ' +
+          'See https://git-scm.com/downloads for suggested ways to install.',
+      );
+    }
     const installCommand = `npm install https://github.com/coda/packs-examples.git`;
     spawnProcess(installCommand);
   }

--- a/dist/cli/init.d.ts
+++ b/dist/cli/init.d.ts
@@ -1,1 +1,1 @@
-export declare function handleInit(): Promise<void>;
+export declare function handleInit(): Promise<undefined>;

--- a/dist/cli/init.js
+++ b/dist/cli/init.js
@@ -6,7 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleInit = void 0;
 const fs_extra_1 = __importDefault(require("fs-extra"));
 const path_1 = __importDefault(require("path"));
-const helpers_1 = require("./helpers");
+const helpers_1 = require("../testing/helpers");
+const helpers_2 = require("./helpers");
 const PacksExamplesDirectory = 'node_modules/@codahq/packs-examples';
 const GitIgnore = `.coda.json
 .coda-credentials.json
@@ -19,9 +20,12 @@ function updateMoldSourceMap() {
     fs_extra_1.default.writeFileSync(packageFileName, validLines.join('\n'));
 }
 function addPatches() {
-    (0, helpers_1.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
+    (0, helpers_2.spawnProcess)(`npm set-script postinstall "npx patch-package"`);
     updateMoldSourceMap();
-    (0, helpers_1.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
+    (0, helpers_2.spawnProcess)(`npx patch-package --exclude 'nothing' mold-source-map`);
+}
+function isGitAvailable() {
+    return (0, helpers_2.spawnProcess)('git --version').status === 0;
 }
 // By no means comprehensive, just an attempt to cover characters that can appear in a package.json declaration.
 function escapeShellCmd(cmd) {
@@ -29,31 +33,35 @@ function escapeShellCmd(cmd) {
 }
 async function handleInit() {
     // stdout looks like `8.1.2\n`.
-    const npmVersion = parseInt((0, helpers_1.spawnProcess)('npm -v', { stdio: 'pipe' }).stdout.toString().trim().split('.', 1)[0], 10);
+    const npmVersion = parseInt((0, helpers_2.spawnProcess)('npm -v', { stdio: 'pipe' }).stdout.toString().trim().split('.', 1)[0], 10);
     if (npmVersion < 7) {
         // need npm 7 to support "npm set-script"
         throw new Error(`Your npm version is older than 7. Please upgrade npm to at least 7 with "npm install -g npm@7"`);
     }
     let isPacksExamplesInstalled;
     try {
-        const listNpmPackages = (0, helpers_1.spawnProcess)('npm list @codahq/packs-examples');
+        const listNpmPackages = (0, helpers_2.spawnProcess)('npm list @codahq/packs-examples');
         isPacksExamplesInstalled = listNpmPackages.status === 0;
     }
     catch (error) {
         isPacksExamplesInstalled = false;
     }
     if (!isPacksExamplesInstalled) {
+        if (!isGitAvailable()) {
+            return (0, helpers_1.printAndExit)('The coda init command requires git to be installed and available in your path. ' +
+                'See https://git-scm.com/downloads for suggested ways to install.');
+        }
         const installCommand = `npm install https://github.com/coda/packs-examples.git`;
-        (0, helpers_1.spawnProcess)(installCommand);
+        (0, helpers_2.spawnProcess)(installCommand);
     }
     const packageJson = JSON.parse(fs_extra_1.default.readFileSync(path_1.default.join(PacksExamplesDirectory, 'package.json'), 'utf-8'));
     const devDependencies = packageJson.devDependencies;
     const devDependencyPackages = Object.keys(devDependencies)
         .map(dependency => `${dependency}@${devDependencies[dependency]}`)
         .join(' ');
-    (0, helpers_1.spawnProcess)(escapeShellCmd(`npm install --save-dev ${devDependencyPackages}`));
-    if ((0, helpers_1.spawnProcess)('npm list @codahq/packs-sdk --depth=0').status !== 0) {
-        (0, helpers_1.spawnProcess)('npm install --save @codahq/packs-sdk');
+    (0, helpers_2.spawnProcess)(escapeShellCmd(`npm install --save-dev ${devDependencyPackages}`));
+    if ((0, helpers_2.spawnProcess)('npm list @codahq/packs-sdk --depth=0').status !== 0) {
+        (0, helpers_2.spawnProcess)('npm install --save @codahq/packs-sdk');
     }
     // developers may run in NodeJs 16 where some packages need to be patched to avoid warnings.
     addPatches();
@@ -64,7 +72,7 @@ async function handleInit() {
     fs_extra_1.default.appendFileSync(path_1.default.join(process.cwd(), '.gitignore'), GitIgnore);
     if (!isPacksExamplesInstalled) {
         const uninstallCommand = `npm uninstall @codahq/packs-examples`;
-        (0, helpers_1.spawnProcess)(uninstallCommand);
+        (0, helpers_2.spawnProcess)(uninstallCommand);
     }
 }
 exports.handleInit = handleInit;


### PR DESCRIPTION
I think git is installed by default on Macs but not on Windows. On Linux, varies with the distribution. Explains why errors running `coda init` cropped up as a "Windows bug".

PTAL @ekoleda-codaio @huayang-codaio @coda/packs 