### PR TITLE
Add a Gitpod tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,11 +35,12 @@ Packs can be created for personal use, shared with a team, or published to the w
 <div class="landing-item" markdown>
 ## :octicons-stopwatch-16: Build your first Pack in minutes.
 
-Using Coda's Pack Studio you can author, build, and deploy your Pack all from your browser. Nothing to download or install.
-
-Our templates and examples make it easy to get started, and in minutes you'll have built your first Pack and installed it in a doc.
+Using Coda's Pack Studio you can write, build, and deploy your Pack all from your browser. Nothing to download or install.
 
 [Get started][get_started]{ .md-button .md-button--primary }
+
+Or for you power users, build a Pack using the `coda` command line tool on your [local machine][tutorial_cli], [GitHub :octicons-mark-github-16:][tutorial_github], [Gitpod :simple-gitpod:][tutorial_gitpod], or [Replit :simple-replit:][tutorial_replit].
+
 </div>
 
 <div class="landing-item" markdown>
@@ -89,7 +90,7 @@ Our passionate community of Pack makers and Coda experts can help answer your qu
 <div class="landing-item" markdown>
 ## :material-youtube: Grab the popcorn.
 
-In this snippet from a recent webinar we demonstrate how to build a Pack from scratch that retrieves your task list from Todoist :simple-todoist:. It was created in under 10 minutes and with less than 30 lines of code in the Pack Studio. 
+In this snippet from a recent webinar we demonstrate how to build a Pack from scratch that retrieves your task list from Todoist :simple-todoist:. It was created in under 10 minutes and with less than 30 lines of code in the Pack Studio.
 
 [Watch webinars][webinars]{ .md-button }
 </div>
@@ -121,3 +122,7 @@ Coda makers have been busy building Packs of all types, and many have published 
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [gallery]: https://coda.io/gallery?filter=packs
 [webinars]: tutorials/webinars.md
+[tutorial_cli]: tutorials/get-started/cli.md
+[tutorial_github]: tutorials/get-started/github.md
+[tutorial_gitpod]: tutorials/get-started/gitpod.md
+[tutorial_replit]: tutorials/get-started/replit.md

--- a/docs/tutorials/get-started/.cli/core.md
+++ b/docs/tutorials/get-started/.cli/core.md
@@ -64,7 +64,7 @@ Your new Pack is now available to use in all your docs, and you can install it j
 
 1. Open [Coda][coda_home] in your browser.
 
-1. Click the **+ New doc** button and select **Start with a blank page**.
+1. Click the **+ New doc** button and select **Start blank doc**.
 
 1. In your doc, click **Insert**, then **Packs**.
 2. Find your new Pack, **Hello World**, and click on it.

--- a/docs/tutorials/get-started/github.md
+++ b/docs/tutorials/get-started/github.md
@@ -55,7 +55,7 @@ From you new repository click the button **Code**. In the resulting dropdown men
 
 ---
 
-It may take a few minutes for the codespace to fully initialize and install the dependencies. When it's complete you should see a `pack.ts` file in your codespace, and you should take a moment to read through it.
+It may take a few minutes for the codespace to fully initialize and install the dependencies. When it's complete you will see a `pack.ts` file in your codespace, and you should take a moment to read through it.
 
 
 ## Test the Pack

--- a/docs/tutorials/get-started/gitpod.md
+++ b/docs/tutorials/get-started/gitpod.md
@@ -1,0 +1,43 @@
+---
+nav: With Gitpod
+description: Build your first Pack using Gitpod and the CLI.
+icon: simple-gitpod
+---
+
+# Get started with Gitpod
+
+[Gitpod][gitpod_home] is an open source developer platform that allows you to write and run that code in a hosted environment. Using Gitpod to build a Pack gives you all of the same the power and flexibility that comes with building on your local machine, but without needing to worry about installing tooling or dependencies.
+
+!!! info
+    While Gitpod comes with a generous free tier, be aware that it is a paid offering at higher usage levels.
+
+
+## Before you get started
+
+You will need a Gitpod account in order to create a Pack using it. If you don't already have one you can [sign up][gitpod_signup] for free on their website.
+
+--8<-- "tutorials/get-started/.cli/before.md"
+
+
+## Create a workspace
+
+A project in Gitpod is called a workspace, and to start you'll need to create one. Click the button below to create a new workspace from the [Packs starter project][github_packs_starter] template.
+
+[Create workspace][gitpod_from_github]{ .md-button .md-button--primary target="_blank" }
+
+It may take a few minutes for the workspace to fully initialize. When it's complete you will see a `pack.ts` file in your workspace, and you should take a moment to read through it.
+
+
+## Test the Pack
+
+--8<-- "tutorials/get-started/.cli/test.md"
+
+
+--8<-- "tutorials/get-started/.cli/core.md"
+
+
+[gitpod_home]: https://www.gitpod.io/
+[gitpod_signup]: https://gitpod.io/workspaces/
+[gitpod_from_github]: https://gitpod.io/#https://github.com/coda/packs-starter
+[github_packs_starter]: https://github.com/coda/packs-starter
+[rebuild]: ../../images/cli_rebuild.gif

--- a/docs/tutorials/get-started/replit.md
+++ b/docs/tutorials/get-started/replit.md
@@ -25,7 +25,7 @@ A project in Replit is called a "repl", and to start you'll need to create one. 
 
 [Create repl][replit_from_github]{ .md-button .md-button--primary target="_blank" }
 
-It may take a few minutes for the repl to fully initialize. When it's complete you should see a `pack.ts` file in your repl, and you should take a moment to read through it.
+It may take a few minutes for the repl to fully initialize. When it's complete you will see a `pack.ts` file in your repl, and you should take a moment to read through it.
 
 
 ## Test the Pack


### PR DESCRIPTION
Also includes these new tutorials on the home page and makes some minor tweaks to other tutorials.

[Preview](https://coda-packs-sdk--2444.com.readthedocs.build/en/2444/tutorials/get-started/gitpod/)