### PR TITLE
Fix breaking changes in MkDocs Material 9

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: "Documentation for the SDK to build Coda Packs."
 site_url: !ENV [MK_DOCS_SITE_URL, "https://coda.io/packs/build/latest/"]
 repo_url: https://github.com/coda/packs-sdk
 repo_name: coda/packs-sdk
-edit_uri: https://github.com/coda/packs-sdk/blob/main/docs
+edit_uri: edit/main/docs
 docs_dir: docs
 extra_css:
   - assets/custom.css
@@ -114,10 +114,13 @@ theme:
   custom_dir: documentation/theme
   features:
     - announce.dismiss
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - navigation.indexes
+    - navigation.sections
     - navigation.tabs
     - navigation.tabs.sticky
-    - navigation.sections
-    - navigation.indexes
 
   palette:
     scheme: coda


### PR DESCRIPTION
In #2519 the MkDocs Material library was upgraded to a new major version, which introduced some [breaking changes](https://github.com/squidfunk/mkdocs-material/issues/4714). Namely, the click to copy button on code blocks and the edit source buttons are now opt-in. 

This PR re-enables those features, as well as takes advantage of the new view source button. Previously the edit button was being used to view the source, so the `edit_uri` has been fixed to that it opens the true edit URL and the new view source button has been enabled.

### Before
<img width="839" alt="Screen Shot 2023-04-10 at 6 12 05 PM" src="https://user-images.githubusercontent.com/88106038/231008830-20024937-66d8-4646-b76e-98e86d020671.png">


### After
<img width="839" alt="Screen Shot 2023-04-10 at 6 12 13 PM" src="https://user-images.githubusercontent.com/88106038/231008844-21b337a0-7849-41aa-b7b8-46c4bd04060e.png">

