### PR TITLE
Rename Lookup to Relation

### DIFF
--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -409,7 +409,7 @@ let MovieSchema = coda.makeObjectSchema({
 
 ### Reference schemas {: #references}
 
-Reference schemas are used by sync tables to create lookups between tables. See the [Sync tables guide][sync_tables_references] for more information on how row references work.
+Reference schemas are used by sync tables to create relations between tables. See the [Sync tables guide][sync_tables_references] for more information on how row references work.
 
 The simplest way to create a reference schema is to use the helper function [`makeReferenceSchemaFromObjectSchema`][makeReferenceSchemaFromObjectSchema]. Simply pass in the full schema and sync table's `identityName` and it will be converted to a reference schema.
 

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -426,7 +426,7 @@ The columns of a Coda table are strongly typed, and the data types in the Pack S
 | Image         | ✅ Yes     | `String`                 | `ImageAttachment` | [`ImageSchema`][ImageSchema]                                                                  |
 | Image URL     | ✅ Yes     | `String`                 | `ImageReference`  | [`ImageSchema`][ImageSchema]                                                                  |
 | File          | ✅ Yes     | `String`                 | `Attachment`      |                                                                                               |
-| Lookup        | ✅ Yes     | `Object`                 | `Reference`       |                                                                                               |
+| Relation      | ✅ Yes     | `Object`                 | `Reference`       |                                                                                               |
 
 [^1]: Embed isn't a column type in Coda, but it can be used in a table or on the canvas to embed content.
 [^2]: Control column types will only render correctly in a sync table, and will not be interactive.

--- a/docs/guides/basics/parameters/index.md
+++ b/docs/guides/basics/parameters/index.md
@@ -415,7 +415,7 @@ The table below shows the recommended parameter type to use with various types o
 | Image         | ✅ Yes    | `ImageArray`  | Image column can contain multiple images.                        |
 | Image URL     | ✅ Yes    | `Image`       |                                                                  |
 | File          | ✅ Yes    | `FileArray`   | File columns can contain multiple files.                         |
-| Lookup        | ❌ No     |               | Use `StringArray` to get the display name of the row(s).         |
+| Relation      | ❌ No     |               | Use `StringArray` to get the display name of the row(s).         |
 | Table         | ❌ No     |               | You can't pass an entire table, pass individual columns instead. |
 | Page          | ✅ Yes    | `Html`        |                                                                  |
 

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -223,7 +223,7 @@ Learn more about this approach in the [two-way sync guide][two_way_sync].
 
 ## Referencing rows from other sync tables {: #references}
 
-It's often the case that the different synced items in a Pack are related to each other. For example, a Pack may have sync tables for projects and tasks, where each task belongs to a single project. Using references you can connect these two tables together. References in sync tables work like [Lookup columns][hc_lookups] in regular tables.
+It's often the case that the different synced items in a Pack are related to each other. For example, a Pack may have sync tables for projects and tasks, where each task belongs to a single project. Using references you can connect these two tables together. References in sync tables work like [relation columns][hc_relations] in regular tables.
 
 A reference must specify the identity of the target table as well as the ID of the target row. If that row has already been synced to the doc, then the reference is replaced with the data from that row. Otherwise a grayed out chip is displayed, indicating that the referenced row hasn't been synced yet.
 
@@ -279,7 +279,7 @@ Since the properties themselves may use the [`fromKey`][fromKey] option to load 
 [actions]: ../actions.md
 [dynamic_sync_tables]: dynamic.md
 [dynamic_sync_tables_schema_only]: dynamic.md#schema-only
-[hc_lookups]: https://help.coda.io/en/articles/1385997-using-lookups#the-lookup-column-format
+[hc_relations]: https://help.coda.io/en/articles/1385997-connect-tables-with-relation-columns
 [sample_continuation]: ../../../samples/topic/sync-table.md#with-continuation
 [sample_reference]: ../../../samples/topic/sync-table.md#with-row-references
 [parmeters]: ../../basics/parameters/index.md


### PR DESCRIPTION
Now that the lookup column has been renamed to relation, update the SDK docs to reflect this.