### PR TITLE
Use standard slack token name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ workflows:
       - utils/slack-notify-waiting-for-approval:
           context:
             - slack
-          slack_bot_token: ${PUSH_REMINDER_BOT_TOKEN}
+          slack_bot_token: ${SLACK_ACCESS_TOKEN}
           requires:
             - push-staging-docs
       - wait-for-approval:


### PR DESCRIPTION
This is the token name used by the slack orb provided by CircleCI. We can standardize on that.

PTAL https://github.com/orgs/coda/teams/internal-tools