### PR TITLE
Some cleanup noticed during hackathon.

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6943,8 +6943,18 @@ module.exports = (() => {
                     default:
                       return ensureSwitchUnreachable(formulaSpec);
                   }
-                } else if (formulaSpec.metadataFormulaType === "SyncGetSchema" /* SyncGetSchema */) {
-                  formula = syncTable.getSchema;
+                } else {
+                  switch (formulaSpec.metadataFormulaType) {
+                    case "SyncGetSchema" /* SyncGetSchema */:
+                      formula = syncTable.getSchema;
+                      break;
+                    case "SyncListDynamicUrls" /* SyncListDynamicUrls */:
+                    case "SyncGetDisplayUrl" /* SyncGetDisplayUrl */:
+                    case "SyncGetTableName" /* SyncGetTableName */:
+                      break;
+                    default:
+                      return ensureSwitchUnreachable(formulaSpec);
+                  }
                 }
                 if (formula) {
                   return formula.execute(params, executionContext);

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6943,8 +6943,18 @@ module.exports = (() => {
                     default:
                       return ensureSwitchUnreachable(formulaSpec);
                   }
-                } else if (formulaSpec.metadataFormulaType === "SyncGetSchema" /* SyncGetSchema */) {
-                  formula = syncTable.getSchema;
+                } else {
+                  switch (formulaSpec.metadataFormulaType) {
+                    case "SyncGetSchema" /* SyncGetSchema */:
+                      formula = syncTable.getSchema;
+                      break;
+                    case "SyncListDynamicUrls" /* SyncListDynamicUrls */:
+                    case "SyncGetDisplayUrl" /* SyncGetDisplayUrl */:
+                    case "SyncGetTableName" /* SyncGetTableName */:
+                      break;
+                    default:
+                      return ensureSwitchUnreachable(formulaSpec);
+                  }
                 }
                 if (formula) {
                   return formula.execute(params, executionContext);

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -115,10 +115,21 @@ function doFindAndExecutePackFunction({ params, formulaSpec, manifest, execution
                                         return ensureSwitchUnreachable(formulaSpec);
                                 }
                             }
-                            else if (formulaSpec.metadataFormulaType === types_3.MetadataFormulaType.SyncGetSchema) {
-                                // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
-                                // in order to augment a static base schema with dynamic properties.
-                                formula = syncTable.getSchema;
+                            else {
+                                switch (formulaSpec.metadataFormulaType) {
+                                    // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
+                                    // in order to augment a static base schema with dynamic properties.
+                                    case types_3.MetadataFormulaType.SyncGetSchema:
+                                        formula = syncTable.getSchema;
+                                        break;
+                                    case types_3.MetadataFormulaType.SyncListDynamicUrls:
+                                    case types_3.MetadataFormulaType.SyncGetDisplayUrl:
+                                    case types_3.MetadataFormulaType.SyncGetTableName:
+                                        // Not applicable to static tables.
+                                        break;
+                                    default:
+                                        return ensureSwitchUnreachable(formulaSpec);
+                                }
                             }
                             if (formula) {
                                 return formula.execute(params, executionContext);

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -163,10 +163,21 @@ function doFindAndExecutePackFunction<T extends FormulaSpecification>({
                   default:
                     return ensureSwitchUnreachable(formulaSpec);
                 }
-              } else if (formulaSpec.metadataFormulaType === MetadataFormulaType.SyncGetSchema) {
-                // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
-                // in order to augment a static base schema with dynamic properties.
-                formula = syncTable.getSchema;
+              } else {
+                switch (formulaSpec.metadataFormulaType) {
+                  // Certain sync tables (Jira Issues, canonically) are not "dynamic" but have a getSchema formula
+                  // in order to augment a static base schema with dynamic properties.
+                  case MetadataFormulaType.SyncGetSchema:
+                    formula = syncTable.getSchema;
+                    break;
+                  case MetadataFormulaType.SyncListDynamicUrls:
+                  case MetadataFormulaType.SyncGetDisplayUrl:
+                  case MetadataFormulaType.SyncGetTableName:
+                    // Not applicable to static tables.
+                    break;
+                  default:
+                    return ensureSwitchUnreachable(formulaSpec);
+                }
               }
               if (formula) {
                 return formula.execute(params as any, executionContext);

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -22,6 +22,7 @@ import type {StringFormulaDefLegacy} from '../api';
 import {Type} from '../api_types';
 import {ValueHintType} from '../schema';
 import {ValueType} from '../schema';
+import {compilePackMetadata} from '../helpers/metadata';
 import {createFakePack} from './test_utils';
 import {createFakePackFormulaMetadata} from './test_utils';
 import {createFakePackVersionMetadata} from './test_utils';
@@ -494,12 +495,15 @@ describe('Pack metadata Validation', () => {
           examples: [],
         },
       });
-      const metadata = createFakePackVersionMetadata({
-        syncTables: [syncTable],
-        defaultAuthentication: {
-          type: AuthenticationType.None,
-        },
-      });
+      const metadata = createFakePackVersionMetadata(
+        compilePackMetadata({
+          version: '1',
+          syncTables: [syncTable],
+          defaultAuthentication: {
+            type: AuthenticationType.None,
+          },
+        }),
+      );
       const err = await validateJsonAndAssertFails(metadata);
       assert.deepEqual(err.validationErrors, [
         {
@@ -533,12 +537,15 @@ describe('Pack metadata Validation', () => {
           examples: [],
         },
       });
-      const metadata = createFakePackVersionMetadata({
-        syncTables: [syncTable],
-        defaultAuthentication: {
-          type: AuthenticationType.None,
-        },
-      });
+      const metadata = createFakePackVersionMetadata(
+        compilePackMetadata({
+          version: '1',
+          syncTables: [syncTable],
+          defaultAuthentication: {
+            type: AuthenticationType.None,
+          },
+        }),
+      );
       const err = await validateJsonAndAssertFails(metadata);
       assert.deepEqual(err.validationErrors, [
         {
@@ -781,9 +788,12 @@ describe('Pack metadata Validation', () => {
           },
         });
 
-        const metadata = createFakePack({
-          syncTables: [syncTable],
-        });
+        const metadata = createFakePackVersionMetadata(
+          compilePackMetadata({
+            version: '1',
+            syncTables: [syncTable],
+          }),
+        );
         await validateJson(metadata);
       });
 
@@ -1830,10 +1840,13 @@ describe('Pack metadata Validation', () => {
           );
         }
 
-        const metadata = createFakePackVersionMetadata({
-          syncTables,
-          formulaNamespace: 'MyNamespace',
-        });
+        const metadata = createFakePackVersionMetadata(
+          compilePackMetadata({
+            version: '1',
+            syncTables,
+            formulaNamespace: 'MyNamespace',
+          }),
+        );
 
         const err = await validateJsonAndAssertFails(metadata);
 
@@ -3675,12 +3688,15 @@ describe('Pack metadata Validation', () => {
           examples: [],
         },
       });
-      const metadata = createFakePackVersionMetadata({
-        syncTables: [syncTable],
-        defaultAuthentication: {
-          type: AuthenticationType.None,
-        },
-      });
+      const metadata = createFakePackVersionMetadata(
+        compilePackMetadata({
+          version: '1',
+          syncTables: [syncTable],
+          defaultAuthentication: {
+            type: AuthenticationType.None,
+          },
+        }),
+      );
       const err = await validateJsonAndAssertFails(metadata, sdkVersionTriggeringDeprecationWarnings);
       assert.deepEqual(err.validationErrors, [
         {
@@ -3790,9 +3806,12 @@ describe('Pack metadata Validation', () => {
           },
         },
       });
-      const metadata = createFakePackVersionMetadata({
-        syncTables: [syncTable],
-      });
+      const metadata = createFakePackVersionMetadata(
+        compilePackMetadata({
+          version: '1',
+          syncTables: [syncTable],
+        }),
+      );
       const err = await validateJsonAndAssertFails(metadata, sdkVersionTriggeringDeprecationWarnings);
       assert.deepEqual(err.validationErrors, [
         {


### PR DESCRIPTION
The `switch` just flags in a nice way where you need to update when adding a new metadata formula type.

The tests are kind of only accidentally working right now, they're treating a raw pack def as metadata, and just coincidentally don't happen to be using or inspecting any fields that get transformed during metadata compilation. If your pack def uses a field whose compiled type is different you'll get a TS error. You'd similarly see weirdness if you made any assertions here. So just actually compiling the inputs so everything lines up as it should.

PTAL @huayang-codaio @patrick-codaio @coda/packs 