### PR TITLE
add setup_remote_docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
       - run:
           name: 'Test'
           command: make test
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           name: 'Ensure clean dist diff'
           command: make validate-no-changes


### PR DESCRIPTION
seems like we need this to run `docker run`. 