### PR TITLE
Bump version 1.2.3 -> 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "engines": {
     "node": ">=14.17.x"


### PR DESCRIPTION
This appears to avoid a regression in eslint performance when packs-sdk is imported at a newer commit hash

Don't ask me why.... I have no explanation