### PR TITLE
Fix XML handling when `isBinaryResponse: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 - Switched the node package manager from yarn to pnpm. This only affects developers contributing changes to the packs-sdk repo.
 
+### Fixed
+
+- Fixed an issue where the fetcher was converting XML responses to JSON even when setting `isBinaryResponse: true`.
+
 ## [1.3.0] - 2023-03-02
 
 ### Added

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -96,7 +96,7 @@ class AuthenticatingFetcher {
             throw new Error(`Response body is too large for Coda. Body is ${responseBody.length} bytes.`);
         }
         try {
-            if (isXmlContentType(response.headers['content-type'])) {
+            if (isXmlContentType(response.headers['content-type']) && !request.isBinaryResponse) {
                 responseBody = await xml2js_1.default.parseStringPromise(responseBody, { explicitRoot: false });
             }
             else {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -138,7 +138,7 @@ export class AuthenticatingFetcher implements Fetcher {
     }
 
     try {
-      if (isXmlContentType(response.headers['content-type'])) {
+      if (isXmlContentType(response.headers['content-type']) && !request.isBinaryResponse) {
         responseBody = await xml2js.parseStringPromise(responseBody, {explicitRoot: false});
       } else {
         responseBody = JSON.parse(responseBody);
@@ -270,7 +270,7 @@ export class AuthenticatingFetcher implements Fetcher {
     if (!this._credentials) {
       throw new Error(
         `${this._authDef.type} authentication is required for this pack, but no local credentials were found. ` +
-          'Run "coda auth path/to/pack/manifest to set up credentials."',
+        'Run "coda auth path/to/pack/manifest to set up credentials."',
       );
     }
 
@@ -554,7 +554,7 @@ export class AuthenticatingFetcher implements Fetcher {
       if (parsedUrl.hostname !== parsedEndpointUrl.hostname) {
         throw new Error(
           `The url ${rawUrl} is not authorized. The host must match the host ${parsedEndpointUrl.hostname} that was specified with the auth credentials. ` +
-            'Or leave the host blank and the host will be filled in automatically from the credentials.',
+          'Or leave the host blank and the host will be filled in automatically from the credentials.',
         );
       }
       return rawUrl;


### PR DESCRIPTION
This was fixed on the server in o/bug/27140, but was still broken in the testing fetcher used locally.