### PR TITLE
Skip building docs for renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,9 @@
   },
 
   postUpgradeTasks: {
-    commands: ['make bs _bootstrap-doc-tools build'],
-    fileFilters: ['dist/**/*', 'documentation/**/*'],
+    // NOTE(dweitzman)): _bootstrap-doc-tools doesn't work in the renovate container
+    // at the moment so we skip building docs and just compile code.
+    commands: ['make bs clean compile'],
+    fileFilters: ['**/*.js', '**/*.d.ts'],
   },
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/coda/packs-sdk/pull/2630

I'm not sure how to get `make _bootstrap-doc-tools` to work in the renovate container, but it's possible that building compiled JS files and typescript definitions will still work.

Failure error message example: https://github.com/coda/packs-sdk/pull/2637#issuecomment-1579226886