### PR TITLE
Move some pages to the support section

### DIFF
--- a/docs/reference/changes.md
+++ b/docs/reference/changes.md
@@ -1,5 +1,0 @@
----
-title: Changes
----
-
---8<-- "CHANGELOG.md"

--- a/docs/support/.nav.yml
+++ b/docs/support/.nav.yml
@@ -1,5 +1,7 @@
 nav:
   - index.md
+  - faq.md
+  - changes.md
   - migration
   - contributing
   - ...

--- a/docs/support/changes.md
+++ b/docs/support/changes.md
@@ -1,0 +1,6 @@
+---
+title: Changes
+description: A log of the changes made to the SDK over time.
+---
+
+--8<-- "CHANGELOG.md"

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -63,6 +63,6 @@ If you have a formula that returns a dynamic set of custom fields, there are two
 [google_verification]: https://support.google.com/cloud/answer/9110914
 [google_verification_exceptions]: https://support.google.com/cloud/answer/9110914#exceptions-ver-reqts&zippy=%2Cexceptions-to-verification-requirements
 [google_verification_line]: https://support.google.com/cloud/answer/9110914?hl=en#zippy=%2Chow-can-i-make-sure-the-verification-process-is-as-streamlined-as-possible
-[oauth_redirect]: basics/authentication/oauth2.md#redirect-url
+[oauth_redirect]: ../guides/basics/authentication/oauth2.md#redirect-url
 [packs_apps_script]: https://coda.io/packs/apps-script-14470
-[dynamic_sync_tables]: ./blocks/sync-tables/dynamic.md
+[dynamic_sync_tables]: ../guides/blocks/sync-tables/dynamic.md

--- a/docs/support/migration/index.md
+++ b/docs/support/migration/index.md
@@ -47,5 +47,5 @@ The following sections walk you through the migration for specific versions of t
 - [Version 0.11.0][v0.11.0]
 
 
-[changelog]: ../../reference/changes.md
+[changelog]: ../changes.md
 [v0.11.0]: v0.11.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,9 @@ plugins:
           "guides/advanced/fetcher.md": "guides/basics/fetcher.md"
           # 2022-09-14: Move Overview page.
           "guides/index.md": "guides/overview.md"
+          # 2023-01-05: Move FAQ and Changelog to Support.
+          "guides/faq.md": "support/faq.md"
+          "reference/changes.md": "support/changes.md"
     # Run Python scripts during the MkDocs generation process.
     - mkdocs-simple-hooks:
         hooks:


### PR DESCRIPTION
I've found myself looking for this information in the support section, and I think it makes more sense for it to live there. Added redirects in case it's been linked to from elsewhere.