### PR TITLE
Add beta warning to Cards docs and samples

### DIFF
--- a/dist/documentation/types.d.ts
+++ b/dist/documentation/types.d.ts
@@ -27,6 +27,7 @@ export interface Example {
     linkData: LinkData;
     contentFile: string;
     exampleSnippets: ExampleSnippet[];
+    status?: ExampleStatus;
 }
 export interface CompiledExample {
     name: string;
@@ -38,6 +39,7 @@ export interface CompiledExample {
     learnMoreLink?: string;
     content: string;
     exampleSnippets: CompiledExampleSnippet[];
+    status?: ExampleStatus;
 }
 export interface LinkData {
     type: UrlType;
@@ -51,4 +53,7 @@ export declare enum UrlType {
 export declare enum ExampleCategory {
     Topic = "Topic",
     Full = "Full"
+}
+export declare enum ExampleStatus {
+    Beta = "Beta"
 }

--- a/dist/documentation/types.js
+++ b/dist/documentation/types.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ExampleCategory = exports.UrlType = void 0;
+exports.ExampleStatus = exports.ExampleCategory = exports.UrlType = void 0;
 var UrlType;
 (function (UrlType) {
     UrlType["SamplePage"] = "SamplePage";
@@ -12,3 +12,7 @@ var ExampleCategory;
     ExampleCategory["Topic"] = "Topic";
     ExampleCategory["Full"] = "Full";
 })(ExampleCategory = exports.ExampleCategory || (exports.ExampleCategory = {}));
+var ExampleStatus;
+(function (ExampleStatus) {
+    ExampleStatus["Beta"] = "Beta";
+})(ExampleStatus = exports.ExampleStatus || (exports.ExampleStatus = {}));

--- a/docs/guides/blocks/cards.md
+++ b/docs/guides/blocks/cards.md
@@ -1,5 +1,5 @@
 ---
-nav: 🚧 Cards
+nav: Cards 🚧
 description: Display structured information as rich cards.
 ---
 

--- a/docs/guides/blocks/cards.md
+++ b/docs/guides/blocks/cards.md
@@ -1,9 +1,12 @@
 ---
-nav: Cards
+nav: 🚧 Cards
 description: Display structured information as rich cards.
 ---
 
 # Preview content with rich cards
+
+!!! warning "Limited beta"
+    This feature is currently only available to a limited group of beta testers.
 
 Pack formulas can return structured data as [objects][data_types_objects], allowing a single call to return a variety of related information. By default these objects are presented as "mentions", shown as chips in the document that you can hover over to get the full set of information.
 

--- a/docs/samples/topic/card.md
+++ b/docs/samples/topic/card.md
@@ -1,5 +1,5 @@
 ---
-nav: Cards
+nav: Cards 🚧
 description: Samples that show how to create cards to preview content.
 icon: material/card-text
 ---
@@ -7,6 +7,8 @@ icon: material/card-text
 # Card samples
 
 A card is an visual way to display key information about an item, typically represented by a URL in an external application.
+
+🚧 This feature is currently only available to a limited group of beta testers.
 
 
 [Learn More](../../../guides/blocks/cards){ .md-button }

--- a/documentation/example_page_template.md
+++ b/documentation/example_page_template.md
@@ -1,5 +1,5 @@
 ---
-nav: {{name}}
+nav: {{name}}{{#if (isBeta this)}} 🚧{{/if}}
 description: {{description}}
 {{#if icon}}icon: {{icon}}{{/if}}
 ---

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -755,9 +755,10 @@
       "type": "SdkReferencePath",
       "url": "/guides/blocks/cards"
     },
+    "status": "Beta",
     "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/cards",
     "learnMoreLink": "/guides/blocks/cards",
-    "content": "A card is an visual way to display key information about an item, typically represented by a URL in an external application.",
+    "content": "A card is an visual way to display key information about an item, typically represented by a URL in an external application.\n\n🚧 This feature is currently only available to a limited group of beta testers.",
     "exampleSnippets": [
       {
         "name": "Template",

--- a/documentation/samples/packs/card/README.md
+++ b/documentation/samples/packs/card/README.md
@@ -1,1 +1,3 @@
 A card is an visual way to display key information about an item, typically represented by a URL in an external application.
+
+🚧 This feature is currently only available to a limited group of beta testers.

--- a/documentation/scripts/documentation_compiler.ts
+++ b/documentation/scripts/documentation_compiler.ts
@@ -3,6 +3,7 @@ import type {CompiledExample} from '../types';
 import type {CompiledExampleSnippet} from '../types';
 import type {Example} from '../types';
 import {ExampleCategory} from '../types';
+import {ExampleStatus} from '../types';
 import {Examples} from './documentation_config';
 import * as Handlebars from 'handlebars';
 import {Snippets} from './documentation_config';
@@ -73,6 +74,7 @@ function compileExamples() {
       category: example.category,
       triggerTokens: example.triggerTokens,
       linkData: example.linkData,
+      status: example.status,
       exampleFooterLink,
       learnMoreLink,
       content,
@@ -190,6 +192,10 @@ Handlebars.registerHelper('indent', (content, numSpaces) => {
 
 Handlebars.registerHelper('isTopic', (example: CompiledExample) => {
   return example.category === ExampleCategory.Topic;
+});
+
+Handlebars.registerHelper('isBeta', (example: CompiledExample) => {
+  return example.status === ExampleStatus.Beta;
 });
 
 Handlebars.registerHelper('pageTitle', (example: CompiledExample) => {

--- a/documentation/scripts/documentation_config.ts
+++ b/documentation/scripts/documentation_config.ts
@@ -1,6 +1,7 @@
 import type {AutocompleteSnippet} from '../types';
 import type {Example} from '../types';
 import {ExampleCategory} from '../types';
+import {ExampleStatus} from '../types';
 import {UrlType} from '../types';
 
 export const Snippets: AutocompleteSnippet[] = [
@@ -920,6 +921,7 @@ export const Examples: Example[] = [
       type: UrlType.SdkReferencePath,
       url: '/guides/blocks/cards',
     },
+    status: ExampleStatus.Beta,
     exampleSnippets: [
       {
         name: 'Template',

--- a/documentation/types.ts
+++ b/documentation/types.ts
@@ -32,6 +32,7 @@ export interface Example {
   linkData: LinkData;
   contentFile: string;
   exampleSnippets: ExampleSnippet[];
+  status?: ExampleStatus;
 }
 
 export interface CompiledExample {
@@ -44,6 +45,7 @@ export interface CompiledExample {
   learnMoreLink?: string;
   content: string;
   exampleSnippets: CompiledExampleSnippet[];
+  status?: ExampleStatus;
 }
 
 export interface LinkData {
@@ -60,4 +62,8 @@ export enum UrlType {
 export enum ExampleCategory {
   Topic = 'Topic',
   Full = 'Full',
+}
+
+export enum ExampleStatus {
+  Beta = 'Beta',
 }


### PR DESCRIPTION
Given that cards will be in beta for a while longer, add clarification to the documentation. Adds an "under construction" icon in the nav and a warning on the pages.

Preview: [Guide](https://coda-packs-sdk--2453.com.readthedocs.build/en/2453/guides/blocks/cards/), [Samples](https://coda-packs-sdk--2453.com.readthedocs.build/en/2453/samples/topic/card/) 