### PR TITLE
Update videos in documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,13 @@ bootstrap:
 lint:
 	find . -name "*.ts" | grep -v /dist/ | grep -v /node_modules/ | grep -v "\.d\.ts" | xargs ${ROOTDIR}/node_modules/.bin/eslint
 
+	# Ensure markdown has frontmatter
+	MISSING="$(shell awk '/^[^-]/{print FILENAME}; {nextfile}' ./docs/**/*.md)"; \
+	if [[ "$$MISSING" != "" ]]; then \
+		echo "These markdown files are missing frontmatter: $$MISSING"; \
+		exit 1; \
+	fi
+
 	# Markdown lint.
 	npx remark docs --quiet --frail --ignore-pattern 'docs/reference/*'
 

--- a/cspell.yml
+++ b/cspell.yml
@@ -18,6 +18,7 @@ words:
   - sandboxing
   - Asana
   - autocompletes
+  - Koleda
 
 # Patterns in the content to ignore.
 ignoreRegExpList:

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,15 +84,15 @@ Our passionate community of Pack makers and Coda experts can help answer your qu
 <section class="landing-row" markdown>
 
 <div class="landing-item" markdown>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/OoR1qX9w4Js" title="YouTube video player: Build a Todoist Coda Pack from Scratch" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/z8J6kBxAod4" title="YouTube video player: Your team hub needs more photos of dogs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <div class="landing-item" markdown>
 ## :material-youtube: Grab the popcorn.
 
-In this snippet from a recent webinar we demonstrate how to build a Pack from scratch that retrieves your task list from Todoist :simple-todoist:. It was created in under 10 minutes and with less than 30 lines of code in the Pack Studio.
+Sit back, relax, and watch as Developer Advocate Eric Koleda builds a Pack from scratch in under 5 minutes and 20 lines of code. After that check out other videos covering topics like building blocks and the CLI.
 
-[Watch webinars][webinars]{ .md-button }
+[More videos][videos]{ .md-button }
 </div>
 
 </section>
@@ -121,7 +121,7 @@ Coda makers have been busy building Packs of all types, and many have published 
 [changelog]: reference/changes.md
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [gallery]: https://coda.io/gallery?filter=packs
-[webinars]: tutorials/webinars.md
+[videos]: tutorials/videos.md
 [tutorial_cli]: tutorials/get-started/cli.md
 [tutorial_github]: tutorials/get-started/github.md
 [tutorial_gitpod]: tutorials/get-started/gitpod.md

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -44,11 +44,11 @@ The tutorials below provide step-by-step instructions and sample code to help yo
 
 {% endfor %}
 
-## Webinars
+## Videos
 
-Sometimes a video is worth a thousand tutorials. Check out recordings from some of our recent webinars.
+Sometimes a video is worth a thousand tutorials. Check out recordings from some of our recent webinars as well as other videos on Pack building.
 
-[Watch][webinars]{ .md-button }
+[Watch][videos]{ .md-button }
 
 
-[webinars]: webinars.md
+[videos]: videos.md

--- a/docs/tutorials/videos.md
+++ b/docs/tutorials/videos.md
@@ -1,6 +1,11 @@
-# Webinars
+---
+nav: Videos
+description: A collection of videos showing how to build Packs or use the SDK.
+---
 
-Coda hosts regular [webinars][webinars] on a variety of topics, including Packs and how to build them. This page includes some recordings from those webinars.
+# Videos
+
+Coda hosts regular [webinars][webinars] on a variety of topics, including Packs and how to build them. This page includes some recordings from those webinars and other videos about building Packs.
 
 
 ## An introduction to Packs in Coda
@@ -25,6 +30,14 @@ _August 2022_
 An introduction to the Pack Command Line Tool (CLI), including what it has to offer, how to set it up and use it, and how to leverage it to create better Packs.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/7K142m0aqBc" title="YouTube video player: Building Packs with the CLI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Your team hub needs more photos of dogs
+_March 2023_
+
+Learn how to develop a simple Pack to bring random dog photos into your docs. In real-time, he shows you everything you need to develop your first Coda Pack.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/z8J6kBxAod4" title="YouTube video player: Your team hub needs more photos of dogs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 [webinars]: https://coda.io/webinars

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ plugins:
           # 2023-01-05: Move FAQ and Changelog to Support.
           "guides/faq.md": "support/faq.md"
           "reference/changes.md": "support/changes.md"
+          # 2023-05-01: Rename Webinars to Videos.
+          "tutorials/webinars.md": "tutorials/videos.md"
     # Run Python scripts during the MkDocs generation process.
     - mkdocs-simple-hooks:
         hooks:


### PR DESCRIPTION
Wanted to include a [recent video](https://www.youtube.com/watch?v=z8J6kBxAod4) I made in the documentation.

- Featured it on the homepage, replacing the previous Todoist video.
  - Added my last name to the custom dictionary used by the spellcheck lint.
- Renamed the webinars page to videos, to allow it to accommodate non-webinar videos.
  - Added redirect.
- Added it to the videos page.
  - Added a missing frontmatter description to the videos page.
    - Added lint check for the existence of frontmatter.