### PR TITLE
don't import our crypto shim if crypto is supported natively

### DIFF
--- a/dist/testing/injections/crypto_shim.js
+++ b/dist/testing/injections/crypto_shim.js
@@ -36,7 +36,7 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = process.version.substring(1); // strip out first char from v19.x.x
+const version = process?.version.substring(1); // strip out first char from v19.x.x
 if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }

--- a/dist/testing/injections/crypto_shim.js
+++ b/dist/testing/injections/crypto_shim.js
@@ -1,37 +1,41 @@
 // ivm doens't have a crypto implementation. since we browserify modules already, this shim implements the browser crypto interface.
 // inspired by https://github.com/kumavis/polyfill-crypto.getrandomvalues/blob/master/index.js
 
-var MersenneTwister = require('mersenne-twister')
+var MersenneTwister = require('mersenne-twister');
+var semver = require('semver');
 
-var twister = new MersenneTwister(Math.random() * Number.MAX_SAFE_INTEGER)
+var twister = new MersenneTwister(Math.random() * Number.MAX_SAFE_INTEGER);
 
-function getRandomValues (abv) {
-  var l = abv.length
+function getRandomValues(abv) {
+  var l = abv.length;
   while (l--) {
-    abv[l] = Math.floor(randomFloat() * 256)
+    abv[l] = Math.floor(randomFloat() * 256);
   }
-  return abv
+  return abv;
 }
 
 function randomFloat() {
-  return twister.random()
+  return twister.random();
 }
 
 export const crypto = {
   getRandomValues,
-}
+};
 
-// esbuild isn't injecting the shim exports into global. in this particular case, crypto 
-// library is usually used as global.crypto which returns undefined otherwise. 
-// 
+// esbuild isn't injecting the shim exports into global. in this particular case, crypto
+// library is usually used as global.crypto which returns undefined otherwise.
+//
 // alternatively a few other approaches are tried:
-// - shim global: which doesn't work with VM somehow since the VM manages context.global which 
+// - shim global: which doesn't work with VM somehow since the VM manages context.global which
 //   seems a different object from the global here. causing manifest to be undefined.
-// - use esbuild define global.crypto: crypto. didn't work. 
+// - use esbuild define global.crypto: crypto. didn't work.
 // - https://github.com/evanw/esbuild/issues/296 Didn't work since we banned eval in VM.
 //
 // Lastly, we can move this shim to thunk bundle and register it into global from the thunk bundle.
-// It has the same side effect of the shim though. 
+// It has the same side effect of the shim though.
 //
 // please note that this causes a global leak and needs be ignored in some configs.
-global.crypto = crypto;
+// Node 19 has native support for crypto module.
+if (semver.compare(process.version, '19.0.0') < 0) {
+  global.crypto = crypto;
+}

--- a/dist/testing/injections/crypto_shim.js
+++ b/dist/testing/injections/crypto_shim.js
@@ -35,7 +35,8 @@ export const crypto = {
 // It has the same side effect of the shim though.
 //
 // please note that this causes a global leak and needs be ignored in some configs.
-// Node 19 has native support for crypto module.
-if (semver.compare(process.version, '19.0.0') < 0) {
+// Node 19 has native support for the crypto module.
+const version = process.version.substring(1); // strip out first char from v19.x.x
+if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }

--- a/dist/testing/injections/crypto_shim.js
+++ b/dist/testing/injections/crypto_shim.js
@@ -36,7 +36,6 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
-if (!semver.valid(version) || semver.compare(version, '19.0.0') < 0) {
+if (!global.crypto?.getRandomValues) {
   global.crypto = crypto;
 }

--- a/dist/testing/injections/crypto_shim.js
+++ b/dist/testing/injections/crypto_shim.js
@@ -36,7 +36,7 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = process?.version.substring(1); // strip out first char from v19.x.x
-if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
+const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
+if (!semver.valid(version) || semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -223,3 +223,14 @@ pack.addFormula({
   },
   cacheTtlSecs: 0,
 });
+
+pack.addFormula({
+  name: 'Random',
+  description: 'calls crypto random',
+  parameters: [],
+  resultType: coda.ValueType.Number,
+  execute: async () => {
+    return crypto.getRandomValues(new Uint32Array(10))[0];
+  },
+  cacheTtlSecs: 0,
+});

--- a/testing/injections/crypto_shim.js
+++ b/testing/injections/crypto_shim.js
@@ -36,7 +36,7 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = process.version.substring(1); // strip out first char from v19.x.x
+const version = process?.version.substring(1); // strip out first char from v19.x.x
 if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }

--- a/testing/injections/crypto_shim.js
+++ b/testing/injections/crypto_shim.js
@@ -1,37 +1,41 @@
 // ivm doens't have a crypto implementation. since we browserify modules already, this shim implements the browser crypto interface.
 // inspired by https://github.com/kumavis/polyfill-crypto.getrandomvalues/blob/master/index.js
 
-var MersenneTwister = require('mersenne-twister')
+var MersenneTwister = require('mersenne-twister');
+var semver = require('semver');
 
-var twister = new MersenneTwister(Math.random() * Number.MAX_SAFE_INTEGER)
+var twister = new MersenneTwister(Math.random() * Number.MAX_SAFE_INTEGER);
 
-function getRandomValues (abv) {
-  var l = abv.length
+function getRandomValues(abv) {
+  var l = abv.length;
   while (l--) {
-    abv[l] = Math.floor(randomFloat() * 256)
+    abv[l] = Math.floor(randomFloat() * 256);
   }
-  return abv
+  return abv;
 }
 
 function randomFloat() {
-  return twister.random()
+  return twister.random();
 }
 
 export const crypto = {
   getRandomValues,
-}
+};
 
-// esbuild isn't injecting the shim exports into global. in this particular case, crypto 
-// library is usually used as global.crypto which returns undefined otherwise. 
-// 
+// esbuild isn't injecting the shim exports into global. in this particular case, crypto
+// library is usually used as global.crypto which returns undefined otherwise.
+//
 // alternatively a few other approaches are tried:
-// - shim global: which doesn't work with VM somehow since the VM manages context.global which 
+// - shim global: which doesn't work with VM somehow since the VM manages context.global which
 //   seems a different object from the global here. causing manifest to be undefined.
-// - use esbuild define global.crypto: crypto. didn't work. 
+// - use esbuild define global.crypto: crypto. didn't work.
 // - https://github.com/evanw/esbuild/issues/296 Didn't work since we banned eval in VM.
 //
 // Lastly, we can move this shim to thunk bundle and register it into global from the thunk bundle.
-// It has the same side effect of the shim though. 
+// It has the same side effect of the shim though.
 //
 // please note that this causes a global leak and needs be ignored in some configs.
-global.crypto = crypto;
+// Node 19 has native support for crypto module.
+if (semver.compare(process.version, '19.0.0') < 0) {
+  global.crypto = crypto;
+}

--- a/testing/injections/crypto_shim.js
+++ b/testing/injections/crypto_shim.js
@@ -35,7 +35,8 @@ export const crypto = {
 // It has the same side effect of the shim though.
 //
 // please note that this causes a global leak and needs be ignored in some configs.
-// Node 19 has native support for crypto module.
-if (semver.compare(process.version, '19.0.0') < 0) {
+// Node 19 has native support for the crypto module.
+const version = process.version.substring(1); // strip out first char from v19.x.x
+if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }

--- a/testing/injections/crypto_shim.js
+++ b/testing/injections/crypto_shim.js
@@ -36,7 +36,6 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
-if (!semver.valid(version) || semver.compare(version, '19.0.0') < 0) {
+if (!global.crypto?.getRandomValues) {
   global.crypto = crypto;
 }

--- a/testing/injections/crypto_shim.js
+++ b/testing/injections/crypto_shim.js
@@ -36,7 +36,7 @@ export const crypto = {
 //
 // please note that this causes a global leak and needs be ignored in some configs.
 // Node 19 has native support for the crypto module.
-const version = process?.version.substring(1); // strip out first char from v19.x.x
-if (semver.valid(version) && semver.compare(version, '19.0.0') < 0) {
+const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
+if (!semver.valid(version) || semver.compare(version, '19.0.0') < 0) {
   global.crypto = crypto;
 }


### PR DESCRIPTION
For environments using Node version >= 19.0.0, running any Coda CLI command would result in the following error:
```
TypeError: Cannot set property crypto of #<Object> which has only a getter
    at ../../../packs/node_modules/@codahq/packs-sdk/dist/testing/injections/crypto_shim.js (/private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:148:21)
    at __init (/private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:15:58)
    at ../../../../../../private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/browserify-bundle.js (/private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:155:7)
    at __require2 (/private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:18:52)
    at /private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:8420:10
    at Object.<anonymous> (/private/var/folders/50/_v53nyjd0vb2r94bzn5nbcqm0000gp/T/coda-packs-4ea73dfd-3391-4b5e-82f7-c91f11182216nGo4p5/bundle.js:8421:3)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
```

This is because, as @ekoleda-codaio pointed out, Node 19 now supports global.crypto natively, and trying to import our shim throws the error. So, for environments with version >= 19.0.0, we skip attempting to import our crypto shim.

Although, we may need to test to make sure our shim and the Node crypto module are compatible before merging/releasing this change.