### PR TITLE
Avoid isolated-vm version 4.4.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "zod": "3.20.2"
   },
   "optionalDependencies": {
-    "isolated-vm": "^4.4.1"
+    "isolated-vm": "=4.4.1 || >4.4.2"
   },
   "devDependencies": {
     "@brightcove/kacl": "^0.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,7 +4448,7 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-isolated-vm@^4.4.1:
+"isolated-vm@=4.4.1 || >4.4.2":
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/isolated-vm/-/isolated-vm-4.4.1.tgz#651ce31e435e769b2a356bb03db2553a478acebe"
   integrity sha512-5aDwxQGm78vHS+qJeUli2ILroG7OS/k3D/Mc0kcT9vyujiL4bV7PYYix1mAvuBm3v44nz2qcfAOqgAbhuACc/w==


### PR DESCRIPTION
Working around https://staging.coda.io/d/_d-GJF-DmEUK#Bugs_tuq-W/r26524&view=modal

There appears to be a bug in 4.4.2. For whatever reason, my installs are still using 4.4.1 so I don't run into this, but it seems like other people are getting 4.4.2 by default.

There aren't a lot of commits in https://github.com/laverdet/isolated-vm/commits/main between the versions, so it's almost certainly the case that https://github.com/laverdet/isolated-vm/commit/dba2aceae18d45106bad1ae0546a6274a38bc7d6 broke something. https://github.com/laverdet/isolated-vm/commit/905abbe0c36f6c143c3512173636443452b024be is a follow-on fix that may or may not address this issue, but there isn't a new patch version out to test with.

Regardless, let's just make sure people who depend on us don't wind up getting 4.4.2. Validated using the (TIL) https://semver.npmjs.com/

PTAL @huayang-codaio @ekoleda-codaio @coda/packs 