### PR TITLE
Add "propertySchema" to PropertyAutocompleteFormulaSpecification

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -2,6 +2,7 @@ import type {$Values} from './type_utils';
 import type {ArraySchema} from './schema';
 import type {Continuation} from './api';
 import type {MetadataFormula} from './api';
+import type {Schema} from './schema';
 
 /**
  * Markers used internally to represent data types for parameters and return values.
@@ -779,6 +780,11 @@ export interface PropertyAutocompleteExecutionContext extends ExecutionContext {
    * Which property is being edited.
    */
   readonly propertyName: string;
+
+  /**
+   * Schema of the property being edited.
+   */
+  readonly propertySchema: Schema;
 
   /**
    * Current values of other properties from the same row. Non-required properties may be missing

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6310,7 +6310,8 @@ module.exports = (() => {
               const propertyAutocompleteExecutionContext = {
                 ...executionContext,
                 propertyName: formulaSpec.propertyName,
-                propertyValues
+                propertyValues,
+                propertySchema: formulaSpec.propertySchema
               };
               const contextUsed = {};
               Object.defineProperty(propertyAutocompleteExecutionContext, "search", {

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -3,6 +3,7 @@ import type { $Values } from './type_utils';
 import type { ArraySchema } from './schema';
 import type { Continuation } from './api';
 import type { MetadataFormula } from './api';
+import type { Schema } from './schema';
 /**
  * Markers used internally to represent data types for parameters and return values.
  * It should not be necessary to ever use these values directly.
@@ -652,6 +653,10 @@ export interface PropertyAutocompleteExecutionContext extends ExecutionContext {
      * Which property is being edited.
      */
     readonly propertyName: string;
+    /**
+     * Schema of the property being edited.
+     */
+    readonly propertySchema: Schema;
     /**
      * Current values of other properties from the same row. Non-required properties may be missing
      * if the doc owner elected not to sync them, or if they have a type that's not yet supported

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -636,6 +636,10 @@ export interface PropertyAutocompleteExecutionContext extends ExecutionContext {
 	 */
 	readonly propertyName: string;
 	/**
+	 * Schema of the property being edited.
+	 */
+	readonly propertySchema: Schema;
+	/**
 	 * Current values of other properties from the same row. Non-required properties may be missing
 	 * if the doc owner elected not to sync them, or if they have a type that's not yet supported
 	 * for autocomplete context. Properties referencing other sync tables may be missing some or

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6310,7 +6310,8 @@ module.exports = (() => {
               const propertyAutocompleteExecutionContext = {
                 ...executionContext,
                 propertyName: formulaSpec.propertyName,
-                propertyValues
+                propertyValues,
+                propertySchema: formulaSpec.propertySchema
               };
               const contextUsed = {};
               Object.defineProperty(propertyAutocompleteExecutionContext, "search", {

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -106,6 +106,7 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                             ...executionContext,
                             propertyName: formulaSpec.propertyName,
                             propertyValues,
+                            propertySchema: formulaSpec.propertySchema,
                         };
                         const contextUsed = {};
                         Object.defineProperty(propertyAutocompleteExecutionContext, 'search', {

--- a/dist/runtime/types.d.ts
+++ b/dist/runtime/types.d.ts
@@ -1,6 +1,5 @@
 import type { GenericSyncFormulaResult } from '../api';
 import type { GenericSyncUpdateResultMarshaled } from '../api';
-import type { ObjectSchemaProperty } from '../schema';
 import type { PackFormulaResult } from '../api_types';
 import type { Schema } from '../schema';
 export declare enum FormulaType {
@@ -61,7 +60,7 @@ export interface PropertyAutocompleteFormulaSpecification {
     autocompleteName: string;
     propertyName: string;
     propertyValues: Record<string, any>;
-    propertySchema: Schema & ObjectSchemaProperty;
+    propertySchema: Schema;
     search: string;
 }
 export declare type FormulaSpecification = StandardFormulaSpecification | SyncFormulaSpecification | SyncUpdateFormulaSpecification | MetadataFormulaSpecification | ParameterAutocompleteMetadataFormulaSpecification | PostSetupMetadataFormulaSpecification | SyncMetadataFormulaSpecification | PropertyAutocompleteFormulaSpecification;

--- a/dist/runtime/types.d.ts
+++ b/dist/runtime/types.d.ts
@@ -1,6 +1,8 @@
 import type { GenericSyncFormulaResult } from '../api';
 import type { GenericSyncUpdateResultMarshaled } from '../api';
+import type { ObjectSchemaProperty } from '../schema';
 import type { PackFormulaResult } from '../api_types';
+import type { Schema } from '../schema';
 export declare enum FormulaType {
     Standard = "Standard",
     Sync = "Sync",
@@ -59,6 +61,7 @@ export interface PropertyAutocompleteFormulaSpecification {
     autocompleteName: string;
     propertyName: string;
     propertyValues: Record<string, any>;
+    propertySchema: Schema & ObjectSchemaProperty;
     search: string;
 }
 export declare type FormulaSpecification = StandardFormulaSpecification | SyncFormulaSpecification | SyncUpdateFormulaSpecification | MetadataFormulaSpecification | ParameterAutocompleteMetadataFormulaSpecification | PostSetupMetadataFormulaSpecification | SyncMetadataFormulaSpecification | PropertyAutocompleteFormulaSpecification;

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -170,6 +170,7 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
               ...executionContext,
               propertyName: formulaSpec.propertyName,
               propertyValues,
+              propertySchema: formulaSpec.propertySchema,
             };
 
             const contextUsed: Omit<PropertyAutocompleteAnnotatedResult, 'packResult' | 'propertiesUsed'> = {};

--- a/runtime/types.ts
+++ b/runtime/types.ts
@@ -1,6 +1,5 @@
 import type {GenericSyncFormulaResult} from '../api';
 import type {GenericSyncUpdateResultMarshaled} from '../api';
-import type {ObjectSchemaProperty} from '../schema';
 import type {PackFormulaResult} from '../api_types';
 import type {Schema} from '../schema';
 
@@ -76,7 +75,7 @@ export interface PropertyAutocompleteFormulaSpecification {
   autocompleteName: string;
   propertyName: string;
   propertyValues: Record<string, any>;
-  propertySchema: Schema & ObjectSchemaProperty;
+  propertySchema: Schema;
   search: string;
 }
 

--- a/runtime/types.ts
+++ b/runtime/types.ts
@@ -1,6 +1,8 @@
 import type {GenericSyncFormulaResult} from '../api';
 import type {GenericSyncUpdateResultMarshaled} from '../api';
+import type {ObjectSchemaProperty} from '../schema';
 import type {PackFormulaResult} from '../api_types';
+import type {Schema} from '../schema';
 
 export enum FormulaType {
   Standard = 'Standard',
@@ -74,6 +76,7 @@ export interface PropertyAutocompleteFormulaSpecification {
   autocompleteName: string;
   propertyName: string;
   propertyValues: Record<string, any>;
+  propertySchema: Schema & ObjectSchemaProperty;
   search: string;
 }
 


### PR DESCRIPTION
This seems like a simple and relatively future-friendly way to put the schema of the property currently being autocompleted somewhere a pack maker can easily access it.

There are still some unresolved questions about whether propertyName and syncTable.schema should or shouldn't be normalized, denormalized to the author-written values, or use the fromKey values when they're set, but this PR may buy us more time before we need to sort that out.

If we decide to start denormalizing schemas for the context it would change the `propertySchema` here, but we'd also have a breaking change with `context.syncTable.schema` to sort out.