### PR TITLE
Allow blank token prefixes for oauth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ### Changed
 
+- Using the empty string as a `tokenPrefix` with OAuth2 authentication will result in no prefix being used in the `Authentication` header. Previously, the empty string would be treated the same as `undefined` which would lead to the default prefix of `Bearer` being used. Note that this change took effect for live packs on April 28, 2023 indepedently of the SDK version; in this SDK version the behavior changed only here in the CLI execution simulator (the `coda execute` command).
+
+### Changed
+
 - **Breaking Change** Removed the "autocomplete" property from EmailSchema. It wasn't useful in practice and we want to free up the name "autocomplete" on BaseSchema for better purposes.
 
 ## [1.3.4] - 2023-04-17

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -203,7 +203,7 @@ class AuthenticatingFetcher {
         this._updateCredentialsCallback(this._credentials);
     }
     async _applyAuthentication({ method, url: rawUrl, headers, body, form, disableAuthentication, }) {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e;
         if (!this._authDef || this._authDef.type === types_1.AuthenticationType.None || disableAuthentication) {
             return { url: rawUrl, headers, body, form };
         }
@@ -288,14 +288,14 @@ class AuthenticatingFetcher {
             }
             case types_1.AuthenticationType.OAuth2: {
                 const { accessToken } = this._credentials;
-                const prefix = this._authDef.tokenPrefix || 'Bearer';
+                const prefix = (_a = this._authDef.tokenPrefix) !== null && _a !== void 0 ? _a : 'Bearer';
                 const requestHeaders = headers || {};
                 let requestUrl = url;
                 if (this._authDef.tokenQueryParam) {
                     requestUrl = addQueryParam(url, this._authDef.tokenQueryParam, (0, ensure_3.ensureNonEmptyString)(accessToken));
                 }
                 else {
-                    requestHeaders.Authorization = `${prefix} ${(0, ensure_3.ensureNonEmptyString)(accessToken)}`;
+                    requestHeaders.Authorization = `${prefix} ${(0, ensure_3.ensureNonEmptyString)(accessToken)}`.trim();
                 }
                 return {
                     url: requestUrl,
@@ -342,10 +342,10 @@ class AuthenticatingFetcher {
                 });
                 const assumeRoleResult = await client.send(command);
                 const credentials = {
-                    accessKeyId: (0, ensure_2.ensureExists)((_a = assumeRoleResult.Credentials) === null || _a === void 0 ? void 0 : _a.AccessKeyId),
-                    secretAccessKey: (0, ensure_2.ensureExists)((_b = assumeRoleResult.Credentials) === null || _b === void 0 ? void 0 : _b.SecretAccessKey),
-                    sessionToken: (_c = assumeRoleResult.Credentials) === null || _c === void 0 ? void 0 : _c.SessionToken,
-                    expiration: (_d = assumeRoleResult.Credentials) === null || _d === void 0 ? void 0 : _d.Expiration,
+                    accessKeyId: (0, ensure_2.ensureExists)((_b = assumeRoleResult.Credentials) === null || _b === void 0 ? void 0 : _b.AccessKeyId),
+                    secretAccessKey: (0, ensure_2.ensureExists)((_c = assumeRoleResult.Credentials) === null || _c === void 0 ? void 0 : _c.SecretAccessKey),
+                    sessionToken: (_d = assumeRoleResult.Credentials) === null || _d === void 0 ? void 0 : _d.SessionToken,
+                    expiration: (_e = assumeRoleResult.Credentials) === null || _e === void 0 ? void 0 : _e.Expiration,
                 };
                 const resultHeaders = await this._signAwsRequest({
                     body,

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -1353,6 +1353,35 @@ describe('Auth', () => {
         });
       });
 
+      it(`${AuthenticationType.OAuth2}, with empty token prefix`, async () => {
+        const pack = createPackWithDefaultAuth({
+          type: AuthenticationType.OAuth2,
+          authorizationUrl: 'https://auth-url.com',
+          tokenUrl: 'https://token-url.com',
+          tokenPrefix: '',
+          scopes: ['scope1', 'scope2'],
+        });
+        setupReadline(['some-client-id', 'some-client-secret']);
+        doSetupAuth(pack);
+
+        await executeFetch(pack, 'https://example.com', {result: 'hello'});
+
+        sinon.assert.calledOnceWithExactly(mockMakeRequest, {
+          body: undefined,
+          form: undefined,
+          headers: {
+            Authorization: 'some-access-token',
+            'User-Agent': 'Coda-Test-Server-Fetcher',
+          },
+          method: 'GET',
+          uri: 'https://example.com',
+          encoding: undefined,
+          resolveWithFullResponse: true,
+          followRedirect: true,
+          throwOnRedirect: false,
+        });
+      });
+
       it(`${AuthenticationType.OAuth2}, leaves existing secrets in place`, async () => {
         const pack = createPackWithDefaultAuth(
           {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -270,7 +270,7 @@ export class AuthenticatingFetcher implements Fetcher {
     if (!this._credentials) {
       throw new Error(
         `${this._authDef.type} authentication is required for this pack, but no local credentials were found. ` +
-        'Run "coda auth path/to/pack/manifest to set up credentials."',
+          'Run "coda auth path/to/pack/manifest to set up credentials."',
       );
     }
 
@@ -385,13 +385,13 @@ export class AuthenticatingFetcher implements Fetcher {
       }
       case AuthenticationType.OAuth2: {
         const {accessToken} = this._credentials as OAuth2Credentials;
-        const prefix = this._authDef.tokenPrefix || 'Bearer';
+        const prefix = this._authDef.tokenPrefix ?? 'Bearer';
         const requestHeaders: {[header: string]: string} = headers || {};
         let requestUrl = url;
         if (this._authDef.tokenQueryParam) {
           requestUrl = addQueryParam(url, this._authDef.tokenQueryParam, ensureNonEmptyString(accessToken));
         } else {
-          requestHeaders.Authorization = `${prefix} ${ensureNonEmptyString(accessToken)}`;
+          requestHeaders.Authorization = `${prefix} ${ensureNonEmptyString(accessToken)}`.trim();
         }
         return {
           url: requestUrl,
@@ -558,7 +558,7 @@ export class AuthenticatingFetcher implements Fetcher {
       if (parsedUrl.hostname !== parsedEndpointUrl.hostname) {
         throw new Error(
           `The url ${rawUrl} is not authorized. The host must match the host ${parsedEndpointUrl.hostname} that was specified with the auth credentials. ` +
-          'Or leave the host blank and the host will be filled in automatically from the credentials.',
+            'Or leave the host blank and the host will be filled in automatically from the credentials.',
         );
       }
       return rawUrl;


### PR DESCRIPTION
Same as the `coda` change.

PTAL @ekoleda-codaio @coda/packs 