### PR TITLE
make release notes required from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ## Unreleased
 
 - Added helper method `getEffectivePropertyKeysFromSchema`. This method can be used in the sync table formulas to retrieve the user manually selected property keys by `getEffectivePropertyKeysFromSchema(context.sync.schema)`.
+- Now `--notes` is a required option in `coda release` command.
 
 ## [1.1.0] - 2022-09-27
 

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -225,6 +225,7 @@ if (require.main === module) {
           string: true,
           alias: 'n',
           describe: 'Notes about the contents of this Pack release',
+          demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
         },
         codaApiEndpoint: {
           string: true,

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -19,7 +19,7 @@ interface ReleaseArgs {
   manifestFile: string;
   packVersion?: string;
   codaApiEndpoint: string;
-  notes?: string;
+  notes: string;
 }
 
 export async function handleRelease({

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -226,6 +226,7 @@ if (require.main === module) {
                 string: true,
                 alias: 'n',
                 describe: 'Notes about the contents of this Pack release',
+                demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
             },
             codaApiEndpoint: {
                 string: true,

--- a/dist/cli/release.d.ts
+++ b/dist/cli/release.d.ts
@@ -3,7 +3,7 @@ interface ReleaseArgs {
     manifestFile: string;
     packVersion?: string;
     codaApiEndpoint: string;
-    notes?: string;
+    notes: string;
 }
 export declare function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }: ArgumentsCamelCase<ReleaseArgs>): Promise<never>;
 export {};


### PR DESCRIPTION
Enforce CLI release to come with an initial release notes to best support the breaking changes story. 

PTAL @jonathan-codaio @patrick-codaio @alan-codaio  

cc @erickoledadevrel 

```
-> % npx ts-node cli/coda.ts release test/packs/fake_v2.ts 
coda.ts release <manifestFile> [packVersion]

Set the Pack version that is installable for users. You may specify a specific
version, or omit a version to use the version currently in the manifest file.
The version must always be higher than that of any previous release.

Options:
      --version  Show version number                                   [boolean]
      --help     Show help                                             [boolean]
  -n, --notes    Notes about the contents of this Pack release
                                                             [string] [required]

Missing required argument: notes
Please provide release notes, which will be shown to Pack users to understand the release.
```