### PR TITLE
[TwoWaySync] Tweak bootstrap for easier use

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -720,6 +720,12 @@ export interface SyncUpdate<K extends string, L extends string, SchemaT extends 
   updatedFields: string[];
 }
 
+/**
+ * Type definition for the parameter used to pass in updates to a sync table update function.
+ * @hidden
+ */
+export type GenericSyncUpdate = SyncUpdate<any, any, any>;
+
 export interface SyncUpdateResult<K extends string, L extends string, SchemaT extends ObjectSchemaDefinition<K, L>> {
   result: Array<ObjectSchemaDefinitionType<K, L, SchemaT> | Error>;
 }

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6442,7 +6442,6 @@ module.exports = (() => {
   // runtime/thunk/thunk.ts
   var thunk_exports = {};
   __export(thunk_exports, {
-    ensureExists: () => ensureExists2,
     ensureSwitchUnreachable: () => ensureSwitchUnreachable,
     findAndExecutePackFunction: () => findAndExecutePackFunction,
     handleError: () => handleError,
@@ -6850,12 +6849,12 @@ module.exports = (() => {
   __name(unmarshalError, "unmarshalError");
 
   // runtime/thunk/thunk.ts
-  async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true, updates) {
+  async function findAndExecutePackFunction({ shouldWrapError = true, ...args }) {
     try {
       if (!global.Buffer) {
         global.Buffer = import_buffer.Buffer;
       }
-      return await doFindAndExecutePackFunction({ params, formulaSpec, manifest, executionContext, updates });
+      return await doFindAndExecutePackFunction(args);
     } catch (err) {
       throw shouldWrapError ? wrapError(err) : err;
     }
@@ -6877,7 +6876,7 @@ module.exports = (() => {
         if (!formula.executeUpdate) {
           throw new Error(`No executeUpdate function defined on sync table formula ${formulaSpec.formulaName}`);
         }
-        return formula.executeUpdate(params, ensureExists2(updates), executionContext);
+        return formula.executeUpdate(params, ensureExists(updates), executionContext);
       }
       case "Metadata" /* Metadata */: {
         switch (formulaSpec.metadataFormulaType) {
@@ -6981,13 +6980,6 @@ module.exports = (() => {
     }
   }
   __name(findParentFormula, "findParentFormula");
-  function ensureExists2(value, message) {
-    if (typeof value === "undefined" || value === null) {
-      throw new Error(message || `Expected value for ${String(value)}`);
-    }
-    return value;
-  }
-  __name(ensureExists2, "ensureExists");
   function ensureSwitchUnreachable(value) {
     throw new Error(`Unreachable code hit with value ${String(value)}`);
   }

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -418,6 +418,11 @@ export interface SyncUpdate<K extends string, L extends string, SchemaT extends 
     newValue: ObjectSchemaDefinitionType<K, L, SchemaT>;
     updatedFields: string[];
 }
+/**
+ * Type definition for the parameter used to pass in updates to a sync table update function.
+ * @hidden
+ */
+export declare type GenericSyncUpdate = SyncUpdate<any, any, any>;
 export interface SyncUpdateResult<K extends string, L extends string, SchemaT extends ObjectSchemaDefinition<K, L>> {
     result: Array<ObjectSchemaDefinitionType<K, L, SchemaT> | Error>;
 }

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2259,6 +2259,11 @@ export interface SyncUpdate<K extends string, L extends string, SchemaT extends 
 	newValue: ObjectSchemaDefinitionType<K, L, SchemaT>;
 	updatedFields: string[];
 }
+/**
+ * Type definition for the parameter used to pass in updates to a sync table update function.
+ * @hidden
+ */
+export declare type GenericSyncUpdate = SyncUpdate<any, any, any>;
 export interface SyncUpdateResult<K extends string, L extends string, SchemaT extends ObjectSchemaDefinition<K, L>> {
 	result: Array<ObjectSchemaDefinitionType<K, L, SchemaT> | Error>;
 }

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6442,7 +6442,6 @@ module.exports = (() => {
   // runtime/thunk/thunk.ts
   var thunk_exports = {};
   __export(thunk_exports, {
-    ensureExists: () => ensureExists2,
     ensureSwitchUnreachable: () => ensureSwitchUnreachable,
     findAndExecutePackFunction: () => findAndExecutePackFunction,
     handleError: () => handleError,
@@ -6850,12 +6849,12 @@ module.exports = (() => {
   __name(unmarshalError, "unmarshalError");
 
   // runtime/thunk/thunk.ts
-  async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true, updates) {
+  async function findAndExecutePackFunction({ shouldWrapError = true, ...args }) {
     try {
       if (!global.Buffer) {
         global.Buffer = import_buffer.Buffer;
       }
-      return await doFindAndExecutePackFunction({ params, formulaSpec, manifest, executionContext, updates });
+      return await doFindAndExecutePackFunction(args);
     } catch (err) {
       throw shouldWrapError ? wrapError(err) : err;
     }
@@ -6877,7 +6876,7 @@ module.exports = (() => {
         if (!formula.executeUpdate) {
           throw new Error(`No executeUpdate function defined on sync table formula ${formulaSpec.formulaName}`);
         }
-        return formula.executeUpdate(params, ensureExists2(updates), executionContext);
+        return formula.executeUpdate(params, ensureExists(updates), executionContext);
       }
       case "Metadata" /* Metadata */: {
         switch (formulaSpec.metadataFormulaType) {
@@ -6981,13 +6980,6 @@ module.exports = (() => {
     }
   }
   __name(findParentFormula, "findParentFormula");
-  function ensureExists2(value, message) {
-    if (typeof value === "undefined" || value === null) {
-      throw new Error(message || `Expected value for ${String(value)}`);
-    }
-    return value;
-  }
-  __name(ensureExists2, "ensureExists");
   function ensureSwitchUnreachable(value) {
     throw new Error(`Unreachable code hit with value ${String(value)}`);
   }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -67,6 +67,7 @@ export type { GenericDynamicSyncTable } from './api';
 export type { GenericSyncFormula } from './api';
 export type { GenericSyncFormulaResult } from './api';
 export type { GenericSyncTable } from './api';
+export type { GenericSyncUpdate } from './api';
 export type { InvocationLocation } from './api_types';
 export type { MetadataContext } from './api';
 export type { MetadataFormulaObjectResultType } from './api';

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -101,7 +101,7 @@ exports.injectFetcherFunction = injectFetcherFunction;
  */
 async function executeThunk(context, { params, formulaSpec, updates }, packBundlePath, packBundleSourceMapPath) {
     try {
-        const resultRef = await context.evalClosure('return coda.findAndExecutePackFunction($0, $1, pack.pack || pack.manifest, executionContext, $2);', [params, formulaSpec, updates], {
+        const resultRef = await context.evalClosure('return coda.findAndExecutePackFunction({params: $0, formulaSpec: $1, updates: $2, manifest: pack.pack || pack.manifest, executionContext: executionContext});', [params, formulaSpec, updates], {
             arguments: { copy: true },
             result: { reference: true, promise: true },
         });

--- a/dist/runtime/thunk/thunk.d.ts
+++ b/dist/runtime/thunk/thunk.d.ts
@@ -4,18 +4,26 @@ import type { FetchRequest } from '../../api_types';
 import type { FetchResponse } from '../../api_types';
 import type { FormulaSpecification } from '../types';
 import type { GenericSyncFormulaResult } from '../../api';
+import type { GenericSyncUpdate } from '../../api';
 import type { PackFormulaResult } from '../../api_types';
 import type { ParamDefs } from '../../api_types';
 import type { ParamValues } from '../../api_types';
 import type { SyncExecutionContext } from '../../api_types';
 import type { SyncFormulaSpecification } from '../types';
-import type { SyncUpdate } from '../../api';
 export { marshalValue, unmarshalValue, marshalValueToString, unmarshalValueFromString, marshalValuesForLogging, } from '../common/marshaling';
+interface FindAndExecutionPackFunctionArgs<T> {
+    params: ParamValues<ParamDefs>;
+    formulaSpec: T;
+    manifest: BasicPackDefinition;
+    executionContext: ExecutionContext | SyncExecutionContext;
+    updates?: GenericSyncUpdate[];
+}
 /**
  * The thunk entrypoint - the first code that runs inside the v8 isolate once control is passed over.
  */
-export declare function findAndExecutePackFunction<T extends FormulaSpecification>(params: ParamValues<ParamDefs>, formulaSpec: T, manifest: BasicPackDefinition, executionContext: ExecutionContext | SyncExecutionContext, shouldWrapError?: boolean, updates?: Array<SyncUpdate<any, any, any>>): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult>;
-export declare function ensureExists<T>(value: T | null | undefined, message?: string): T;
+export declare function findAndExecutePackFunction<T extends FormulaSpecification>({ shouldWrapError, ...args }: {
+    shouldWrapError: boolean;
+} & FindAndExecutionPackFunctionArgs<T>): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult>;
 export declare function ensureSwitchUnreachable(value: never): never;
 export declare function handleErrorAsync(func: () => Promise<any>): Promise<any>;
 export declare function handleError(func: () => any): any;

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -1,12 +1,13 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setUpBufferForTest = exports.handleFetcherStatusError = exports.handleError = exports.handleErrorAsync = exports.ensureSwitchUnreachable = exports.ensureExists = exports.findAndExecutePackFunction = exports.marshalValuesForLogging = exports.unmarshalValueFromString = exports.marshalValueToString = exports.unmarshalValue = exports.marshalValue = void 0;
+exports.setUpBufferForTest = exports.handleFetcherStatusError = exports.handleError = exports.handleErrorAsync = exports.ensureSwitchUnreachable = exports.findAndExecutePackFunction = exports.marshalValuesForLogging = exports.unmarshalValueFromString = exports.marshalValueToString = exports.unmarshalValue = exports.marshalValue = void 0;
 const types_1 = require("../../types");
 const buffer_1 = require("buffer");
 const types_2 = require("../types");
 const types_3 = require("../types");
 const types_4 = require("../../types");
 const api_1 = require("../../api");
+const ensure_1 = require("../../helpers/ensure");
 const helpers_1 = require("../common/helpers");
 const helpers_2 = require("../common/helpers");
 const api_2 = require("../../api");
@@ -22,13 +23,13 @@ Object.defineProperty(exports, "marshalValuesForLogging", { enumerable: true, ge
 /**
  * The thunk entrypoint - the first code that runs inside the v8 isolate once control is passed over.
  */
-async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, shouldWrapError = true, updates) {
+async function findAndExecutePackFunction({ shouldWrapError = true, ...args }) {
     try {
         // in case the pack bundle is compiled in the browser, Buffer may not be browserified yet.
         if (!global.Buffer) {
             global.Buffer = buffer_1.Buffer;
         }
-        return await doFindAndExecutePackFunction({ params, formulaSpec, manifest, executionContext, updates });
+        return await doFindAndExecutePackFunction(args);
     }
     catch (err) {
         // all errors should be marshaled to avoid IVM dropping essential fields / name.
@@ -54,7 +55,7 @@ function doFindAndExecutePackFunction({ params, formulaSpec, manifest, execution
             if (!formula.executeUpdate) {
                 throw new Error(`No executeUpdate function defined on sync table formula ${formulaSpec.formulaName}`);
             }
-            return formula.executeUpdate(params, ensureExists(updates), executionContext);
+            return formula.executeUpdate(params, (0, ensure_1.ensureExists)(updates), executionContext);
         }
         case types_2.FormulaType.Metadata: {
             switch (formulaSpec.metadataFormulaType) {
@@ -161,13 +162,6 @@ function findParentFormula(manifest, formulaSpec) {
         return paramDef === null || paramDef === void 0 ? void 0 : paramDef.autocomplete;
     }
 }
-function ensureExists(value, message) {
-    if (typeof value === 'undefined' || value === null) {
-        throw new Error(message || `Expected value for ${String(value)}`);
-    }
-    return value;
-}
-exports.ensureExists = ensureExists;
 function ensureSwitchUnreachable(value) {
     throw new Error(`Unreachable code hit with value ${String(value)}`);
 }

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -80,7 +80,9 @@ useDeprecatedResultNormalization = true, } = {}) {
     if (shouldValidateParams && formula) {
         (0, validation_1.validateParams)(formula, params);
     }
-    let result = await thunk.findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, false);
+    let result = await thunk.findAndExecutePackFunction({
+        params, formulaSpec, manifest, executionContext, shouldWrapError: false,
+    });
     if (useDeprecatedResultNormalization && formula) {
         const resultToNormalize = formulaSpec.type === types_1.FormulaType.Sync ? result.result : result;
         // Matches legacy behavior within handler_templates:generateObjectResponseHandler where we never

--- a/index.ts
+++ b/index.ts
@@ -77,6 +77,7 @@ export type {GenericDynamicSyncTable} from './api';
 export type {GenericSyncFormula} from './api';
 export type {GenericSyncFormulaResult} from './api';
 export type {GenericSyncTable} from './api';
+export type {GenericSyncUpdate} from './api';
 export type {InvocationLocation} from './api_types';
 export type {MetadataContext} from './api';
 export type {MetadataFormulaObjectResultType} from './api';

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -154,7 +154,7 @@ export async function executeThunk<T extends FormulaSpecification>(
 ): Promise<T extends SyncFormulaSpecification ? GenericSyncFormulaResult : PackFormulaResult> {
   try {
     const resultRef = await context.evalClosure(
-      'return coda.findAndExecutePackFunction($0, $1, pack.pack || pack.manifest, executionContext, $2);',
+      'return coda.findAndExecutePackFunction({params: $0, formulaSpec: $1, updates: $2, manifest: pack.pack || pack.manifest, executionContext: executionContext});',
       [params, formulaSpec, updates],
       {
         arguments: {copy: true},

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -92,7 +92,9 @@ async function findAndExecutePackFunction<T extends FormulaSpecification>(
   if (shouldValidateParams && formula) {
     validateParams(formula, params);
   }
-  let result = await thunk.findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, false);
+  let result = await thunk.findAndExecutePackFunction({
+    params, formulaSpec, manifest, executionContext, shouldWrapError: false,
+  });
 
   if (useDeprecatedResultNormalization && formula) {
     const resultToNormalize =


### PR DESCRIPTION
* Cleanup thunk to take a hash instead of ordered params
* Export a generic version of the update payload type

PTAL @jonathan-codaio @huayang-codaio 
CC @coda/packs 