### PR TITLE
Bring CHANGELOG inline with spec and add linter

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,7 @@
       "addUnreleased": true,
       "addVersionUrl": true,
       "versionUrlFormats": {
-        "repositoryUrl": "https://github.com/coda"
+        "repositoryUrl": "https://github.com/coda/packs-sdk"
       }
     }
   }

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,9 @@
   },
   "plugins": {
     "@release-it/keep-a-changelog": {
-      "filename": "CHANGELOG.md"
+      "filename": "CHANGELOG.md",
+      "addUnreleased": true,
+      "addVersionUrl": true
     }
   }
 }

--- a/.release-it.json
+++ b/.release-it.json
@@ -9,7 +9,10 @@
     "@release-it/keep-a-changelog": {
       "filename": "CHANGELOG.md",
       "addUnreleased": true,
-      "addVersionUrl": true
+      "addVersionUrl": true,
+      "versionUrlFormats": {
+        "repositoryUrl": "https://github.com/coda"
+      }
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,53 +4,87 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## Unreleased
 
+### Added
+
 - Added helper method `getEffectivePropertyKeysFromSchema`. This method can be used in the sync table formulas to retrieve the user manually selected property keys by `getEffectivePropertyKeysFromSchema(context.sync.schema)`.
+- Added a `--maxRows` flag to the `coda execute` command, allowing you to cap a sync execution to a maximum number of rows.
+
+### Changed
+
 - Now `--notes` is a required option in `coda release` command.
 - **Breaking Change** Parameter names and sync table names now have strict limitations at build time (alphanumeric characters & underscores).
-- Added a `--maxRows` flag to the `coda execute` command, allowing you to cap a sync execution to a maximum number of rows.
 
 ## [1.1.0] - 2022-09-27
 
-- The `isolated-vm` npm package is no longer a required dependency. It will be installed automatically if your system supports it, otherwise npm will ignore it. When running `coda execute`, if `isolated-vm` is available, your formula will be executed inside of a virtual machine sandbox to better simulate the actual Coda runtime environment for packs. If not available, your formula will still be executed, just not within a sandbox.
+### Added
+
 - Adds support for render hits for progress bars, with the new `ValueHintType.ProgressBar`.
 - Also adds in the `showValue` field on `SliderSchema` to indicate whether to show the underlying numeric value associated with a slider.
-- Parameters that are declared as `optional: true` will be inferred as possibly `undefined` in the `execute` method of a formula. Previously, if you had declared, say, a string parameter as optional, the automatic type it would receive as an input to the `execute` method would be `string`, which is inaccurate. It will now be typed as `string | undefined`.
 - Added validation that building blocks of the same type do not share a name.
 
+### Changed
+
+- The `isolated-vm` npm package is no longer a required dependency. It will be installed automatically if your system supports it, otherwise npm will ignore it. When running `coda execute`, if `isolated-vm` is available, your formula will be executed inside of a virtual machine sandbox to better simulate the actual Coda runtime environment for packs. If not available, your formula will still be executed, just not within a sandbox.
+- Parameters that are declared as `optional: true` will be inferred as possibly `undefined` in the `execute` method of a formula. Previously, if you had declared, say, a string parameter as optional, the automatic type it would receive as an input to the `execute` method would be `string`, which is inaccurate. It will now be typed as `string | undefined`.
+
 ## [1.0.5] - 2022-08-05
+
+### Fixed
 
 - Fixed the CLI compiler throwing for using common node modules.
 
 ## [1.0.4] - 2022-08-04
 
+### Changed
+
 - Increased building block description limit to 1000.
+
+### Fixed
+
 - Fixed class name (e.g. `StatusCodeError.name`) which resolved to random values in the final build.
 
 ## [1.0.3] - 2022-08-03
 
+### Added
+
 - Added `ImageSchema`, for use with images. Allows packs to set two flags on a formula returning an image: if the image should be rendered with or without an outline, and whether to turn off the rounded corners. If the outline flag `ImageOutline` is not set on a schema, the default is `Solid`, and the image will be rendered with an outline. If the corners flag `ImageCornerStyle` is not set, the default is `Rounded`, and the image will be rendered with rounded corners.
 - Added `NumericDurationSchema`, which will allow packs to return `ValueType.Number` values that are interpreted in Coda as a duration in seconds.
 - Added autocomplete support for `ParameterType.StringArray` and `ParameterType.SparseStringArray` parameters.
+
+### Changed
+
 - Changed OAuth2 validation to check that authorizationUrl and tokenUrl parse as URLs.
 - Limited number of formulas, column formats, and sync tables to 100 each. Added character limits to names and descriptions, and to length of column matchers and network domains.
 
 ## [1.0.2] - 2022-07-14
+
+### Added
 
 - Added `MissingScopesError`, for use with OAuth authentication. If a user's connection is missing a scope and the Pack throws a 403 StatusCodeError, Coda will automatically prompt the user to reauthenticate. For APIs that return different status codes, or to be more explicit, the Pack can instead throw this new type of error to trigger the same reauthentication flow.
 - Added `pkceChallengeMethod` option to OAuth2 authentication to allow choosing the `code_challenge_method` of PKCE extension. The default value is `S256` but some OAuth providers may only support `plain`.
 
 ## [1.0.1] - 2022-06-22
 
+### Added
+
 - Added validation that `networkDomain` does not include slashes since it's a domain, not a path.
-- Changed Pack compilation to explicitly target Node version 14, to ensure compatibility with the Packs runtime.
 - Added parameter type validation for `execute` command.
 - Added several implicitly-allowed domains including codahosted.io to the `execute` command.
 
+### Changed
+
+- Changed Pack compilation to explicitly target Node version 14, to ensure compatibility with the Packs runtime.
+
 ## [1.0.0] - 2022-06-16
 
-- Fixed `temporaryBlobStorage.storeBlob` error from CLI built Packs.
+### Changed
+
 - The `coda init` command now installs `@codahq/packs-sdk` if it was not previously installed.
 - **Breaking Change** The `identityName` field is now required on every sync table, even ones with dynamic schemas.
+
+### Fixed
+
+- Fixed `temporaryBlobStorage.storeBlob` error from CLI built Packs.
 
 ## [0.12.1] - 2022-06-06
 
@@ -118,47 +152,71 @@ await myHelper(context);
 
 ## [0.9.0] - 2022-03-17
 
-- **Breaking Change** ValueHintType.Url will now create a column of type "Link" instead of "Text".
+### Added
+
 - Added ValueHintType.Email for new column type "Email".
 
-## [0.8.2]
+### Changed
+
+- **Breaking Change** ValueHintType.Url will now create a column of type "Link" instead of "Text".
+
+## [0.8.2] - 2022-03-04
+
+### Added
 
 - Added `coda whoami` command to see API token details.
 - Added `coda link` command to set up upload for an existing Pack ID instead of creating a new one.
 - Added `StringEmbedSchema` to handle configuration on how embed values appear in docs
 - Added "coda clone <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
-## 0.8.1
+## [0.8.1] - 2022-01-19
+
+### Removed
 
 - Removed postinstall to avoid patching failure for npm 6 or older versions.
 
-## 0.8.0
+## [0.8.0] - 2022-01-14
+
+### Added
+
+- An optional "description" field is added to sync table definition, that will be used to display in the UI.
+- OAuth2 authentication now supports a `scopeDelimiter` option for non-compliant APIs that use something other than a space to delimit OAuth scopes in authorization URLs.
+
+### Changed
 
 - **Breaking Change** The connection requirement for metadata formulas now defaults to optional instead of required. If your pack is using sematic versions, this will likely lead to a major version bump in your next release.
 - **Breaking Change** Updated `coda upload` to use new parameters to tag the source of Pack version uploads as coming from the CLI.
-- An optional "description" field is added to sync table definition, that will be used to display in the UI.
 - You no longer need to use the `--fetch` flag with `coda execute` to use a real fetcher. Set `--no-fetch` to use a mock fetcher (the old default behavior).
-- OAuth2 authentication now supports a `scopeDelimiter` option for non-compliant APIs that use something other than a space to delimit OAuth scopes in authorization URLs.
+
+### Deprecated
+
 - Deprecated `hidden` field is now fully removed on formula parameter.
 
-## 0.7.3
+## [0.7.3] - 2021-12-06
+
+### Changed
+
+- Formulas that use optional parameters can specify `undefined` for an omitted parameter in `examples`.
+
+### Fixed
 
 - Fixed a typo that broke local fetcher testing with a pack using the `AuthenticationType.Custom` authentication.
 - Fixed a bug where `examples` using array parameters would fail upload validation.
 - Fixed an inconsistency where `SetEndpoint.getOptionsFormulas` required using the obsolete `makeMetadataFormula` wrapper instead of allowing you to provide a raw function.
-- Formulas that use optional parameters can specify `undefined` for an omitted parameter in `examples`.
 
-## 0.7.2
+## [0.7.2] - 2021-11-24
+
+### Fixed
 
 - Fixed missing schema description in compiled metadata.
 - Fixed the fetcher to properly recognize more XML content type headers and parse those responses int objects using `xml2js`.
   - Previously only `text/xml` and `application/xml` were recognized, but headers like `application/atom+xml` were ignored and response bodies returned as strings.
 - Fixed `coda init` and `coda execute` to stop throwing errors on Windows.
 
-## 0.7.1
+## [0.7.1] - 2021-11-17
 
-- Update internal authentication mechanisms for interacting with AWS. Not currently available externally.
-- `makeObjectSchema` no longer requires you to redundantly specify `type: ValueType.Object` in your schema definition.
+### Added
+
 - Added support for `AuthenticationType.Custom` which formalizes the ability to use templating to insert secret credentials onto network requests that previously relied on `AuthenticationType.WebBasic`. This enables authenticating with APIs that use non-standard authentication methods. See an example of using this new authentication method below.
   ```typescript
   // pack authentication
@@ -189,13 +247,20 @@ await myHelper(context);
   }
   ```
 
-## 0.7.0
+### Changed
+
+- Update internal authentication mechanisms for interacting with AWS. Not currently available externally.
+- `makeObjectSchema` no longer requires you to redundantly specify `type: ValueType.Object` in your schema definition.
+
+## [0.7.0] - 2021-11-04
+
+### Changed
 
 - Pack bundle format is changed to IIFE to fix occasional stacktrace misinterpretation. Previously compiled bundles will still be supported but may suffer from inaccurate sourcemap issue until the pack is built with the new SDK.
 
-## 0.6.0
+## [0.6.0] - 2021-10-13
 
-- **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.
+### Added
 
 - If your pack uses fake timers (to simulate setTimeout) you can now store this as a persistent
   build option. Previously, you had to remember to include the flag --timerStrategy=fake any time
@@ -203,233 +268,251 @@ await myHelper(context);
   `coda setOption path/to/pack.ts timerStrategy fake` and it will store the option persistently
   in your `.coda-pack.json` file and use it for all builds.
 
-## 0.5.0
+### Changed
+
+- **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.
+
+## [0.5.0] - 2021-10-13
+
+### Changed
 
 - **Breaking Change** `context.logger` has been removed. It has been redundant with `console.log`
   for a while, so we've eliminated the unnecessary extra interface to avoid confusion.
   (Also `console.trace/debug/warn/info/error` are all valid.)
-
 - Formula return types are now strong-typed (except if you are using the fromKey attribute of object properties).
-
 - CLI `coda execute` now defaults to run with vm. To execute without vm, use `--no-vm`.
-
-- Bug fix: Numeric and string `codaType` properties are no longer erroneously removed in upload validation.
-
 - CLI: You may omit a Pack version in your definition, either by using the pack builder (`coda.newPack()`)
   or using the `BasicPackDefinition` type (if you are using TypeScript). When you upload your pack,
   the next available version number will be selected and assigned on your behalf. This behavior matches
   what happens in the web editor.
-
 - CLI: `coda release` no longer requires an explicit Pack version to release a Pack version (if no Pack version is supplied, the latest version is marked for release instead).
 
-## 0.4.6
+### Fixed
+
+- Bug fix: Numeric and string `codaType` properties are no longer erroneously removed in upload validation.
+
+## [0.4.6] - 2021-08-18
+
+### Fixed
 
 - Bug fix: Executing sync table formulas via CLI now validates results correctly.
 
-## 0.4.5
+## [0.4.5] - 2021-08-02
+
+### Changed
 
 - Make a few testing functions (e.g. `executeFormulaFromPackDef`) optionally typed.
-
 - Update `StatusCodeError` constructor, which now requires the fetch request.
 
-## 0.4.4
+## [0.4.4] - 2021-07-27
+
+### Fixed
 
 - Fixed a bug where using `pack.setSystemAuthentication()` would add a required connection
   parameter to every formula.
 
-## 0.4.3
+## [0.4.3] - 2021-07-26
+
+### Fixed
 
 - Fixed a bug where using `setUserAuthentication()` with `AuthenticationType.None` would
   inadvertently make accounts required.
-
 - Fixed a TypeScript bug where using `setUserAuthentication()` with authentication types like OAuth2 would give
   TypeScript errors even for valid definitions.
-
 - Parse XML fetcher responses to JSON for respones with content type `application/xml`. Previously only `text/xml` worked.
 
-## 0.4.2
+## [0.4.2] - 2021-07-14
 
-Fixed a bug preventing `coda init` from working.
+### Fixed
 
-## 0.4.1
+- Fixed a bug preventing `coda init` from working.
 
-The pack builder now sets a default connection (account) requirement when you specify authentication.
-Normally, to indicate on a particular formula or sync table that an account is required,
-you manually specify a `connectionRequirement` option. To simplify the common case, when you
-call `pack.setUserAuthentication()` or `pack.setSystemAuthentication()`, all of the formulas
-and sync tables in your pack will be set to use `ConnectionRequirement.Required` unless
-that formula/sync explicitly defines a different `connectionRequirement`.
+## [0.4.1] - 2021-07-13
 
-If you wish to use a different default, you can supply a `defaultConnectionRequirement` option
-to `setUserAuthentication()` or `setSystemAuthentication()`.
+### Changed
 
-```typescript
-export const pack = newPack();
+-   The pack builder now sets a default connection (account) requirement when you specify authentication.
+    Normally, to indicate on a particular formula or sync table that an account is required,
+    you manually specify a `connectionRequirement` option. To simplify the common case, when you
+    call `pack.setUserAuthentication()` or `pack.setSystemAuthentication()`, all of the formulas
+    and sync tables in your pack will be set to use `ConnectionRequirement.Required` unless
+    that formula/sync explicitly defines a different `connectionRequirement`.
 
-// Implicitly sets all formulas and sync tables to use `connectionRequirement: ConnectionRequirement.Required`.
-pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
-// OR, to use a different default:
-pack.setUserAuthentication({
-  type: AuthenticationType.HeaderBearerToken,
-  defaultConnectionRequirememnt: ConnectionRequirement.None,
-});
+    If you wish to use a different default, you can supply a `defaultConnectionRequirement` option
+    to `setUserAuthentication()` or `setSystemAuthentication()`.
 
-pack.addFormula(...);
-pack.addSyncTable(...);
-```
+    ```typescript
+    export const pack = newPack();
 
-## 0.4.0
+    // Implicitly sets all formulas and sync tables to use `connectionRequirement: ConnectionRequirement.Required`.
+    pack.setUserAuthentication({type: AuthenticationType.HeaderBearerToken});
+    // OR, to use a different default:
+    pack.setUserAuthentication({
+      type: AuthenticationType.HeaderBearerToken,
+      defaultConnectionRequirememnt: ConnectionRequirement.None,
+    });
 
-### TypedStandardFormula renamed to Formula (TypeScript only)
+    pack.addFormula(...);
+    pack.addSyncTable(...);
+    ```
 
-The type `TypedStandardFormula`, which is the type used for the `formulas` array in main
-`PackVersionDefinition` type has been renamed `Formula` to be simpler and more intuitive.
+## [0.4.0] - 2021-07-09
 
-## 0.3.1
+### Changed
 
-### Metadata formulas no longer need to be wrapped in `makeMetadataFormula()`.
+-   **TypedStandardFormula renamed to Formula (TypeScript only)** - 
+    The type `TypedStandardFormula`, which is the type used for the `formulas` array in main
+    `PackVersionDefinition` type has been renamed `Formula` to be simpler and more intuitive.
 
-Packs support various kinds of "metadata formulas", which aren't explicitly callable by the user
-but provide supporting functionality to the pack. Examples of these include `getConnectionName`
-in the authentication section of a pack def, `autocomplete` for formula and sync parameters,
-and `getSchema` for dynamic sync tables.
+## [0.3.1] - 2021-07-01
 
-You now need only provide the JavaScript function that implements your metadata formula,
-and the SDK will wrap it in `makeMetadataFormula()` on your behalf.
+### Changed
 
-```typescript
-// Old
-makeParameter({type: ParameterTypeString, name: 'p', autocomplete: makeMetadataFormula(async (context, search) => ...)});
+-   **Metadata formulas no longer need to be wrapped in `makeMetadataFormula()`** - 
+    Packs support various kinds of "metadata formulas", which aren't explicitly callable by the user
+    but provide supporting functionality to the pack. Examples of these include `getConnectionName`
+    in the authentication section of a pack def, `autocomplete` for formula and sync parameters,
+    and `getSchema` for dynamic sync tables.
 
-// New
-makeParameter({type: ParameterTypeString, name: 'p', autocomplete: async (context, search) => ...});
-```
+    You now need only provide the JavaScript function that implements your metadata formula,
+    and the SDK will wrap it in `makeMetadataFormula()` on your behalf.
 
-```typescript
-// Old
-export const pack: PackVersionDefinition = {
-  defaultAuthentication: {
-    type: AuthenticationType.HeaderBearerToken,
-    getConnectionName: makeMetadataFormula(async (context, search) => {
+    ```typescript
+    // Old
+    makeParameter({type: ParameterTypeString, name: 'p', autocomplete: makeMetadataFormula(async (context, search) => ...)});
+
+    // New
+    makeParameter({type: ParameterTypeString, name: 'p', autocomplete: async (context, search) => ...});
+    ```
+
+    ```typescript
+    // Old
+    export const pack: PackVersionDefinition = {
+      defaultAuthentication: {
+        type: AuthenticationType.HeaderBearerToken,
+        getConnectionName: makeMetadataFormula(async (context, search) => {
+          ...
+        }),
+      },
       ...
-    }),
-  },
-  ...
-};
+    };
 
-// New
-export const pack = newPack();
+    // New
+    export const pack = newPack();
 
-pack.setUserAuthentication({
-  type: AuthenticationType.HeaderBearerToken,
-  getConnectionName: async (context, search) => {
-    ...
-  },
-  ...
-};
-```
+    pack.setUserAuthentication({
+      type: AuthenticationType.HeaderBearerToken,
+      getConnectionName: async (context, search) => {
+        ...
+      },
+      ...
+    };
+    ```
 
-Additionally, if you are only using hardcoded values for your autocomplete options,
-you may specify them directly without needing to wrap them in a function. The SDK
-will create a function on your behalf that searches over the given options.
+    Additionally, if you are only using hardcoded values for your autocomplete options,
+    you may specify them directly without needing to wrap them in a function. The SDK
+    will create a function on your behalf that searches over the given options.
 
-```typescript
-makeParameter({
-  ...
-  autocomplete: ['apple', 'banana'],
-});
+    ```typescript
+    makeParameter({
+      ...
+      autocomplete: ['apple', 'banana'],
+    });
 
-// Or
+    // Or
 
-makeParameter({
-  ...
-  autocomplete: [{display: 'Apple', value: 1}, {display: 'Banana', value: 2}],
-});
-```
+    makeParameter({
+      ...
+      autocomplete: [{display: 'Apple', value: 1}, {display: 'Banana', value: 2}],
+    });
+    ```
 
-The one caveat is that if you need to override the default `connectionRequirement` for
-a metadata formula, you will still need to use `makeMetadataFormula(fn, {connectionRequirement})`
-to provide that override. This is very rare, but it is sometimes needed for autocomplete formulas
-that need not use authentication even when the parent formula does.
+    The one caveat is that if you need to override the default `connectionRequirement` for
+    a metadata formula, you will still need to use `makeMetadataFormula(fn, {connectionRequirement})`
+    to provide that override. This is very rare, but it is sometimes needed for autocomplete formulas
+    that need not use authentication even when the parent formula does.
 
-## 0.3.0
+## [0.3.0] - 2021-06-29
 
-### Clarity around sync table identities
+### Changed
 
-`makeSyncTable()` now takes a top-level field `identityName`, replacing the `identity` field
-on the sync table's schema. To migrate, you can simply remove the `identity` field of your
-schema and move the identity name string to the new `identityName` value.
+-   **Clarity around sync table identities** - 
+    `makeSyncTable()` now takes a top-level field `identityName`, replacing the `identity` field
+    on the sync table's schema. To migrate, you can simply remove the `identity` field of your
+    schema and move the identity name string to the new `identityName` value.
 
-The identity name is essentially the unique id for a sync table. It is also used if you want
-to return objects from other syncs or formulas that reference rows in this single table.
-To do that, you would use this identity name in the `identity` field of the schema
-for that other formula/sync.
+    The identity name is essentially the unique id for a sync table. It is also used if you want
+    to return objects from other syncs or formulas that reference rows in this single table.
+    To do that, you would use this identity name in the `identity` field of the schema
+    for that other formula/sync.
 
-```typescript
-// Old
-makeSyncTable({
-  name: 'MySync',
-  schema: makeObjectSchema({
-    identity: {name: 'MyIdentity'},
-    ...
-  }),
-  formula: ...
-});
+    ```typescript
+    // Old
+    makeSyncTable({
+      name: 'MySync',
+      schema: makeObjectSchema({
+        identity: {name: 'MyIdentity'},
+        ...
+      }),
+      formula: ...
+    });
 
-// New
-makeSyncTable({
-  name: 'MySync',
-  identityName: 'MyIdentity',
-  schema: makeObjectSchema({
-    ...
-  }),
-  formula: ...
-});
-```
+    // New
+    makeSyncTable({
+      name: 'MySync',
+      identityName: 'MyIdentity',
+      schema: makeObjectSchema({
+        ...
+      }),
+      formula: ...
+    });
+    ```
 
-## 0.2.0
+## [0.2.0] - 2021-06-28
 
-### `makeSyncTable()` now accepts a single parameter dictionary instead of having some positional parameters first.
+### Changed
 
-This eliminates an inconsistency between this function and most similar wrapper functions elsewhere in the SDK.
+-   **`makeSyncTable()` now accepts a single parameter dictionary instead of having some positional parameters first** - 
+    This eliminates an inconsistency between this function and most similar wrapper functions elsewhere in the SDK.
 
-To migrate existing usage:
+    To migrate existing usage:
 
-```typescript
-// Old
-makeSyncTable('Name', {<schema>}, {<formula>});
+    ```typescript
+    // Old
+    makeSyncTable('Name', {<schema>}, {<formula>});
 
-// New
-makeSynctable({name: 'Name', schema: {<schema>}, formula: {<formula>}});
-```
+    // New
+    makeSynctable({name: 'Name', schema: {<schema>}, formula: {<formula>}});
+    ```
 
-If you wish to continue using the old syntax (temporarily while we still support it), you can simply update
-your imports to this and leave your code unchanged:
+    If you wish to continue using the old syntax (temporarily while we still support it), you can simply update
+    your imports to this and leave your code unchanged:
 
-```typescript
-import {makeSyncTableLegacy as makeSyncTable} from '@codahq/packs-sdk/dist/legacy_exports';
-```
+    ```typescript
+    import {makeSyncTableLegacy as makeSyncTable} from '@codahq/packs-sdk/dist/legacy_exports';
+    ```
 
-The new syntax has also been applied to the pack builder's `addSyncTable()` method.
+    The new syntax has also been applied to the pack builder's `addSyncTable()` method.
 
-### `makeParameter()` type input change
+-   **`makeParameter()` type input change** - 
+    The recently-introduced wrapper `makeParameter()` used a confusing input enum for the parameter type
+    that was largely drawn from an internal representation parameters. It has been changed to use a new
+    enum that is specific to parameters.
 
-The recently-introduced wrapper `makeParameter()` used a confusing input enum for the parameter type
-that was largely drawn from an internal representation parameters. It has been changed to use a new
-enum that is specific to parameters.
+    ```typescript
+    // Old
+    makeParameter({type: Type.string, name: 'param', ...});
+    // New
+    makeParameter({type: ParameterType.String, name: 'param', ...});
 
-```typescript
-// Old
-makeParameter({type: Type.string, name: 'param', ...});
-// New
-makeParameter({type: ParameterType.String, name: 'param', ...});
+    // Old
+    makeParameter({arrayType: Type.string, name: 'param', ...});
+    // New
+    makeParameter({type: ParameterType.StringArray, name: 'param', ...});
+    ```
 
-// Old
-makeParameter({arrayType: Type.string, name: 'param', ...});
-// New
-makeParameter({type: ParameterType.StringArray, name: 'param', ...});
-```
+## [0.1.0] - 2021-06-22
 
-## 0.1.0
+### Added
 
-Beginning of alpha versioning.
+- Beginning of alpha versioning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog keeps track of all changes to the Packs SDK. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -160,7 +160,7 @@ await myHelper(context);
 
 - **Breaking Change** ValueHintType.Url will now create a column of type "Link" instead of "Text".
 
-## [0.8.2] - 2022-03-04
+## 0.8.2 - 2022-03-04
 
 ### Added
 
@@ -169,13 +169,13 @@ await myHelper(context);
 - Added `StringEmbedSchema` to handle configuration on how embed values appear in docs
 - Added "coda clone <packId>", similar to "coda init" but for packs that were already created in the Pack Studio.
 
-## [0.8.1] - 2022-01-19
+## 0.8.1 - 2022-01-19
 
 ### Removed
 
 - Removed postinstall to avoid patching failure for npm 6 or older versions.
 
-## [0.8.0] - 2022-01-14
+## 0.8.0 - 2022-01-14
 
 ### Added
 
@@ -192,7 +192,7 @@ await myHelper(context);
 
 - Deprecated `hidden` field is now fully removed on formula parameter.
 
-## [0.7.3] - 2021-12-06
+## 0.7.3 - 2021-12-06
 
 ### Changed
 
@@ -204,7 +204,7 @@ await myHelper(context);
 - Fixed a bug where `examples` using array parameters would fail upload validation.
 - Fixed an inconsistency where `SetEndpoint.getOptionsFormulas` required using the obsolete `makeMetadataFormula` wrapper instead of allowing you to provide a raw function.
 
-## [0.7.2] - 2021-11-24
+## 0.7.2 - 2021-11-24
 
 ### Fixed
 
@@ -213,7 +213,7 @@ await myHelper(context);
   - Previously only `text/xml` and `application/xml` were recognized, but headers like `application/atom+xml` were ignored and response bodies returned as strings.
 - Fixed `coda init` and `coda execute` to stop throwing errors on Windows.
 
-## [0.7.1] - 2021-11-17
+## 0.7.1 - 2021-11-17
 
 ### Added
 
@@ -252,13 +252,13 @@ await myHelper(context);
 - Update internal authentication mechanisms for interacting with AWS. Not currently available externally.
 - `makeObjectSchema` no longer requires you to redundantly specify `type: ValueType.Object` in your schema definition.
 
-## [0.7.0] - 2021-11-04
+## 0.7.0 - 2021-11-04
 
 ### Changed
 
 - Pack bundle format is changed to IIFE to fix occasional stacktrace misinterpretation. Previously compiled bundles will still be supported but may suffer from inaccurate sourcemap issue until the pack is built with the new SDK.
 
-## [0.6.0] - 2021-10-13
+## 0.6.0 - 2021-10-13
 
 ### Added
 
@@ -272,7 +272,7 @@ await myHelper(context);
 
 - **Breaking Change** Column Formats must now use only real Regex objects in their `matchers` array.
 
-## [0.5.0] - 2021-10-13
+## 0.5.0 - 2021-10-13
 
 ### Changed
 
@@ -291,27 +291,27 @@ await myHelper(context);
 
 - Bug fix: Numeric and string `codaType` properties are no longer erroneously removed in upload validation.
 
-## [0.4.6] - 2021-08-18
+## 0.4.6 - 2021-08-18
 
 ### Fixed
 
 - Bug fix: Executing sync table formulas via CLI now validates results correctly.
 
-## [0.4.5] - 2021-08-02
+## 0.4.5 - 2021-08-02
 
 ### Changed
 
 - Make a few testing functions (e.g. `executeFormulaFromPackDef`) optionally typed.
 - Update `StatusCodeError` constructor, which now requires the fetch request.
 
-## [0.4.4] - 2021-07-27
+## 0.4.4 - 2021-07-27
 
 ### Fixed
 
 - Fixed a bug where using `pack.setSystemAuthentication()` would add a required connection
   parameter to every formula.
 
-## [0.4.3] - 2021-07-26
+## 0.4.3 - 2021-07-26
 
 ### Fixed
 
@@ -321,13 +321,13 @@ await myHelper(context);
   TypeScript errors even for valid definitions.
 - Parse XML fetcher responses to JSON for respones with content type `application/xml`. Previously only `text/xml` worked.
 
-## [0.4.2] - 2021-07-14
+## 0.4.2 - 2021-07-14
 
 ### Fixed
 
 - Fixed a bug preventing `coda init` from working.
 
-## [0.4.1] - 2021-07-13
+## 0.4.1 - 2021-07-13
 
 ### Changed
 
@@ -356,7 +356,7 @@ await myHelper(context);
     pack.addSyncTable(...);
     ```
 
-## [0.4.0] - 2021-07-09
+## 0.4.0 - 2021-07-09
 
 ### Changed
 
@@ -364,7 +364,7 @@ await myHelper(context);
     The type `TypedStandardFormula`, which is the type used for the `formulas` array in main
     `PackVersionDefinition` type has been renamed `Formula` to be simpler and more intuitive.
 
-## [0.3.1] - 2021-07-01
+## 0.3.1 - 2021-07-01
 
 ### Changed
 
@@ -432,7 +432,7 @@ await myHelper(context);
     to provide that override. This is very rare, but it is sometimes needed for autocomplete formulas
     that need not use authentication even when the parent formula does.
 
-## [0.3.0] - 2021-06-29
+## 0.3.0 - 2021-06-29
 
 ### Changed
 
@@ -468,7 +468,7 @@ await myHelper(context);
     });
     ```
 
-## [0.2.0] - 2021-06-28
+## 0.2.0 - 2021-06-28
 
 ### Changed
 
@@ -511,8 +511,21 @@ await myHelper(context);
     makeParameter({type: ParameterType.StringArray, name: 'param', ...});
     ```
 
-## [0.1.0] - 2021-06-22
+## 0.1.0 - 2021-06-22
 
 ### Added
 
 - Beginning of alpha versioning.
+
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/coda/packs-sdk/compare/v1.0.5...v1.1.0
+[1.0.5]: https://github.com/coda/packs-sdk/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/coda/packs-sdk/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/coda/packs-sdk/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/coda/packs-sdk/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/coda/packs-sdk/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/coda/packs-sdk/compare/v0.12.1...v1.0.0
+[0.12.1]: https://github.com/coda/packs-sdk/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/coda/packs-sdk/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/coda/packs-sdk/compare/v0.9.0...v0.11.0
+[0.9.0]: https://github.com/coda/packs-sdk/compare/v0.8.2...v0.9.0

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ lint:
 	# Markdown lint.
 	npx remark docs --quiet --frail --ignore-pattern 'docs/reference/*'
 
+	# Changelog lint.
+	npx kacl lint
+
 	# release-it only understands "Unreleased" as the name of an upcoming release
 	RELEASE_NAME="$(shell egrep -m 1 '^## ' CHANGELOG.md | egrep -v "^## \[")"; \
 	if [[ "$$RELEASE_NAME" != "" && "$$RELEASE_NAME" != "## Unreleased" ]]; then \

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "isolated-vm": "^4.4.1"
   },
   "devDependencies": {
+    "@brightcove/kacl": "^0.1.11",
     "@getify/eslint-plugin-proper-arrows": "^11.0.3",
     "@julian_cataldo/remark-lint-frontmatter-schema": "^3.7.4",
     "@release-it/keep-a-changelog": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,14 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@brightcove/kacl@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@brightcove/kacl/-/kacl-0.1.11.tgz#c924a59a98f7d08ba294098f43d22606c341a9ca"
+  integrity sha512-1KdQpJKb6GhU5V6uAlmCIUvgVNcxyU8Wswzt2Gbe4O4sjnxCGWxNhDtbmkdvqyM0Qr+b5cvlw/Ophc9zzVl76w==
+  dependencies:
+    chalk "^2.4.1"
+    keep-a-changelog "^0.10.0"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -2013,6 +2021,11 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz"
@@ -2046,7 +2059,7 @@ chalk@5.0.1, chalk@^5.0.0, chalk@^5.0.1:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
   integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2432,6 +2445,11 @@ debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
 decamelize@^4.0.0:
   version "4.0.0"
@@ -3561,6 +3579,13 @@ git-url-parse@13.0.0:
   dependencies:
     git-up "^7.0.0"
 
+gitconfiglocal@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz#07c28685c55cc5338b27b5acbcfe34aeb92e43d1"
+  integrity sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==
+  dependencies:
+    ini "^1.3.2"
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -3914,7 +3939,7 @@ ini@2.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
-ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -4455,6 +4480,15 @@ just-extend@^4.0.2:
   version "4.2.1"
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
+
+keep-a-changelog@^0.10.0:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/keep-a-changelog/-/keep-a-changelog-0.10.4.tgz#fd2af71e7beccba26a8cf3857c7c47e524ade1cb"
+  integrity sha512-egtoaVyuQD5xFfZ/q3prVZM0TF8YYHcuWxbLg6jlPNu/PVkJba2Bvl6QukY+InoN6uXElbopE/gCLS3hNunhLg==
+  dependencies:
+    gitconfiglocal "^2.1.0"
+    semver "^7.3.2"
+    yargs-parser "^18.1.3"
 
 keyv@^4.0.0:
   version "4.3.0"
@@ -6172,6 +6206,13 @@ semver@7.3.7, semver@^7.0.0, semver@^7.3.4, semver@^7.3.5, semver@^7.3.6, semver
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.2:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
@@ -7383,6 +7424,14 @@ yargs-parser@21.1.1, yargs-parser@^21.0.0:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs-parser@^18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
Although [keepachangelog.com](https://keepachangelog.com) doesn't include a formal spec, tools have been built around it's recommended format ([example](https://github.com/oscarotero/keep-a-changelog)), resulting in an unofficial one. Our CHANGELOG wasn't parseable by those tools, since we didn't always follow the conventions.

This PR updates our CHANGELOG to bring it inline with the spec:
- All changes in bulleted lists.
- All changes grouped under h3's that indicate the type of change.
- All versions have a title (the part after the dash)
- Added version URLs (for versions that exist in GitHub)

Also adds a linter to make sure we stay in compliance, and adjusts the existing plugin to generate correct links.