### PR TITLE
Add stale PR workflow to packs-sdk repo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+# This workflow warns stale PRs after 7 days
+# Closes stale PRs after 30 days
+# Marks renovate PRs stale after 30 days -- no closure
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 10 * * *' # 10 AM UTC -> 2 AM PST
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Mark Codan PRs As Stale
+      uses: actions/stale@v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been inactive for 7 days: labeled as stale. To avoid auto-closure in 7 days, please do one of the following: Add `keep-active` label, comment on PR, push new commit on PR.'
+        stale-pr-label: 'stale'
+        days-before-stale: 7 # mark as stale
+        days-before-close: 7 # close stale
+        close-pr-message: 'This stale PR has been inactive for 14 days; Closing PR.'
+        exempt-pr-labels: 'keep-active,dependencies'
+        operations-per-run: 1000
+        remove-pr-stale-when-updated: true
+    - name: Mark Renovate PRs As Stale
+      uses: actions/stale@v7 # mark dependencies labeled as stale after 30 days (auto labeled by renovate)
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been inactive for 30 days: labeled as stale. Please either merge or close or add the label `keep-active`'
+        stale-pr-label: 'stale'
+        days-before-stale: 30 # mark as stale
+        any-of-pr-labels: 'dependencies' #only to process the pull requests that contains these labels
+        operations-per-run: 1000
+        exempt-pr-labels: 'keep-active'


### PR DESCRIPTION
I copied the workflow from one of the other repos. I'm not sure if other configuration would be needed to make this work, but it seems like the worst case scenario is that it does nothing