### PR TITLE
Relax URL validation to accept data: URLs (not just http/https)

### DIFF
--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -212,11 +212,11 @@ function tryParseDateTimeString(result, schema) {
 }
 function tryParseUrl(result, schema) {
     const invalidUrlError = {
-        message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) or data url, but got "${result}".`,
+        message: `Property with codaType "${schema.codaType}" must be a valid HTTPS or data url, but got "${result}".`,
     };
     try {
         const url = (0, url_parse_1.default)(result);
-        if (!(url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'data:')) {
+        if (!(url.protocol === 'https:' || url.protocol === 'data:')) {
             return invalidUrlError;
         }
     }

--- a/dist/testing/validation.js
+++ b/dist/testing/validation.js
@@ -212,11 +212,11 @@ function tryParseDateTimeString(result, schema) {
 }
 function tryParseUrl(result, schema) {
     const invalidUrlError = {
-        message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) url, but got "${result}".`,
+        message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) or data url, but got "${result}".`,
     };
     try {
         const url = (0, url_parse_1.default)(result);
-        if (!(url.protocol === 'http:' || url.protocol === 'https:')) {
+        if (!(url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'data:')) {
             return invalidUrlError;
         }
     }

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -286,21 +286,25 @@ describe('Property validation in objects', () => {
     );
   });
 
-  it('validates properly formatted url', async () => {
+  it('validates properly formatted http url', async () => {
     await executeFormulaFromPackDef(fakePack, 'Url', ['http://google.com']);
+  });
+
+  it('validates properly formatted data url', async () => {
+    await executeFormulaFromPackDef(fakePack, 'Url', ['data:image/png;base64,iVBORw0KGg']);
   });
 
   it('rejects improperly formatted url', async () => {
     await testHelper.willBeRejectedWith(
       executeFormulaFromPackDef(fakePack, 'Url', ['mailto:http://google.com']),
-      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) url, but got "mailto:http:\/\/google.com"./,
+      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) or data url, but got "mailto:http:\/\/google.com"./,
     );
   });
 
   it('rejects garbage url', async () => {
     await testHelper.willBeRejectedWith(
       executeFormulaFromPackDef(fakePack, 'Url', ['jasiofjsdofjiaof']),
-      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) url, but got "jasiofjsdofjiaof"./,
+      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) or data url, but got "jasiofjsdofjiaof"./,
     );
   });
 

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -286,25 +286,32 @@ describe('Property validation in objects', () => {
     );
   });
 
-  it('validates properly formatted http url', async () => {
-    await executeFormulaFromPackDef(fakePack, 'Url', ['http://google.com']);
+  it('validates properly formatted https url', async () => {
+    await executeFormulaFromPackDef(fakePack, 'Url', ['https://google.com']);
   });
 
   it('validates properly formatted data url', async () => {
     await executeFormulaFromPackDef(fakePack, 'Url', ['data:image/png;base64,iVBORw0KGg']);
   });
 
+  it('rejects http url', async () => {
+    await testHelper.willBeRejectedWith(
+      executeFormulaFromPackDef(fakePack, 'Url', ['http://google.com']),
+      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTPS or data url, but got "http:\/\/google.com"./,
+    );
+  });
+
   it('rejects improperly formatted url', async () => {
     await testHelper.willBeRejectedWith(
       executeFormulaFromPackDef(fakePack, 'Url', ['mailto:http://google.com']),
-      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) or data url, but got "mailto:http:\/\/google.com"./,
+      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTPS or data url, but got "mailto:http:\/\/google.com"./,
     );
   });
 
   it('rejects garbage url', async () => {
     await testHelper.willBeRejectedWith(
       executeFormulaFromPackDef(fakePack, 'Url', ['jasiofjsdofjiaof']),
-      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTP\(S\) or data url, but got "jasiofjsdofjiaof"./,
+      /The following errors were found when validating the result of the formula "Url":\nProperty with codaType "url" must be a valid HTTPS or data url, but got "jasiofjsdofjiaof"./,
     );
   });
 

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -219,12 +219,12 @@ function tryParseDateTimeString(result: unknown, schema: BaseStringSchema) {
 
 function tryParseUrl(result: unknown, schema: BaseStringSchema) {
   const invalidUrlError = {
-    message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) url, but got "${result}".`,
+    message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) or data url, but got "${result}".`,
   };
   try {
     const url = urlParse(result as string);
 
-    if (!(url.protocol === 'http:' || url.protocol === 'https:')) {
+    if (!(url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'data:')) {
       return invalidUrlError;
     }
   } catch (error: any) {

--- a/testing/validation.ts
+++ b/testing/validation.ts
@@ -219,12 +219,12 @@ function tryParseDateTimeString(result: unknown, schema: BaseStringSchema) {
 
 function tryParseUrl(result: unknown, schema: BaseStringSchema) {
   const invalidUrlError = {
-    message: `Property with codaType "${schema.codaType}" must be a valid HTTP(S) or data url, but got "${result}".`,
+    message: `Property with codaType "${schema.codaType}" must be a valid HTTPS or data url, but got "${result}".`,
   };
   try {
     const url = urlParse(result as string);
 
-    if (!(url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'data:')) {
+    if (!(url.protocol === 'https:' || url.protocol === 'data:')) {
       return invalidUrlError;
     }
   } catch (error: any) {


### PR DESCRIPTION
## Summary
Relax URL validation to accept `data:` URLs (not just http/https)

We already use `data:` urls in ImageAttachment fields in the Google Drive pack – this change makes it so validation passes when testing locally using `coda execute`.

## Testing
- Updated validation unit tests
- Tested this locally with `coda execute` on the google drive pack. Verified that with the change, we no longer get a URL validation error.