### PR TITLE
enforce node version to be >=14 and < 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - Added an option `credentialsLocation` to `OAuth2Authentication`, to specify how the client ID and secret should be passed during the token exchange. The default `Automatic` should be sufficient for most OAuth2 providers.
+- Enforce Node version to be >=14.17 and <19 from the CLI.
 
 ## [1.2.1] - 2022-11-15
 

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -17,8 +17,15 @@ import {handleSetOption} from './set_option';
 import {handleUpload} from './upload';
 import {handleValidate} from './validate';
 import {handleWhoami} from './whoami';
+import {printAndExit} from '../testing/helpers';
+import semver from 'semver';
 import {tryGetIvm} from '../testing/ivm_wrapper';
 import yargs from 'yargs';
+
+const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
+if (!semver.valid(version) || semver.compare(version, '19.0.0') >= 0 || semver.compare(version, '14.17')) {
+  printAndExit(`Unsupported node verison ${version}`);
+}
 
 if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -21,8 +21,14 @@ const set_option_1 = require("./set_option");
 const upload_1 = require("./upload");
 const validate_1 = require("./validate");
 const whoami_1 = require("./whoami");
+const helpers_1 = require("../testing/helpers");
+const semver_1 = __importDefault(require("semver"));
 const ivm_wrapper_1 = require("../testing/ivm_wrapper");
 const yargs_1 = __importDefault(require("yargs"));
+const version = typeof process !== 'undefined' ? process.version.substring(1) : ''; // strip out first char from v19.x.x
+if (!semver_1.default.valid(version) || semver_1.default.compare(version, '19.0.0') >= 0 || semver_1.default.compare(version, '14.17')) {
+    (0, helpers_1.printAndExit)(`Unsupported node verison ${version}`);
+}
 if (require.main === module) {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     void yargs_1.default

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "license": "MIT",
   "engines": {
-    "node": ">=14.17.x"
+    "node": ">=14.17.x <19"
   },
   "main": "dist/index.js",
   "bin": {

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -223,3 +223,14 @@ pack.addFormula({
   },
   cacheTtlSecs: 0,
 });
+
+pack.addFormula({
+  name: 'Random',
+  description: 'calls crypto random',
+  parameters: [],
+  resultType: coda.ValueType.Number,
+  execute: async () => {
+    return crypto.getRandomValues(new Uint32Array(10))[0];
+  },
+  cacheTtlSecs: 0,
+});


### PR DESCRIPTION
when we play with https://github.com/coda/packs-sdk/pull/2350, it turns out that isolated-vm doesn't support node 19 at all.

also I was worried that skipping crypto shim would make the bundle erroring out in isolated-vm. 

let's enforce the node version to be 14 and <19. Ideally we may want to ping it to 14 but I guess any version <19 works as far as we know. 

PTAL @alan-codaio @jonathan-codaio @patrick-codaio 

## Testing

```
huayang@Huayangs-MacBook-Pro [16:25:43] [~/code/packs-sdk] [hg-enforce-node-version]
-> % node -v 
v19.2.0
huayang@Huayangs-MacBook-Pro [16:27:49] [~/code/packs-sdk] [hg-enforce-node-version]
-> % make bs 
yarn config v1.22.19
warning ../package.json: No license field
success Set "cache-folder" to "/Users/huayang/.yarncache".
✨  Done in 0.05s.
yarn install v1.22.19
warning ../package.json: No license field
[1/5] 🔍  Validating package.json...
error @codahq/packs-sdk@1.2.1: The engine "node" is incompatible with this module. Expected version ">=14.17.x <19". Got "19.2.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
make[1]: *** [_bootstrap-node] Error 1
make: *** [bootstrap] Error 2
```

CLI check. 
```
huayang@Huayangs-MacBook-Pro [16:30:54] [~/code/packs-sdk] [hg-enforce-node-version *]
-> % node -v 
v19.2.0
huayang@Huayangs-MacBook-Pro [16:30:55] [~/code/packs-sdk] [hg-enforce-node-version *]
-> % npx ts-node cli/coda.ts execute test/packs/fake_v2.ts Random --no-vm
Unsupported node verison 19.2.0
```