### PR TITLE
Add option to pass API token as CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Added
+
+- Added an `--apiToken` argument to the `clone`, `create`, `link`, `release`, and `upload` CLI commands. This makes it easier to use the CLI in a CI/CD environment where the API token is passed as an environment variable (GitHub Actions, etc).
+
 ### Changed
 
 - Updated `PrecannedDateRange` to match the date range picker in the Coda UI: added `Last90Days`, `Last180Days`, `Last365Days`, `Next90Days`, `Next180Days`, `Next365Days`, `Last7AndNext7Days`, `Last30AndNext30Days`, deprecated `Last3Months`, `Last6Months`, `Next3Months`, and `Next6Months`, and removed `ThisWeekStart`, `ThisMonthStart`, and `ThisYearStart`, which never actually worked.

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -1,12 +1,12 @@
 import type {ArgumentsCamelCase} from 'yargs';
 import type {Client} from '../helpers/external-api/coda';
+import {assertApiToken} from './helpers';
+import {assertPackIdOrUrl} from './helpers';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import fs from 'fs-extra';
-import {getApiKey} from './config_storage';
 import {handleInit} from './init';
 import {isResponseError} from '../helpers/external-api/coda';
-import {parsePackIdOrUrl} from './link';
 import path from 'path';
 import {print} from '../testing/helpers';
 import {printAndExit} from '../testing/helpers';
@@ -21,19 +21,9 @@ interface CloneArgs {
 
 export async function handleClone({packIdOrUrl, codaApiEndpoint, apiToken}: ArgumentsCamelCase<CloneArgs>) {
   const manifestDir = process.cwd();
-  const packId = parsePackIdOrUrl(packIdOrUrl);
-  if (!packId) {
-    return printAndExit(`Not a valid pack ID or URL: ${packIdOrUrl}`);
-  }
-
+  const packId = assertPackIdOrUrl(packIdOrUrl);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
-
-  if (!apiToken) {
-    apiToken = getApiKey(codaApiEndpoint);
-    if (!apiToken) {
-      return printAndExit('Missing API token. Please run `coda register` to register one.');
-    }
-  }
+  apiToken = assertApiToken(codaApiEndpoint, apiToken);
 
   const codeAlreadyExists = fs.existsSync(path.join(manifestDir, 'pack.ts'));
   if (codeAlreadyExists) {

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -16,9 +16,10 @@ import {storePackId} from './config_storage';
 interface CloneArgs {
   packIdOrUrl: string;
   codaApiEndpoint: string;
+  apiToken?: string;
 }
 
-export async function handleClone({packIdOrUrl, codaApiEndpoint}: ArgumentsCamelCase<CloneArgs>) {
+export async function handleClone({packIdOrUrl, codaApiEndpoint, apiToken}: ArgumentsCamelCase<CloneArgs>) {
   const manifestDir = process.cwd();
   const packId = parsePackIdOrUrl(packIdOrUrl);
   if (!packId) {
@@ -27,9 +28,11 @@ export async function handleClone({packIdOrUrl, codaApiEndpoint}: ArgumentsCamel
 
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
 
-  const apiKey = getApiKey(codaApiEndpoint);
-  if (!apiKey) {
-    return printAndExit('Missing API token. Please run `coda register <apiKey>` to register one.');
+  if (!apiToken) {
+    apiToken = getApiKey(codaApiEndpoint);
+    if (!apiToken) {
+      return printAndExit('Missing API token. Please run `coda register` to register one.');
+    }
   }
 
   const codeAlreadyExists = fs.existsSync(path.join(manifestDir, 'pack.ts'));
@@ -42,7 +45,7 @@ export async function handleClone({packIdOrUrl, codaApiEndpoint}: ArgumentsCamel
     }
   }
 
-  const client = createCodaClient(apiKey, formattedEndpoint);
+  const client = createCodaClient(apiToken, formattedEndpoint);
 
   let packVersion: string | null;
   try {

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -85,6 +85,11 @@ if (require.main === module) {
       command: 'clone <packIdOrUrl>',
       describe: 'Clone an existing Pack that was created using Pack Studio',
       builder: {
+        apiToken: {
+          string: true,
+          alias: 't',
+          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+        },
         codaApiEndpoint: {
           string: true,
           hidden: true,
@@ -151,11 +156,6 @@ if (require.main === module) {
           alias: 'n',
           describe: 'Notes about the contents of this Pack version',
         },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
         intermediateOutputDirectory: {
           string: true,
           alias: 'o',
@@ -165,6 +165,16 @@ if (require.main === module) {
           string: true,
           default: TimerShimStrategy.None,
           desc: 'Options: none, error, fake.',
+        },
+        apiToken: {
+          string: true,
+          alias: 't',
+          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+        },
+        codaApiEndpoint: {
+          string: true,
+          hidden: true,
+          default: DEFAULT_API_ENDPOINT,
         },
       },
       handler: handleUpload,
@@ -188,6 +198,11 @@ if (require.main === module) {
           alias: 'w',
           describe: 'The workspace ID, or workspace URL that you want your Pack to be created under.',
         },
+        apiToken: {
+          string: true,
+          alias: 't',
+          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+        },
         codaApiEndpoint: {
           string: true,
           hidden: true,
@@ -200,6 +215,11 @@ if (require.main === module) {
       command: 'link <manifestDir> <packIdOrUrl>',
       describe: "Link to a pre-existing Pack ID on Coda's servers",
       builder: {
+        apiToken: {
+          string: true,
+          alias: 't',
+          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+        },
         codaApiEndpoint: {
           string: true,
           hidden: true,
@@ -232,6 +252,11 @@ if (require.main === module) {
           alias: 'n',
           describe: 'Notes about the contents of this Pack release',
           demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
+        },
+        apiToken: {
+          string: true,
+          alias: 't',
+          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
         },
         codaApiEndpoint: {
           string: true,

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -20,6 +20,18 @@ import {handleWhoami} from './whoami';
 import {tryGetIvm} from '../testing/ivm_wrapper';
 import yargs from 'yargs';
 
+const ApiTokenArg = {
+  string: true,
+  alias: 't',
+  desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+};
+
+const CodaApiEndpointArg = {
+  string: true,
+  hidden: true,
+  default: DEFAULT_API_ENDPOINT,
+}
+
 if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   void yargs
@@ -85,16 +97,8 @@ if (require.main === module) {
       command: 'clone <packIdOrUrl>',
       describe: 'Clone an existing Pack that was created using Pack Studio',
       builder: {
-        apiToken: {
-          string: true,
-          alias: 't',
-          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-        },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        apiToken: ApiTokenArg,
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleClone,
     })
@@ -102,11 +106,7 @@ if (require.main === module) {
       command: 'register [apiToken]',
       describe: 'Register API token to publish a Pack',
       builder: {
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleRegister,
     })
@@ -114,11 +114,7 @@ if (require.main === module) {
       command: 'whoami [apiToken]',
       describe: 'Looks up information about the API token that is registered in this environment',
       builder: {
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleWhoami,
     })
@@ -166,16 +162,8 @@ if (require.main === module) {
           default: TimerShimStrategy.None,
           desc: 'Options: none, error, fake.',
         },
-        apiToken: {
-          string: true,
-          alias: 't',
-          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-        },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        apiToken: ApiTokenArg,
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleUpload,
     })
@@ -198,16 +186,8 @@ if (require.main === module) {
           alias: 'w',
           describe: 'The workspace ID, or workspace URL that you want your Pack to be created under.',
         },
-        apiToken: {
-          string: true,
-          alias: 't',
-          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-        },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        apiToken: ApiTokenArg,
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleCreate,
     })
@@ -215,16 +195,8 @@ if (require.main === module) {
       command: 'link <manifestDir> <packIdOrUrl>',
       describe: "Link to a pre-existing Pack ID on Coda's servers",
       builder: {
-        apiToken: {
-          string: true,
-          alias: 't',
-          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-        },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        apiToken: ApiTokenArg,
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleLink,
     })
@@ -253,16 +225,8 @@ if (require.main === module) {
           describe: 'Notes about the contents of this Pack release',
           demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
         },
-        apiToken: {
-          string: true,
-          alias: 't',
-          desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-        },
-        codaApiEndpoint: {
-          string: true,
-          hidden: true,
-          default: DEFAULT_API_ENDPOINT,
-        },
+        apiToken: ApiTokenArg,
+        codaApiEndpoint: CodaApiEndpointArg,
       },
       handler: handleRelease,
     })

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -1,11 +1,11 @@
 import type {ArgumentsCamelCase} from 'yargs';
 import {PACK_ID_FILE_NAME} from './config_storage';
+import {assertApiToken} from './helpers';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
 import {formatResponseError} from './errors';
 import fs from 'fs';
-import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {isResponseError} from '../helpers/external-api/coda';
 import * as path from 'path';
@@ -41,14 +41,7 @@ export async function createPack(
 ) {
   const manifestDir = path.dirname(manifestFile);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
-  // TODO(alan): we probably want to redirect them to the `coda register`
-  // flow if they don't have a Coda API token.
-  if (!apiToken) {
-    apiToken = getApiKey(codaApiEndpoint);
-    if (!apiToken) {
-      return printAndExit('Missing API token. Please run `coda register` to register one.');
-    }
-  }
+  apiToken = assertApiToken(codaApiEndpoint, apiToken);
 
   if (!fs.existsSync(manifestFile)) {
     return printAndExit(`${manifestFile} is not a valid pack definition file. Check the filename and try again.`);

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -1,7 +1,8 @@
 import type {ArgumentsCamelCase} from 'yargs';
+import {assertApiToken} from './helpers';
+import {assertPackIdOrUrl} from './helpers';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
-import {getApiKey} from './config_storage';
 import {getPackId} from './config_storage';
 import {isResponseError} from '../helpers/external-api/coda';
 import {printAndExit} from '../testing/helpers';
@@ -22,21 +23,13 @@ interface LinkArgs {
 }
 
 export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl, apiToken}: ArgumentsCamelCase<LinkArgs>) {
-  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
   // TODO(dweitzman): Add a download command to fetch the latest code from
   // the server and ask people if they want to download after linking.
-  if (!apiToken) {
-    apiToken = getApiKey(codaApiEndpoint);
-    if (!apiToken) {
-      return printAndExit('Missing API token. Please run `coda register` to register one.');
-    }
-  }
+  const formattedEndpoint = formatEndpoint(codaApiEndpoint);
+  apiToken = assertApiToken(codaApiEndpoint, apiToken);
+  const packId = assertPackIdOrUrl(packIdOrUrl);
 
   const codaClient = createCodaClient(apiToken, formattedEndpoint);
-  const packId = parsePackIdOrUrl(packIdOrUrl);
-  if (packId === null) {
-    return printAndExit(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
-  }
 
   // Verify that the user has edit access to the pack. Currently only editors
   // can call getPack().

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -18,18 +18,21 @@ interface LinkArgs {
   manifestDir: string;
   codaApiEndpoint: string;
   packIdOrUrl: string;
+  apiToken?: string;
 }
 
-export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl}: ArgumentsCamelCase<LinkArgs>) {
+export async function handleLink({manifestDir, codaApiEndpoint, packIdOrUrl, apiToken}: ArgumentsCamelCase<LinkArgs>) {
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
   // TODO(dweitzman): Add a download command to fetch the latest code from
   // the server and ask people if they want to download after linking.
-  const apiKey = getApiKey(codaApiEndpoint);
-  if (!apiKey) {
-    return printAndExit('Missing API token. Please run `coda register` to register one.');
+  if (!apiToken) {
+    apiToken = getApiKey(codaApiEndpoint);
+    if (!apiToken) {
+      return printAndExit('Missing API token. Please run `coda register` to register one.');
+    }
   }
 
-  const codaClient = createCodaClient(apiKey, formattedEndpoint);
+  const codaClient = createCodaClient(apiToken, formattedEndpoint);
   const packId = parsePackIdOrUrl(packIdOrUrl);
   if (packId === null) {
     return printAndExit(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -1,13 +1,13 @@
 import type {ArgumentsCamelCase} from 'yargs';
 import type {BasicPackDefinition} from '..';
 import type {PackVersionDefinition} from '..';
+import {assertApiToken} from './helpers';
+import {assertPackId} from './helpers';
 import {build} from './build';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {formatError} from './errors';
 import {formatResponseError} from './errors';
-import {getApiKey} from './config_storage';
-import {getPackId} from './config_storage';
 import {importManifest} from './helpers';
 import {isResponseError} from '../helpers/external-api/coda';
 import * as path from 'path';
@@ -32,19 +32,8 @@ export async function handleRelease({
 }: ArgumentsCamelCase<ReleaseArgs>) {
   const manifestDir = path.dirname(manifestFile);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
-
-  if (!apiToken) {
-    apiToken = getApiKey(codaApiEndpoint);
-    if (!apiToken) {
-      return printAndExit('Missing API token. Please run `coda register` to register one.');
-    }
-  }
-  const packId = getPackId(manifestDir, codaApiEndpoint);
-  if (!packId) {
-    return printAndExit(
-      `Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`,
-    );
-  }
+  apiToken = assertApiToken(codaApiEndpoint, apiToken);
+  const packId = assertPackId(manifestDir, codaApiEndpoint);
 
   const codaClient = createCodaClient(apiToken, formattedEndpoint);
 

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -20,6 +20,7 @@ interface ReleaseArgs {
   packVersion?: string;
   codaApiEndpoint: string;
   notes: string;
+  apiToken?: string;
 }
 
 export async function handleRelease({
@@ -27,15 +28,17 @@ export async function handleRelease({
   packVersion: explicitPackVersion,
   codaApiEndpoint,
   notes,
+  apiToken,
 }: ArgumentsCamelCase<ReleaseArgs>) {
   const manifestDir = path.dirname(manifestFile);
-  const apiKey = getApiKey(codaApiEndpoint);
   const formattedEndpoint = formatEndpoint(codaApiEndpoint);
 
-  if (!apiKey) {
-    return printAndExit('Missing API token. Please run `coda register` to register one.');
+  if (!apiToken) {
+    apiToken = getApiKey(codaApiEndpoint);
+    if (!apiToken) {
+      return printAndExit('Missing API token. Please run `coda register` to register one.');
+    }
   }
-
   const packId = getPackId(manifestDir, codaApiEndpoint);
   if (!packId) {
     return printAndExit(
@@ -43,7 +46,7 @@ export async function handleRelease({
     );
   }
 
-  const codaClient = createCodaClient(apiKey, formattedEndpoint);
+  const codaClient = createCodaClient(apiToken, formattedEndpoint);
 
   let packVersion = explicitPackVersion;
   if (!packVersion) {

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -35,6 +35,7 @@ interface UploadArgs {
   notes?: string;
   intermediateOutputDirectory: string;
   timerStrategy: TimerShimStrategy;
+  apiToken?: string;
 }
 
 function cleanup(intermediateOutputDirectory: string, logger: Logger) {
@@ -54,6 +55,7 @@ export async function handleUpload({
   codaApiEndpoint,
   notes,
   timerStrategy,
+  apiToken,
 }: ArgumentsCamelCase<UploadArgs>) {
   const logger = console;
   function printAndExit(message: string): never {
@@ -88,12 +90,14 @@ export async function handleUpload({
   const packageJson = await import(isTestCommand() ? '../package.json' : '../../package.json');
   const codaPacksSDKVersion = packageJson.version as string;
 
-  const apiKey = getApiKey(codaApiEndpoint);
-  if (!apiKey) {
-    printAndExit('Missing API token. Please run `coda register` to register one.');
+  if (!apiToken) {
+    apiToken = getApiKey(codaApiEndpoint);
+    if (!apiToken) {
+      return printAndExit('Missing API token. Please run `coda register` to register one.');
+    }
   }
 
-  const client = createCodaClient(apiKey, formattedEndpoint);
+  const client = createCodaClient(apiToken, formattedEndpoint);
 
   const packId = getPackId(manifestDir, codaApiEndpoint);
   if (!packId) {

--- a/dist/cli/clone.d.ts
+++ b/dist/cli/clone.d.ts
@@ -2,6 +2,7 @@ import type { ArgumentsCamelCase } from 'yargs';
 interface CloneArgs {
     packIdOrUrl: string;
     codaApiEndpoint: string;
+    apiToken?: string;
 }
-export declare function handleClone({ packIdOrUrl, codaApiEndpoint }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
+export declare function handleClone({ packIdOrUrl, codaApiEndpoint, apiToken }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -6,44 +6,36 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleClone = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("./helpers");
 const fs_extra_1 = __importDefault(require("fs-extra"));
-const config_storage_1 = require("./config_storage");
 const init_1 = require("./init");
 const coda_1 = require("../helpers/external-api/coda");
-const link_1 = require("./link");
 const path_1 = __importDefault(require("path"));
-const helpers_3 = require("../testing/helpers");
-const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
-const config_storage_2 = require("./config_storage");
+const helpers_6 = require("../testing/helpers");
+const helpers_7 = require("../testing/helpers");
+const config_storage_1 = require("./config_storage");
 async function handleClone({ packIdOrUrl, codaApiEndpoint, apiToken }) {
     const manifestDir = process.cwd();
-    const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
-    if (!packId) {
-        return (0, helpers_4.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
-    }
-    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    if (!apiToken) {
-        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-        if (!apiToken) {
-            return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
-        }
-    }
+    const packId = (0, helpers_2.assertPackIdOrUrl)(packIdOrUrl);
+    const formattedEndpoint = (0, helpers_4.formatEndpoint)(codaApiEndpoint);
+    apiToken = (0, helpers_1.assertApiToken)(codaApiEndpoint, apiToken);
     const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(manifestDir, 'pack.ts'));
     if (codeAlreadyExists) {
-        const shouldOverwrite = (0, helpers_5.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
+        const shouldOverwrite = (0, helpers_7.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
             yesOrNo: true,
         });
         if (shouldOverwrite.toLocaleLowerCase() !== 'yes') {
-            return (0, helpers_4.printAndExit)('Aborting');
+            return (0, helpers_6.printAndExit)('Aborting');
         }
     }
-    const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
+    const client = (0, helpers_3.createCodaClient)(apiToken, formattedEndpoint);
     let packVersion;
     try {
         packVersion = await getPackLatestVersion(client, packId);
         if (!packVersion) {
-            return (0, helpers_4.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
+            return (0, helpers_6.printAndExit)(`No built versions found for pack ${packId}. Only built versions can be cloned.`);
         }
     }
     catch (err) {
@@ -59,20 +51,20 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint, apiToken }) {
         throw err;
     }
     if (!sourceCode) {
-        (0, helpers_3.print)(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
-        const shouldInitializeWithoutDownload = (0, helpers_5.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?', { yesOrNo: true });
+        (0, helpers_5.print)(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
+        const shouldInitializeWithoutDownload = (0, helpers_7.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?', { yesOrNo: true });
         if (shouldInitializeWithoutDownload !== 'yes') {
             return process.exit(1);
         }
         await (0, init_1.handleInit)();
-        (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
+        (0, config_storage_1.storePackId)(manifestDir, packId, codaApiEndpoint);
         return;
     }
-    (0, helpers_3.print)(`Fetched source at version ${packVersion}`);
+    (0, helpers_5.print)(`Fetched source at version ${packVersion}`);
     await (0, init_1.handleInit)();
-    (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
+    (0, config_storage_1.storePackId)(manifestDir, packId, codaApiEndpoint);
     fs_extra_1.default.writeFileSync(path_1.default.join(manifestDir, 'pack.ts'), sourceCode);
-    (0, helpers_4.printAndExit)("Successfully updated pack.ts with the Pack's code!", 0);
+    (0, helpers_6.printAndExit)("Successfully updated pack.ts with the Pack's code!", 0);
 }
 exports.handleClone = handleClone;
 function maybeHandleClientError(err) {
@@ -81,7 +73,7 @@ function maybeHandleClientError(err) {
             case 401:
             case 403:
             case 404:
-                return (0, helpers_4.printAndExit)("You don't have permission to edit this pack.");
+                return (0, helpers_6.printAndExit)("You don't have permission to edit this pack.");
         }
     }
 }
@@ -106,7 +98,7 @@ async function getPackSource(client, packId, version) {
         },
     });
     if (response.status >= 400) {
-        return (0, helpers_4.printAndExit)(`Error while fetching pack source code: ${response.statusText}`);
+        return (0, helpers_6.printAndExit)(`Error while fetching pack source code: ${response.statusText}`);
     }
     return response.text();
 }

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -16,16 +16,18 @@ const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
 const config_storage_2 = require("./config_storage");
-async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
+async function handleClone({ packIdOrUrl, codaApiEndpoint, apiToken }) {
     const manifestDir = process.cwd();
     const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
     if (!packId) {
         return (0, helpers_4.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
     }
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-    if (!apiKey) {
-        return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register <apiKey>` to register one.');
+    if (!apiToken) {
+        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+        if (!apiToken) {
+            return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
+        }
     }
     const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(manifestDir, 'pack.ts'));
     if (codeAlreadyExists) {
@@ -36,7 +38,7 @@ async function handleClone({ packIdOrUrl, codaApiEndpoint }) {
             return (0, helpers_4.printAndExit)('Aborting');
         }
     }
-    const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     let packVersion;
     try {
         packVersion = await getPackLatestVersion(client, packId);

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -87,6 +87,11 @@ if (require.main === module) {
         command: 'clone <packIdOrUrl>',
         describe: 'Clone an existing Pack that was created using Pack Studio',
         builder: {
+            apiToken: {
+                string: true,
+                alias: 't',
+                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+            },
             codaApiEndpoint: {
                 string: true,
                 hidden: true,
@@ -153,11 +158,6 @@ if (require.main === module) {
                 alias: 'n',
                 describe: 'Notes about the contents of this Pack version',
             },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
             intermediateOutputDirectory: {
                 string: true,
                 alias: 'o',
@@ -167,6 +167,16 @@ if (require.main === module) {
                 string: true,
                 default: compile_1.TimerShimStrategy.None,
                 desc: 'Options: none, error, fake.',
+            },
+            apiToken: {
+                string: true,
+                alias: 't',
+                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+            },
+            codaApiEndpoint: {
+                string: true,
+                hidden: true,
+                default: config_storage_1.DEFAULT_API_ENDPOINT,
             },
         },
         handler: upload_1.handleUpload,
@@ -190,6 +200,11 @@ if (require.main === module) {
                 alias: 'w',
                 describe: 'The workspace ID, or workspace URL that you want your Pack to be created under.',
             },
+            apiToken: {
+                string: true,
+                alias: 't',
+                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+            },
             codaApiEndpoint: {
                 string: true,
                 hidden: true,
@@ -202,6 +217,11 @@ if (require.main === module) {
         command: 'link <manifestDir> <packIdOrUrl>',
         describe: "Link to a pre-existing Pack ID on Coda's servers",
         builder: {
+            apiToken: {
+                string: true,
+                alias: 't',
+                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+            },
             codaApiEndpoint: {
                 string: true,
                 hidden: true,
@@ -233,6 +253,11 @@ if (require.main === module) {
                 alias: 'n',
                 describe: 'Notes about the contents of this Pack release',
                 demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
+            },
+            apiToken: {
+                string: true,
+                alias: 't',
+                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
             },
             codaApiEndpoint: {
                 string: true,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -23,6 +23,16 @@ const validate_1 = require("./validate");
 const whoami_1 = require("./whoami");
 const ivm_wrapper_1 = require("../testing/ivm_wrapper");
 const yargs_1 = __importDefault(require("yargs"));
+const ApiTokenArg = {
+    string: true,
+    alias: 't',
+    desc: 'API token to use for the operation. Use the `register` command to define a default token.',
+};
+const CodaApiEndpointArg = {
+    string: true,
+    hidden: true,
+    default: config_storage_1.DEFAULT_API_ENDPOINT,
+};
 if (require.main === module) {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     void yargs_1.default
@@ -87,16 +97,8 @@ if (require.main === module) {
         command: 'clone <packIdOrUrl>',
         describe: 'Clone an existing Pack that was created using Pack Studio',
         builder: {
-            apiToken: {
-                string: true,
-                alias: 't',
-                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-            },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            apiToken: ApiTokenArg,
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: clone_1.handleClone,
     })
@@ -104,11 +106,7 @@ if (require.main === module) {
         command: 'register [apiToken]',
         describe: 'Register API token to publish a Pack',
         builder: {
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: register_1.handleRegister,
     })
@@ -116,11 +114,7 @@ if (require.main === module) {
         command: 'whoami [apiToken]',
         describe: 'Looks up information about the API token that is registered in this environment',
         builder: {
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: whoami_1.handleWhoami,
     })
@@ -168,16 +162,8 @@ if (require.main === module) {
                 default: compile_1.TimerShimStrategy.None,
                 desc: 'Options: none, error, fake.',
             },
-            apiToken: {
-                string: true,
-                alias: 't',
-                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-            },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            apiToken: ApiTokenArg,
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: upload_1.handleUpload,
     })
@@ -200,16 +186,8 @@ if (require.main === module) {
                 alias: 'w',
                 describe: 'The workspace ID, or workspace URL that you want your Pack to be created under.',
             },
-            apiToken: {
-                string: true,
-                alias: 't',
-                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-            },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            apiToken: ApiTokenArg,
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: create_1.handleCreate,
     })
@@ -217,16 +195,8 @@ if (require.main === module) {
         command: 'link <manifestDir> <packIdOrUrl>',
         describe: "Link to a pre-existing Pack ID on Coda's servers",
         builder: {
-            apiToken: {
-                string: true,
-                alias: 't',
-                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-            },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            apiToken: ApiTokenArg,
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: link_1.handleLink,
     })
@@ -254,16 +224,8 @@ if (require.main === module) {
                 describe: 'Notes about the contents of this Pack release',
                 demandOption: 'Please provide release notes, which will be shown to Pack users to understand the release.',
             },
-            apiToken: {
-                string: true,
-                alias: 't',
-                desc: 'API token to use for the operation. Use the `register` command to define a default token.',
-            },
-            codaApiEndpoint: {
-                string: true,
-                hidden: true,
-                default: config_storage_1.DEFAULT_API_ENDPOINT,
-            },
+            apiToken: ApiTokenArg,
+            codaApiEndpoint: CodaApiEndpointArg,
         },
         handler: release_1.handleRelease,
     })

--- a/dist/cli/create.d.ts
+++ b/dist/cli/create.d.ts
@@ -5,11 +5,12 @@ interface CreateArgs {
     name?: string;
     description?: string;
     workspace?: string;
+    apiToken?: string;
 }
-export declare function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, }: ArgumentsCamelCase<CreateArgs>): Promise<void>;
+export declare function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, apiToken, }: ArgumentsCamelCase<CreateArgs>): Promise<void>;
 export declare function createPack(manifestFile: string, codaApiEndpoint: string, { name, description, workspace }: {
     name?: string;
     description?: string;
     workspace?: string;
-}): Promise<never>;
+}, apiToken?: string): Promise<never>;
 export {};

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -30,15 +30,15 @@ exports.createPack = exports.handleCreate = void 0;
 const config_storage_1 = require("./config_storage");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const helpers_3 = require("./helpers");
 const errors_1 = require("./errors");
 const errors_2 = require("./errors");
 const fs_1 = __importDefault(require("fs"));
 const config_storage_2 = require("./config_storage");
-const config_storage_3 = require("./config_storage");
 const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
-const helpers_3 = require("../testing/helpers");
-const config_storage_4 = require("./config_storage");
+const helpers_4 = require("../testing/helpers");
+const config_storage_3 = require("./config_storage");
 const errors_3 = require("./errors");
 async function handleCreate({ manifestFile, codaApiEndpoint, name, description, workspace, apiToken, }) {
     await createPack(manifestFile, codaApiEndpoint, { name, description, workspace }, apiToken);
@@ -46,37 +46,30 @@ async function handleCreate({ manifestFile, codaApiEndpoint, name, description, 
 exports.handleCreate = handleCreate;
 async function createPack(manifestFile, codaApiEndpoint, { name, description, workspace }, apiToken) {
     const manifestDir = path.dirname(manifestFile);
-    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    // TODO(alan): we probably want to redirect them to the `coda register`
-    // flow if they don't have a Coda API token.
-    if (!apiToken) {
-        apiToken = (0, config_storage_2.getApiKey)(codaApiEndpoint);
-        if (!apiToken) {
-            return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
-        }
-    }
+    const formattedEndpoint = (0, helpers_3.formatEndpoint)(codaApiEndpoint);
+    apiToken = (0, helpers_1.assertApiToken)(codaApiEndpoint, apiToken);
     if (!fs_1.default.existsSync(manifestFile)) {
-        return (0, helpers_3.printAndExit)(`${manifestFile} is not a valid pack definition file. Check the filename and try again.`);
+        return (0, helpers_4.printAndExit)(`${manifestFile} is not a valid pack definition file. Check the filename and try again.`);
     }
-    const existingPackId = (0, config_storage_3.getPackId)(manifestDir, codaApiEndpoint);
+    const existingPackId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (existingPackId) {
-        return (0, helpers_3.printAndExit)(`This directory has already been registered on ${codaApiEndpoint} with pack id ${existingPackId}.\n` +
+        return (0, helpers_4.printAndExit)(`This directory has already been registered on ${codaApiEndpoint} with pack id ${existingPackId}.\n` +
             `If you're trying to create a new pack from a different manifest, you should put the new manifest in a different directory.\n` +
             `If you're intentionally trying to create a new pack, you can delete ${config_storage_1.PACK_ID_FILE_NAME} in this directory and try again.`);
     }
-    const codaClient = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
+    const codaClient = (0, helpers_2.createCodaClient)(apiToken, formattedEndpoint);
     try {
         const response = await codaClient.createPack({}, { name, description, workspaceId: parseWorkspace(workspace) });
         const packId = response.packId;
-        (0, config_storage_4.storePackId)(manifestDir, packId, codaApiEndpoint);
-        return (0, helpers_3.printAndExit)(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
+        (0, config_storage_3.storePackId)(manifestDir, packId, codaApiEndpoint);
+        return (0, helpers_4.printAndExit)(`Pack created successfully! You can manage pack settings at ${codaApiEndpoint}/p/${packId}`, 0);
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {
-            return (0, helpers_3.printAndExit)(`Unable to create your pack, received error: ${await (0, errors_2.formatResponseError)(err)}`);
+            return (0, helpers_4.printAndExit)(`Unable to create your pack, received error: ${await (0, errors_2.formatResponseError)(err)}`);
         }
         const errors = [`Unable to create your pack, received error: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
-        return (0, helpers_3.printAndExit)(errors.join('\n'));
+        return (0, helpers_4.printAndExit)(errors.join('\n'));
     }
 }
 exports.createPack = createPack;

--- a/dist/cli/helpers.d.ts
+++ b/dist/cli/helpers.d.ts
@@ -11,3 +11,6 @@ export declare function isTestCommand(): boolean;
 export declare function makeManifestFullPath(manifestPath: string): string;
 export declare function getPackAuth(packDef: BasicPackDefinition): Authentication | undefined;
 export declare function importManifest<T extends BasicPackDefinition = BasicPackDefinition>(bundleFilename: string): Promise<T>;
+export declare function assertApiToken(codaApiEndpoint: string, cliApiToken?: string): string;
+export declare function assertPackId(manifestDir: string, codaApiEndpoint: string): number;
+export declare function assertPackIdOrUrl(packIdOrUrl: string): number;

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -26,10 +26,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.importManifest = exports.getPackAuth = exports.makeManifestFullPath = exports.isTestCommand = exports.formatEndpoint = exports.createCodaClient = exports.spawnProcess = void 0;
+exports.assertPackIdOrUrl = exports.assertPackId = exports.assertApiToken = exports.importManifest = exports.getPackAuth = exports.makeManifestFullPath = exports.isTestCommand = exports.formatEndpoint = exports.createCodaClient = exports.spawnProcess = void 0;
 const coda_1 = require("../helpers/external-api/coda");
+const config_storage_1 = require("./config_storage");
+const config_storage_2 = require("./config_storage");
+const link_1 = require("./link");
 const path_1 = __importDefault(require("path"));
 const helpers_1 = require("../testing/helpers");
+const helpers_2 = require("../testing/helpers");
 const child_process_1 = require("child_process");
 function spawnProcess(command, { stdio = 'inherit' } = {}) {
     return (0, child_process_1.spawnSync)(command, {
@@ -76,3 +80,30 @@ async function importManifest(bundleFilename) {
     return module.pack || module.manifest;
 }
 exports.importManifest = importManifest;
+function assertApiToken(codaApiEndpoint, cliApiToken) {
+    if (cliApiToken) {
+        return cliApiToken;
+    }
+    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+    if (!apiKey) {
+        return (0, helpers_2.printAndExit)('Missing API token. Please run `coda register` to register one.');
+    }
+    return apiKey;
+}
+exports.assertApiToken = assertApiToken;
+function assertPackId(manifestDir, codaApiEndpoint) {
+    const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
+    if (!packId) {
+        return (0, helpers_2.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
+    }
+    return packId;
+}
+exports.assertPackId = assertPackId;
+function assertPackIdOrUrl(packIdOrUrl) {
+    const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
+    if (!packId) {
+        return (0, helpers_2.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
+    }
+    return packId;
+}
+exports.assertPackIdOrUrl = assertPackIdOrUrl;

--- a/dist/cli/link.d.ts
+++ b/dist/cli/link.d.ts
@@ -3,7 +3,8 @@ interface LinkArgs {
     manifestDir: string;
     codaApiEndpoint: string;
     packIdOrUrl: string;
+    apiToken?: string;
 }
-export declare function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
+export declare function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl, apiToken }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
 export declare function parsePackIdOrUrl(packIdOrUrl: string): number | null;
 export {};

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -3,32 +3,25 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parsePackIdOrUrl = exports.handleLink = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("./helpers");
 const config_storage_1 = require("./config_storage");
-const config_storage_2 = require("./config_storage");
 const coda_1 = require("../helpers/external-api/coda");
-const helpers_3 = require("../testing/helpers");
-const helpers_4 = require("../testing/helpers");
-const config_storage_3 = require("./config_storage");
+const helpers_5 = require("../testing/helpers");
+const helpers_6 = require("../testing/helpers");
+const config_storage_2 = require("./config_storage");
 // Regular expression that matches coda.io/p/<packId> or <packId>.
 const PackEditUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/([0-9]+)(:?[^0-9].*)?$/;
 const PackGalleryUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/packs\/[^/]*-([0-9]+)$/;
 const PackPlainIdRegex = /^([0-9]+)$/;
 const PackRegexes = [PackEditUrlRegex, PackGalleryUrlRegex, PackPlainIdRegex];
 async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl, apiToken }) {
-    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     // TODO(dweitzman): Add a download command to fetch the latest code from
     // the server and ask people if they want to download after linking.
-    if (!apiToken) {
-        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-        if (!apiToken) {
-            return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
-        }
-    }
-    const codaClient = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
-    const packId = parsePackIdOrUrl(packIdOrUrl);
-    if (packId === null) {
-        return (0, helpers_3.printAndExit)(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);
-    }
+    const formattedEndpoint = (0, helpers_4.formatEndpoint)(codaApiEndpoint);
+    apiToken = (0, helpers_1.assertApiToken)(codaApiEndpoint, apiToken);
+    const packId = (0, helpers_2.assertPackIdOrUrl)(packIdOrUrl);
+    const codaClient = (0, helpers_3.createCodaClient)(apiToken, formattedEndpoint);
     // Verify that the user has edit access to the pack. Currently only editors
     // can call getPack().
     try {
@@ -40,23 +33,23 @@ async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl, apiToken 
                 case 401:
                 case 403:
                 case 404:
-                    return (0, helpers_3.printAndExit)("You don't have permission to edit this pack");
+                    return (0, helpers_5.printAndExit)("You don't have permission to edit this pack");
             }
         }
         throw err;
     }
-    const existingPackId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
+    const existingPackId = (0, config_storage_1.getPackId)(manifestDir, codaApiEndpoint);
     if (existingPackId) {
         if (existingPackId === packId) {
-            return (0, helpers_3.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
+            return (0, helpers_5.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
         }
-        const input = (0, helpers_4.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `, { yesOrNo: true });
+        const input = (0, helpers_6.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `, { yesOrNo: true });
         if (input.toLocaleLowerCase() !== 'yes') {
             return process.exit(1);
         }
     }
-    (0, config_storage_3.storePackId)(manifestDir, packId, codaApiEndpoint);
-    return (0, helpers_3.printAndExit)(`Linked successfully!`, 0);
+    (0, config_storage_2.storePackId)(manifestDir, packId, codaApiEndpoint);
+    return (0, helpers_5.printAndExit)(`Linked successfully!`, 0);
 }
 exports.handleLink = handleLink;
 function parsePackIdOrUrl(packIdOrUrl) {

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -14,15 +14,17 @@ const PackEditUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/([0-9]+)(
 const PackGalleryUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/packs\/[^/]*-([0-9]+)$/;
 const PackPlainIdRegex = /^([0-9]+)$/;
 const PackRegexes = [PackEditUrlRegex, PackGalleryUrlRegex, PackPlainIdRegex];
-async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl }) {
+async function handleLink({ manifestDir, codaApiEndpoint, packIdOrUrl, apiToken }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
     // TODO(dweitzman): Add a download command to fetch the latest code from
     // the server and ask people if they want to download after linking.
-    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-    if (!apiKey) {
-        return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
+    if (!apiToken) {
+        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+        if (!apiToken) {
+            return (0, helpers_3.printAndExit)('Missing API token. Please run `coda register` to register one.');
+        }
     }
-    const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    const codaClient = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     const packId = parsePackIdOrUrl(packIdOrUrl);
     if (packId === null) {
         return (0, helpers_3.printAndExit)(`packIdOrUrl must be a pack ID or URL, not ${packIdOrUrl}`);

--- a/dist/cli/release.d.ts
+++ b/dist/cli/release.d.ts
@@ -4,6 +4,7 @@ interface ReleaseArgs {
     packVersion?: string;
     codaApiEndpoint: string;
     notes: string;
+    apiToken?: string;
 }
-export declare function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }: ArgumentsCamelCase<ReleaseArgs>): Promise<never>;
+export declare function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, apiToken, }: ArgumentsCamelCase<ReleaseArgs>): Promise<never>;
 export {};

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -37,18 +37,20 @@ const path = __importStar(require("path"));
 const helpers_4 = require("../testing/helpers");
 const helpers_5 = require("../testing/helpers");
 const errors_3 = require("./errors");
-async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, }) {
+async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, apiToken, }) {
     const manifestDir = path.dirname(manifestFile);
-    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    if (!apiKey) {
-        return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
+    if (!apiToken) {
+        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+        if (!apiToken) {
+            return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
+        }
     }
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (!packId) {
         return (0, helpers_4.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
     }
-    const codaClient = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    const codaClient = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     let packVersion = explicitPackVersion;
     if (!packVersion) {
         try {

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -24,61 +24,53 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleRelease = void 0;
-const build_1 = require("./build");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const build_1 = require("./build");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("./helpers");
 const errors_1 = require("./errors");
 const errors_2 = require("./errors");
-const config_storage_1 = require("./config_storage");
-const config_storage_2 = require("./config_storage");
-const helpers_3 = require("./helpers");
+const helpers_5 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
 const path = __importStar(require("path"));
-const helpers_4 = require("../testing/helpers");
-const helpers_5 = require("../testing/helpers");
+const helpers_6 = require("../testing/helpers");
+const helpers_7 = require("../testing/helpers");
 const errors_3 = require("./errors");
 async function handleRelease({ manifestFile, packVersion: explicitPackVersion, codaApiEndpoint, notes, apiToken, }) {
     const manifestDir = path.dirname(manifestFile);
-    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
-    if (!apiToken) {
-        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-        if (!apiToken) {
-            return (0, helpers_4.printAndExit)('Missing API token. Please run `coda register` to register one.');
-        }
-    }
-    const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
-    if (!packId) {
-        return (0, helpers_4.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "coda create" first if this is a brand new pack.`);
-    }
-    const codaClient = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
+    const formattedEndpoint = (0, helpers_4.formatEndpoint)(codaApiEndpoint);
+    apiToken = (0, helpers_1.assertApiToken)(codaApiEndpoint, apiToken);
+    const packId = (0, helpers_2.assertPackId)(manifestDir, codaApiEndpoint);
+    const codaClient = (0, helpers_3.createCodaClient)(apiToken, formattedEndpoint);
     let packVersion = explicitPackVersion;
     if (!packVersion) {
         try {
             const bundleFilename = await (0, build_1.build)(manifestFile);
-            const manifest = await (0, helpers_3.importManifest)(bundleFilename);
+            const manifest = await (0, helpers_5.importManifest)(bundleFilename);
             if ('version' in manifest) {
                 packVersion = manifest.version;
             }
         }
         catch (err) {
-            return (0, helpers_4.printAndExit)(`Got an error while building your pack to get the current pack version: ${(0, errors_1.formatError)(err)}`);
+            return (0, helpers_6.printAndExit)(`Got an error while building your pack to get the current pack version: ${(0, errors_1.formatError)(err)}`);
         }
     }
     if (!packVersion) {
         const { items: versions } = await codaClient.listPackVersions(packId, { limit: 1 });
         if (!versions.length) {
-            (0, helpers_4.printAndExit)('No version was found to release for your Pack.');
+            (0, helpers_6.printAndExit)('No version was found to release for your Pack.');
         }
         const [latestPackVersionData] = versions;
         const { packVersion: latestPackVersion } = latestPackVersionData;
-        const shouldReleaseLatestPackVersion = (0, helpers_5.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`, { yesOrNo: true });
+        const shouldReleaseLatestPackVersion = (0, helpers_7.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`, { yesOrNo: true });
         if (shouldReleaseLatestPackVersion !== 'yes') {
             return process.exit(1);
         }
         packVersion = latestPackVersion;
     }
     await handleResponse(codaClient.createPackRelease(packId, {}, { packVersion, releaseNotes: notes }));
-    return (0, helpers_4.printAndExit)('Success!', 0);
+    return (0, helpers_6.printAndExit)('Success!', 0);
 }
 exports.handleRelease = handleRelease;
 async function handleResponse(p) {
@@ -87,9 +79,9 @@ async function handleResponse(p) {
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {
-            return (0, helpers_4.printAndExit)(`Error while creating pack release: ${await (0, errors_2.formatResponseError)(err)}`);
+            return (0, helpers_6.printAndExit)(`Error while creating pack release: ${await (0, errors_2.formatResponseError)(err)}`);
         }
         const errors = [`Unexpected error while creating release: ${(0, errors_1.formatError)(err)}`, (0, errors_3.tryParseSystemError)(err)];
-        return (0, helpers_4.printAndExit)(errors.join('\n'));
+        return (0, helpers_6.printAndExit)(errors.join('\n'));
     }
 }

--- a/dist/cli/upload.d.ts
+++ b/dist/cli/upload.d.ts
@@ -6,6 +6,7 @@ interface UploadArgs {
     notes?: string;
     intermediateOutputDirectory: string;
     timerStrategy: TimerShimStrategy;
+    apiToken?: string;
 }
-export declare function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, }: ArgumentsCamelCase<UploadArgs>): Promise<undefined>;
+export declare function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, }: ArgumentsCamelCase<UploadArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -28,24 +28,24 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleUpload = void 0;
 const v1_1 = require("../helpers/external-api/v1");
+const helpers_1 = require("./helpers");
+const helpers_2 = require("./helpers");
 const compile_1 = require("../testing/compile");
 const metadata_1 = require("../helpers/metadata");
 const crypto_1 = require("../helpers/crypto");
-const helpers_1 = require("./helpers");
-const helpers_2 = require("./helpers");
+const helpers_3 = require("./helpers");
+const helpers_4 = require("./helpers");
 const errors_1 = require("./errors");
 const errors_2 = require("./errors");
 const fs_extra_1 = __importDefault(require("fs-extra"));
-const config_storage_1 = require("./config_storage");
-const config_storage_2 = require("./config_storage");
-const helpers_3 = require("./helpers");
+const helpers_5 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
-const helpers_4 = require("./helpers");
+const helpers_6 = require("./helpers");
 const os_1 = __importDefault(require("os"));
 const path = __importStar(require("path"));
-const helpers_5 = require("../testing/helpers");
-const helpers_6 = require("../testing/helpers");
 const helpers_7 = require("../testing/helpers");
+const helpers_8 = require("../testing/helpers");
+const helpers_9 = require("../testing/helpers");
 const request_promise_native_1 = __importDefault(require("request-promise-native"));
 const errors_3 = require("./errors");
 const uuid_1 = require("uuid");
@@ -62,10 +62,12 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     const logger = console;
     function printAndExit(message) {
         cleanup(intermediateOutputDirectory, logger);
-        (0, helpers_6.printAndExit)(message);
+        (0, helpers_8.printAndExit)(message);
     }
     const manifestDir = path.dirname(manifestFile);
-    const formattedEndpoint = (0, helpers_2.formatEndpoint)(codaApiEndpoint);
+    const formattedEndpoint = (0, helpers_4.formatEndpoint)(codaApiEndpoint);
+    apiToken = (0, helpers_1.assertApiToken)(codaApiEndpoint, apiToken);
+    const packId = (0, helpers_2.assertPackId)(manifestDir, codaApiEndpoint);
     logger.info('Building Pack bundle...');
     if (fs_extra_1.default.existsSync(intermediateOutputDirectory)) {
         logger.info(`Existing directory ${intermediateOutputDirectory} detected. Probably left over from previous build. Removing it...`);
@@ -80,21 +82,11 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         intermediateOutputDirectory,
         timerStrategy,
     });
-    const manifest = await (0, helpers_3.importManifest)(bundlePath);
+    const manifest = await (0, helpers_5.importManifest)(bundlePath);
     // Since package.json isn't in dist, we grab it from the root directory instead.
-    const packageJson = await Promise.resolve().then(() => __importStar(require((0, helpers_4.isTestCommand)() ? '../package.json' : '../../package.json')));
+    const packageJson = await Promise.resolve().then(() => __importStar(require((0, helpers_6.isTestCommand)() ? '../package.json' : '../../package.json')));
     const codaPacksSDKVersion = packageJson.version;
-    if (!apiToken) {
-        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-        if (!apiToken) {
-            return printAndExit('Missing API token. Please run `coda register` to register one.');
-        }
-    }
-    const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
-    const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
-    if (!packId) {
-        printAndExit(`Could not find a Pack id registered in directory "${manifestDir}"`);
-    }
+    const client = (0, helpers_3.createCodaClient)(apiToken, formattedEndpoint);
     const metadata = (0, metadata_1.compilePackMetadata)(manifest);
     let packVersion = manifest.version;
     try {
@@ -109,7 +101,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
             try {
                 const nextPackVersionInfo = await client.getNextPackVersion(packId, {}, { proposedMetadata: JSON.stringify(metadata), sdkVersion: codaPacksSDKVersion });
                 packVersion = nextPackVersionInfo.nextVersion;
-                (0, helpers_5.print)(`Pack version not provided. Generated one for you: version is ${packVersion}`);
+                (0, helpers_7.print)(`Pack version not provided. Generated one for you: version is ${packVersion}`);
             }
             catch (err) {
                 if ((0, coda_1.isResponseError)(err)) {
@@ -119,11 +111,11 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
             }
         }
         metadata.version = packVersion;
-        const bundle = (0, helpers_7.readFile)(bundlePath);
+        const bundle = (0, helpers_9.readFile)(bundlePath);
         if (!bundle) {
             printAndExit(`Could not find bundle file at path ${bundlePath}`);
         }
-        const sourceMap = (0, helpers_7.readFile)(bundleSourceMapPath);
+        const sourceMap = (0, helpers_9.readFile)(bundleSourceMapPath);
         if (!sourceMap) {
             printAndExit(`Could not find bundle source map at path ${bundleSourceMapPath}`);
         }
@@ -162,10 +154,10 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         }
         const { deprecationWarnings } = uploadCompleteResponse;
         if (deprecationWarnings === null || deprecationWarnings === void 0 ? void 0 : deprecationWarnings.length) {
-            (0, helpers_5.print)('\nYour Pack version uploaded successfully. ' +
+            (0, helpers_7.print)('\nYour Pack version uploaded successfully. ' +
                 'However, your Pack is using deprecated properties or features that will become errors in a future SDK version.\n');
             for (const { path, message } of deprecationWarnings) {
-                (0, helpers_5.print)(`Warning in field at path "${path}": ${message}`);
+                (0, helpers_7.print)(`Warning in field at path "${path}": ${message}`);
             }
         }
     }
@@ -185,6 +177,6 @@ async function uploadPack(uploadUrl, uploadPayload, headers) {
         });
     }
     catch (err) {
-        (0, helpers_6.printAndExit)(`Error in uploading Pack to signed url: ${(0, errors_1.formatError)(err)}`);
+        (0, helpers_8.printAndExit)(`Error in uploading Pack to signed url: ${(0, errors_1.formatError)(err)}`);
     }
 }

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -58,7 +58,7 @@ function cleanup(intermediateOutputDirectory, logger) {
         logger.info(`Intermediate files are moved to ${tempDirectory}`);
     }
 }
-async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, }) {
+async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, }) {
     const logger = console;
     function printAndExit(message) {
         cleanup(intermediateOutputDirectory, logger);
@@ -84,11 +84,13 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     // Since package.json isn't in dist, we grab it from the root directory instead.
     const packageJson = await Promise.resolve().then(() => __importStar(require((0, helpers_4.isTestCommand)() ? '../package.json' : '../../package.json')));
     const codaPacksSDKVersion = packageJson.version;
-    const apiKey = (0, config_storage_1.getApiKey)(codaApiEndpoint);
-    if (!apiKey) {
-        printAndExit('Missing API token. Please run `coda register` to register one.');
+    if (!apiToken) {
+        apiToken = (0, config_storage_1.getApiKey)(codaApiEndpoint);
+        if (!apiToken) {
+            return printAndExit('Missing API token. Please run `coda register` to register one.');
+        }
     }
-    const client = (0, helpers_1.createCodaClient)(apiKey, formattedEndpoint);
+    const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     const packId = (0, config_storage_2.getPackId)(manifestDir, codaApiEndpoint);
     if (!packId) {
         printAndExit(`Could not find a Pack id registered in directory "${manifestDir}"`);


### PR DESCRIPTION
I've had at least two developers ask for this ([1](https://community.coda.io/t/apikey-environment-variable-instead-of-coda-json-file/37612?u=eric_koleda), [2](https://community.coda.io/t/feedback-on-passing-coda-api-key-as-a-command-line-argument-when-running-coda-upload-command/32748?u=eric_koleda)), to make it easier to set up auto-deployments of their Pack in a GitHub action. It was possible to work around this be generating a `.coda.json` file on the fly, but this is a lot simpler.
