### PR TITLE
Add webinars page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,12 +187,10 @@ docs: typedoc generated-documentation build-mkdocs
 
 .PHONY: view-docs
 view-docs:
-	# By default don't generate social cards when previewing, for performance.
-	MK_DOCS_GENERATE_CARDS=${MK_DOCS_GENERATE_CARDS:-false}
 	if command -v expect &> /dev/null; then \
-		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'; \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk MK_DOCS_GENERATE_CARDS=false expect -c 'set timeout 60; spawn pipenv run mkdocs serve; expect "Serving on"; exec open "http://localhost:8000"; interact'; \
 	else \
-		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk pipenv run mkdocs serve; \
+		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk MK_DOCS_GENERATE_CARDS=false pipenv run mkdocs serve; \
 	fi
 
 ###############################################################################

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,8 @@ A Pack is an extension that adds new powers to your doc. Packs work by supplemen
 
 With a little JavaScript, anyone can create and publish a Pack to the Gallery. All you need to do is write the code and Coda will deploy and host the Pack for you.
 
+Packs can be created for personal use, shared with a team, or published to the world. Everything from simple utilities to rich integrations can be built with Packs.
+
 [Learn more][overview]{ .md-button .md-button--primary }
 </div>
 
@@ -81,6 +83,22 @@ Our passionate community of Pack makers and Coda experts can help answer your qu
 <section class="landing-row" markdown>
 
 <div class="landing-item" markdown>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/OoR1qX9w4Js" title="YouTube video player: Build a Todoist Coda Pack from Scratch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
+<div class="landing-item" markdown>
+## :material-youtube: Grab the popcorn.
+
+In this snippet from a recent webinar we demonstrate how to build a Pack from scratch that retrieves your task list from Todoist :simple-todoist:. It was created in under 10 minutes and with less than 30 lines of code in the Pack Studio. 
+
+[Watch webinars][webinars]{ .md-button }
+</div>
+
+</section>
+
+<section class="landing-row" markdown>
+
+<div class="landing-item" markdown>
 ## :fontawesome-regular-lightbulb: Get inspired.
 
 Coda makers have been busy building Packs of all types, and many have published their work to the Gallery. Try installing a few Packs to get a sense for what you could build.
@@ -102,3 +120,4 @@ Coda makers have been busy building Packs of all types, and many have published 
 [changelog]: reference/changes.md
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [gallery]: https://coda.io/gallery?filter=packs
+[webinars]: tutorials/webinars.md

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -33,3 +33,12 @@ The tutorials below provide step-by-step instructions and sample code to help yo
 </section>
 
 {% endfor %}
+
+## Webinars
+
+Sometimes a video is worth a thousand tutorials. Check out recordings from some of our recent webinars.
+
+[Watch][webinars]{ .md-button }
+
+
+[webinars]: webinars.md

--- a/docs/tutorials/webinars.md
+++ b/docs/tutorials/webinars.md
@@ -1,0 +1,30 @@
+# Webinars
+
+Coda hosts regular [webinars][webinars] on a variety of topics, including Packs and how to build them. This page includes some recordings from those webinars.
+
+
+## An introduction to Packs in Coda
+_June 2022_
+
+A basic overview of Packs and how they can be used to enrich your docs.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/OGfudEBEW1U" title="YouTube video player: An introduction to Packs in Coda" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Build a Todoist Coda Pack from Scratch
+_June 2022_
+
+Learn how to build a Pack from scratch that retrieves your task list from Todoist. It was built in under 10 minutes and with less than 30 lines of code in Coda's browser-based Pack Studio.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/OoR1qX9w4Js" title="YouTube video player: Build a Todoist Coda Pack from Scratch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Building Packs with the CLI
+_August 2022_
+
+An introduction to the Pack Command Line Tool (CLI), including what it has to offer, how to set it up and use it, and how to leverage it to create better Packs.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/7K142m0aqBc" title="YouTube video player: Building Packs with the CLI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+[webinars]: https://coda.io/webinars


### PR DESCRIPTION
Add page to collect videos of past webinars. Also:
- Fix the preview server not generating social cards.
- Add one webinar to the homepage.