### PR TITLE
Update core.autocompleteSearchObjects.md to correct inaccuracy

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1214,7 +1214,7 @@ export function simpleAutocomplete<T extends AutocompleteParameterTypes>(
  * filtering to only those that match a search string, and converting the matching
  * objects into the format needed for autocomplete results.
  *
- * A case-sensitive search is performed over each object's `displayKey` property.
+ * A case-insensitive search is performed over each object's `displayKey` property.
  *
  * A common pattern for implementing autocomplete for a formula pattern is to
  * make a request to an API endpoint that returns a list of all entities,

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -713,7 +713,7 @@ export declare function simpleAutocomplete<T extends AutocompleteParameterTypes>
  * filtering to only those that match a search string, and converting the matching
  * objects into the format needed for autocomplete results.
  *
- * A case-sensitive search is performed over each object's `displayKey` property.
+ * A case-insensitive search is performed over each object's `displayKey` property.
  *
  * A common pattern for implementing autocomplete for a formula pattern is to
  * make a request to an API endpoint that returns a list of all entities,

--- a/dist/api.js
+++ b/dist/api.js
@@ -534,7 +534,7 @@ exports.simpleAutocomplete = simpleAutocomplete;
  * filtering to only those that match a search string, and converting the matching
  * objects into the format needed for autocomplete results.
  *
- * A case-sensitive search is performed over each object's `displayKey` property.
+ * A case-insensitive search is performed over each object's `displayKey` property.
  *
  * A common pattern for implementing autocomplete for a formula pattern is to
  * make a request to an API endpoint that returns a list of all entities,

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2528,7 +2528,7 @@ export declare function simpleAutocomplete<T extends AutocompleteParameterTypes>
  * filtering to only those that match a search string, and converting the matching
  * objects into the format needed for autocomplete results.
  *
- * A case-sensitive search is performed over each object's `displayKey` property.
+ * A case-insensitive search is performed over each object's `displayKey` property.
  *
  * A common pattern for implementing autocomplete for a formula pattern is to
  * make a request to an API endpoint that returns a list of all entities,

--- a/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
+++ b/docs/reference/sdk/functions/core.autocompleteSearchObjects.md
@@ -11,7 +11,7 @@ A helper to search over a list of objects representing candidate search results,
 filtering to only those that match a search string, and converting the matching
 objects into the format needed for autocomplete results.
 
-A case-sensitive search is performed over each object's `displayKey` property.
+A case-insensitive search is performed over each object's `displayKey` property.
 
 A common pattern for implementing autocomplete for a formula pattern is to
 make a request to an API endpoint that returns a list of all entities,


### PR DESCRIPTION
See https://github.com/coda/packs-sdk/blob/main/api.ts#L1253-L1254

`search` query and `displayKey` prop of searched objects are both made lowercase, making the search case-insensitive (or non case-sensitive, feel free to rename).