### PR TITLE
Attempt to limit/block external collaborators from opening issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Coda Community Forum
+    url: https://community.coda.io/c/15
+    about: Please ask and answer questions here.
+  - name: Coda Support
+    url: https://help.coda.io/
+    about: Coda's support site.
+  - name: Coda Security Bug Bounty
+    url: https://hackerone.com/coda_bbp
+    about: Please report security issues here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Coda Community Forum
-    url: https://community.coda.io/c/15
-    about: Please ask and answer questions here.
-  - name: Coda Support
-    url: https://help.coda.io/
-    about: Coda's support site.
-  - name: Coda Security Bug Bounty
-    url: https://hackerone.com/coda_bbp
-    about: Please report security issues here.
+  - name: Coda Packs SDK support
+    url: https://coda.io/packs/build/latest/support/
+    about: Please ask and answer all questions here rather than opening issues in this repo.


### PR DESCRIPTION
Instead, forward users to our forum, help center, and bug bounty locations where we can help them.

Not sure if this will completely work, but giving it a try.

PTAL @ekoleda-codaio @coda/packs 