### PR TITLE
Define property autocomplete properties as "enumerable"

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6581,6 +6581,7 @@ module.exports = (() => {
             const cacheKeysUsed = [];
             for (const [key, value] of Object.entries(formulaSpec.propertyValues)) {
               Object.defineProperty(propertyValues, key, {
+                enumerable: true,
                 get() {
                   recordPropertyAccess2(key);
                   return value;
@@ -6594,6 +6595,7 @@ module.exports = (() => {
             };
             const contextUsed = {};
             Object.defineProperty(propertyAutocompleteExecutionContext, "search", {
+              enumerable: true,
               get() {
                 contextUsed.searchUsed = true;
                 return formulaSpec.search;

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6581,6 +6581,7 @@ module.exports = (() => {
             const cacheKeysUsed = [];
             for (const [key, value] of Object.entries(formulaSpec.propertyValues)) {
               Object.defineProperty(propertyValues, key, {
+                enumerable: true,
                 get() {
                   recordPropertyAccess2(key);
                   return value;
@@ -6594,6 +6595,7 @@ module.exports = (() => {
             };
             const contextUsed = {};
             Object.defineProperty(propertyAutocompleteExecutionContext, "search", {
+              enumerable: true,
               get() {
                 contextUsed.searchUsed = true;
                 return formulaSpec.search;

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -92,6 +92,7 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                     }
                     for (const [key, value] of Object.entries(formulaSpec.propertyValues)) {
                         Object.defineProperty(propertyValues, key, {
+                            enumerable: true,
                             get() {
                                 recordPropertyAccess(key);
                                 return value;
@@ -105,6 +106,7 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                     };
                     const contextUsed = {};
                     Object.defineProperty(propertyAutocompleteExecutionContext, 'search', {
+                        enumerable: true,
                         get() {
                             contextUsed.searchUsed = true;
                             return formulaSpec.search;

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -155,6 +155,7 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
 
           for (const [key, value] of Object.entries(formulaSpec.propertyValues)) {
             Object.defineProperty(propertyValues, key, {
+              enumerable: true,
               get() {
                 recordPropertyAccess(key);
                 return value;
@@ -171,6 +172,7 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
           const contextUsed: Omit<PropertyAutocompleteAnnotatedResult, 'packResult' | 'propertiesUsed'> = {};
 
           Object.defineProperty(propertyAutocompleteExecutionContext, 'search', {
+            enumerable: true,
             get() {
               contextUsed.searchUsed = true;
               return formulaSpec.search;


### PR DESCRIPTION
This is necessary for the properties to show up in `Object.keys()` or a `for...in` loop