### PR TITLE
Fallback to reading api key from env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - Added the command `coda extensions` to the CLI for installing developer extensions that help with building Packs. Currently it only supports Visual Studio Code (`coda extensions vscode`), creating a code snippets file which provides the same slash commands as the Pack Studio.
+- Added support for specifying an API key using `CODA_PACKS_API_KEY` environment variable
 
 ### Changed
 

--- a/cli/config_storage.ts
+++ b/cli/config_storage.ts
@@ -50,6 +50,7 @@ export function getApiKey(codaApiEndpoint: string): string | undefined {
       }
     }
   }
+  return process.env.CODA_PACKS_API_KEY;
 }
 export function storeCodaApiKey(apiKey: string, projectDir: string = '.', codaApiEndpoint: string) {
   const filename = path.join(projectDir, API_KEY_FILE_NAME);

--- a/dist/cli/config_storage.js
+++ b/dist/cli/config_storage.js
@@ -59,6 +59,7 @@ function getApiKey(codaApiEndpoint) {
             }
         }
     }
+    return process.env.CODA_PACKS_API_KEY;
 }
 exports.getApiKey = getApiKey;
 function storeCodaApiKey(apiKey, projectDir = '.', codaApiEndpoint) {


### PR DESCRIPTION
When running in codespaces containers are ephemeral so its much more natural to store this in its secret management solution