### PR TITLE
Try bumping patch version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
When I try to bump to this version in `coda`, `modules/server/base/test/static_error_pages_test.ts` fails with:

```
Error: global leak(s) detected: '__esDecorate', '__runInitializers', '__propKey', '__setFunctionName'
    at Runner.checkGlobals (node_modules/.aspect_rules_js/mocha@10.2.0/node_modules/mocha/lib/runner.js:398:21)
    at Runner.<anonymous> (node_modules/.aspect_rules_js/mocha@10.2.0/node_modules/mocha/lib/runner.js:165:12)
    at Runner.emit (node:events:525:35)
    at node_modules/.aspect_rules_js/mocha@10.2.0/node_modules/mocha/lib/runner.js:822:14
    at done (node_modules/.aspect_rules_js/mocha@10.2.0/node_modules/mocha/lib/runnable.js:310:5)
    at node_modules/.aspect_rules_js/mocha@10.2.0/node_modules/mocha/lib/runnable.js:371:11
```

I think it's now succeeding once I bump the semantic version. David you had some mysterious problem where you couldn't make `coda` happy without bumping the semantic version, was it the same as this?

Will confirm that this alone fixes things on the CI before merging.

PTAL @dweitzman-codaio @huayang-codaio @coda/packs 