### PR TITLE
Fix search suggestion sizing

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -140,3 +140,14 @@ div.no pre code {
 .md-banner a {
   color: var(--md-code-hl-color);
 }
+
+/*
+ * Work around search suggest results being too large.
+ * See: https://github.com/squidfunk/mkdocs-material/issues/4278#issuecomment-1562597537
+ */
+.md-search-result .md-typeset {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  max-height: 140px;
+}


### PR DESCRIPTION
MkDocs Material recently swapped out the search implementation, and the search suggestions can be very large, requiring a lot of scrolling to scan the results. It's a [known issue](https://github.com/squidfunk/mkdocs-material/issues/4278) and being worked on, but applying a workaround for now, [recommended](https://github.com/squidfunk/mkdocs-material/issues/4278#issuecomment-1562597537) by the author of MkDocs Material. 

### Before

![image](https://github.com/coda/packs-sdk/assets/88106038/0e555c63-2a0f-4c6e-b293-9868a7dc9e32)

### After

![image](https://github.com/coda/packs-sdk/assets/88106038/20b730cd-ab94-4af3-a207-b112fc37008f)