### PR TITLE
Fix bug with AWS signatures in testing fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Fixed
 
 - Fixed an issue where the fetcher was converting XML responses to JSON even when setting `isBinaryResponse: true`.
+- Fixed an issue where the authentication type `AWSAccessKey` wasn't generating correct signatures when used locally.
 
 ## [1.3.0] - 2023-03-02
 

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -212,6 +212,7 @@ class AuthenticatingFetcher {
                 'Run "coda auth path/to/pack/manifest to set up credentials."');
         }
         const url = this._applyAndValidateEndpoint(rawUrl);
+        const { host } = (0, url_parse_1.default)(url);
         switch (this._authDef.type) {
             case types_1.AuthenticationType.WebBasic: {
                 const { username, password = '' } = this._credentials;
@@ -315,7 +316,10 @@ class AuthenticatingFetcher {
                     method,
                     url,
                     service,
-                    headers: headers || {},
+                    headers: {
+                        ...headers,
+                        host,
+                    },
                     credentials,
                 });
                 return {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -275,6 +275,7 @@ export class AuthenticatingFetcher implements Fetcher {
     }
 
     const url = this._applyAndValidateEndpoint(rawUrl);
+    const {host} = urlParse(url);
 
     switch (this._authDef.type) {
       case AuthenticationType.WebBasic: {
@@ -411,7 +412,10 @@ export class AuthenticatingFetcher implements Fetcher {
           method,
           url,
           service,
-          headers: headers || {},
+          headers: {
+            ...headers,
+            host,
+          },
           credentials,
         });
         return {


### PR DESCRIPTION
Fixes [bug-22180](https://go/bug/22180). Assigning to Chris since I think you're most familiar with this auth method.