### PR TITLE
Ignore esm only module versions for yn and node-fetch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     open-pull-requests-limit: 50
     reviewers:
       - "coda/packs"
+    ignore:
+      # Node-fetch 3.x is ESM only; 2.x will continue to receive updates.
+      - dependency-name: "node-fetch"
+        versions: [ "3.x" ]
+      # yn 5.X and above is ESM only.
+      - dependency-name: "yn"
+        versions: [ "5.x" ]


### PR DESCRIPTION
PTAL @coda/packs 
Context: https://codaproject.slack.com/archives/C02K6EABVMK/p1673043621769529