### PR TITLE
Homebrew path setup for Apple macs.

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -4,4 +4,8 @@
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+if [[ "$(uname -s)" == "Darwin" ]] && [[ "$(arch)" == "arm64" ]]; then
+  export PATH="/opt/homebrew/bin:${PATH}"
+fi
+
 export PATH=${BASEDIR}/build/node/bin:${BASEDIR}/node_modules/.bin:${PATH}


### PR DESCRIPTION
Looks like Gary had to do this same thing last year in the `packs` repo, to get homebrew working properly so that you can install `yarn`. (Ideally we'd make all this hermetic.)

PTAL @gary-codaio @coda/packs 