### PR TITLE
Set --frozen-lockfile for yarn install on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ bs: bootstrap
 _bootstrap-node:
 	mkdir -p ${YARN_CACHE_DIR}
 	yarn config set cache-folder ${YARN_CACHE_DIR}
-	yarn install
+	if [ -z ${CIRCLE_BRANCH} ]; then \
+	  yarn install; \
+	else \
+	  yarn install --frozen-lockfile; \
+	fi
 	# Install a symlink of the working directory as @codahq/packs-sdk, so that the sample code compiles.
 	yarn unlink || true # Remove any existing links providing @codahq/packs-sdk
 	yarn link  # Provide @codahq/packs-sdk from this directory

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es6-promise": "^4.2.8",
     "esbuild": "^0.16.16",
     "exorcist": "^2.0.0",
-    "express": "4.18.2",
+    "express": "4.18.1",
     "fs-extra": "^11.1.0",
     "handlebars": "^4.7.7",
     "jsonpath-plus": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es6-promise": "^4.2.8",
     "esbuild": "^0.16.16",
     "exorcist": "^2.0.0",
-    "express": "4.18.1",
+    "express": "4.18.2",
     "fs-extra": "^11.1.0",
     "handlebars": "^4.7.7",
     "jsonpath-plus": "^7.2.0",


### PR DESCRIPTION
To catch situations where a person (or a tool like renovate) hasn't updated `yarn.lock` before sending a PR

Tested by temporarily having a commit on this branch where package.json and yarn.lock don't match: https://app.circleci.com/pipelines/github/coda/packs-sdk?branch=dweitzman-yarn-frozen