### PR TITLE
Bump npm:qs to version ^6.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "typedoc-plugin-markdown": "^3.13.6"
   },
   "resolutions": {
+    "**/request/qs": "^6.5.3",
     "release-it/node-fetch": "^3.2.10",
     "ansi-regex": "^5.0.1",
     "got": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5811,17 +5811,12 @@ pupa@^3.1.0:
   dependencies:
     escape-goat "^4.0.0"
 
-qs@6.11.0, qs@^6.11.0:
+qs@6.11.0, qs@^6.11.0, qs@^6.5.3, qs@~6.5.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
-
-qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@~0.2.0:
   version "0.2.1"


### PR DESCRIPTION
# Summary
 
Resolves dependabot alert: https://github.com/coda/packs-sdk/security/dependabot/25