### PR TITLE
Condition all zod validation on sdk version

### DIFF
--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -28,10 +28,10 @@ export declare class PackMetadataValidationError extends Error {
 export declare function validatePackVersionMetadata(metadata: Record<string, any>, sdkVersion: string | undefined, { warningMode }?: {
     warningMode?: boolean;
 }): Promise<PackVersionMetadata>;
-export declare function validateVariousAuthenticationMetadata(auth: any, options: buildMetadataSchemaArgs): VariousAuthentication;
-export declare function validateSyncTableSchema(schema: any, options: buildMetadataSchemaArgs): ArraySchema<ObjectSchema<any, any>>;
+export declare function validateVariousAuthenticationMetadata(auth: any, options: BuildMetadataSchemaArgs): VariousAuthentication;
+export declare function validateSyncTableSchema(schema: any, options: BuildMetadataSchemaArgs): ArraySchema<ObjectSchema<any, any>>;
 export declare function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[];
-interface buildMetadataSchemaArgs {
+interface BuildMetadataSchemaArgs {
     sdkVersion?: string;
     warningMode?: boolean;
 }

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -28,6 +28,11 @@ export declare class PackMetadataValidationError extends Error {
 export declare function validatePackVersionMetadata(metadata: Record<string, any>, sdkVersion: string | undefined, { warningMode }?: {
     warningMode?: boolean;
 }): Promise<PackVersionMetadata>;
-export declare function validateVariousAuthenticationMetadata(auth: any): VariousAuthentication;
-export declare function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<any, any>>;
+export declare function validateVariousAuthenticationMetadata(auth: any, options: buildMetadataSchemaArgs): VariousAuthentication;
+export declare function validateSyncTableSchema(schema: any, options: buildMetadataSchemaArgs): ArraySchema<ObjectSchema<any, any>>;
 export declare function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[];
+interface buildMetadataSchemaArgs {
+    sdkVersion?: string;
+    warningMode?: boolean;
+}
+export {};

--- a/dist/testing/upload_validation.d.ts
+++ b/dist/testing/upload_validation.d.ts
@@ -29,7 +29,7 @@ export declare function validatePackVersionMetadata(metadata: Record<string, any
     warningMode?: boolean;
 }): Promise<PackVersionMetadata>;
 export declare function validateVariousAuthenticationMetadata(auth: any, options: BuildMetadataSchemaArgs): VariousAuthentication;
-export declare function validateSyncTableSchema(schema: any, options: BuildMetadataSchemaArgs): ArraySchema<ObjectSchema<any, any>>;
+export declare function validateSyncTableSchema(schema: any, options: BuildMetadataSchemaArgs & Required<Pick<BuildMetadataSchemaArgs, 'sdkVersion'>>): ArraySchema<ObjectSchema<any, any>>;
 export declare function zodErrorDetailToValidationError(subError: z.ZodIssue): ValidationError[];
 interface BuildMetadataSchemaArgs {
     sdkVersion?: string;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -105,6 +105,7 @@ class PackMetadataValidationError extends Error {
 }
 exports.PackMetadataValidationError = PackMetadataValidationError;
 async function validatePackVersionMetadata(metadata, sdkVersion, { warningMode } = {}) {
+    const { legacyPackMetadataSchema } = buildMetadataSchema({ sdkVersion, warningMode });
     let combinedSchema = legacyPackMetadataSchema;
     // Server-side validation may be running a different SDK version than the pack maker
     // is using, so some breaking changes to metadata validation can be set up to only
@@ -127,7 +128,8 @@ async function validatePackVersionMetadata(metadata, sdkVersion, { warningMode }
 exports.validatePackVersionMetadata = validatePackVersionMetadata;
 // Note: This is called within Coda for validating user-provided authentication metadata
 // as part of Various connections.
-function validateVariousAuthenticationMetadata(auth) {
+function validateVariousAuthenticationMetadata(auth, options) {
+    const { variousSupportedAuthenticationValidators } = buildMetadataSchema(options);
     const validated = z.union(zodUnionInput(variousSupportedAuthenticationValidators)).safeParse(auth);
     if (validated.success) {
         return auth;
@@ -136,7 +138,8 @@ function validateVariousAuthenticationMetadata(auth) {
 }
 exports.validateVariousAuthenticationMetadata = validateVariousAuthenticationMetadata;
 // Note: This is called within Coda for validating the result of getSchema calls for dynamic sync tables.
-function validateSyncTableSchema(schema) {
+function validateSyncTableSchema(schema, options) {
+    const { arrayPropertySchema } = buildMetadataSchema(options);
     const validated = arrayPropertySchema.safeParse(schema);
     if (validated.success) {
         return validated.data;
@@ -272,1182 +275,1195 @@ const setEndpointPostSetupValidator = zodCompleteObject({
     getOptions: z.unknown().optional(),
     getOptionsFormula: z.unknown().optional(),
 }).refine(data => data.getOptions || data.getOptionsFormula, 'Either getOptions or getOptionsFormula must be specified.');
-const singleAuthDomainSchema = z
-    .string()
-    .nonempty()
-    .refine(domain => domain.indexOf(' ') < 0, {
-    message: 'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
-});
-const baseAuthenticationValidators = {
-    // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
-    // in the full bundle, not the metadata.
-    getConnectionName: z.unknown().optional(),
-    getConnectionUserId: z.unknown().optional(),
-    instructionsUrl: z.string().optional(),
-    requiresEndpointUrl: z.boolean().optional(),
-    endpointDomain: z.string().optional(),
-    // The items are technically a discriminated union type but that union currently only has one member.
-    postSetup: z.array(setEndpointPostSetupValidator).optional(),
-    networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
-};
-const defaultAuthenticationValidators = {
-    [types_1.AuthenticationType.None]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.None),
-    }),
-    [types_1.AuthenticationType.HeaderBearerToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.HeaderBearerToken),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.CodaApiHeaderBearerToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.CodaApiHeaderBearerToken),
-        deferConnectionSetup: z.boolean().optional(),
-        shouldAutoAuthSetup: z.boolean().optional(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.CustomHeaderToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.CustomHeaderToken),
-        headerName: z.string(),
-        tokenPrefix: z.string().optional(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.MultiHeaderToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.MultiHeaderToken),
-        headers: z
-            .array(zodCompleteStrictObject({
-            name: z.string(),
-            description: z.string(),
-            tokenPrefix: z.string().optional(),
-        }))
-            .refine(headers => {
-            const keys = headers.map(header => header.name.toLowerCase());
-            return keys.length === new Set(keys).size;
-        }, { message: 'Duplicated header names in the MultiHeaderToken authentication config' }),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.QueryParamToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.QueryParamToken),
-        paramName: z.string(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.MultiQueryParamToken]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.MultiQueryParamToken),
-        params: z
-            .array(zodCompleteStrictObject({
-            name: z.string(),
-            description: z.string(),
-        }))
-            .refine(params => {
-            const keys = params.map(param => param.name);
-            return keys.length === new Set(keys).size;
-        }, { message: 'Duplicated parameter names in the MultiQueryParamToken authentication config' }),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.OAuth2]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.OAuth2),
-        authorizationUrl: z.string().url(),
-        tokenUrl: z.string().url(),
-        scopes: z.array(z.string()).optional(),
-        scopeDelimiter: z.enum([' ', ',', ';']).optional(),
-        tokenPrefix: z.string().optional(),
-        additionalParams: z.record(z.any()).optional(),
-        endpointKey: z.string().optional(),
-        tokenQueryParam: z.string().optional(),
-        useProofKeyForCodeExchange: z.boolean().optional(),
-        pkceChallengeMethod: z.enum(['plain', 'S256']).optional(),
-        scopeParamName: z.string().optional(),
-        nestedResponseKey: z.string().optional(),
-        credentialsLocation: z.nativeEnum(types_5.TokenExchangeCredentialsLocation).optional(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.WebBasic]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.WebBasic),
-        uxConfig: zodCompleteStrictObject({
-            placeholderUsername: z.string().optional(),
-            placeholderPassword: z.string().optional(),
-            usernameOnly: z.boolean().optional(),
-        }).optional(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.AWSAccessKey]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.AWSAccessKey),
-        service: z.string(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.AWSAssumeRole]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.AWSAssumeRole),
-        service: z.string(),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.Custom]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.Custom),
-        params: z
-            .array(zodCompleteStrictObject({
-            name: z.string(),
-            description: z.string(),
-        }))
-            .refine(params => {
-            const keys = params.map(param => param.name);
-            return keys.length === new Set(keys).size;
-        }, { message: 'Duplicated parameter names in the mutli-query-token authentication config' }),
-        ...baseAuthenticationValidators,
-    }),
-    [types_1.AuthenticationType.Various]: zodCompleteStrictObject({
-        type: zodDiscriminant(types_1.AuthenticationType.Various),
-    }),
-};
-const systemAuthenticationTypes = {
-    [types_1.AuthenticationType.HeaderBearerToken]: true,
-    [types_1.AuthenticationType.CustomHeaderToken]: true,
-    [types_1.AuthenticationType.MultiHeaderToken]: true,
-    [types_1.AuthenticationType.MultiQueryParamToken]: true,
-    [types_1.AuthenticationType.QueryParamToken]: true,
-    [types_1.AuthenticationType.WebBasic]: true,
-    [types_1.AuthenticationType.AWSAccessKey]: true,
-    [types_1.AuthenticationType.AWSAssumeRole]: true,
-    [types_1.AuthenticationType.Custom]: true,
-};
-const systemAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
-    .filter(([authType]) => authType in systemAuthenticationTypes)
-    .map(([_authType, schema]) => schema);
-const variousSupportedAuthenticationTypes = {
-    [types_1.AuthenticationType.HeaderBearerToken]: true,
-    [types_1.AuthenticationType.CustomHeaderToken]: true,
-    [types_1.AuthenticationType.MultiHeaderToken]: true,
-    [types_1.AuthenticationType.MultiQueryParamToken]: true,
-    [types_1.AuthenticationType.QueryParamToken]: true,
-    [types_1.AuthenticationType.WebBasic]: true,
-    [types_1.AuthenticationType.None]: true,
-};
-const variousSupportedAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
-    .filter(([authType]) => authType in variousSupportedAuthenticationTypes)
-    .map(([_authType, schema]) => schema);
-const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
-const paramDefValidator = zodCompleteObject({
-    name: z
+function buildMetadataSchema({ sdkVersion }) {
+    const singleAuthDomainSchema = z
         .string()
-        .max(exports.Limits.BuildingBlockName)
-        .regex(regexParameterName, 'Parameter names can only contain alphanumeric characters and underscores.'),
-    type: z
-        .union([
-        z.nativeEnum(api_types_4.Type),
-        z.object({
-            type: zodDiscriminant('array'),
-            items: z.nativeEnum(api_types_4.Type),
-            allowEmpty: z.boolean().optional(),
+        .nonempty()
+        .refine(domain => domain.indexOf(' ') < 0, {
+        message: 'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+    });
+    const baseAuthenticationValidators = {
+        // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
+        // in the full bundle, not the metadata.
+        getConnectionName: z.unknown().optional(),
+        getConnectionUserId: z.unknown().optional(),
+        instructionsUrl: z.string().optional(),
+        requiresEndpointUrl: z.boolean().optional(),
+        endpointDomain: z.string().optional(),
+        // The items are technically a discriminated union type but that union currently only has one member.
+        postSetup: z.array(setEndpointPostSetupValidator).optional(),
+        networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
+    };
+    const defaultAuthenticationValidators = {
+        [types_1.AuthenticationType.None]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.None),
         }),
-    ])
-        .refine(paramType => paramType !== api_types_4.Type.object &&
-        !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === api_types_4.Type.object), {
-        message: 'Object parameters are not currently supported.',
-    }),
-    description: z.string().max(exports.Limits.BuildingBlockDescription),
-    optional: z.boolean().optional(),
-    autocomplete: z.unknown().optional(),
-    defaultValue: z.unknown().optional(),
-    suggestedValue: z.unknown().optional(),
-});
-const commonPackFormulaSchema = {
-    // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
-    // whose getter names violate the validator, and those exemptions require the pack id, so this has to be
-    // done as a superRefine on the top-level object that also contains the pack id.
-    name: z.string().max(exports.Limits.BuildingBlockName),
-    description: z.string().max(exports.Limits.BuildingBlockDescription),
-    examples: z
-        .array(z.object({
-        params: z.array(z.union([
-            primitiveUnion,
-            z.array(primitiveUnion),
-            z.undefined(),
-            // Our TS only accepts undefined for optional params, but when an upload gets JSONified
-            // and there is an undefined value in array, it gets serialized to null so we have
-            // to accept it here.
-            z.null(),
-        ])),
-        result: z.any(),
-    }))
-        .optional(),
-    parameters: z.array(paramDefValidator).refine(params => {
-        let hasOptional = false;
-        for (const param of params) {
-            if (param.optional) {
-                hasOptional = true;
+        [types_1.AuthenticationType.HeaderBearerToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.HeaderBearerToken),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.CodaApiHeaderBearerToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.CodaApiHeaderBearerToken),
+            deferConnectionSetup: z.boolean().optional(),
+            shouldAutoAuthSetup: z.boolean().optional(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.CustomHeaderToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.CustomHeaderToken),
+            headerName: z.string(),
+            tokenPrefix: z.string().optional(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.MultiHeaderToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.MultiHeaderToken),
+            headers: z
+                .array(zodCompleteStrictObject({
+                name: z.string(),
+                description: z.string(),
+                tokenPrefix: z.string().optional(),
+            }))
+                .refine(headers => {
+                const keys = headers.map(header => header.name.toLowerCase());
+                return keys.length === new Set(keys).size;
+            }, { message: 'Duplicated header names in the MultiHeaderToken authentication config' }),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.QueryParamToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.QueryParamToken),
+            paramName: z.string(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.MultiQueryParamToken]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.MultiQueryParamToken),
+            params: z
+                .array(zodCompleteStrictObject({
+                name: z.string(),
+                description: z.string(),
+            }))
+                .refine(params => {
+                const keys = params.map(param => param.name);
+                return keys.length === new Set(keys).size;
+            }, { message: 'Duplicated parameter names in the MultiQueryParamToken authentication config' }),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.OAuth2]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.OAuth2),
+            authorizationUrl: z.string().url(),
+            tokenUrl: z.string().url(),
+            scopes: z.array(z.string()).optional(),
+            scopeDelimiter: z.enum([' ', ',', ';']).optional(),
+            tokenPrefix: z.string().optional(),
+            additionalParams: z.record(z.any()).optional(),
+            endpointKey: z.string().optional(),
+            tokenQueryParam: z.string().optional(),
+            useProofKeyForCodeExchange: z.boolean().optional(),
+            pkceChallengeMethod: z.enum(['plain', 'S256']).optional(),
+            scopeParamName: z.string().optional(),
+            nestedResponseKey: z.string().optional(),
+            credentialsLocation: z.nativeEnum(types_5.TokenExchangeCredentialsLocation).optional(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.WebBasic]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.WebBasic),
+            uxConfig: zodCompleteStrictObject({
+                placeholderUsername: z.string().optional(),
+                placeholderPassword: z.string().optional(),
+                usernameOnly: z.boolean().optional(),
+            }).optional(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.AWSAccessKey]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.AWSAccessKey),
+            service: z.string(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.AWSAssumeRole]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.AWSAssumeRole),
+            service: z.string(),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.Custom]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.Custom),
+            params: z
+                .array(zodCompleteStrictObject({
+                name: z.string(),
+                description: z.string(),
+            }))
+                .refine(params => {
+                const keys = params.map(param => param.name);
+                return keys.length === new Set(keys).size;
+            }, { message: 'Duplicated parameter names in the mutli-query-token authentication config' }),
+            ...baseAuthenticationValidators,
+        }),
+        [types_1.AuthenticationType.Various]: zodCompleteStrictObject({
+            type: zodDiscriminant(types_1.AuthenticationType.Various),
+        }),
+    };
+    const systemAuthenticationTypes = {
+        [types_1.AuthenticationType.HeaderBearerToken]: true,
+        [types_1.AuthenticationType.CustomHeaderToken]: true,
+        [types_1.AuthenticationType.MultiHeaderToken]: true,
+        [types_1.AuthenticationType.MultiQueryParamToken]: true,
+        [types_1.AuthenticationType.QueryParamToken]: true,
+        [types_1.AuthenticationType.WebBasic]: true,
+        [types_1.AuthenticationType.AWSAccessKey]: true,
+        [types_1.AuthenticationType.AWSAssumeRole]: true,
+        [types_1.AuthenticationType.Custom]: true,
+    };
+    const systemAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
+        .filter(([authType]) => authType in systemAuthenticationTypes)
+        .map(([_authType, schema]) => schema);
+    const variousSupportedAuthenticationTypes = {
+        [types_1.AuthenticationType.HeaderBearerToken]: true,
+        [types_1.AuthenticationType.CustomHeaderToken]: true,
+        [types_1.AuthenticationType.MultiHeaderToken]: true,
+        [types_1.AuthenticationType.MultiQueryParamToken]: true,
+        [types_1.AuthenticationType.QueryParamToken]: true,
+        [types_1.AuthenticationType.WebBasic]: true,
+        [types_1.AuthenticationType.None]: true,
+    };
+    const variousSupportedAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
+        .filter(([authType]) => authType in variousSupportedAuthenticationTypes)
+        .map(([_authType, schema]) => schema);
+    const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
+    const paramDefValidator = zodCompleteObject({
+        name: z
+            .string()
+            .max(exports.Limits.BuildingBlockName)
+            .regex(regexParameterName, 'Parameter names can only contain alphanumeric characters and underscores.'),
+        type: z
+            .union([
+            z.nativeEnum(api_types_4.Type),
+            z.object({
+                type: zodDiscriminant('array'),
+                items: z.nativeEnum(api_types_4.Type),
+                allowEmpty: z.boolean().optional(),
+            }),
+        ])
+            .refine(paramType => paramType !== api_types_4.Type.object &&
+            !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === api_types_4.Type.object), {
+            message: 'Object parameters are not currently supported.',
+        }),
+        description: z.string().max(exports.Limits.BuildingBlockDescription),
+        optional: z.boolean().optional(),
+        autocomplete: z.unknown().optional(),
+        defaultValue: z.unknown().optional(),
+        suggestedValue: z.unknown().optional(),
+    });
+    const commonPackFormulaSchema = {
+        // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
+        // whose getter names violate the validator, and those exemptions require the pack id, so this has to be
+        // done as a superRefine on the top-level object that also contains the pack id.
+        name: z.string().max(exports.Limits.BuildingBlockName),
+        description: z.string().max(exports.Limits.BuildingBlockDescription),
+        examples: z
+            .array(z.object({
+            params: z.array(z.union([
+                primitiveUnion,
+                z.array(primitiveUnion),
+                z.undefined(),
+                // Our TS only accepts undefined for optional params, but when an upload gets JSONified
+                // and there is an undefined value in array, it gets serialized to null so we have
+                // to accept it here.
+                z.null(),
+            ])),
+            result: z.any(),
+        }))
+            .optional(),
+        parameters: z.array(paramDefValidator).refine(params => {
+            let hasOptional = false;
+            for (const param of params) {
+                if (param.optional) {
+                    hasOptional = true;
+                }
+                else if (!param.optional && hasOptional) {
+                    return false;
+                }
             }
-            else if (!param.optional && hasOptional) {
-                return false;
-            }
-        }
-        return true;
-    }, { message: 'All optional parameters must come after all non-optional parameters.' }),
-    varargParameters: z.array(paramDefValidator).optional(),
-    isAction: z.boolean().optional(),
-    connectionRequirement: z.nativeEnum(api_types_2.ConnectionRequirement).optional(),
-    // TODO(jonathan): Remove after removing `network` from formula def.
-    network: zodCompleteObject({
-        hasSideEffect: z.boolean().optional(),
-        requiresConnection: z.boolean().optional(),
-        connection: z.nativeEnum(api_types_3.NetworkConnection).optional(),
-    }).optional(),
-    cacheTtlSecs: z.number().min(0).optional(),
-    isExperimental: z.boolean().optional(),
-    isSystem: z.boolean().optional(),
-    extraOAuthScopes: z.array(z.string()).optional(),
-};
-const booleanPackFormulaSchema = zodCompleteObject({
-    ...commonPackFormulaSchema,
-    resultType: zodDiscriminant(api_types_4.Type.boolean),
-    schema: zodCompleteObject({
-        type: zodDiscriminant(schema_13.ValueType.Boolean),
-        codaType: z.enum([...schema_2.BooleanHintValueTypes]).optional(),
+            return true;
+        }, { message: 'All optional parameters must come after all non-optional parameters.' }),
+        varargParameters: z.array(paramDefValidator).optional(),
+        isAction: z.boolean().optional(),
+        connectionRequirement: z.nativeEnum(api_types_2.ConnectionRequirement).optional(),
+        // TODO(jonathan): Remove after removing `network` from formula def.
+        network: zodCompleteObject({
+            hasSideEffect: z.boolean().optional(),
+            requiresConnection: z.boolean().optional(),
+            connection: z.nativeEnum(api_types_3.NetworkConnection).optional(),
+        }).optional(),
+        cacheTtlSecs: z.number().min(0).optional(),
+        isExperimental: z.boolean().optional(),
+        isSystem: z.boolean().optional(),
+        extraOAuthScopes: z.array(z.string()).optional(),
+    };
+    const booleanPackFormulaSchema = zodCompleteObject({
+        ...commonPackFormulaSchema,
+        resultType: zodDiscriminant(api_types_4.Type.boolean),
+        schema: zodCompleteObject({
+            type: zodDiscriminant(schema_13.ValueType.Boolean),
+            codaType: z.enum([...schema_2.BooleanHintValueTypes]).optional(),
+            description: z.string().optional(),
+            mutable: z.boolean().optional(),
+            fixedId: z.string().optional(),
+            // Only properties in sync tables would need to define "autocomplete"
+            autocomplete: z.undefined().optional(),
+        }).optional(),
+    });
+    // TODO(jonathan): Use zodCompleteObject on these after exporting these types.
+    const textAttributionNodeSchema = z.object({
+        type: zodDiscriminant(schema_1.AttributionNodeType.Text),
+        text: z.string(),
+    });
+    const linkAttributionNodeSchema = z.object({
+        type: zodDiscriminant(schema_1.AttributionNodeType.Link),
+        anchorUrl: z.string(),
+        anchorText: z.string(),
+    });
+    const imageAttributionNodeSchema = z.object({
+        type: zodDiscriminant(schema_1.AttributionNodeType.Image),
+        anchorUrl: z.string(),
+        imageUrl: z.string(),
+    });
+    function zodAutocompleteFieldWithValues(valueType, allowDisplayNames) {
+        const literalType = allowDisplayNames
+            ? z.union([
+                valueType,
+                z.strictObject({
+                    display: z.string(),
+                    value: valueType,
+                }),
+            ])
+            : valueType;
+        return z.union([z.string(), z.array(literalType)]).optional();
+    }
+    const basePropertyValidators = {
         description: z.string().optional(),
         mutable: z.boolean().optional(),
         fixedId: z.string().optional(),
-        // Only properties in sync tables would need to define "autocomplete"
-        autocomplete: z.undefined().optional(),
-    }).optional(),
-});
-// TODO(jonathan): Use zodCompleteObject on these after exporting these types.
-const textAttributionNodeSchema = z.object({
-    type: zodDiscriminant(schema_1.AttributionNodeType.Text),
-    text: z.string(),
-});
-const linkAttributionNodeSchema = z.object({
-    type: zodDiscriminant(schema_1.AttributionNodeType.Link),
-    anchorUrl: z.string(),
-    anchorText: z.string(),
-});
-const imageAttributionNodeSchema = z.object({
-    type: zodDiscriminant(schema_1.AttributionNodeType.Image),
-    anchorUrl: z.string(),
-    imageUrl: z.string(),
-});
-function zodAutocompleteFieldWithValues(valueType, allowDisplayNames) {
-    const literalType = allowDisplayNames
-        ? z.union([
-            valueType,
-            z.strictObject({
-                display: z.string(),
-                value: valueType,
-            }),
-        ])
-        : valueType;
-    return z.union([z.string(), z.array(literalType)]).optional();
-}
-const basePropertyValidators = {
-    description: z.string().optional(),
-    mutable: z.boolean().optional(),
-    fixedId: z.string().optional(),
-    fromKey: z.string().optional(),
-    required: z.boolean().optional(),
-};
-const baseStringPropertyValidators = {
-    ...basePropertyValidators,
-};
-const baseNumericPropertyValidators = {
-    ...basePropertyValidators,
-    autocomplete: zodAutocompleteFieldWithValues(z.number(), true),
-};
-const booleanPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Boolean),
-    codaType: z.enum([...schema_2.BooleanHintValueTypes]).optional(),
-    ...basePropertyValidators,
-    autocomplete: zodAutocompleteFieldWithValues(z.boolean(), true),
-});
-const numericPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Percent).optional(),
-    precision: z.number().optional(),
-    useThousandsSeparator: z.boolean().optional(),
-    ...baseNumericPropertyValidators,
-});
-const scalePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Scale),
-    maximum: z.number().optional(),
-    icon: z.nativeEnum(schema_10.ScaleIconSet).optional(),
-    ...baseNumericPropertyValidators,
-});
-const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
-const sliderPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Slider),
-    maximum: optionalStringOrNumber,
-    minimum: optionalStringOrNumber,
-    step: optionalStringOrNumber,
-    showValue: z.boolean().optional(),
-    ...baseNumericPropertyValidators,
-});
-const progressBarPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.ProgressBar),
-    maximum: optionalStringOrNumber,
-    minimum: optionalStringOrNumber,
-    step: optionalStringOrNumber,
-    showValue: z.boolean().optional(),
-    ...baseNumericPropertyValidators,
-});
-const currencyPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Currency),
-    precision: z.number().optional(),
-    currencyCode: z.string().optional(),
-    format: z.nativeEnum(schema_3.CurrencyFormat).optional(),
-    ...baseNumericPropertyValidators,
-});
-const numericDatePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Date),
-    format: z.string().optional(),
-    ...baseNumericPropertyValidators,
-});
-const numericTimePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Time),
-    format: z.string().optional(),
-    ...baseNumericPropertyValidators,
-});
-const numericDateTimePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.DateTime),
-    dateFormat: z.string().optional(),
-    timeFormat: z.string().optional(),
-    ...baseNumericPropertyValidators,
-});
-const numericDurationPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Number),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Duration),
-    precision: z.number().optional(),
-    maxUnit: z.nativeEnum(schema_4.DurationUnit).optional(),
-    ...baseNumericPropertyValidators,
-});
-const numberPropertySchema = z.union([
-    numericPropertySchema,
-    scalePropertySchema,
-    sliderPropertySchema,
-    progressBarPropertySchema,
-    currencyPropertySchema,
-    numericDatePropertySchema,
-    numericTimePropertySchema,
-    numericDateTimePropertySchema,
-    numericDurationPropertySchema,
-]);
-const numericPackFormulaSchema = zodCompleteObject({
-    ...commonPackFormulaSchema,
-    resultType: zodDiscriminant(api_types_4.Type.number),
-    schema: numberPropertySchema.optional(),
-});
-const simpleStringPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: z.enum([...schema_11.SimpleStringHintValueTypes]).optional(),
-    ...baseStringPropertyValidators,
-});
-const stringDatePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Date),
-    format: z.string().optional(),
-    ...baseStringPropertyValidators,
-});
-const stringTimePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Time),
-    format: z.string().optional(),
-    ...baseStringPropertyValidators,
-});
-const stringDateTimePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.DateTime),
-    dateFormat: z.string().optional(),
-    timeFormat: z.string().optional(),
-    ...baseStringPropertyValidators,
-});
-const durationPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Duration),
-    precision: z.number().optional(),
-    maxUnit: z.nativeEnum(schema_4.DurationUnit).optional(),
-    ...baseStringPropertyValidators,
-});
-const codaInternalRichTextSchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.CodaInternalRichText),
-    isCanvas: z.boolean().optional(),
-    ...baseStringPropertyValidators,
-});
-const embedPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Embed),
-    force: z.boolean().optional(),
-    ...baseStringPropertyValidators,
-});
-const emailPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Email),
-    display: z.nativeEnum(schema_5.EmailDisplayType).optional(),
-    ...baseStringPropertyValidators,
-});
-const linkPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.Url),
-    display: z.nativeEnum(schema_8.LinkDisplayType).optional(),
-    force: z.boolean().optional(),
-    ...baseStringPropertyValidators,
-});
-const stringWithOptionsPropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: zodDiscriminant(schema_12.ValueHintType.SelectList),
-    ...baseStringPropertyValidators,
-    autocomplete: zodAutocompleteFieldWithValues(z.string(), true),
-});
-const imagePropertySchema = zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.String),
-    codaType: z.union([zodDiscriminant(schema_12.ValueHintType.ImageAttachment), zodDiscriminant(schema_12.ValueHintType.ImageReference)]),
-    imageOutline: z.nativeEnum(schema_7.ImageOutline).optional(),
-    imageCornerStyle: z.nativeEnum(schema_6.ImageCornerStyle).optional(),
-    ...baseStringPropertyValidators,
-});
-const stringPropertySchema = z.union([
-    simpleStringPropertySchema,
-    stringDatePropertySchema,
-    stringTimePropertySchema,
-    stringDateTimePropertySchema,
-    codaInternalRichTextSchema,
-    durationPropertySchema,
-    embedPropertySchema,
-    emailPropertySchema,
-    linkPropertySchema,
-    imagePropertySchema,
-    stringWithOptionsPropertySchema,
-]);
-const stringPackFormulaSchema = zodCompleteObject({
-    ...commonPackFormulaSchema,
-    resultType: zodDiscriminant(api_types_4.Type.string),
-    schema: stringPropertySchema.optional(),
-});
-// TODO(jonathan): Give this a better type than ZodTypeAny after figuring out
-// recursive typing better.
-const arrayPropertySchema = z.lazy(() => zodCompleteStrictObject({
-    type: zodDiscriminant(schema_13.ValueType.Array),
-    items: objectPropertyUnionSchema,
-    ...basePropertyValidators,
-}));
-const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
-// This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
-function isValidObjectId(component) {
-    return Base64ObjectRegex.test(component);
-}
-const SystemColumnNames = ['id', 'value', 'synced', 'connection'];
-var ExemptionType;
-(function (ExemptionType) {
-    ExemptionType["IdentityName"] = "IdentityName";
-    ExemptionType["SyncTableGetterName"] = "SyncTableGetterName";
-})(ExemptionType || (ExemptionType = {}));
-const Exemptions = [
-    [1013, 'Pull Request', ExemptionType.IdentityName],
-    [1021, 'Doc Analytics', ExemptionType.IdentityName],
-    [1060, 'Candidate Stage', ExemptionType.IdentityName],
-    [1075, 'G Suite Directory User', ExemptionType.IdentityName],
-    [1079, 'Campaign Group', ExemptionType.IdentityName],
-    [1083, 'Merge Request', ExemptionType.IdentityName],
-    [1013, 'Sync commit history', ExemptionType.SyncTableGetterName],
-    [1013, 'Sync issues', ExemptionType.SyncTableGetterName],
-    [1013, 'Sync pull requests', ExemptionType.SyncTableGetterName],
-    [1013, 'Sync repos', ExemptionType.SyncTableGetterName],
-    [1054, 'Sync table', ExemptionType.SyncTableGetterName],
-    [1062, 'Form responses', ExemptionType.SyncTableGetterName],
-    [1062, 'Sync forms', ExemptionType.SyncTableGetterName],
-    [1078, 'Ad Creatives', ExemptionType.SyncTableGetterName],
-    [1078, 'Ad Sets', ExemptionType.SyncTableGetterName],
-    [1078, 'Custom Audiences', ExemptionType.SyncTableGetterName],
-    [1078, 'Page Posts', ExemptionType.SyncTableGetterName],
-    [1083, 'Sync commits', ExemptionType.SyncTableGetterName],
-    [1083, 'Sync issues', ExemptionType.SyncTableGetterName],
-    [1083, 'Sync merge requests', ExemptionType.SyncTableGetterName],
-    [1083, 'Sync projects', ExemptionType.SyncTableGetterName],
-    [1084, 'Ad Groups', ExemptionType.SyncTableGetterName],
-    [1093, 'Sync table', ExemptionType.SyncTableGetterName],
-];
-function exemptionKey(packId, entityName) {
-    return `${packId}/${entityName}`;
-}
-const IdentityNameExemptions = new Set(Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.IdentityName).map(([packId, name]) => exemptionKey(packId, name)));
-const SyncTableGetterNameExemptions = new Set(Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.SyncTableGetterName).map(([packId, name]) => exemptionKey(packId, name)));
-function isValidIdentityName(packId, name) {
-    if (packId && IdentityNameExemptions.has(exemptionKey(packId, name))) {
-        return true;
+        fromKey: z.string().optional(),
+        required: z.boolean().optional(),
+    };
+    const baseStringPropertyValidators = {
+        ...basePropertyValidators,
+    };
+    const baseNumericPropertyValidators = {
+        ...basePropertyValidators,
+        autocomplete: zodAutocompleteFieldWithValues(z.number(), true),
+    };
+    const booleanPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Boolean),
+        codaType: z.enum([...schema_2.BooleanHintValueTypes]).optional(),
+        ...basePropertyValidators,
+        autocomplete: zodAutocompleteFieldWithValues(z.boolean(), true),
+    });
+    const numericPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Percent).optional(),
+        precision: z.number().optional(),
+        useThousandsSeparator: z.boolean().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const scalePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Scale),
+        maximum: z.number().optional(),
+        icon: z.nativeEnum(schema_10.ScaleIconSet).optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
+    const sliderPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Slider),
+        maximum: optionalStringOrNumber,
+        minimum: optionalStringOrNumber,
+        step: optionalStringOrNumber,
+        showValue: z.boolean().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const progressBarPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.ProgressBar),
+        maximum: optionalStringOrNumber,
+        minimum: optionalStringOrNumber,
+        step: optionalStringOrNumber,
+        showValue: z.boolean().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const currencyPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Currency),
+        precision: z.number().optional(),
+        currencyCode: z.string().optional(),
+        format: z.nativeEnum(schema_3.CurrencyFormat).optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const numericDatePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Date),
+        format: z.string().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const numericTimePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Time),
+        format: z.string().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const numericDateTimePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.DateTime),
+        dateFormat: z.string().optional(),
+        timeFormat: z.string().optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const numericDurationPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Number),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Duration),
+        precision: z.number().optional(),
+        maxUnit: z.nativeEnum(schema_4.DurationUnit).optional(),
+        ...baseNumericPropertyValidators,
+    });
+    const numberPropertySchema = z.union([
+        numericPropertySchema,
+        scalePropertySchema,
+        sliderPropertySchema,
+        progressBarPropertySchema,
+        currencyPropertySchema,
+        numericDatePropertySchema,
+        numericTimePropertySchema,
+        numericDateTimePropertySchema,
+        numericDurationPropertySchema,
+    ]);
+    const numericPackFormulaSchema = zodCompleteObject({
+        ...commonPackFormulaSchema,
+        resultType: zodDiscriminant(api_types_4.Type.number),
+        schema: numberPropertySchema.optional(),
+    });
+    const simpleStringPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: z.enum([...schema_11.SimpleStringHintValueTypes]).optional(),
+        ...baseStringPropertyValidators,
+    });
+    const stringDatePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Date),
+        format: z.string().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const stringTimePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Time),
+        format: z.string().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const stringDateTimePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.DateTime),
+        dateFormat: z.string().optional(),
+        timeFormat: z.string().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const durationPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Duration),
+        precision: z.number().optional(),
+        maxUnit: z.nativeEnum(schema_4.DurationUnit).optional(),
+        ...baseStringPropertyValidators,
+    });
+    const codaInternalRichTextSchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.CodaInternalRichText),
+        isCanvas: z.boolean().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const embedPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Embed),
+        force: z.boolean().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const emailPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Email),
+        display: z.nativeEnum(schema_5.EmailDisplayType).optional(),
+        ...baseStringPropertyValidators,
+    });
+    const linkPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.Url),
+        display: z.nativeEnum(schema_8.LinkDisplayType).optional(),
+        force: z.boolean().optional(),
+        ...baseStringPropertyValidators,
+    });
+    const stringWithOptionsPropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: zodDiscriminant(schema_12.ValueHintType.SelectList),
+        ...baseStringPropertyValidators,
+        autocomplete: zodAutocompleteFieldWithValues(z.string(), true),
+    });
+    const imagePropertySchema = zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.String),
+        codaType: z.union([zodDiscriminant(schema_12.ValueHintType.ImageAttachment), zodDiscriminant(schema_12.ValueHintType.ImageReference)]),
+        imageOutline: z.nativeEnum(schema_7.ImageOutline).optional(),
+        imageCornerStyle: z.nativeEnum(schema_6.ImageCornerStyle).optional(),
+        ...baseStringPropertyValidators,
+    });
+    const stringPropertySchema = z.union([
+        simpleStringPropertySchema,
+        stringDatePropertySchema,
+        stringTimePropertySchema,
+        stringDateTimePropertySchema,
+        codaInternalRichTextSchema,
+        durationPropertySchema,
+        embedPropertySchema,
+        emailPropertySchema,
+        linkPropertySchema,
+        imagePropertySchema,
+        stringWithOptionsPropertySchema,
+    ]);
+    const stringPackFormulaSchema = zodCompleteObject({
+        ...commonPackFormulaSchema,
+        resultType: zodDiscriminant(api_types_4.Type.string),
+        schema: stringPropertySchema.optional(),
+    });
+    // TODO(jonathan): Give this a better type than ZodTypeAny after figuring out
+    // recursive typing better.
+    const arrayPropertySchema = z.lazy(() => zodCompleteStrictObject({
+        type: zodDiscriminant(schema_13.ValueType.Array),
+        items: objectPropertyUnionSchema,
+        ...basePropertyValidators,
+    }));
+    const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
+    // This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
+    function isValidObjectId(component) {
+        return Base64ObjectRegex.test(component);
     }
-    if (packId === 1090) {
-        // SalesForce pack has a large number of dynamic identity ids that include empty spaces.
-        return true;
+    const SystemColumnNames = ['id', 'value', 'synced', 'connection'];
+    let ExemptionType;
+    (function (ExemptionType) {
+        ExemptionType["IdentityName"] = "IdentityName";
+        ExemptionType["SyncTableGetterName"] = "SyncTableGetterName";
+    })(ExemptionType || (ExemptionType = {}));
+    const Exemptions = [
+        [1013, 'Pull Request', ExemptionType.IdentityName],
+        [1021, 'Doc Analytics', ExemptionType.IdentityName],
+        [1060, 'Candidate Stage', ExemptionType.IdentityName],
+        [1075, 'G Suite Directory User', ExemptionType.IdentityName],
+        [1079, 'Campaign Group', ExemptionType.IdentityName],
+        [1083, 'Merge Request', ExemptionType.IdentityName],
+        [1013, 'Sync commit history', ExemptionType.SyncTableGetterName],
+        [1013, 'Sync issues', ExemptionType.SyncTableGetterName],
+        [1013, 'Sync pull requests', ExemptionType.SyncTableGetterName],
+        [1013, 'Sync repos', ExemptionType.SyncTableGetterName],
+        [1054, 'Sync table', ExemptionType.SyncTableGetterName],
+        [1062, 'Form responses', ExemptionType.SyncTableGetterName],
+        [1062, 'Sync forms', ExemptionType.SyncTableGetterName],
+        [1078, 'Ad Creatives', ExemptionType.SyncTableGetterName],
+        [1078, 'Ad Sets', ExemptionType.SyncTableGetterName],
+        [1078, 'Custom Audiences', ExemptionType.SyncTableGetterName],
+        [1078, 'Page Posts', ExemptionType.SyncTableGetterName],
+        [1083, 'Sync commits', ExemptionType.SyncTableGetterName],
+        [1083, 'Sync issues', ExemptionType.SyncTableGetterName],
+        [1083, 'Sync merge requests', ExemptionType.SyncTableGetterName],
+        [1083, 'Sync projects', ExemptionType.SyncTableGetterName],
+        [1084, 'Ad Groups', ExemptionType.SyncTableGetterName],
+        [1093, 'Sync table', ExemptionType.SyncTableGetterName],
+    ];
+    function exemptionKey(packId, entityName) {
+        return `${packId}/${entityName}`;
     }
-    return isValidObjectId(name);
-}
-function isValidUseOfCodaInternalRichText(packId) {
-    // CrossDoc pack is allowed to use this type hint.
-    return packId === 1054;
-}
-const attributionSchema = z
-    .array(z.union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema]))
-    .optional();
-const propertySchema = z.union([
-    z.string().min(1),
-    zodCompleteObject({
-        property: z.string().min(1),
-        label: z.string().optional(),
-        placeholder: z.string().optional(),
-    }),
-]);
-const genericObjectSchema = z.lazy(() => zodCompleteObject({
-    ...basePropertyValidators,
-    type: zodDiscriminant(schema_13.ValueType.Object),
-    description: z.string().optional(),
-    id: z.string().min(1).optional(),
-    idProperty: z.string().min(1).optional(),
-    primary: z.string().min(1).optional(),
-    displayProperty: z.string().min(1).optional(),
-    codaType: z.enum([...schema_9.ObjectHintValueTypes]).optional(),
-    featured: z.array(z.string()).optional(),
-    featuredProperties: z.array(z.string()).optional(),
-    identity: zodCompleteObject({
-        packId: z.number().optional(),
-        name: z.string().nonempty(),
-        dynamicUrl: z.string().optional(),
-        attribution: attributionSchema,
-    }).optional(),
-    attribution: attributionSchema,
-    properties: z.record(objectPropertyUnionSchema),
-    includeUnknownProperties: z.boolean().optional(),
-    __packId: z.number().optional(),
-    titleProperty: propertySchema.optional(),
-    linkProperty: propertySchema.optional(),
-    subtitleProperties: z.array(propertySchema).optional(),
-    snippetProperty: propertySchema.optional(),
-    imageProperty: propertySchema.optional(),
-    autocomplete: zodAutocompleteFieldWithValues(z.object({}).passthrough(), false),
-})
-    .superRefine((data, context) => {
-    var _a, _b;
-    if (!isValidIdentityName((_a = data.identity) === null || _a === void 0 ? void 0 : _a.packId, (_b = data.identity) === null || _b === void 0 ? void 0 : _b.name)) {
-        context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['identity', 'name'],
-            message: 'Invalid name. Identity names can only contain alphanumeric characters, underscores, and dashes, and no spaces.',
-        });
-    }
-})
-    .superRefine((data, context) => {
-    const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
-    const fixedIds = new Set();
-    for (const prop of Object.values(schemaHelper.properties)) {
-        if (!prop.fixedId) {
-            continue;
+    const IdentityNameExemptions = new Set(Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.IdentityName).map(([packId, name]) => exemptionKey(packId, name)));
+    const SyncTableGetterNameExemptions = new Set(Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.SyncTableGetterName).map(([packId, name]) => exemptionKey(packId, name)));
+    function isValidIdentityName(packId, name) {
+        if (packId && IdentityNameExemptions.has(exemptionKey(packId, name))) {
+            return true;
         }
-        if (fixedIds.has(prop.fixedId)) {
+        if (packId === 1090) {
+            // SalesForce pack has a large number of dynamic identity ids that include empty spaces.
+            return true;
+        }
+        return isValidObjectId(name);
+    }
+    function isValidUseOfCodaInternalRichText(packId) {
+        // CrossDoc pack is allowed to use this type hint.
+        return packId === 1054;
+    }
+    const attributionSchema = z
+        .array(z.union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema]))
+        .optional();
+    const propertySchema = z.union([
+        z.string().min(1),
+        zodCompleteObject({
+            property: z.string().min(1),
+            label: z.string().optional(),
+            placeholder: z.string().optional(),
+        }),
+    ]);
+    const genericObjectSchema = z.lazy(() => zodCompleteObject({
+        ...basePropertyValidators,
+        type: zodDiscriminant(schema_13.ValueType.Object),
+        description: z.string().optional(),
+        id: z.string().min(1).optional(),
+        idProperty: z.string().min(1).optional(),
+        primary: z.string().min(1).optional(),
+        displayProperty: z.string().min(1).optional(),
+        codaType: z.enum([...schema_9.ObjectHintValueTypes]).optional(),
+        featured: z.array(z.string()).optional(),
+        featuredProperties: z.array(z.string()).optional(),
+        identity: zodCompleteObject({
+            packId: z.number().optional(),
+            name: z.string().nonempty(),
+            dynamicUrl: z.string().optional(),
+            attribution: attributionSchema,
+        }).optional(),
+        attribution: attributionSchema,
+        properties: z.record(objectPropertyUnionSchema),
+        includeUnknownProperties: z.boolean().optional(),
+        __packId: z.number().optional(),
+        titleProperty: propertySchema.optional(),
+        linkProperty: propertySchema.optional(),
+        subtitleProperties: z.array(propertySchema).optional(),
+        snippetProperty: propertySchema.optional(),
+        imageProperty: propertySchema.optional(),
+        autocomplete: zodAutocompleteFieldWithValues(z.object({}).passthrough(), false),
+    })
+        .superRefine((data, context) => {
+        var _a, _b;
+        if (!isValidIdentityName((_a = data.identity) === null || _a === void 0 ? void 0 : _a.packId, (_b = data.identity) === null || _b === void 0 ? void 0 : _b.name)) {
             context.addIssue({
                 code: z.ZodIssueCode.custom,
-                path: ['properties'],
-                message: `fixedIds must be unique. Found duplicate "${prop.fixedId}".`,
+                path: ['identity', 'name'],
+                message: 'Invalid name. Identity names can only contain alphanumeric characters, underscores, and dashes, and no spaces.',
             });
         }
-        fixedIds.add(prop.fixedId);
-    }
-})
-    .refine(data => {
-    const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
-    return (0, object_utils_2.isNil)(schemaHelper.id) || schemaHelper.id in schemaHelper.properties;
-}, {
-    message: 'The "idProperty" property must appear as a key in the "properties" object.',
-})
-    .refine(data => {
-    const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
-    return (0, object_utils_2.isNil)(schemaHelper.primary) || schemaHelper.primary in schemaHelper.properties;
-}, {
-    message: 'The "displayProperty" property must appear as a key in the "properties" object.',
-})
-    .superRefine((data, context) => {
-    const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
-    (schemaHelper.featured || []).forEach((f, i) => {
-        if (!(f in schemaHelper.properties)) {
+    })
+        .superRefine((data, context) => {
+        const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
+        const fixedIds = new Set();
+        for (const prop of Object.values(schemaHelper.properties)) {
+            if (!prop.fixedId) {
+                continue;
+            }
+            if (fixedIds.has(prop.fixedId)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['properties'],
+                    message: `fixedIds must be unique. Found duplicate "${prop.fixedId}".`,
+                });
+            }
+            fixedIds.add(prop.fixedId);
+        }
+    })
+        .refine(data => {
+        const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
+        return (0, object_utils_2.isNil)(schemaHelper.id) || schemaHelper.id in schemaHelper.properties;
+    }, {
+        message: 'The "idProperty" property must appear as a key in the "properties" object.',
+    })
+        .refine(data => {
+        const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
+        return (0, object_utils_2.isNil)(schemaHelper.primary) || schemaHelper.primary in schemaHelper.properties;
+    }, {
+        message: 'The "displayProperty" property must appear as a key in the "properties" object.',
+    })
+        .superRefine((data, context) => {
+        const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
+        (schemaHelper.featured || []).forEach((f, i) => {
+            if (!(f in schemaHelper.properties)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['featured', i],
+                    message: `The "featuredProperties" field name "${f}" does not exist in the "properties" object.`,
+                });
+            }
+        });
+    })
+        .superRefine((data, context) => {
+        const schema = data;
+        /**
+         * Validates a PropertyIdentifier key in the object schema.
+         */
+        function validateProperty(propertyKey, isValidSchema, invalidSchemaMessage) {
+            function validatePropertyIdentifier(value, objectPath = [propertyKey]) {
+                var _a;
+                const propertyValue = typeof value === 'string' ? value : value === null || value === void 0 ? void 0 : value.property;
+                let propertyValueIsPath = false;
+                let propertySchema = typeof propertyValueRaw === 'string' && propertyValue in schema.properties
+                    ? schema.properties[propertyValue]
+                    : undefined;
+                if (!propertySchema) {
+                    const schemaPropertyPath = (0, schema_19.normalizePropertyValuePathIntoSchemaPath)(propertyValue);
+                    propertySchema = (_a = (0, jsonpath_plus_1.JSONPath)({
+                        path: schemaPropertyPath,
+                        json: schema.properties,
+                    })) === null || _a === void 0 ? void 0 : _a[0];
+                    propertyValueIsPath = true;
+                }
+                const propertyIdentifierDisplay = propertyValueIsPath
+                    ? `"${propertyKey}" path`
+                    : `"${propertyKey}" field name`;
+                if (!propertySchema) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: objectPath,
+                        message: `The ${propertyIdentifierDisplay} "${propertyValue}" does not exist in the "properties" object.`,
+                    });
+                    return;
+                }
+                if (!isValidSchema(propertySchema)) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: objectPath,
+                        message: `The ${propertyIdentifierDisplay} "${propertyValue}" ${invalidSchemaMessage}`,
+                    });
+                    return;
+                }
+            }
+            const propertyValueRaw = schema[propertyKey];
+            if (propertyValueRaw) {
+                if (Array.isArray(propertyValueRaw)) {
+                    propertyValueRaw.forEach((propertyIdentifier, i) => {
+                        validatePropertyIdentifier(propertyIdentifier, [propertyKey, i]);
+                    });
+                    return;
+                }
+                validatePropertyIdentifier(propertyValueRaw);
+            }
+        }
+        const validateTitleProperty = () => {
+            return validateProperty('titleProperty', propertySchema => [schema_13.ValueType.String, schema_13.ValueType.Object].includes(propertySchema.type), `must refer to a "ValueType.String" or "ValueType.Object" property.`);
+        };
+        const validateImageProperty = () => {
+            return validateProperty('imageProperty', imagePropertySchema => imagePropertySchema.type === schema_13.ValueType.String &&
+                [schema_12.ValueHintType.ImageAttachment, schema_12.ValueHintType.ImageReference].includes(imagePropertySchema.codaType), `must refer to a "ValueType.String" property with a "ValueHintType.ImageAttachment" or "ValueHintType.ImageReference" "codaType".`);
+        };
+        const validateSnippetProperty = () => {
+            return validateProperty('snippetProperty', snippetPropertySchema => snippetPropertySchema.type === schema_13.ValueType.String ||
+                (snippetPropertySchema.type === schema_13.ValueType.Array && snippetPropertySchema.items.type === schema_13.ValueType.String), `must refer to a "ValueType.String" property or array of strings.`);
+        };
+        const validateLinkProperty = () => {
+            return validateProperty('linkProperty', linkPropertySchema => linkPropertySchema.type === schema_13.ValueType.String && linkPropertySchema.codaType === schema_12.ValueHintType.Url, `must refer to a "ValueType.String" property with a "ValueHintType.Url" "codaType".`);
+        };
+        const validateSubtitleProperties = () => {
+            return validateProperty('subtitleProperties', subtitlePropertySchema => {
+                if (!('codaType' in subtitlePropertySchema && subtitlePropertySchema.codaType)) {
+                    return true;
+                }
+                switch (subtitlePropertySchema.codaType) {
+                    case schema_12.ValueHintType.ImageAttachment:
+                    case schema_12.ValueHintType.Attachment:
+                    case schema_12.ValueHintType.ImageReference:
+                    case schema_12.ValueHintType.Embed:
+                    case schema_12.ValueHintType.Scale:
+                        return false;
+                    case schema_12.ValueHintType.CodaInternalRichText:
+                    case schema_12.ValueHintType.Currency:
+                    case schema_12.ValueHintType.Date:
+                    case schema_12.ValueHintType.DateTime:
+                    case schema_12.ValueHintType.Duration:
+                    case schema_12.ValueHintType.Email:
+                    case schema_12.ValueHintType.Html:
+                    case schema_12.ValueHintType.Markdown:
+                    case schema_12.ValueHintType.Percent:
+                    case schema_12.ValueHintType.Person:
+                    case schema_12.ValueHintType.ProgressBar:
+                    case schema_12.ValueHintType.Reference:
+                    case schema_12.ValueHintType.SelectList:
+                    case schema_12.ValueHintType.Slider:
+                    case schema_12.ValueHintType.Toggle:
+                    case schema_12.ValueHintType.Time:
+                    case schema_12.ValueHintType.Url:
+                        return true;
+                    default:
+                        (0, ensure_2.ensureUnreachable)(subtitlePropertySchema.codaType);
+                }
+            }, `must refer to a value that does not have a codaType corresponding to one of ImageAttachment, Attachment, ImageReference, Embed, or Scale.`);
+        };
+        validateTitleProperty();
+        validateLinkProperty();
+        validateImageProperty();
+        validateSnippetProperty();
+        validateSubtitleProperties();
+    })
+        .superRefine((data, context) => {
+        var _a;
+        const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
+        const internalRichTextPropertyTuple = Object.entries(schemaHelper.properties).find(([_key, prop]) => prop.type === schema_13.ValueType.String && prop.codaType === schema_12.ValueHintType.CodaInternalRichText);
+        if (internalRichTextPropertyTuple && !isValidUseOfCodaInternalRichText((_a = data.identity) === null || _a === void 0 ? void 0 : _a.packId)) {
             context.addIssue({
                 code: z.ZodIssueCode.custom,
-                path: ['featured', i],
-                message: `The "featuredProperties" field name "${f}" does not exist in the "properties" object.`,
+                path: ['identity', 'properties', internalRichTextPropertyTuple[0]],
+                message: 'Invalid codaType. CodaInternalRichText is not a supported value.',
+            });
+            return;
+        }
+    }));
+    const objectPropertyUnionSchema = z
+        .union([
+        booleanPropertySchema,
+        numberPropertySchema,
+        stringPropertySchema,
+        arrayPropertySchema,
+        genericObjectSchema,
+    ])
+        .refine((schema) => {
+        if (sdkVersion && semver_1.default.satisfies(sdkVersion, '<=1.4.0')) {
+            // ValueHintType.SelectList is only required for autocomplete starting in version 1.4.1
+            return true;
+        }
+        const schemaForAutocomplete = (0, schema_18.maybeUnwrapArraySchema)(schema);
+        const result = !schemaForAutocomplete ||
+            (0, schema_20.unwrappedSchemaSupportsAutocomplete)(schemaForAutocomplete) ||
+            !('autocomplete' in schemaForAutocomplete && schemaForAutocomplete.autocomplete);
+        return result;
+    }, 'You must set "codaType" to ValueHintType.SelectList or ValueHintType.Reference when setting an "autocomplete" property.');
+    const objectPackFormulaSchema = zodCompleteObject({
+        ...commonPackFormulaSchema,
+        resultType: zodDiscriminant(api_types_4.Type.object),
+        // TODO(jonathan): See if we should really allow this. The SDK right now explicitly tolerates an undefined
+        // schema for objects, but that doesn't seem like a use case we actually want to support.
+        schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
+    });
+    const formulaMetadataSchema = z
+        .union([numericPackFormulaSchema, stringPackFormulaSchema, booleanPackFormulaSchema, objectPackFormulaSchema])
+        .superRefine((data, context) => {
+        const parameters = data.parameters;
+        const varargParameters = data.varargParameters || [];
+        const paramNames = new Set();
+        for (const param of [...parameters, ...varargParameters]) {
+            if (paramNames.has(param.name)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['parameters'],
+                    message: `Parameter names must be unique. Found duplicate name "${param.name}".`,
+                });
+            }
+            paramNames.add(param.name);
+        }
+    });
+    const formatMetadataSchema = zodCompleteObject({
+        name: z.string().max(exports.Limits.BuildingBlockName),
+        formulaNamespace: z.string().optional(),
+        formulaName: z.string(),
+        hasNoConnection: z.boolean().optional(),
+        instructions: z.string().optional(),
+        placeholder: z.string().optional(),
+        matchers: z
+            .array(z.string().max(exports.Limits.ColumnMatcherRegex).refine(validateFormatMatcher))
+            .max(exports.Limits.NumColumnMatchersPerFormat),
+    });
+    const syncFormulaSchema = zodCompleteObject({
+        schema: arrayPropertySchema.optional(),
+        resultType: z.any(),
+        isSyncFormula: z.literal(true),
+        maxUpdateBatchSize: z.number().min(1).max(exports.Limits.UpdateBatchSize).optional(),
+        supportsUpdates: z.boolean().optional(),
+        ...commonPackFormulaSchema,
+    });
+    const baseSyncTableSchema = {
+        name: z
+            .string()
+            .nonempty()
+            .max(exports.Limits.BuildingBlockName)
+            .regex(regexFormulaName, 'Sync Table names can only contain alphanumeric characters and underscores.'),
+        description: z.string().max(exports.Limits.BuildingBlockDescription).optional(),
+        schema: genericObjectSchema,
+        getter: syncFormulaSchema,
+        entityName: z.string().optional(),
+        defaultAddDynamicColumns: z.boolean().optional(),
+        // TODO(patrick): Make identityName non-optional after SDK v1.0.0 is required
+        identityName: z
+            .string()
+            .min(1)
+            .max(exports.Limits.BuildingBlockName)
+            .optional()
+            .refine(val => !val || !SystemColumnNames.includes(val), `This property name is reserved for internal use by Coda and can't be used as an identityName, sorry!`),
+        namedAutocompletes: z
+            .record(formulaMetadataSchema)
+            .optional()
+            .default({})
+            .superRefine((data, context) => {
+            if (Object.keys(data).length > exports.Limits.BuildingBlockName) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Too many autocomplete formulas for sync table. Max allowed is "${exports.Limits.BuildingBlockName}".`,
+                });
+            }
+        }),
+    };
+    const genericSyncTableSchema = zodCompleteObject({
+        ...baseSyncTableSchema,
+        // Add a fake discriminant here so that we can flag union errors as related to a non-matching discriminant
+        // and filter them out. A real regular sync table wouldn't specify `isDynamic` at all here, but including
+        // it in the validator like this helps zod flag it in the way we need.
+        isDynamic: zodDiscriminant(false).optional(),
+        getSchema: formulaMetadataSchema.optional(),
+    }).strict();
+    const genericDynamicSyncTableSchema = zodCompleteObject({
+        ...baseSyncTableSchema,
+        isDynamic: zodDiscriminant(true),
+        getName: formulaMetadataSchema,
+        getDisplayUrl: formulaMetadataSchema,
+        listDynamicUrls: formulaMetadataSchema.optional(),
+        searchDynamicUrls: formulaMetadataSchema.optional(),
+        getSchema: formulaMetadataSchema,
+        autocomplete: objectPackFormulaSchema.optional(),
+    }).strict();
+    const syncTableSchema = z
+        .union([genericDynamicSyncTableSchema, genericSyncTableSchema])
+        .superRefine((data, context) => {
+        const syncTable = data;
+        if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['getter', 'varargParameters'],
+                message: 'Sync table formulas do not currently support varargParameters.',
             });
         }
     });
-})
-    .superRefine((data, context) => {
-    const schema = data;
-    /**
-     * Validates a PropertyIdentifier key in the object schema.
-     */
-    function validateProperty(propertyKey, isValidSchema, invalidSchemaMessage) {
-        function validatePropertyIdentifier(value, objectPath = [propertyKey]) {
-            var _a;
-            const propertyValue = typeof value === 'string' ? value : value === null || value === void 0 ? void 0 : value.property;
-            let propertyValueIsPath = false;
-            let propertySchema = typeof propertyValueRaw === 'string' && propertyValue in schema.properties
-                ? schema.properties[propertyValue]
-                : undefined;
-            if (!propertySchema) {
-                const schemaPropertyPath = (0, schema_19.normalizePropertyValuePathIntoSchemaPath)(propertyValue);
-                propertySchema = (_a = (0, jsonpath_plus_1.JSONPath)({
-                    path: schemaPropertyPath,
-                    json: schema.properties,
-                })) === null || _a === void 0 ? void 0 : _a[0];
-                propertyValueIsPath = true;
-            }
-            const propertyIdentifierDisplay = propertyValueIsPath
-                ? `"${propertyKey}" path`
-                : `"${propertyKey}" field name`;
-            if (!propertySchema) {
+    // Make sure to call the refiners on this after removing legacyPackMetadataSchema.
+    // (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
+    // schema we actually use.)
+    const unrefinedPackVersionMetadataSchema = zodCompleteObject({
+        version: z
+            .string()
+            .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".')
+            .refine(
+        // Version numbers must not be bigger than a postgres integer.
+        version => version.split('.').filter(part => Number(part) > 2147483647).length === 0, 'Pack version number too large'),
+        defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
+        networkDomains: z
+            .array(z
+            .string()
+            .max(exports.Limits.NetworkDomainUrl)
+            .refine(domain => !(domain.startsWith('http:') || domain.startsWith('https:') || domain.indexOf('/') >= 0), {
+            message: 'Invalid network domain. Instead of "https://www.example.com", just specify "example.com".',
+        }))
+            .optional(),
+        formulaNamespace: z.string().optional().refine(validateNamespace, {
+            message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
+        }),
+        systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
+        formulas: z
+            .array(formulaMetadataSchema)
+            .max(exports.Limits.BuildingBlockCountPerType)
+            .optional()
+            .default([])
+            .superRefine((data, context) => {
+            const formulaNames = data.map(formulaDef => formulaDef.name);
+            for (const dupe of getNonUniqueElements(formulaNames)) {
                 context.addIssue({
                     code: z.ZodIssueCode.custom,
-                    path: objectPath,
-                    message: `The ${propertyIdentifierDisplay} "${propertyValue}" does not exist in the "properties" object.`,
+                    message: `Formula names must be unique. Found duplicate name "${dupe}".`,
                 });
-                return;
             }
-            if (!isValidSchema(propertySchema)) {
+        }),
+        formats: z
+            .array(formatMetadataSchema)
+            .max(exports.Limits.BuildingBlockCountPerType)
+            .optional()
+            .default([])
+            .superRefine((data, context) => {
+            const formatNames = data.map(formatDef => formatDef.name);
+            for (const dupe of getNonUniqueElements(formatNames)) {
                 context.addIssue({
                     code: z.ZodIssueCode.custom,
-                    path: objectPath,
-                    message: `The ${propertyIdentifierDisplay} "${propertyValue}" ${invalidSchemaMessage}`,
-                });
-                return;
-            }
-        }
-        const propertyValueRaw = schema[propertyKey];
-        if (propertyValueRaw) {
-            if (Array.isArray(propertyValueRaw)) {
-                propertyValueRaw.forEach((propertyIdentifier, i) => {
-                    validatePropertyIdentifier(propertyIdentifier, [propertyKey, i]);
-                });
-                return;
-            }
-            validatePropertyIdentifier(propertyValueRaw);
-        }
-    }
-    const validateTitleProperty = () => {
-        return validateProperty('titleProperty', propertySchema => [schema_13.ValueType.String, schema_13.ValueType.Object].includes(propertySchema.type), `must refer to a "ValueType.String" or "ValueType.Object" property.`);
-    };
-    const validateImageProperty = () => {
-        return validateProperty('imageProperty', imagePropertySchema => imagePropertySchema.type === schema_13.ValueType.String &&
-            [schema_12.ValueHintType.ImageAttachment, schema_12.ValueHintType.ImageReference].includes(imagePropertySchema.codaType), `must refer to a "ValueType.String" property with a "ValueHintType.ImageAttachment" or "ValueHintType.ImageReference" "codaType".`);
-    };
-    const validateSnippetProperty = () => {
-        return validateProperty('snippetProperty', snippetPropertySchema => snippetPropertySchema.type === schema_13.ValueType.String ||
-            (snippetPropertySchema.type === schema_13.ValueType.Array && snippetPropertySchema.items.type === schema_13.ValueType.String), `must refer to a "ValueType.String" property or array of strings.`);
-    };
-    const validateLinkProperty = () => {
-        return validateProperty('linkProperty', linkPropertySchema => linkPropertySchema.type === schema_13.ValueType.String && linkPropertySchema.codaType === schema_12.ValueHintType.Url, `must refer to a "ValueType.String" property with a "ValueHintType.Url" "codaType".`);
-    };
-    const validateSubtitleProperties = () => {
-        return validateProperty('subtitleProperties', subtitlePropertySchema => {
-            if (!('codaType' in subtitlePropertySchema && subtitlePropertySchema.codaType)) {
-                return true;
-            }
-            switch (subtitlePropertySchema.codaType) {
-                case schema_12.ValueHintType.ImageAttachment:
-                case schema_12.ValueHintType.Attachment:
-                case schema_12.ValueHintType.ImageReference:
-                case schema_12.ValueHintType.Embed:
-                case schema_12.ValueHintType.Scale:
-                    return false;
-                case schema_12.ValueHintType.CodaInternalRichText:
-                case schema_12.ValueHintType.Currency:
-                case schema_12.ValueHintType.Date:
-                case schema_12.ValueHintType.DateTime:
-                case schema_12.ValueHintType.Duration:
-                case schema_12.ValueHintType.Email:
-                case schema_12.ValueHintType.Html:
-                case schema_12.ValueHintType.Markdown:
-                case schema_12.ValueHintType.Percent:
-                case schema_12.ValueHintType.Person:
-                case schema_12.ValueHintType.ProgressBar:
-                case schema_12.ValueHintType.Reference:
-                case schema_12.ValueHintType.SelectList:
-                case schema_12.ValueHintType.Slider:
-                case schema_12.ValueHintType.Toggle:
-                case schema_12.ValueHintType.Time:
-                case schema_12.ValueHintType.Url:
-                    return true;
-                default:
-                    (0, ensure_2.ensureUnreachable)(subtitlePropertySchema.codaType);
-            }
-        }, `must refer to a value that does not have a codaType corresponding to one of ImageAttachment, Attachment, ImageReference, Embed, or Scale.`);
-    };
-    validateTitleProperty();
-    validateLinkProperty();
-    validateImageProperty();
-    validateSnippetProperty();
-    validateSubtitleProperties();
-})
-    .superRefine((data, context) => {
-    var _a;
-    const schemaHelper = (0, migration_1.objectSchemaHelper)(data);
-    const internalRichTextPropertyTuple = Object.entries(schemaHelper.properties).find(([_key, prop]) => prop.type === schema_13.ValueType.String && prop.codaType === schema_12.ValueHintType.CodaInternalRichText);
-    if (internalRichTextPropertyTuple && !isValidUseOfCodaInternalRichText((_a = data.identity) === null || _a === void 0 ? void 0 : _a.packId)) {
-        context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['identity', 'properties', internalRichTextPropertyTuple[0]],
-            message: 'Invalid codaType. CodaInternalRichText is not a supported value.',
-        });
-        return;
-    }
-}));
-const objectPropertyUnionSchema = z
-    .union([booleanPropertySchema, numberPropertySchema, stringPropertySchema, arrayPropertySchema, genericObjectSchema])
-    .refine((schema) => {
-    const schemaForAutocomplete = (0, schema_18.maybeUnwrapArraySchema)(schema);
-    const result = !schemaForAutocomplete ||
-        (0, schema_20.unwrappedSchemaSupportsAutocomplete)(schemaForAutocomplete) ||
-        !('autocomplete' in schemaForAutocomplete && schemaForAutocomplete.autocomplete);
-    return result;
-}, 'You must set "codaType" to ValueHintType.SelectList or ValueHintType.Reference when setting an "autocomplete" property.');
-const objectPackFormulaSchema = zodCompleteObject({
-    ...commonPackFormulaSchema,
-    resultType: zodDiscriminant(api_types_4.Type.object),
-    // TODO(jonathan): See if we should really allow this. The SDK right now explicitly tolerates an undefined
-    // schema for objects, but that doesn't seem like a use case we actually want to support.
-    schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
-});
-const formulaMetadataSchema = z
-    .union([numericPackFormulaSchema, stringPackFormulaSchema, booleanPackFormulaSchema, objectPackFormulaSchema])
-    .superRefine((data, context) => {
-    const parameters = data.parameters;
-    const varargParameters = data.varargParameters || [];
-    const paramNames = new Set();
-    for (const param of [...parameters, ...varargParameters]) {
-        if (paramNames.has(param.name)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['parameters'],
-                message: `Parameter names must be unique. Found duplicate name "${param.name}".`,
-            });
-        }
-        paramNames.add(param.name);
-    }
-});
-const formatMetadataSchema = zodCompleteObject({
-    name: z.string().max(exports.Limits.BuildingBlockName),
-    formulaNamespace: z.string().optional(),
-    formulaName: z.string(),
-    hasNoConnection: z.boolean().optional(),
-    instructions: z.string().optional(),
-    placeholder: z.string().optional(),
-    matchers: z
-        .array(z.string().max(exports.Limits.ColumnMatcherRegex).refine(validateFormatMatcher))
-        .max(exports.Limits.NumColumnMatchersPerFormat),
-});
-const syncFormulaSchema = zodCompleteObject({
-    schema: arrayPropertySchema.optional(),
-    resultType: z.any(),
-    isSyncFormula: z.literal(true),
-    maxUpdateBatchSize: z.number().min(1).max(exports.Limits.UpdateBatchSize).optional(),
-    supportsUpdates: z.boolean().optional(),
-    ...commonPackFormulaSchema,
-});
-const baseSyncTableSchema = {
-    name: z
-        .string()
-        .nonempty()
-        .max(exports.Limits.BuildingBlockName)
-        .regex(regexFormulaName, 'Sync Table names can only contain alphanumeric characters and underscores.'),
-    description: z.string().max(exports.Limits.BuildingBlockDescription).optional(),
-    schema: genericObjectSchema,
-    getter: syncFormulaSchema,
-    entityName: z.string().optional(),
-    defaultAddDynamicColumns: z.boolean().optional(),
-    // TODO(patrick): Make identityName non-optional after SDK v1.0.0 is required
-    identityName: z
-        .string()
-        .min(1)
-        .max(exports.Limits.BuildingBlockName)
-        .optional()
-        .refine(val => !val || !SystemColumnNames.includes(val), `This property name is reserved for internal use by Coda and can't be used as an identityName, sorry!`),
-    namedAutocompletes: z
-        .record(formulaMetadataSchema)
-        .optional()
-        .default({})
-        .superRefine((data, context) => {
-        if (Object.keys(data).length > exports.Limits.BuildingBlockName) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Too many autocomplete formulas for sync table. Max allowed is "${exports.Limits.BuildingBlockName}".`,
-            });
-        }
-    }),
-};
-const genericSyncTableSchema = zodCompleteObject({
-    ...baseSyncTableSchema,
-    // Add a fake discriminant here so that we can flag union errors as related to a non-matching discriminant
-    // and filter them out. A real regular sync table wouldn't specify `isDynamic` at all here, but including
-    // it in the validator like this helps zod flag it in the way we need.
-    isDynamic: zodDiscriminant(false).optional(),
-    getSchema: formulaMetadataSchema.optional(),
-}).strict();
-const genericDynamicSyncTableSchema = zodCompleteObject({
-    ...baseSyncTableSchema,
-    isDynamic: zodDiscriminant(true),
-    getName: formulaMetadataSchema,
-    getDisplayUrl: formulaMetadataSchema,
-    listDynamicUrls: formulaMetadataSchema.optional(),
-    searchDynamicUrls: formulaMetadataSchema.optional(),
-    getSchema: formulaMetadataSchema,
-    autocomplete: objectPackFormulaSchema.optional(),
-}).strict();
-const syncTableSchema = z
-    .union([genericDynamicSyncTableSchema, genericSyncTableSchema])
-    .superRefine((data, context) => {
-    const syncTable = data;
-    if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
-        context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['getter', 'varargParameters'],
-            message: 'Sync table formulas do not currently support varargParameters.',
-        });
-    }
-});
-// Make sure to call the refiners on this after removing legacyPackMetadataSchema.
-// (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
-// schema we actually use.)
-const unrefinedPackVersionMetadataSchema = zodCompleteObject({
-    version: z
-        .string()
-        .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".')
-        .refine(
-    // Version numbers must not be bigger than a postgres integer.
-    version => version.split('.').filter(part => Number(part) > 2147483647).length === 0, 'Pack version number too large'),
-    defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
-    networkDomains: z
-        .array(z
-        .string()
-        .max(exports.Limits.NetworkDomainUrl)
-        .refine(domain => !(domain.startsWith('http:') || domain.startsWith('https:') || domain.indexOf('/') >= 0), {
-        message: 'Invalid network domain. Instead of "https://www.example.com", just specify "example.com".',
-    }))
-        .optional(),
-    formulaNamespace: z.string().optional().refine(validateNamespace, {
-        message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
-    }),
-    systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
-    formulas: z
-        .array(formulaMetadataSchema)
-        .max(exports.Limits.BuildingBlockCountPerType)
-        .optional()
-        .default([])
-        .superRefine((data, context) => {
-        const formulaNames = data.map(formulaDef => formulaDef.name);
-        for (const dupe of getNonUniqueElements(formulaNames)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Formula names must be unique. Found duplicate name "${dupe}".`,
-            });
-        }
-    }),
-    formats: z
-        .array(formatMetadataSchema)
-        .max(exports.Limits.BuildingBlockCountPerType)
-        .optional()
-        .default([])
-        .superRefine((data, context) => {
-        const formatNames = data.map(formatDef => formatDef.name);
-        for (const dupe of getNonUniqueElements(formatNames)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Format names must be unique. Found duplicate name "${dupe}".`,
-            });
-        }
-    }),
-    syncTables: z
-        .array(syncTableSchema)
-        .max(exports.Limits.BuildingBlockCountPerType)
-        .optional()
-        .default([])
-        .superRefine((data, context) => {
-        var _a, _b;
-        const identityNames = [];
-        for (const tableDef of data) {
-            if (tableDef.identityName && ((_a = tableDef.schema.identity) === null || _a === void 0 ? void 0 : _a.name)) {
-                if (tableDef.identityName !== tableDef.schema.identity.name) {
-                    context.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        message: `Sync table "${tableDef.name}" defines identityName "${tableDef.identityName}" that conflicts with its schema's identity.name "${tableDef.schema.identity.name}".`,
-                    });
-                }
-            }
-            // only add identity names that are not undefined to check for dupes
-            if (tableDef.schema.identity) {
-                identityNames.push((_b = tableDef.schema.identity) === null || _b === void 0 ? void 0 : _b.name);
-            }
-        }
-        for (const dupe of getNonUniqueElements(identityNames)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
-            });
-        }
-        const tableNames = data.map(tableDef => tableDef.name);
-        for (const dupe of getNonUniqueElements(tableNames)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Sync table names must be unique. Found duplicate name "${dupe}".`,
-            });
-        }
-    }),
-});
-function validateNamespace(namespace) {
-    if (typeof namespace === 'undefined') {
-        return true;
-    }
-    return validateFormulaName(namespace);
-}
-function validateFormulaName(value) {
-    return regexFormulaName.test(value);
-}
-function validateFormulas(schema) {
-    return schema
-        .refine(data => {
-        if (data.formulas && data.formulas.length > 0) {
-            return data.formulaNamespace;
-        }
-        return true;
-    }, { message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace'] })
-        .refine(untypedMetadata => {
-        var _a, _b;
-        const metadata = untypedMetadata;
-        if (((_a = metadata.defaultAuthentication) === null || _a === void 0 ? void 0 : _a.type) !== types_1.AuthenticationType.CodaApiHeaderBearerToken) {
-            return true;
-        }
-        const codaDomains = ['coda.io', 'localhost'];
-        const hasNonCodaNetwork = (_b = metadata.networkDomains) === null || _b === void 0 ? void 0 : _b.some((domain) => !codaDomains.includes(domain));
-        if (!hasNonCodaNetwork) {
-            return true;
-        }
-        const authDomains = getAuthNetworkDomains(metadata);
-        if (!(authDomains === null || authDomains === void 0 ? void 0 : authDomains.length)) {
-            // A non-Coda network domain without auth domain restriction isn't allowed.
-            return false;
-        }
-        const hasNonCodaAuthDomain = authDomains.some((domain) => !codaDomains.includes(domain));
-        // A non-coda auth domain is always an issue.
-        return !hasNonCodaAuthDomain;
-    }, {
-        message: 'CodaApiHeaderBearerToken can only be used for coda.io domains. Restrict `defaultAuthentication.networkDomain` to coda.io',
-        path: ['defaultAuthentication.networkDomain'],
-    })
-        .superRefine((data, context) => {
-        if (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) {
-            return;
-        }
-        // if the pack has no default authentication, make sure all formulas don't set connection requirements.
-        (data.formulas || []).forEach((formula, i) => {
-            if (formula.connectionRequirement && formula.connectionRequirement !== api_types_2.ConnectionRequirement.None) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['formulas', i],
-                    message: 'Formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
+                    message: `Format names must be unique. Found duplicate name "${dupe}".`,
                 });
             }
-        });
-        (data.syncTables || []).forEach((syncTable, i) => {
-            const connectionRequirement = syncTable.getter.connectionRequirement;
-            if (connectionRequirement && connectionRequirement !== api_types_2.ConnectionRequirement.None) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['syncTables', i, 'getter', 'connectionRequirement'],
-                    message: 'Sync table formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
-                });
-            }
-        });
-    })
-        .superRefine((data, context) => {
-        const formulas = (data.formulas || []);
-        (data.formats || []).forEach((format, i) => {
-            var _a;
-            const formula = formulas.find(f => f.name === format.formulaName);
-            if (!formula) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['formats', i],
-                    message: 'Could not find a formula definition for this format. Each format must reference the name of a formula defined in this pack.',
-                });
-            }
-            else {
-                let hasError = !((_a = formula.parameters) === null || _a === void 0 ? void 0 : _a.length);
-                const [_, ...extraParams] = formula.parameters || [];
-                for (const extraParam of extraParams) {
-                    if (!extraParam.optional) {
-                        hasError = true;
+        }),
+        syncTables: z
+            .array(syncTableSchema)
+            .max(exports.Limits.BuildingBlockCountPerType)
+            .optional()
+            .default([])
+            .superRefine((data, context) => {
+            var _a, _b;
+            const identityNames = [];
+            for (const tableDef of data) {
+                if (tableDef.identityName && ((_a = tableDef.schema.identity) === null || _a === void 0 ? void 0 : _a.name)) {
+                    if (tableDef.identityName !== tableDef.schema.identity.name) {
+                        context.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            message: `Sync table "${tableDef.name}" defines identityName "${tableDef.identityName}" that conflicts with its schema's identity.name "${tableDef.schema.identity.name}".`,
+                        });
                     }
                 }
-                if (hasError) {
+                // only add identity names that are not undefined to check for dupes
+                if (tableDef.schema.identity) {
+                    identityNames.push((_b = tableDef.schema.identity) === null || _b === void 0 ? void 0 : _b.name);
+                }
+            }
+            for (const dupe of getNonUniqueElements(identityNames)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
+                });
+            }
+            const tableNames = data.map(tableDef => tableDef.name);
+            for (const dupe of getNonUniqueElements(tableNames)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Sync table names must be unique. Found duplicate name "${dupe}".`,
+                });
+            }
+        }),
+    });
+    function validateNamespace(namespace) {
+        if (typeof namespace === 'undefined') {
+            return true;
+        }
+        return validateFormulaName(namespace);
+    }
+    function validateFormulaName(value) {
+        return regexFormulaName.test(value);
+    }
+    function validateFormulas(schema) {
+        return schema
+            .refine(data => {
+            if (data.formulas && data.formulas.length > 0) {
+                return data.formulaNamespace;
+            }
+            return true;
+        }, { message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace'] })
+            .refine(untypedMetadata => {
+            var _a, _b;
+            const metadata = untypedMetadata;
+            if (((_a = metadata.defaultAuthentication) === null || _a === void 0 ? void 0 : _a.type) !== types_1.AuthenticationType.CodaApiHeaderBearerToken) {
+                return true;
+            }
+            const codaDomains = ['coda.io', 'localhost'];
+            const hasNonCodaNetwork = (_b = metadata.networkDomains) === null || _b === void 0 ? void 0 : _b.some((domain) => !codaDomains.includes(domain));
+            if (!hasNonCodaNetwork) {
+                return true;
+            }
+            const authDomains = getAuthNetworkDomains(metadata);
+            if (!(authDomains === null || authDomains === void 0 ? void 0 : authDomains.length)) {
+                // A non-Coda network domain without auth domain restriction isn't allowed.
+                return false;
+            }
+            const hasNonCodaAuthDomain = authDomains.some((domain) => !codaDomains.includes(domain));
+            // A non-coda auth domain is always an issue.
+            return !hasNonCodaAuthDomain;
+        }, {
+            message: 'CodaApiHeaderBearerToken can only be used for coda.io domains. Restrict `defaultAuthentication.networkDomain` to coda.io',
+            path: ['defaultAuthentication.networkDomain'],
+        })
+            .superRefine((data, context) => {
+            if (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) {
+                return;
+            }
+            // if the pack has no default authentication, make sure all formulas don't set connection requirements.
+            (data.formulas || []).forEach((formula, i) => {
+                if (formula.connectionRequirement && formula.connectionRequirement !== api_types_2.ConnectionRequirement.None) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['formulas', i],
+                        message: 'Formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
+                    });
+                }
+            });
+            (data.syncTables || []).forEach((syncTable, i) => {
+                const connectionRequirement = syncTable.getter.connectionRequirement;
+                if (connectionRequirement && connectionRequirement !== api_types_2.ConnectionRequirement.None) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['syncTables', i, 'getter', 'connectionRequirement'],
+                        message: 'Sync table formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
+                    });
+                }
+            });
+        })
+            .superRefine((data, context) => {
+            const formulas = (data.formulas || []);
+            (data.formats || []).forEach((format, i) => {
+                var _a;
+                const formula = formulas.find(f => f.name === format.formulaName);
+                if (!formula) {
                     context.addIssue({
                         code: z.ZodIssueCode.custom,
                         path: ['formats', i],
-                        message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
+                        message: 'Could not find a formula definition for this format. Each format must reference the name of a formula defined in this pack.',
                     });
+                }
+                else {
+                    let hasError = !((_a = formula.parameters) === null || _a === void 0 ? void 0 : _a.length);
+                    const [_, ...extraParams] = formula.parameters || [];
+                    for (const extraParam of extraParams) {
+                        if (!extraParam.optional) {
+                            hasError = true;
+                        }
+                    }
+                    if (hasError) {
+                        context.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ['formats', i],
+                            message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
+                        });
+                    }
+                }
+            });
+        });
+    }
+    function validateFormatMatcher(value) {
+        try {
+            const parsed = value.match(exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX);
+            if (!parsed) {
+                return false;
+            }
+            const [, pattern, flags] = parsed;
+            new RegExp(pattern, flags);
+            return true;
+        }
+        catch (error) {
+            return false;
+        }
+    }
+    // We temporarily allow our legacy packs to provide non-versioned data until we sufficiently migrate them.
+    // But all fields must be optional, because this is the top-level object we use for validation,
+    // so we must be able to pass validation while providing only fields from PackVersionMetadata.
+    const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSchema.extend({
+        id: z.number().optional(),
+        name: z.string().nonempty().optional(),
+        shortDescription: z.string().nonempty().optional(),
+        description: z.string().nonempty().optional(),
+        permissionsDescription: z.string().optional(),
+        category: z.nativeEnum(types_3.PackCategory).optional(),
+        logoPath: z.string().optional(),
+        exampleImages: z.array(z.string()).optional(),
+        exampleVideoIds: z.array(z.string()).optional(),
+        minimumFeatureSet: z.nativeEnum(types_2.FeatureSet).optional(),
+        quotas: z.any().optional(),
+        rateLimits: z.any().optional(),
+        isSystem: z.boolean().optional(),
+    }))
+        .superRefine((data, context) => {
+        (data.syncTables || []).forEach((syncTable, i) => {
+            var _a;
+            if (!((_a = syncTable.schema) === null || _a === void 0 ? void 0 : _a.identity)) {
+                return;
+            }
+            const identityName = syncTable.schema.identity.name;
+            if (syncTable.schema.properties[identityName]) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['syncTables', i, 'schema', 'properties', identityName],
+                    message: "Cannot have a sync table property with the same name as the sync table's schema identity.",
+                });
+            }
+        });
+    })
+        .superRefine((data, context) => {
+        (data.syncTables || []).forEach((syncTable, i) => {
+            const packId = data.id;
+            const getterName = syncTable.getter.name;
+            if (packId && SyncTableGetterNameExemptions.has(exemptionKey(packId, getterName))) {
+                return;
+            }
+            if (!validateFormulaName(getterName)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['syncTables', i, 'getter', 'name'],
+                    message: 'Formula names can only contain alphanumeric characters and underscores.',
+                });
+            }
+        });
+    })
+        .superRefine((data, context) => {
+        (data.formulas || []).forEach((formula, i) => {
+            // We have to validate regular formula names here as a superRefine because formulas share
+            // a validator with sync table getters, and we need pack ids to exempt certain legacy
+            // formula getters with spaces in their names.
+            if (!validateFormulaName(formula.name)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['formulas', i, 'name'],
+                    message: 'Formula names can only contain alphanumeric characters and underscores.',
+                });
+            }
+        });
+    })
+        .refine(data => {
+        var _a, _b, _c;
+        const usesAuthentication = (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) ||
+            data.systemConnectionAuthentication;
+        if (!usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length) || ((_b = data.defaultAuthentication) === null || _b === void 0 ? void 0 : _b.requiresEndpointUrl)) {
+            return true;
+        }
+        // Various is an internal authentication type that's only applicable to whitelisted Pack Ids.
+        // Skipping validation here to let it exempt from network domains.
+        if (((_c = data.defaultAuthentication) === null || _c === void 0 ? void 0 : _c.type) === types_1.AuthenticationType.Various) {
+            return true;
+        }
+        return false;
+    }, {
+        message: 'This pack uses authentication but did not declare a network domain. ' +
+            "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+        path: ['networkDomains'],
+    })
+        .superRefine((untypedData, context) => {
+        var _a;
+        const data = untypedData;
+        const authNetworkDomains = getAuthNetworkDomains(data);
+        if (!(0, object_utils_1.isDefined)(authNetworkDomains)) {
+            // This is a Various or None auth pack.
+            return;
+        }
+        // Auth network domains must match pack network domains.
+        for (const authNetworkDomain of authNetworkDomains) {
+            if (!((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.includes(authNetworkDomain))) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['defaultAuthentication.networkDomain'],
+                    message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
+                });
+                return;
+            }
+        }
+    })
+        .superRefine((untypedData, context) => {
+        const data = untypedData;
+        const authNetworkDomains = getAuthNetworkDomains(data);
+        if (!(0, object_utils_1.isDefined)(authNetworkDomains)) {
+            // This is a Various or None auth pack.
+            return;
+        }
+        // A pack with multiple networks and auth must choose which domain(s) get auth on them.
+        if (!(authNetworkDomains === null || authNetworkDomains === void 0 ? void 0 : authNetworkDomains.length)) {
+            if (data.networkDomains && data.networkDomains.length > 1) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['defaultAuthentication.networkDomain'],
+                    message: 'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
+                });
+            }
+            return;
+        }
+    })
+        .superRefine((untypedData, context) => {
+        const data = untypedData;
+        (data.syncTables || []).forEach((syncTable, i) => {
+            const schema = syncTable.schema;
+            for (const [propertyName, childSchema] of Object.entries(schema.properties)) {
+                const autocomplete = (0, schema_17.maybeSchemaAutocompleteValue)(childSchema);
+                if (!autocomplete || Array.isArray(autocomplete)) {
+                    continue;
+                }
+                if (typeof autocomplete !== 'string' || !(autocomplete in (syncTable.namedAutocompletes || {}))) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['syncTables', i, 'properties', propertyName, 'autocomplete'],
+                        message: autocomplete === api_types_1.AutocompleteType.Dynamic
+                            ? `Sync table ${syncTable.name} must define "autocomplete" for this property to use AutocompleteType.Dynamic`
+                            : `"${autocomplete}" is not registered as an autocomplete function for this sync table.`,
+                    });
+                    continue;
                 }
             }
         });
     });
+    return { legacyPackMetadataSchema, variousSupportedAuthenticationValidators, arrayPropertySchema };
 }
-function validateFormatMatcher(value) {
-    try {
-        const parsed = value.match(exports.PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX);
-        if (!parsed) {
-            return false;
-        }
-        const [, pattern, flags] = parsed;
-        new RegExp(pattern, flags);
-        return true;
-    }
-    catch (error) {
-        return false;
-    }
-}
-// We temporarily allow our legacy packs to provide non-versioned data until we sufficiently migrate them.
-// But all fields must be optional, because this is the top-level object we use for validation,
-// so we must be able to pass validation while providing only fields from PackVersionMetadata.
-const legacyPackMetadataSchema = validateFormulas(unrefinedPackVersionMetadataSchema.extend({
-    id: z.number().optional(),
-    name: z.string().nonempty().optional(),
-    shortDescription: z.string().nonempty().optional(),
-    description: z.string().nonempty().optional(),
-    permissionsDescription: z.string().optional(),
-    category: z.nativeEnum(types_3.PackCategory).optional(),
-    logoPath: z.string().optional(),
-    exampleImages: z.array(z.string()).optional(),
-    exampleVideoIds: z.array(z.string()).optional(),
-    minimumFeatureSet: z.nativeEnum(types_2.FeatureSet).optional(),
-    quotas: z.any().optional(),
-    rateLimits: z.any().optional(),
-    isSystem: z.boolean().optional(),
-}))
-    .superRefine((data, context) => {
-    (data.syncTables || []).forEach((syncTable, i) => {
-        var _a;
-        if (!((_a = syncTable.schema) === null || _a === void 0 ? void 0 : _a.identity)) {
-            return;
-        }
-        const identityName = syncTable.schema.identity.name;
-        if (syncTable.schema.properties[identityName]) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['syncTables', i, 'schema', 'properties', identityName],
-                message: "Cannot have a sync table property with the same name as the sync table's schema identity.",
-            });
-        }
-    });
-})
-    .superRefine((data, context) => {
-    (data.syncTables || []).forEach((syncTable, i) => {
-        const packId = data.id;
-        const getterName = syncTable.getter.name;
-        if (packId && SyncTableGetterNameExemptions.has(exemptionKey(packId, getterName))) {
-            return;
-        }
-        if (!validateFormulaName(getterName)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['syncTables', i, 'getter', 'name'],
-                message: 'Formula names can only contain alphanumeric characters and underscores.',
-            });
-        }
-    });
-})
-    .superRefine((data, context) => {
-    (data.formulas || []).forEach((formula, i) => {
-        // We have to validate regular formula names here as a superRefine because formulas share
-        // a validator with sync table getters, and we need pack ids to exempt certain legacy
-        // formula getters with spaces in their names.
-        if (!validateFormulaName(formula.name)) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['formulas', i, 'name'],
-                message: 'Formula names can only contain alphanumeric characters and underscores.',
-            });
-        }
-    });
-})
-    .refine(data => {
-    var _a, _b, _c;
-    const usesAuthentication = (data.defaultAuthentication && data.defaultAuthentication.type !== types_1.AuthenticationType.None) ||
-        data.systemConnectionAuthentication;
-    if (!usesAuthentication || ((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length) || ((_b = data.defaultAuthentication) === null || _b === void 0 ? void 0 : _b.requiresEndpointUrl)) {
-        return true;
-    }
-    // Various is an internal authentication type that's only applicable to whitelisted Pack Ids.
-    // Skipping validation here to let it exempt from network domains.
-    if (((_c = data.defaultAuthentication) === null || _c === void 0 ? void 0 : _c.type) === types_1.AuthenticationType.Various) {
-        return true;
-    }
-    return false;
-}, {
-    message: 'This pack uses authentication but did not declare a network domain. ' +
-        "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
-    path: ['networkDomains'],
-})
-    .superRefine((untypedData, context) => {
-    var _a;
-    const data = untypedData;
-    const authNetworkDomains = getAuthNetworkDomains(data);
-    if (!(0, object_utils_1.isDefined)(authNetworkDomains)) {
-        // This is a Various or None auth pack.
-        return;
-    }
-    // Auth network domains must match pack network domains.
-    for (const authNetworkDomain of authNetworkDomains) {
-        if (!((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.includes(authNetworkDomain))) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['defaultAuthentication.networkDomain'],
-                message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
-            });
-            return;
-        }
-    }
-})
-    .superRefine((untypedData, context) => {
-    const data = untypedData;
-    const authNetworkDomains = getAuthNetworkDomains(data);
-    if (!(0, object_utils_1.isDefined)(authNetworkDomains)) {
-        // This is a Various or None auth pack.
-        return;
-    }
-    // A pack with multiple networks and auth must choose which domain(s) get auth on them.
-    if (!(authNetworkDomains === null || authNetworkDomains === void 0 ? void 0 : authNetworkDomains.length)) {
-        if (data.networkDomains && data.networkDomains.length > 1) {
-            context.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['defaultAuthentication.networkDomain'],
-                message: 'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-            });
-        }
-        return;
-    }
-})
-    .superRefine((untypedData, context) => {
-    const data = untypedData;
-    (data.syncTables || []).forEach((syncTable, i) => {
-        const schema = syncTable.schema;
-        for (const [propertyName, childSchema] of Object.entries(schema.properties)) {
-            const autocomplete = (0, schema_17.maybeSchemaAutocompleteValue)(childSchema);
-            if (!autocomplete || Array.isArray(autocomplete)) {
-                continue;
-            }
-            if (typeof autocomplete !== 'string' || !(autocomplete in (syncTable.namedAutocompletes || {}))) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['syncTables', i, 'properties', propertyName, 'autocomplete'],
-                    message: autocomplete === api_types_1.AutocompleteType.Dynamic
-                        ? `Sync table ${syncTable.name} must define "autocomplete" for this property to use AutocompleteType.Dynamic`
-                        : `"${autocomplete}" is not registered as an autocomplete function for this sync table.`,
-                });
-                continue;
-            }
-        }
-    });
-});
 // Returns undefined for None or Various auth, otherwise returns a string array.
 function getAuthNetworkDomains(data) {
     if (!data.defaultAuthentication ||
@@ -1524,6 +1540,23 @@ const packMetadataSchemaBySdkVersion = [
                         });
                     });
                 }
+            });
+        },
+    },
+    {
+        versionRange: '>1.4.0',
+        schemaExtend: schema => {
+            return schema.superRefine((untypedData, context) => {
+                const data = untypedData;
+                data.syncTables.forEach((syncTable, i) => {
+                    const schemaPathPrefix = ['syncTables', i, 'schema'];
+                    validateSchemaDeprecatedFields(syncTable.schema, schemaPathPrefix, context);
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['syncTables', i, 'schema'],
+                        message: 'Needs SelectList codaType',
+                    });
+                });
             });
         },
     },

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1483,6 +1483,8 @@ function getAuthNetworkDomains(data) {
     }
     return [];
 }
+// TODO(dweitzman): Migrate SchemaExtensions to use conditionals in buildMetadataSchema() and delete
+// the SchemaExtension feature.
 const packMetadataSchemaBySdkVersion = [
     {
         versionRange: '>=1.0.0',
@@ -1540,23 +1542,6 @@ const packMetadataSchemaBySdkVersion = [
                         });
                     });
                 }
-            });
-        },
-    },
-    {
-        versionRange: '>1.4.0',
-        schemaExtend: schema => {
-            return schema.superRefine((untypedData, context) => {
-                const data = untypedData;
-                data.syncTables.forEach((syncTable, i) => {
-                    const schemaPathPrefix = ['syncTables', i, 'schema'];
-                    validateSchemaDeprecatedFields(syncTable.schema, schemaPathPrefix, context);
-                    context.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['syncTables', i, 'schema'],
-                        message: 'Needs SelectList codaType',
-                    });
-                });
             });
         },
     },

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -49,7 +49,14 @@ import {validatePackVersionMetadata} from '../testing/upload_validation';
 import {validateSyncTableSchema} from '../testing/upload_validation';
 import {validateVariousAuthenticationMetadata} from '../testing/upload_validation';
 
-describe('Pack metadata Validation', () => {
+describe('Pack metadata Validation', async () => {
+  async function getCurrentSdkVersion(): Promise<string> {
+    const packageJson = await import('' + '../package.json');
+    const codaPacksSDKVersion = packageJson.version as string;
+    return codaPacksSDKVersion;
+  }
+  const codaPacksSDKVersion = await getCurrentSdkVersion();
+
   async function validateJson(obj: Record<string, any>, sdkVersion?: string) {
     try {
       return await doValidateJson(obj, sdkVersion);
@@ -60,8 +67,6 @@ describe('Pack metadata Validation', () => {
   }
 
   async function doValidateJson(obj: Record<string, any>, sdkVersion?: string) {
-    const packageJson = await import('' + '../package.json');
-    const codaPacksSDKVersion = packageJson.version as string;
     return validatePackVersionMetadata(obj, sdkVersion === null ? codaPacksSDKVersion : sdkVersion);
   }
 
@@ -3758,7 +3763,7 @@ describe('Pack metadata Validation', () => {
   describe('validateSyncTableSchema', () => {
     function validateAndAssertFails(schema: any, details?: string): PackMetadataValidationError {
       try {
-        validateSyncTableSchema(schema, {});
+        validateSyncTableSchema(schema, {sdkVersion: codaPacksSDKVersion});
         assert.fail('Expected validateSyncTableSchema to fail but it succeeded');
       } catch (err: any) {
         assert.isTrue(err.message.startsWith('Schema failed validation'));
@@ -3789,10 +3794,10 @@ describe('Pack metadata Validation', () => {
         items: itemSchema,
       });
       // Test an array schema
-      const arraySchemaResult = validateSyncTableSchema(arraySchema, {});
+      const arraySchemaResult = validateSyncTableSchema(arraySchema, {sdkVersion: codaPacksSDKVersion});
       assert.ok(arraySchemaResult);
       // Test an object schema
-      const objectSchemaResult = validateSyncTableSchema(itemSchema, {});
+      const objectSchemaResult = validateSyncTableSchema(itemSchema, {sdkVersion: codaPacksSDKVersion});
       assert.ok(objectSchemaResult);
       // It should be changed into an Array schema automatically.
       assert.equal(objectSchemaResult.type, ValueType.Array);
@@ -3863,9 +3868,9 @@ describe('Pack metadata Validation', () => {
         type: ValueType.Array,
         items: itemSchema,
       });
-      const arraySchemaResult = validateSyncTableSchema(arraySchema, {});
+      const arraySchemaResult = validateSyncTableSchema(arraySchema, {sdkVersion: codaPacksSDKVersion});
       assert.ok(arraySchemaResult);
-      const objectSchemaResult = validateSyncTableSchema(itemSchema, {});
+      const objectSchemaResult = validateSyncTableSchema(itemSchema, {sdkVersion: codaPacksSDKVersion});
       assert.ok(objectSchemaResult);
     });
 

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -150,6 +150,8 @@ export async function validatePackVersionMetadata(
   sdkVersion: string | undefined,
   {warningMode}: {warningMode?: boolean} = {},
 ): Promise<PackVersionMetadata> {
+  const {legacyPackMetadataSchema} = buildMetadataSchema({sdkVersion, warningMode});
+
   let combinedSchema: z.ZodType<Partial<PackVersionMetadata>> = legacyPackMetadataSchema;
 
   // Server-side validation may be running a different SDK version than the pack maker
@@ -179,7 +181,11 @@ export async function validatePackVersionMetadata(
 
 // Note: This is called within Coda for validating user-provided authentication metadata
 // as part of Various connections.
-export function validateVariousAuthenticationMetadata(auth: any): VariousAuthentication {
+export function validateVariousAuthenticationMetadata(
+  auth: any,
+  options: buildMetadataSchemaArgs,
+): VariousAuthentication {
+  const {variousSupportedAuthenticationValidators} = buildMetadataSchema(options);
   const validated = z.union(zodUnionInput(variousSupportedAuthenticationValidators)).safeParse(auth);
   if (validated.success) {
     return auth as VariousAuthentication;
@@ -193,7 +199,11 @@ export function validateVariousAuthenticationMetadata(auth: any): VariousAuthent
 }
 
 // Note: This is called within Coda for validating the result of getSchema calls for dynamic sync tables.
-export function validateSyncTableSchema(schema: any): ArraySchema<ObjectSchema<any, any>> {
+export function validateSyncTableSchema(
+  schema: any,
+  options: buildMetadataSchemaArgs,
+): ArraySchema<ObjectSchema<any, any>> {
+  const {arrayPropertySchema} = buildMetadataSchema(options);
   const validated = arrayPropertySchema.safeParse(schema);
   if (validated.success) {
     return validated.data;
@@ -355,1385 +365,1405 @@ const setEndpointPostSetupValidator = zodCompleteObject<SetEndpoint>({
   'Either getOptions or getOptionsFormula must be specified.',
 );
 
-const singleAuthDomainSchema = z
-  .string()
-  .nonempty()
-  .refine(domain => domain.indexOf(' ') < 0, {
-    message: 'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+interface buildMetadataSchemaArgs {
+  sdkVersion?: string;
+  warningMode?: boolean;
+}
+function buildMetadataSchema({sdkVersion}: buildMetadataSchemaArgs) {
+  const singleAuthDomainSchema = z
+    .string()
+    .nonempty()
+    .refine(domain => domain.indexOf(' ') < 0, {
+      message:
+        'The `networkDomain` in setUserAuthentication() cannot contain spaces. Use an array for multiple domains.',
+    });
+
+  const baseAuthenticationValidators = {
+    // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
+    // in the full bundle, not the metadata.
+    getConnectionName: z.unknown().optional(),
+    getConnectionUserId: z.unknown().optional(),
+    instructionsUrl: z.string().optional(),
+    requiresEndpointUrl: z.boolean().optional(),
+    endpointDomain: z.string().optional(),
+    // The items are technically a discriminated union type but that union currently only has one member.
+    postSetup: z.array(setEndpointPostSetupValidator).optional(),
+    networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
+  };
+
+  const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> = {
+    [AuthenticationType.None]: zodCompleteStrictObject<NoAuthentication>({
+      type: zodDiscriminant(AuthenticationType.None),
+    }),
+    [AuthenticationType.HeaderBearerToken]: zodCompleteStrictObject<HeaderBearerTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.HeaderBearerToken),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.CodaApiHeaderBearerToken]: zodCompleteStrictObject<CodaApiBearerTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.CodaApiHeaderBearerToken),
+      deferConnectionSetup: z.boolean().optional(),
+      shouldAutoAuthSetup: z.boolean().optional(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.CustomHeaderToken]: zodCompleteStrictObject<CustomHeaderTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.CustomHeaderToken),
+      headerName: z.string(),
+      tokenPrefix: z.string().optional(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.MultiHeaderToken]: zodCompleteStrictObject<MultiHeaderTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.MultiHeaderToken),
+      headers: z
+        .array(
+          zodCompleteStrictObject<MultiHeaderTokenAuthentication['headers'][number]>({
+            name: z.string(),
+            description: z.string(),
+            tokenPrefix: z.string().optional(),
+          }),
+        )
+        .refine(
+          headers => {
+            const keys = headers.map(header => header.name.toLowerCase());
+            return keys.length === new Set(keys).size;
+          },
+          {message: 'Duplicated header names in the MultiHeaderToken authentication config'},
+        ),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.QueryParamToken]: zodCompleteStrictObject<QueryParamTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.QueryParamToken),
+      paramName: z.string(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.MultiQueryParamToken]: zodCompleteStrictObject<MultiQueryParamTokenAuthentication>({
+      type: zodDiscriminant(AuthenticationType.MultiQueryParamToken),
+      params: z
+        .array(
+          zodCompleteStrictObject<MultiQueryParamTokenAuthentication['params'][number]>({
+            name: z.string(),
+            description: z.string(),
+          }),
+        )
+        .refine(
+          params => {
+            const keys = params.map(param => param.name);
+            return keys.length === new Set(keys).size;
+          },
+          {message: 'Duplicated parameter names in the MultiQueryParamToken authentication config'},
+        ),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.OAuth2]: zodCompleteStrictObject<OAuth2Authentication>({
+      type: zodDiscriminant(AuthenticationType.OAuth2),
+      authorizationUrl: z.string().url(),
+      tokenUrl: z.string().url(),
+      scopes: z.array(z.string()).optional(),
+      scopeDelimiter: z.enum([' ', ',', ';']).optional(),
+      tokenPrefix: z.string().optional(),
+      additionalParams: z.record(z.any()).optional(),
+      endpointKey: z.string().optional(),
+      tokenQueryParam: z.string().optional(),
+      useProofKeyForCodeExchange: z.boolean().optional(),
+      pkceChallengeMethod: z.enum(['plain', 'S256']).optional(),
+      scopeParamName: z.string().optional(),
+      nestedResponseKey: z.string().optional(),
+      credentialsLocation: z.nativeEnum(TokenExchangeCredentialsLocation).optional(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.WebBasic]: zodCompleteStrictObject<WebBasicAuthentication>({
+      type: zodDiscriminant(AuthenticationType.WebBasic),
+      uxConfig: zodCompleteStrictObject<WebBasicAuthentication['uxConfig']>({
+        placeholderUsername: z.string().optional(),
+        placeholderPassword: z.string().optional(),
+        usernameOnly: z.boolean().optional(),
+      }).optional(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.AWSAccessKey]: zodCompleteStrictObject<AWSAccessKeyAuthentication>({
+      type: zodDiscriminant(AuthenticationType.AWSAccessKey),
+      service: z.string(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.AWSAssumeRole]: zodCompleteStrictObject<AWSAssumeRoleAuthentication>({
+      type: zodDiscriminant(AuthenticationType.AWSAssumeRole),
+      service: z.string(),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.Custom]: zodCompleteStrictObject<CustomAuthentication>({
+      type: zodDiscriminant(AuthenticationType.Custom),
+      params: z
+        .array(
+          zodCompleteStrictObject<CustomAuthentication['params'][number]>({
+            name: z.string(),
+            description: z.string(),
+          }),
+        )
+        .refine(
+          params => {
+            const keys = params.map(param => param.name);
+            return keys.length === new Set(keys).size;
+          },
+          {message: 'Duplicated parameter names in the mutli-query-token authentication config'},
+        ),
+      ...baseAuthenticationValidators,
+    }),
+    [AuthenticationType.Various]: zodCompleteStrictObject<VariousAuthentication>({
+      type: zodDiscriminant(AuthenticationType.Various),
+    }),
+  };
+  const systemAuthenticationTypes: {[key in SystemAuthenticationTypes]: true} = {
+    [AuthenticationType.HeaderBearerToken]: true,
+    [AuthenticationType.CustomHeaderToken]: true,
+    [AuthenticationType.MultiHeaderToken]: true,
+    [AuthenticationType.MultiQueryParamToken]: true,
+    [AuthenticationType.QueryParamToken]: true,
+    [AuthenticationType.WebBasic]: true,
+    [AuthenticationType.AWSAccessKey]: true,
+    [AuthenticationType.AWSAssumeRole]: true,
+    [AuthenticationType.Custom]: true,
+  };
+
+  const systemAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
+    .filter(([authType]) => authType in systemAuthenticationTypes)
+    .map(([_authType, schema]) => schema);
+
+  const variousSupportedAuthenticationTypes: {[key in VariousSupportedAuthenticationTypes]: true} = {
+    [AuthenticationType.HeaderBearerToken]: true,
+    [AuthenticationType.CustomHeaderToken]: true,
+    [AuthenticationType.MultiHeaderToken]: true,
+    [AuthenticationType.MultiQueryParamToken]: true,
+    [AuthenticationType.QueryParamToken]: true,
+    [AuthenticationType.WebBasic]: true,
+    [AuthenticationType.None]: true,
+  };
+
+  const variousSupportedAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
+    .filter(([authType]) => authType in variousSupportedAuthenticationTypes)
+    .map(([_authType, schema]) => schema);
+
+  const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
+
+  const paramDefValidator = zodCompleteObject<ParamDef<any>>({
+    name: z
+      .string()
+      .max(Limits.BuildingBlockName)
+      .regex(regexParameterName, 'Parameter names can only contain alphanumeric characters and underscores.'),
+    type: z
+      .union([
+        z.nativeEnum(Type),
+        z.object({
+          type: zodDiscriminant('array'),
+          items: z.nativeEnum(Type),
+          allowEmpty: z.boolean().optional(),
+        }),
+      ])
+      .refine(
+        paramType =>
+          paramType !== Type.object &&
+          !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === Type.object),
+        {
+          message: 'Object parameters are not currently supported.',
+        },
+      ),
+    description: z.string().max(Limits.BuildingBlockDescription),
+    optional: z.boolean().optional(),
+    autocomplete: z.unknown().optional(),
+    defaultValue: z.unknown().optional(),
+    suggestedValue: z.unknown().optional(),
   });
 
-const baseAuthenticationValidators = {
-  // TODO(jonathan): Remove these after fixing/exporting types for Authentication metadata, as they're only present
-  // in the full bundle, not the metadata.
-  getConnectionName: z.unknown().optional(),
-  getConnectionUserId: z.unknown().optional(),
-  instructionsUrl: z.string().optional(),
-  requiresEndpointUrl: z.boolean().optional(),
-  endpointDomain: z.string().optional(),
-  // The items are technically a discriminated union type but that union currently only has one member.
-  postSetup: z.array(setEndpointPostSetupValidator).optional(),
-  networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
-};
-
-const defaultAuthenticationValidators: Record<AuthenticationType, z.ZodTypeAny> = {
-  [AuthenticationType.None]: zodCompleteStrictObject<NoAuthentication>({
-    type: zodDiscriminant(AuthenticationType.None),
-  }),
-  [AuthenticationType.HeaderBearerToken]: zodCompleteStrictObject<HeaderBearerTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.HeaderBearerToken),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.CodaApiHeaderBearerToken]: zodCompleteStrictObject<CodaApiBearerTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.CodaApiHeaderBearerToken),
-    deferConnectionSetup: z.boolean().optional(),
-    shouldAutoAuthSetup: z.boolean().optional(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.CustomHeaderToken]: zodCompleteStrictObject<CustomHeaderTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.CustomHeaderToken),
-    headerName: z.string(),
-    tokenPrefix: z.string().optional(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.MultiHeaderToken]: zodCompleteStrictObject<MultiHeaderTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.MultiHeaderToken),
-    headers: z
+  const commonPackFormulaSchema = {
+    // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
+    // whose getter names violate the validator, and those exemptions require the pack id, so this has to be
+    // done as a superRefine on the top-level object that also contains the pack id.
+    name: z.string().max(Limits.BuildingBlockName),
+    description: z.string().max(Limits.BuildingBlockDescription),
+    examples: z
       .array(
-        zodCompleteStrictObject<MultiHeaderTokenAuthentication['headers'][number]>({
-          name: z.string(),
-          description: z.string(),
-          tokenPrefix: z.string().optional(),
+        z.object({
+          params: z.array(
+            z.union([
+              primitiveUnion,
+              z.array(primitiveUnion),
+              z.undefined(),
+              // Our TS only accepts undefined for optional params, but when an upload gets JSONified
+              // and there is an undefined value in array, it gets serialized to null so we have
+              // to accept it here.
+              z.null(),
+            ]),
+          ),
+          result: z.any(),
         }),
       )
-      .refine(
-        headers => {
-          const keys = headers.map(header => header.name.toLowerCase());
-          return keys.length === new Set(keys).size;
-        },
-        {message: 'Duplicated header names in the MultiHeaderToken authentication config'},
-      ),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.QueryParamToken]: zodCompleteStrictObject<QueryParamTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.QueryParamToken),
-    paramName: z.string(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.MultiQueryParamToken]: zodCompleteStrictObject<MultiQueryParamTokenAuthentication>({
-    type: zodDiscriminant(AuthenticationType.MultiQueryParamToken),
-    params: z
-      .array(
-        zodCompleteStrictObject<MultiQueryParamTokenAuthentication['params'][number]>({
-          name: z.string(),
-          description: z.string(),
-        }),
-      )
-      .refine(
-        params => {
-          const keys = params.map(param => param.name);
-          return keys.length === new Set(keys).size;
-        },
-        {message: 'Duplicated parameter names in the MultiQueryParamToken authentication config'},
-      ),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.OAuth2]: zodCompleteStrictObject<OAuth2Authentication>({
-    type: zodDiscriminant(AuthenticationType.OAuth2),
-    authorizationUrl: z.string().url(),
-    tokenUrl: z.string().url(),
-    scopes: z.array(z.string()).optional(),
-    scopeDelimiter: z.enum([' ', ',', ';']).optional(),
-    tokenPrefix: z.string().optional(),
-    additionalParams: z.record(z.any()).optional(),
-    endpointKey: z.string().optional(),
-    tokenQueryParam: z.string().optional(),
-    useProofKeyForCodeExchange: z.boolean().optional(),
-    pkceChallengeMethod: z.enum(['plain', 'S256']).optional(),
-    scopeParamName: z.string().optional(),
-    nestedResponseKey: z.string().optional(),
-    credentialsLocation: z.nativeEnum(TokenExchangeCredentialsLocation).optional(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.WebBasic]: zodCompleteStrictObject<WebBasicAuthentication>({
-    type: zodDiscriminant(AuthenticationType.WebBasic),
-    uxConfig: zodCompleteStrictObject<WebBasicAuthentication['uxConfig']>({
-      placeholderUsername: z.string().optional(),
-      placeholderPassword: z.string().optional(),
-      usernameOnly: z.boolean().optional(),
-    }).optional(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.AWSAccessKey]: zodCompleteStrictObject<AWSAccessKeyAuthentication>({
-    type: zodDiscriminant(AuthenticationType.AWSAccessKey),
-    service: z.string(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.AWSAssumeRole]: zodCompleteStrictObject<AWSAssumeRoleAuthentication>({
-    type: zodDiscriminant(AuthenticationType.AWSAssumeRole),
-    service: z.string(),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.Custom]: zodCompleteStrictObject<CustomAuthentication>({
-    type: zodDiscriminant(AuthenticationType.Custom),
-    params: z
-      .array(
-        zodCompleteStrictObject<CustomAuthentication['params'][number]>({
-          name: z.string(),
-          description: z.string(),
-        }),
-      )
-      .refine(
-        params => {
-          const keys = params.map(param => param.name);
-          return keys.length === new Set(keys).size;
-        },
-        {message: 'Duplicated parameter names in the mutli-query-token authentication config'},
-      ),
-    ...baseAuthenticationValidators,
-  }),
-  [AuthenticationType.Various]: zodCompleteStrictObject<VariousAuthentication>({
-    type: zodDiscriminant(AuthenticationType.Various),
-  }),
-};
-const systemAuthenticationTypes: {[key in SystemAuthenticationTypes]: true} = {
-  [AuthenticationType.HeaderBearerToken]: true,
-  [AuthenticationType.CustomHeaderToken]: true,
-  [AuthenticationType.MultiHeaderToken]: true,
-  [AuthenticationType.MultiQueryParamToken]: true,
-  [AuthenticationType.QueryParamToken]: true,
-  [AuthenticationType.WebBasic]: true,
-  [AuthenticationType.AWSAccessKey]: true,
-  [AuthenticationType.AWSAssumeRole]: true,
-  [AuthenticationType.Custom]: true,
-};
-
-const systemAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
-  .filter(([authType]) => authType in systemAuthenticationTypes)
-  .map(([_authType, schema]) => schema);
-
-const variousSupportedAuthenticationTypes: {[key in VariousSupportedAuthenticationTypes]: true} = {
-  [AuthenticationType.HeaderBearerToken]: true,
-  [AuthenticationType.CustomHeaderToken]: true,
-  [AuthenticationType.MultiHeaderToken]: true,
-  [AuthenticationType.MultiQueryParamToken]: true,
-  [AuthenticationType.QueryParamToken]: true,
-  [AuthenticationType.WebBasic]: true,
-  [AuthenticationType.None]: true,
-};
-
-const variousSupportedAuthenticationValidators = Object.entries(defaultAuthenticationValidators)
-  .filter(([authType]) => authType in variousSupportedAuthenticationTypes)
-  .map(([_authType, schema]) => schema);
-
-const primitiveUnion = z.union([z.number(), z.string(), z.boolean(), z.date()]);
-
-const paramDefValidator = zodCompleteObject<ParamDef<any>>({
-  name: z
-    .string()
-    .max(Limits.BuildingBlockName)
-    .regex(regexParameterName, 'Parameter names can only contain alphanumeric characters and underscores.'),
-  type: z
-    .union([
-      z.nativeEnum(Type),
-      z.object({
-        type: zodDiscriminant('array'),
-        items: z.nativeEnum(Type),
-        allowEmpty: z.boolean().optional(),
-      }),
-    ])
-    .refine(
-      paramType =>
-        paramType !== Type.object &&
-        !(typeof paramType === 'object' && paramType.type === 'array' && paramType.items === Type.object),
-      {
-        message: 'Object parameters are not currently supported.',
-      },
-    ),
-  description: z.string().max(Limits.BuildingBlockDescription),
-  optional: z.boolean().optional(),
-  autocomplete: z.unknown().optional(),
-  defaultValue: z.unknown().optional(),
-  suggestedValue: z.unknown().optional(),
-});
-
-const commonPackFormulaSchema = {
-  // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
-  // whose getter names violate the validator, and those exemptions require the pack id, so this has to be
-  // done as a superRefine on the top-level object that also contains the pack id.
-  name: z.string().max(Limits.BuildingBlockName),
-  description: z.string().max(Limits.BuildingBlockDescription),
-  examples: z
-    .array(
-      z.object({
-        params: z.array(
-          z.union([
-            primitiveUnion,
-            z.array(primitiveUnion),
-            z.undefined(),
-            // Our TS only accepts undefined for optional params, but when an upload gets JSONified
-            // and there is an undefined value in array, it gets serialized to null so we have
-            // to accept it here.
-            z.null(),
-          ]),
-        ),
-        result: z.any(),
-      }),
-    )
-    .optional(),
-  parameters: z.array(paramDefValidator).refine(
-    params => {
-      let hasOptional = false;
-      for (const param of params) {
-        if (param.optional) {
-          hasOptional = true;
-        } else if (!param.optional && hasOptional) {
-          return false;
+      .optional(),
+    parameters: z.array(paramDefValidator).refine(
+      params => {
+        let hasOptional = false;
+        for (const param of params) {
+          if (param.optional) {
+            hasOptional = true;
+          } else if (!param.optional && hasOptional) {
+            return false;
+          }
         }
-      }
-      return true;
-    },
-    {message: 'All optional parameters must come after all non-optional parameters.'},
-  ),
-  varargParameters: z.array(paramDefValidator).optional(),
-  isAction: z.boolean().optional(),
-  connectionRequirement: z.nativeEnum(ConnectionRequirement).optional(),
-  // TODO(jonathan): Remove after removing `network` from formula def.
-  network: zodCompleteObject<Network>({
-    hasSideEffect: z.boolean().optional(),
-    requiresConnection: z.boolean().optional(),
-    connection: z.nativeEnum(NetworkConnection).optional(),
-  }).optional(),
-  cacheTtlSecs: z.number().min(0).optional(),
-  isExperimental: z.boolean().optional(),
-  isSystem: z.boolean().optional(),
-  extraOAuthScopes: z.array(z.string()).optional(),
-};
+        return true;
+      },
+      {message: 'All optional parameters must come after all non-optional parameters.'},
+    ),
+    varargParameters: z.array(paramDefValidator).optional(),
+    isAction: z.boolean().optional(),
+    connectionRequirement: z.nativeEnum(ConnectionRequirement).optional(),
+    // TODO(jonathan): Remove after removing `network` from formula def.
+    network: zodCompleteObject<Network>({
+      hasSideEffect: z.boolean().optional(),
+      requiresConnection: z.boolean().optional(),
+      connection: z.nativeEnum(NetworkConnection).optional(),
+    }).optional(),
+    cacheTtlSecs: z.number().min(0).optional(),
+    isExperimental: z.boolean().optional(),
+    isSystem: z.boolean().optional(),
+    extraOAuthScopes: z.array(z.string()).optional(),
+  };
 
-const booleanPackFormulaSchema = zodCompleteObject<Omit<BooleanPackFormula<any>, 'execute'>>({
-  ...commonPackFormulaSchema,
-  resultType: zodDiscriminant(Type.boolean),
-  schema: zodCompleteObject<BooleanSchema>({
-    type: zodDiscriminant(ValueType.Boolean),
-    codaType: z.enum([...BooleanHintValueTypes]).optional(),
+  const booleanPackFormulaSchema = zodCompleteObject<Omit<BooleanPackFormula<any>, 'execute'>>({
+    ...commonPackFormulaSchema,
+    resultType: zodDiscriminant(Type.boolean),
+    schema: zodCompleteObject<BooleanSchema>({
+      type: zodDiscriminant(ValueType.Boolean),
+      codaType: z.enum([...BooleanHintValueTypes]).optional(),
+      description: z.string().optional(),
+      mutable: z.boolean().optional(),
+      fixedId: z.string().optional(),
+      // Only properties in sync tables would need to define "autocomplete"
+      autocomplete: z.undefined().optional(),
+    }).optional(),
+  });
+
+  // TODO(jonathan): Use zodCompleteObject on these after exporting these types.
+
+  const textAttributionNodeSchema = z.object({
+    type: zodDiscriminant(AttributionNodeType.Text),
+    text: z.string(),
+  });
+
+  const linkAttributionNodeSchema = z.object({
+    type: zodDiscriminant(AttributionNodeType.Link),
+    anchorUrl: z.string(),
+    anchorText: z.string(),
+  });
+
+  const imageAttributionNodeSchema = z.object({
+    type: zodDiscriminant(AttributionNodeType.Image),
+    anchorUrl: z.string(),
+    imageUrl: z.string(),
+  });
+
+  function zodAutocompleteFieldWithValues(valueType: z.ZodTypeAny, allowDisplayNames: boolean) {
+    const literalType = allowDisplayNames
+      ? z.union([
+          valueType,
+          z.strictObject({
+            display: z.string(),
+            value: valueType,
+          }),
+        ])
+      : valueType;
+    return z.union([z.string(), z.array(literalType)]).optional();
+  }
+
+  const basePropertyValidators = {
     description: z.string().optional(),
     mutable: z.boolean().optional(),
     fixedId: z.string().optional(),
-    // Only properties in sync tables would need to define "autocomplete"
-    autocomplete: z.undefined().optional(),
-  }).optional(),
-});
+    fromKey: z.string().optional(),
+    required: z.boolean().optional(),
+  };
 
-// TODO(jonathan): Use zodCompleteObject on these after exporting these types.
-
-const textAttributionNodeSchema = z.object({
-  type: zodDiscriminant(AttributionNodeType.Text),
-  text: z.string(),
-});
-
-const linkAttributionNodeSchema = z.object({
-  type: zodDiscriminant(AttributionNodeType.Link),
-  anchorUrl: z.string(),
-  anchorText: z.string(),
-});
-
-const imageAttributionNodeSchema = z.object({
-  type: zodDiscriminant(AttributionNodeType.Image),
-  anchorUrl: z.string(),
-  imageUrl: z.string(),
-});
-
-function zodAutocompleteFieldWithValues(valueType: z.ZodTypeAny, allowDisplayNames: boolean) {
-  const literalType = allowDisplayNames
-    ? z.union([
-        valueType,
-        z.strictObject({
-          display: z.string(),
-          value: valueType,
-        }),
-      ])
-    : valueType;
-  return z.union([z.string(), z.array(literalType)]).optional();
-}
-
-const basePropertyValidators = {
-  description: z.string().optional(),
-  mutable: z.boolean().optional(),
-  fixedId: z.string().optional(),
-  fromKey: z.string().optional(),
-  required: z.boolean().optional(),
-};
-
-const baseStringPropertyValidators = {
-  ...basePropertyValidators,
-};
-
-const baseNumericPropertyValidators = {
-  ...basePropertyValidators,
-  autocomplete: zodAutocompleteFieldWithValues(z.number(), true),
-};
-
-const booleanPropertySchema = zodCompleteStrictObject<BooleanSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Boolean),
-  codaType: z.enum([...BooleanHintValueTypes]).optional(),
-  ...basePropertyValidators,
-  autocomplete: zodAutocompleteFieldWithValues(z.boolean(), true),
-});
-
-const numericPropertySchema = zodCompleteStrictObject<NumericSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Percent).optional(),
-  precision: z.number().optional(),
-  useThousandsSeparator: z.boolean().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const scalePropertySchema = zodCompleteStrictObject<ScaleSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Scale),
-  maximum: z.number().optional(),
-  icon: z.nativeEnum(ScaleIconSet).optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
-
-const sliderPropertySchema = zodCompleteStrictObject<SliderSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Slider),
-  maximum: optionalStringOrNumber,
-  minimum: optionalStringOrNumber,
-  step: optionalStringOrNumber,
-  showValue: z.boolean().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const progressBarPropertySchema = zodCompleteStrictObject<ProgressBarSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.ProgressBar),
-  maximum: optionalStringOrNumber,
-  minimum: optionalStringOrNumber,
-  step: optionalStringOrNumber,
-  showValue: z.boolean().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const currencyPropertySchema = zodCompleteStrictObject<CurrencySchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Currency),
-  precision: z.number().optional(),
-  currencyCode: z.string().optional(),
-  format: z.nativeEnum(CurrencyFormat).optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const numericDatePropertySchema = zodCompleteStrictObject<NumericDateSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Date),
-  format: z.string().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const numericTimePropertySchema = zodCompleteStrictObject<NumericTimeSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Time),
-  format: z.string().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const numericDateTimePropertySchema = zodCompleteStrictObject<NumericDateTimeSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.DateTime),
-  dateFormat: z.string().optional(),
-  timeFormat: z.string().optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const numericDurationPropertySchema = zodCompleteStrictObject<NumericDurationSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.Number),
-  codaType: zodDiscriminant(ValueHintType.Duration),
-  precision: z.number().optional(),
-  maxUnit: z.nativeEnum(DurationUnit).optional(),
-  ...baseNumericPropertyValidators,
-});
-
-const numberPropertySchema = z.union([
-  numericPropertySchema,
-  scalePropertySchema,
-  sliderPropertySchema,
-  progressBarPropertySchema,
-  currencyPropertySchema,
-  numericDatePropertySchema,
-  numericTimePropertySchema,
-  numericDateTimePropertySchema,
-  numericDurationPropertySchema,
-]);
-
-const numericPackFormulaSchema = zodCompleteObject<Omit<NumericPackFormula<any>, 'execute'>>({
-  ...commonPackFormulaSchema,
-  resultType: zodDiscriminant(Type.number),
-  schema: numberPropertySchema.optional(),
-});
-
-const simpleStringPropertySchema = zodCompleteStrictObject<SimpleStringSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: z.enum([...SimpleStringHintValueTypes]).optional(),
-  ...baseStringPropertyValidators,
-});
-
-const stringDatePropertySchema = zodCompleteStrictObject<StringDateSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Date),
-  format: z.string().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const stringTimePropertySchema = zodCompleteStrictObject<StringTimeSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Time),
-  format: z.string().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const stringDateTimePropertySchema = zodCompleteStrictObject<StringDateTimeSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.DateTime),
-  dateFormat: z.string().optional(),
-  timeFormat: z.string().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const durationPropertySchema = zodCompleteStrictObject<DurationSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Duration),
-  precision: z.number().optional(),
-  maxUnit: z.nativeEnum(DurationUnit).optional(),
-  ...baseStringPropertyValidators,
-});
-
-const codaInternalRichTextSchema = zodCompleteStrictObject<CodaInternalRichTextSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.CodaInternalRichText),
-  isCanvas: z.boolean().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const embedPropertySchema = zodCompleteStrictObject<StringEmbedSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Embed),
-  force: z.boolean().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const emailPropertySchema = zodCompleteStrictObject<EmailSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Email),
-  display: z.nativeEnum(EmailDisplayType).optional(),
-  ...baseStringPropertyValidators,
-});
-
-const linkPropertySchema = zodCompleteStrictObject<LinkSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.Url),
-  display: z.nativeEnum(LinkDisplayType).optional(),
-  force: z.boolean().optional(),
-  ...baseStringPropertyValidators,
-});
-
-const stringWithOptionsPropertySchema = zodCompleteStrictObject<StringWithOptionsSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: zodDiscriminant(ValueHintType.SelectList),
-  ...baseStringPropertyValidators,
-  autocomplete: zodAutocompleteFieldWithValues(z.string(), true),
-});
-
-const imagePropertySchema = zodCompleteStrictObject<ImageSchema & ObjectSchemaProperty>({
-  type: zodDiscriminant(ValueType.String),
-  codaType: z.union([zodDiscriminant(ValueHintType.ImageAttachment), zodDiscriminant(ValueHintType.ImageReference)]),
-  imageOutline: z.nativeEnum(ImageOutline).optional(),
-  imageCornerStyle: z.nativeEnum(ImageCornerStyle).optional(),
-  ...baseStringPropertyValidators,
-});
-
-const stringPropertySchema = z.union([
-  simpleStringPropertySchema,
-  stringDatePropertySchema,
-  stringTimePropertySchema,
-  stringDateTimePropertySchema,
-  codaInternalRichTextSchema,
-  durationPropertySchema,
-  embedPropertySchema,
-  emailPropertySchema,
-  linkPropertySchema,
-  imagePropertySchema,
-  stringWithOptionsPropertySchema,
-]);
-
-const stringPackFormulaSchema = zodCompleteObject<Omit<StringPackFormula<any>, 'execute'>>({
-  ...commonPackFormulaSchema,
-  resultType: zodDiscriminant(Type.string),
-  schema: stringPropertySchema.optional(),
-});
-
-// TODO(jonathan): Give this a better type than ZodTypeAny after figuring out
-// recursive typing better.
-const arrayPropertySchema: z.ZodTypeAny = z.lazy(() =>
-  zodCompleteStrictObject<ArraySchema & ObjectSchemaProperty>({
-    type: zodDiscriminant(ValueType.Array),
-    items: objectPropertyUnionSchema,
+  const baseStringPropertyValidators = {
     ...basePropertyValidators,
-  }),
-);
+  };
 
-const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
-// This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
-function isValidObjectId(component: string): boolean {
-  return Base64ObjectRegex.test(component);
-}
-
-const SystemColumnNames = ['id', 'value', 'synced', 'connection'];
-
-enum ExemptionType {
-  IdentityName = 'IdentityName',
-  SyncTableGetterName = 'SyncTableGetterName',
-}
-
-type Exemption = [number, string, ExemptionType];
-
-const Exemptions: Exemption[] = [
-  [1013, 'Pull Request', ExemptionType.IdentityName],
-  [1021, 'Doc Analytics', ExemptionType.IdentityName],
-  [1060, 'Candidate Stage', ExemptionType.IdentityName],
-  [1075, 'G Suite Directory User', ExemptionType.IdentityName],
-  [1079, 'Campaign Group', ExemptionType.IdentityName],
-  [1083, 'Merge Request', ExemptionType.IdentityName],
-
-  [1013, 'Sync commit history', ExemptionType.SyncTableGetterName],
-  [1013, 'Sync issues', ExemptionType.SyncTableGetterName],
-  [1013, 'Sync pull requests', ExemptionType.SyncTableGetterName],
-  [1013, 'Sync repos', ExemptionType.SyncTableGetterName],
-  [1054, 'Sync table', ExemptionType.SyncTableGetterName],
-  [1062, 'Form responses', ExemptionType.SyncTableGetterName],
-  [1062, 'Sync forms', ExemptionType.SyncTableGetterName],
-  [1078, 'Ad Creatives', ExemptionType.SyncTableGetterName],
-  [1078, 'Ad Sets', ExemptionType.SyncTableGetterName],
-  [1078, 'Custom Audiences', ExemptionType.SyncTableGetterName],
-  [1078, 'Page Posts', ExemptionType.SyncTableGetterName],
-  [1083, 'Sync commits', ExemptionType.SyncTableGetterName],
-  [1083, 'Sync issues', ExemptionType.SyncTableGetterName],
-  [1083, 'Sync merge requests', ExemptionType.SyncTableGetterName],
-  [1083, 'Sync projects', ExemptionType.SyncTableGetterName],
-  [1084, 'Ad Groups', ExemptionType.SyncTableGetterName],
-  [1093, 'Sync table', ExemptionType.SyncTableGetterName],
-];
-
-function exemptionKey(packId: number, entityName: string): string {
-  return `${packId}/${entityName}`;
-}
-
-const IdentityNameExemptions = new Set(
-  Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.IdentityName).map(
-    ([packId, name]) => exemptionKey(packId, name),
-  ),
-);
-
-const SyncTableGetterNameExemptions = new Set(
-  Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.SyncTableGetterName).map(
-    ([packId, name]) => exemptionKey(packId, name),
-  ),
-);
-
-function isValidIdentityName(packId: number | undefined, name: string): boolean {
-  if (packId && IdentityNameExemptions.has(exemptionKey(packId, name))) {
-    return true;
-  }
-  if (packId === 1090) {
-    // SalesForce pack has a large number of dynamic identity ids that include empty spaces.
-    return true;
-  }
-  return isValidObjectId(name);
-}
-
-function isValidUseOfCodaInternalRichText(packId: number | undefined): boolean {
-  // CrossDoc pack is allowed to use this type hint.
-  return packId === 1054;
-}
-
-const attributionSchema = z
-  .array(z.union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema]))
-  .optional();
-
-const propertySchema = z.union([
-  z.string().min(1),
-  zodCompleteObject<PropertyIdentifier>({
-    property: z.string().min(1),
-    label: z.string().optional(),
-    placeholder: z.string().optional(),
-  }),
-]);
-
-const genericObjectSchema: z.ZodTypeAny = z.lazy(() =>
-  zodCompleteObject<ObjectSchema<any, any>>({
+  const baseNumericPropertyValidators = {
     ...basePropertyValidators,
-    type: zodDiscriminant(ValueType.Object),
-    description: z.string().optional(),
-    id: z.string().min(1).optional(),
-    idProperty: z.string().min(1).optional(),
-    primary: z.string().min(1).optional(),
-    displayProperty: z.string().min(1).optional(),
-    codaType: z.enum([...ObjectHintValueTypes]).optional(),
-    featured: z.array(z.string()).optional(),
-    featuredProperties: z.array(z.string()).optional(),
-    identity: zodCompleteObject<Identity>({
-      packId: z.number().optional(),
-      name: z.string().nonempty(),
-      dynamicUrl: z.string().optional(),
+    autocomplete: zodAutocompleteFieldWithValues(z.number(), true),
+  };
+
+  const booleanPropertySchema = zodCompleteStrictObject<BooleanSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Boolean),
+    codaType: z.enum([...BooleanHintValueTypes]).optional(),
+    ...basePropertyValidators,
+    autocomplete: zodAutocompleteFieldWithValues(z.boolean(), true),
+  });
+
+  const numericPropertySchema = zodCompleteStrictObject<NumericSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Percent).optional(),
+    precision: z.number().optional(),
+    useThousandsSeparator: z.boolean().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const scalePropertySchema = zodCompleteStrictObject<ScaleSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Scale),
+    maximum: z.number().optional(),
+    icon: z.nativeEnum(ScaleIconSet).optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const optionalStringOrNumber = z.union([z.number(), z.string()]).optional();
+
+  const sliderPropertySchema = zodCompleteStrictObject<SliderSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Slider),
+    maximum: optionalStringOrNumber,
+    minimum: optionalStringOrNumber,
+    step: optionalStringOrNumber,
+    showValue: z.boolean().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const progressBarPropertySchema = zodCompleteStrictObject<ProgressBarSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.ProgressBar),
+    maximum: optionalStringOrNumber,
+    minimum: optionalStringOrNumber,
+    step: optionalStringOrNumber,
+    showValue: z.boolean().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const currencyPropertySchema = zodCompleteStrictObject<CurrencySchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Currency),
+    precision: z.number().optional(),
+    currencyCode: z.string().optional(),
+    format: z.nativeEnum(CurrencyFormat).optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const numericDatePropertySchema = zodCompleteStrictObject<NumericDateSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Date),
+    format: z.string().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const numericTimePropertySchema = zodCompleteStrictObject<NumericTimeSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Time),
+    format: z.string().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const numericDateTimePropertySchema = zodCompleteStrictObject<NumericDateTimeSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.DateTime),
+    dateFormat: z.string().optional(),
+    timeFormat: z.string().optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const numericDurationPropertySchema = zodCompleteStrictObject<NumericDurationSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.Number),
+    codaType: zodDiscriminant(ValueHintType.Duration),
+    precision: z.number().optional(),
+    maxUnit: z.nativeEnum(DurationUnit).optional(),
+    ...baseNumericPropertyValidators,
+  });
+
+  const numberPropertySchema = z.union([
+    numericPropertySchema,
+    scalePropertySchema,
+    sliderPropertySchema,
+    progressBarPropertySchema,
+    currencyPropertySchema,
+    numericDatePropertySchema,
+    numericTimePropertySchema,
+    numericDateTimePropertySchema,
+    numericDurationPropertySchema,
+  ]);
+
+  const numericPackFormulaSchema = zodCompleteObject<Omit<NumericPackFormula<any>, 'execute'>>({
+    ...commonPackFormulaSchema,
+    resultType: zodDiscriminant(Type.number),
+    schema: numberPropertySchema.optional(),
+  });
+
+  const simpleStringPropertySchema = zodCompleteStrictObject<SimpleStringSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: z.enum([...SimpleStringHintValueTypes]).optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const stringDatePropertySchema = zodCompleteStrictObject<StringDateSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Date),
+    format: z.string().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const stringTimePropertySchema = zodCompleteStrictObject<StringTimeSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Time),
+    format: z.string().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const stringDateTimePropertySchema = zodCompleteStrictObject<StringDateTimeSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.DateTime),
+    dateFormat: z.string().optional(),
+    timeFormat: z.string().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const durationPropertySchema = zodCompleteStrictObject<DurationSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Duration),
+    precision: z.number().optional(),
+    maxUnit: z.nativeEnum(DurationUnit).optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const codaInternalRichTextSchema = zodCompleteStrictObject<CodaInternalRichTextSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.CodaInternalRichText),
+    isCanvas: z.boolean().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const embedPropertySchema = zodCompleteStrictObject<StringEmbedSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Embed),
+    force: z.boolean().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const emailPropertySchema = zodCompleteStrictObject<EmailSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Email),
+    display: z.nativeEnum(EmailDisplayType).optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const linkPropertySchema = zodCompleteStrictObject<LinkSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.Url),
+    display: z.nativeEnum(LinkDisplayType).optional(),
+    force: z.boolean().optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const stringWithOptionsPropertySchema = zodCompleteStrictObject<StringWithOptionsSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: zodDiscriminant(ValueHintType.SelectList),
+    ...baseStringPropertyValidators,
+    autocomplete: zodAutocompleteFieldWithValues(z.string(), true),
+  });
+
+  const imagePropertySchema = zodCompleteStrictObject<ImageSchema & ObjectSchemaProperty>({
+    type: zodDiscriminant(ValueType.String),
+    codaType: z.union([zodDiscriminant(ValueHintType.ImageAttachment), zodDiscriminant(ValueHintType.ImageReference)]),
+    imageOutline: z.nativeEnum(ImageOutline).optional(),
+    imageCornerStyle: z.nativeEnum(ImageCornerStyle).optional(),
+    ...baseStringPropertyValidators,
+  });
+
+  const stringPropertySchema = z.union([
+    simpleStringPropertySchema,
+    stringDatePropertySchema,
+    stringTimePropertySchema,
+    stringDateTimePropertySchema,
+    codaInternalRichTextSchema,
+    durationPropertySchema,
+    embedPropertySchema,
+    emailPropertySchema,
+    linkPropertySchema,
+    imagePropertySchema,
+    stringWithOptionsPropertySchema,
+  ]);
+
+  const stringPackFormulaSchema = zodCompleteObject<Omit<StringPackFormula<any>, 'execute'>>({
+    ...commonPackFormulaSchema,
+    resultType: zodDiscriminant(Type.string),
+    schema: stringPropertySchema.optional(),
+  });
+
+  // TODO(jonathan): Give this a better type than ZodTypeAny after figuring out
+  // recursive typing better.
+  const arrayPropertySchema: z.ZodTypeAny = z.lazy(() =>
+    zodCompleteStrictObject<ArraySchema & ObjectSchemaProperty>({
+      type: zodDiscriminant(ValueType.Array),
+      items: objectPropertyUnionSchema,
+      ...basePropertyValidators,
+    }),
+  );
+
+  const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
+  // This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
+  function isValidObjectId(component: string): boolean {
+    return Base64ObjectRegex.test(component);
+  }
+
+  const SystemColumnNames = ['id', 'value', 'synced', 'connection'];
+
+  enum ExemptionType {
+    IdentityName = 'IdentityName',
+    SyncTableGetterName = 'SyncTableGetterName',
+  }
+
+  type Exemption = [number, string, ExemptionType];
+
+  const Exemptions: Exemption[] = [
+    [1013, 'Pull Request', ExemptionType.IdentityName],
+    [1021, 'Doc Analytics', ExemptionType.IdentityName],
+    [1060, 'Candidate Stage', ExemptionType.IdentityName],
+    [1075, 'G Suite Directory User', ExemptionType.IdentityName],
+    [1079, 'Campaign Group', ExemptionType.IdentityName],
+    [1083, 'Merge Request', ExemptionType.IdentityName],
+
+    [1013, 'Sync commit history', ExemptionType.SyncTableGetterName],
+    [1013, 'Sync issues', ExemptionType.SyncTableGetterName],
+    [1013, 'Sync pull requests', ExemptionType.SyncTableGetterName],
+    [1013, 'Sync repos', ExemptionType.SyncTableGetterName],
+    [1054, 'Sync table', ExemptionType.SyncTableGetterName],
+    [1062, 'Form responses', ExemptionType.SyncTableGetterName],
+    [1062, 'Sync forms', ExemptionType.SyncTableGetterName],
+    [1078, 'Ad Creatives', ExemptionType.SyncTableGetterName],
+    [1078, 'Ad Sets', ExemptionType.SyncTableGetterName],
+    [1078, 'Custom Audiences', ExemptionType.SyncTableGetterName],
+    [1078, 'Page Posts', ExemptionType.SyncTableGetterName],
+    [1083, 'Sync commits', ExemptionType.SyncTableGetterName],
+    [1083, 'Sync issues', ExemptionType.SyncTableGetterName],
+    [1083, 'Sync merge requests', ExemptionType.SyncTableGetterName],
+    [1083, 'Sync projects', ExemptionType.SyncTableGetterName],
+    [1084, 'Ad Groups', ExemptionType.SyncTableGetterName],
+    [1093, 'Sync table', ExemptionType.SyncTableGetterName],
+  ];
+
+  function exemptionKey(packId: number, entityName: string): string {
+    return `${packId}/${entityName}`;
+  }
+
+  const IdentityNameExemptions = new Set(
+    Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.IdentityName).map(
+      ([packId, name]) => exemptionKey(packId, name),
+    ),
+  );
+
+  const SyncTableGetterNameExemptions = new Set(
+    Exemptions.filter(([_packId, _name, exemptionType]) => exemptionType === ExemptionType.SyncTableGetterName).map(
+      ([packId, name]) => exemptionKey(packId, name),
+    ),
+  );
+
+  function isValidIdentityName(packId: number | undefined, name: string): boolean {
+    if (packId && IdentityNameExemptions.has(exemptionKey(packId, name))) {
+      return true;
+    }
+    if (packId === 1090) {
+      // SalesForce pack has a large number of dynamic identity ids that include empty spaces.
+      return true;
+    }
+    return isValidObjectId(name);
+  }
+
+  function isValidUseOfCodaInternalRichText(packId: number | undefined): boolean {
+    // CrossDoc pack is allowed to use this type hint.
+    return packId === 1054;
+  }
+
+  const attributionSchema = z
+    .array(z.union([textAttributionNodeSchema, linkAttributionNodeSchema, imageAttributionNodeSchema]))
+    .optional();
+
+  const propertySchema = z.union([
+    z.string().min(1),
+    zodCompleteObject<PropertyIdentifier>({
+      property: z.string().min(1),
+      label: z.string().optional(),
+      placeholder: z.string().optional(),
+    }),
+  ]);
+
+  const genericObjectSchema: z.ZodTypeAny = z.lazy(() =>
+    zodCompleteObject<ObjectSchema<any, any>>({
+      ...basePropertyValidators,
+      type: zodDiscriminant(ValueType.Object),
+      description: z.string().optional(),
+      id: z.string().min(1).optional(),
+      idProperty: z.string().min(1).optional(),
+      primary: z.string().min(1).optional(),
+      displayProperty: z.string().min(1).optional(),
+      codaType: z.enum([...ObjectHintValueTypes]).optional(),
+      featured: z.array(z.string()).optional(),
+      featuredProperties: z.array(z.string()).optional(),
+      identity: zodCompleteObject<Identity>({
+        packId: z.number().optional(),
+        name: z.string().nonempty(),
+        dynamicUrl: z.string().optional(),
+        attribution: attributionSchema,
+      }).optional(),
       attribution: attributionSchema,
-    }).optional(),
-    attribution: attributionSchema,
-    properties: z.record(objectPropertyUnionSchema),
-    includeUnknownProperties: z.boolean().optional(),
-    __packId: z.number().optional(),
-    titleProperty: propertySchema.optional(),
-    linkProperty: propertySchema.optional(),
-    subtitleProperties: z.array(propertySchema).optional(),
-    snippetProperty: propertySchema.optional(),
-    imageProperty: propertySchema.optional(),
-    autocomplete: zodAutocompleteFieldWithValues(z.object({}).passthrough(), false),
-  })
-    .superRefine((data, context) => {
-      if (!isValidIdentityName(data.identity?.packId, data.identity?.name as string)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['identity', 'name'],
-          message:
-            'Invalid name. Identity names can only contain alphanumeric characters, underscores, and dashes, and no spaces.',
+      properties: z.record(objectPropertyUnionSchema),
+      includeUnknownProperties: z.boolean().optional(),
+      __packId: z.number().optional(),
+      titleProperty: propertySchema.optional(),
+      linkProperty: propertySchema.optional(),
+      subtitleProperties: z.array(propertySchema).optional(),
+      snippetProperty: propertySchema.optional(),
+      imageProperty: propertySchema.optional(),
+      autocomplete: zodAutocompleteFieldWithValues(z.object({}).passthrough(), false),
+    })
+      .superRefine((data, context) => {
+        if (!isValidIdentityName(data.identity?.packId, data.identity?.name as string)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['identity', 'name'],
+            message:
+              'Invalid name. Identity names can only contain alphanumeric characters, underscores, and dashes, and no spaces.',
+          });
+        }
+      })
+      .superRefine((data, context) => {
+        const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
+        const fixedIds = new Set();
+        for (const prop of Object.values(schemaHelper.properties)) {
+          if (!prop.fixedId) {
+            continue;
+          }
+
+          if (fixedIds.has(prop.fixedId)) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['properties'],
+              message: `fixedIds must be unique. Found duplicate "${prop.fixedId}".`,
+            });
+          }
+          fixedIds.add(prop.fixedId);
+        }
+      })
+      .refine(
+        data => {
+          const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
+          return isNil(schemaHelper.id) || schemaHelper.id in schemaHelper.properties;
+        },
+        {
+          message: 'The "idProperty" property must appear as a key in the "properties" object.',
+        },
+      )
+      .refine(
+        data => {
+          const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
+          return isNil(schemaHelper.primary) || schemaHelper.primary in schemaHelper.properties;
+        },
+        {
+          message: 'The "displayProperty" property must appear as a key in the "properties" object.',
+        },
+      )
+      .superRefine((data, context) => {
+        const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
+        (schemaHelper.featured || []).forEach((f, i) => {
+          if (!(f in schemaHelper.properties)) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['featured', i],
+              message: `The "featuredProperties" field name "${f}" does not exist in the "properties" object.`,
+            });
+          }
         });
-      }
-    })
-    .superRefine((data, context) => {
-      const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
-      const fixedIds = new Set();
-      for (const prop of Object.values(schemaHelper.properties)) {
-        if (!prop.fixedId) {
-          continue;
-        }
+      })
+      .superRefine((data, context) => {
+        const schema = data as GenericObjectSchema;
 
-        if (fixedIds.has(prop.fixedId)) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['properties'],
-            message: `fixedIds must be unique. Found duplicate "${prop.fixedId}".`,
-          });
-        }
-        fixedIds.add(prop.fixedId);
-      }
-    })
-    .refine(
-      data => {
-        const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
-        return isNil(schemaHelper.id) || schemaHelper.id in schemaHelper.properties;
-      },
-      {
-        message: 'The "idProperty" property must appear as a key in the "properties" object.',
-      },
-    )
-    .refine(
-      data => {
-        const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
-        return isNil(schemaHelper.primary) || schemaHelper.primary in schemaHelper.properties;
-      },
-      {
-        message: 'The "displayProperty" property must appear as a key in the "properties" object.',
-      },
-    )
-    .superRefine((data, context) => {
-      const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
-      (schemaHelper.featured || []).forEach((f, i) => {
-        if (!(f in schemaHelper.properties)) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['featured', i],
-            message: `The "featuredProperties" field name "${f}" does not exist in the "properties" object.`,
-          });
-        }
-      });
-    })
-    .superRefine((data, context) => {
-      const schema = data as GenericObjectSchema;
-
-      /**
-       * Validates a PropertyIdentifier key in the object schema.
-       */
-      function validateProperty(
-        propertyKey: keyof ObjectSchemaPathProperties,
-        isValidSchema: (schema: Schema & ObjectSchemaProperty) => boolean,
-        invalidSchemaMessage: string,
-      ) {
-        function validatePropertyIdentifier(
-          value: PropertyIdentifier,
-          objectPath: Array<string | number> = [propertyKey],
+        /**
+         * Validates a PropertyIdentifier key in the object schema.
+         */
+        function validateProperty(
+          propertyKey: keyof ObjectSchemaPathProperties,
+          isValidSchema: (schema: Schema & ObjectSchemaProperty) => boolean,
+          invalidSchemaMessage: string,
         ) {
-          const propertyValue = typeof value === 'string' ? value : value?.property;
+          function validatePropertyIdentifier(
+            value: PropertyIdentifier,
+            objectPath: Array<string | number> = [propertyKey],
+          ) {
+            const propertyValue = typeof value === 'string' ? value : value?.property;
 
-          let propertyValueIsPath = false;
-          let propertySchema =
-            typeof propertyValueRaw === 'string' && propertyValue in schema.properties
-              ? schema.properties[propertyValue]
-              : undefined;
-          if (!propertySchema) {
-            const schemaPropertyPath = normalizePropertyValuePathIntoSchemaPath(propertyValue);
-            propertySchema = JSONPath({
-              path: schemaPropertyPath,
-              json: schema.properties,
-            })?.[0];
-            propertyValueIsPath = true;
-          }
-
-          const propertyIdentifierDisplay = propertyValueIsPath
-            ? `"${propertyKey}" path`
-            : `"${propertyKey}" field name`;
-
-          if (!propertySchema) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: objectPath,
-              message: `The ${propertyIdentifierDisplay} "${propertyValue}" does not exist in the "properties" object.`,
-            });
-            return;
-          }
-
-          if (!isValidSchema(propertySchema)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: objectPath,
-              message: `The ${propertyIdentifierDisplay} "${propertyValue}" ${invalidSchemaMessage}`,
-            });
-            return;
-          }
-        }
-
-        const propertyValueRaw = schema[propertyKey];
-        if (propertyValueRaw) {
-          if (Array.isArray(propertyValueRaw)) {
-            propertyValueRaw.forEach((propertyIdentifier, i) => {
-              validatePropertyIdentifier(propertyIdentifier, [propertyKey, i]);
-            });
-            return;
-          }
-
-          validatePropertyIdentifier(propertyValueRaw);
-        }
-      }
-
-      const validateTitleProperty = () => {
-        return validateProperty(
-          'titleProperty',
-          propertySchema => [ValueType.String, ValueType.Object].includes(propertySchema.type),
-          `must refer to a "ValueType.String" or "ValueType.Object" property.`,
-        );
-      };
-      const validateImageProperty = () => {
-        return validateProperty(
-          'imageProperty',
-          imagePropertySchema =>
-            imagePropertySchema.type === ValueType.String &&
-            [ValueHintType.ImageAttachment, ValueHintType.ImageReference].includes(
-              imagePropertySchema.codaType as ValueHintType,
-            ),
-          `must refer to a "ValueType.String" property with a "ValueHintType.ImageAttachment" or "ValueHintType.ImageReference" "codaType".`,
-        );
-      };
-      const validateSnippetProperty = () => {
-        return validateProperty(
-          'snippetProperty',
-          snippetPropertySchema =>
-            snippetPropertySchema.type === ValueType.String ||
-            (snippetPropertySchema.type === ValueType.Array && snippetPropertySchema.items.type === ValueType.String),
-          `must refer to a "ValueType.String" property or array of strings.`,
-        );
-      };
-      const validateLinkProperty = () => {
-        return validateProperty(
-          'linkProperty',
-          linkPropertySchema =>
-            linkPropertySchema.type === ValueType.String && linkPropertySchema.codaType === ValueHintType.Url,
-          `must refer to a "ValueType.String" property with a "ValueHintType.Url" "codaType".`,
-        );
-      };
-
-      const validateSubtitleProperties = () => {
-        return validateProperty(
-          'subtitleProperties',
-          subtitlePropertySchema => {
-            if (!('codaType' in subtitlePropertySchema && subtitlePropertySchema.codaType)) {
-              return true;
+            let propertyValueIsPath = false;
+            let propertySchema =
+              typeof propertyValueRaw === 'string' && propertyValue in schema.properties
+                ? schema.properties[propertyValue]
+                : undefined;
+            if (!propertySchema) {
+              const schemaPropertyPath = normalizePropertyValuePathIntoSchemaPath(propertyValue);
+              propertySchema = JSONPath({
+                path: schemaPropertyPath,
+                json: schema.properties,
+              })?.[0];
+              propertyValueIsPath = true;
             }
 
-            switch (subtitlePropertySchema.codaType) {
-              case ValueHintType.ImageAttachment:
-              case ValueHintType.Attachment:
-              case ValueHintType.ImageReference:
-              case ValueHintType.Embed:
-              case ValueHintType.Scale:
-                return false;
-              case ValueHintType.CodaInternalRichText:
-              case ValueHintType.Currency:
-              case ValueHintType.Date:
-              case ValueHintType.DateTime:
-              case ValueHintType.Duration:
-              case ValueHintType.Email:
-              case ValueHintType.Html:
-              case ValueHintType.Markdown:
-              case ValueHintType.Percent:
-              case ValueHintType.Person:
-              case ValueHintType.ProgressBar:
-              case ValueHintType.Reference:
-              case ValueHintType.SelectList:
-              case ValueHintType.Slider:
-              case ValueHintType.Toggle:
-              case ValueHintType.Time:
-              case ValueHintType.Url:
+            const propertyIdentifierDisplay = propertyValueIsPath
+              ? `"${propertyKey}" path`
+              : `"${propertyKey}" field name`;
+
+            if (!propertySchema) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: objectPath,
+                message: `The ${propertyIdentifierDisplay} "${propertyValue}" does not exist in the "properties" object.`,
+              });
+              return;
+            }
+
+            if (!isValidSchema(propertySchema)) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: objectPath,
+                message: `The ${propertyIdentifierDisplay} "${propertyValue}" ${invalidSchemaMessage}`,
+              });
+              return;
+            }
+          }
+
+          const propertyValueRaw = schema[propertyKey];
+          if (propertyValueRaw) {
+            if (Array.isArray(propertyValueRaw)) {
+              propertyValueRaw.forEach((propertyIdentifier, i) => {
+                validatePropertyIdentifier(propertyIdentifier, [propertyKey, i]);
+              });
+              return;
+            }
+
+            validatePropertyIdentifier(propertyValueRaw);
+          }
+        }
+
+        const validateTitleProperty = () => {
+          return validateProperty(
+            'titleProperty',
+            propertySchema => [ValueType.String, ValueType.Object].includes(propertySchema.type),
+            `must refer to a "ValueType.String" or "ValueType.Object" property.`,
+          );
+        };
+        const validateImageProperty = () => {
+          return validateProperty(
+            'imageProperty',
+            imagePropertySchema =>
+              imagePropertySchema.type === ValueType.String &&
+              [ValueHintType.ImageAttachment, ValueHintType.ImageReference].includes(
+                imagePropertySchema.codaType as ValueHintType,
+              ),
+            `must refer to a "ValueType.String" property with a "ValueHintType.ImageAttachment" or "ValueHintType.ImageReference" "codaType".`,
+          );
+        };
+        const validateSnippetProperty = () => {
+          return validateProperty(
+            'snippetProperty',
+            snippetPropertySchema =>
+              snippetPropertySchema.type === ValueType.String ||
+              (snippetPropertySchema.type === ValueType.Array && snippetPropertySchema.items.type === ValueType.String),
+            `must refer to a "ValueType.String" property or array of strings.`,
+          );
+        };
+        const validateLinkProperty = () => {
+          return validateProperty(
+            'linkProperty',
+            linkPropertySchema =>
+              linkPropertySchema.type === ValueType.String && linkPropertySchema.codaType === ValueHintType.Url,
+            `must refer to a "ValueType.String" property with a "ValueHintType.Url" "codaType".`,
+          );
+        };
+
+        const validateSubtitleProperties = () => {
+          return validateProperty(
+            'subtitleProperties',
+            subtitlePropertySchema => {
+              if (!('codaType' in subtitlePropertySchema && subtitlePropertySchema.codaType)) {
                 return true;
-              default:
-                ensureUnreachable(subtitlePropertySchema.codaType);
-            }
-          },
-          `must refer to a value that does not have a codaType corresponding to one of ImageAttachment, Attachment, ImageReference, Embed, or Scale.`,
+              }
+
+              switch (subtitlePropertySchema.codaType) {
+                case ValueHintType.ImageAttachment:
+                case ValueHintType.Attachment:
+                case ValueHintType.ImageReference:
+                case ValueHintType.Embed:
+                case ValueHintType.Scale:
+                  return false;
+                case ValueHintType.CodaInternalRichText:
+                case ValueHintType.Currency:
+                case ValueHintType.Date:
+                case ValueHintType.DateTime:
+                case ValueHintType.Duration:
+                case ValueHintType.Email:
+                case ValueHintType.Html:
+                case ValueHintType.Markdown:
+                case ValueHintType.Percent:
+                case ValueHintType.Person:
+                case ValueHintType.ProgressBar:
+                case ValueHintType.Reference:
+                case ValueHintType.SelectList:
+                case ValueHintType.Slider:
+                case ValueHintType.Toggle:
+                case ValueHintType.Time:
+                case ValueHintType.Url:
+                  return true;
+                default:
+                  ensureUnreachable(subtitlePropertySchema.codaType);
+              }
+            },
+            `must refer to a value that does not have a codaType corresponding to one of ImageAttachment, Attachment, ImageReference, Embed, or Scale.`,
+          );
+        };
+
+        validateTitleProperty();
+        validateLinkProperty();
+        validateImageProperty();
+        validateSnippetProperty();
+        validateSubtitleProperties();
+      })
+      .superRefine((data, context) => {
+        const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
+        const internalRichTextPropertyTuple = Object.entries(schemaHelper.properties).find(
+          ([_key, prop]) => prop.type === ValueType.String && prop.codaType === ValueHintType.CodaInternalRichText,
         );
-      };
+        if (internalRichTextPropertyTuple && !isValidUseOfCodaInternalRichText(data.identity?.packId)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['identity', 'properties', internalRichTextPropertyTuple[0]],
+            message: 'Invalid codaType. CodaInternalRichText is not a supported value.',
+          });
+          return;
+        }
+      }),
+  );
 
-      validateTitleProperty();
-      validateLinkProperty();
-      validateImageProperty();
-      validateSnippetProperty();
-      validateSubtitleProperties();
-    })
-    .superRefine((data, context) => {
-      const schemaHelper = objectSchemaHelper(data as GenericObjectSchema);
-      const internalRichTextPropertyTuple = Object.entries(schemaHelper.properties).find(
-        ([_key, prop]) => prop.type === ValueType.String && prop.codaType === ValueHintType.CodaInternalRichText,
-      );
-      if (internalRichTextPropertyTuple && !isValidUseOfCodaInternalRichText(data.identity?.packId)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['identity', 'properties', internalRichTextPropertyTuple[0]],
-          message: 'Invalid codaType. CodaInternalRichText is not a supported value.',
-        });
-        return;
+  const objectPropertyUnionSchema = z
+    .union([
+      booleanPropertySchema,
+      numberPropertySchema,
+      stringPropertySchema,
+      arrayPropertySchema,
+      genericObjectSchema,
+    ])
+    .refine((schema: Schema) => {
+      if (sdkVersion && semver.satisfies(sdkVersion, '<=1.4.0')) {
+        // ValueHintType.SelectList is only required for autocomplete starting in version 1.4.1
+        return true;
       }
-    }),
-);
-
-const objectPropertyUnionSchema = z
-  .union([booleanPropertySchema, numberPropertySchema, stringPropertySchema, arrayPropertySchema, genericObjectSchema])
-  .refine((schema: Schema) => {
-    const schemaForAutocomplete = maybeUnwrapArraySchema(schema);
-    const result =
-      !schemaForAutocomplete ||
-      unwrappedSchemaSupportsAutocomplete(schemaForAutocomplete) ||
-      !('autocomplete' in schemaForAutocomplete && schemaForAutocomplete.autocomplete);
-    return result;
-  }, 'You must set "codaType" to ValueHintType.SelectList or ValueHintType.Reference when setting an "autocomplete" property.');
-const objectPackFormulaSchema = zodCompleteObject<Omit<ObjectPackFormula<any, any>, 'execute'>>({
-  ...commonPackFormulaSchema,
-  resultType: zodDiscriminant(Type.object),
-  // TODO(jonathan): See if we should really allow this. The SDK right now explicitly tolerates an undefined
-  // schema for objects, but that doesn't seem like a use case we actually want to support.
-  schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
-});
-
-const formulaMetadataSchema = z
-  .union([numericPackFormulaSchema, stringPackFormulaSchema, booleanPackFormulaSchema, objectPackFormulaSchema])
-  .superRefine((data, context) => {
-    const parameters = data.parameters as ParamDefs;
-    const varargParameters = data.varargParameters || ([] as ParamDefs);
-    const paramNames = new Set();
-    for (const param of [...parameters, ...varargParameters]) {
-      if (paramNames.has(param.name)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['parameters'],
-          message: `Parameter names must be unique. Found duplicate name "${param.name}".`,
-        });
-      }
-      paramNames.add(param.name);
-    }
+      const schemaForAutocomplete = maybeUnwrapArraySchema(schema);
+      const result =
+        !schemaForAutocomplete ||
+        unwrappedSchemaSupportsAutocomplete(schemaForAutocomplete) ||
+        !('autocomplete' in schemaForAutocomplete && schemaForAutocomplete.autocomplete);
+      return result;
+    }, 'You must set "codaType" to ValueHintType.SelectList or ValueHintType.Reference when setting an "autocomplete" property.');
+  const objectPackFormulaSchema = zodCompleteObject<Omit<ObjectPackFormula<any, any>, 'execute'>>({
+    ...commonPackFormulaSchema,
+    resultType: zodDiscriminant(Type.object),
+    // TODO(jonathan): See if we should really allow this. The SDK right now explicitly tolerates an undefined
+    // schema for objects, but that doesn't seem like a use case we actually want to support.
+    schema: z.union([genericObjectSchema, arrayPropertySchema]).optional(),
   });
 
-const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
-  name: z.string().max(Limits.BuildingBlockName),
-  formulaNamespace: z.string().optional(), // Will be removed once we deprecate namespace objects.
-  formulaName: z.string(),
-  hasNoConnection: z.boolean().optional(),
-  instructions: z.string().optional(),
-  placeholder: z.string().optional(),
-  matchers: z
-    .array(z.string().max(Limits.ColumnMatcherRegex).refine(validateFormatMatcher))
-    .max(Limits.NumColumnMatchersPerFormat),
-});
-
-const syncFormulaSchema = zodCompleteObject<
-  Omit<SyncFormula<any, any, ParamDefs, ObjectSchema<any, any>>, 'execute' | 'executeUpdate'>
->({
-  schema: arrayPropertySchema.optional(),
-  resultType: z.any(),
-  isSyncFormula: z.literal(true),
-  maxUpdateBatchSize: z.number().min(1).max(Limits.UpdateBatchSize).optional(),
-  supportsUpdates: z.boolean().optional(),
-  ...commonPackFormulaSchema,
-});
-
-const baseSyncTableSchema = {
-  name: z
-    .string()
-    .nonempty()
-    .max(Limits.BuildingBlockName)
-    .regex(regexFormulaName, 'Sync Table names can only contain alphanumeric characters and underscores.'),
-  description: z.string().max(Limits.BuildingBlockDescription).optional(),
-  schema: genericObjectSchema,
-  getter: syncFormulaSchema,
-  entityName: z.string().optional(),
-  defaultAddDynamicColumns: z.boolean().optional(),
-  // TODO(patrick): Make identityName non-optional after SDK v1.0.0 is required
-  identityName: z
-    .string()
-    .min(1)
-    .max(Limits.BuildingBlockName)
-    .optional()
-    .refine(
-      val => !val || !SystemColumnNames.includes(val),
-      `This property name is reserved for internal use by Coda and can't be used as an identityName, sorry!`,
-    ),
-  namedAutocompletes: z
-    .record(formulaMetadataSchema)
-    .optional()
-    .default({})
+  const formulaMetadataSchema = z
+    .union([numericPackFormulaSchema, stringPackFormulaSchema, booleanPackFormulaSchema, objectPackFormulaSchema])
     .superRefine((data, context) => {
-      if (Object.keys(data).length > Limits.BuildingBlockName) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Too many autocomplete formulas for sync table. Max allowed is "${Limits.BuildingBlockName}".`,
-        });
+      const parameters = data.parameters as ParamDefs;
+      const varargParameters = data.varargParameters || ([] as ParamDefs);
+      const paramNames = new Set();
+      for (const param of [...parameters, ...varargParameters]) {
+        if (paramNames.has(param.name)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['parameters'],
+            message: `Parameter names must be unique. Found duplicate name "${param.name}".`,
+          });
+        }
+        paramNames.add(param.name);
       }
-    }),
-};
+    });
 
-type GenericSyncTableDef = SyncTableDef<any, any, ParamDefs, ObjectSchema<any, any>>;
-
-const genericSyncTableSchema = zodCompleteObject<GenericSyncTableDef & {isDynamic?: false}>({
-  ...baseSyncTableSchema,
-  // Add a fake discriminant here so that we can flag union errors as related to a non-matching discriminant
-  // and filter them out. A real regular sync table wouldn't specify `isDynamic` at all here, but including
-  // it in the validator like this helps zod flag it in the way we need.
-  isDynamic: zodDiscriminant(false).optional(),
-  getSchema: formulaMetadataSchema.optional(),
-}).strict();
-
-const genericDynamicSyncTableSchema = zodCompleteObject<
-  DynamicSyncTableDef<any, any, ParamDefs, ObjectSchema<any, any>>
->({
-  ...baseSyncTableSchema,
-  isDynamic: zodDiscriminant(true),
-  getName: formulaMetadataSchema,
-  getDisplayUrl: formulaMetadataSchema,
-  listDynamicUrls: formulaMetadataSchema.optional(),
-  searchDynamicUrls: formulaMetadataSchema.optional(),
-  getSchema: formulaMetadataSchema,
-  autocomplete: objectPackFormulaSchema.optional(),
-}).strict();
-
-const syncTableSchema = z
-  .union([genericDynamicSyncTableSchema, genericSyncTableSchema])
-  .superRefine((data, context) => {
-    const syncTable = data as SyncTable;
-
-    if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['getter', 'varargParameters'],
-        message: 'Sync table formulas do not currently support varargParameters.',
-      });
-    }
+  const formatMetadataSchema = zodCompleteObject<PackFormatMetadata>({
+    name: z.string().max(Limits.BuildingBlockName),
+    formulaNamespace: z.string().optional(), // Will be removed once we deprecate namespace objects.
+    formulaName: z.string(),
+    hasNoConnection: z.boolean().optional(),
+    instructions: z.string().optional(),
+    placeholder: z.string().optional(),
+    matchers: z
+      .array(z.string().max(Limits.ColumnMatcherRegex).refine(validateFormatMatcher))
+      .max(Limits.NumColumnMatchersPerFormat),
   });
 
-// Make sure to call the refiners on this after removing legacyPackMetadataSchema.
-// (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
-// schema we actually use.)
-const unrefinedPackVersionMetadataSchema = zodCompleteObject<PackVersionMetadata>({
-  version: z
-    .string()
-    .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".')
-    .refine(
-      // Version numbers must not be bigger than a postgres integer.
-      version => version.split('.').filter(part => Number(part) > 2_147_483_647).length === 0,
-      'Pack version number too large',
-    ),
-  defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
-  networkDomains: z
-    .array(
-      z
-        .string()
-        .max(Limits.NetworkDomainUrl)
-        .refine(domain => !(domain.startsWith('http:') || domain.startsWith('https:') || domain.indexOf('/') >= 0), {
-          message: 'Invalid network domain. Instead of "https://www.example.com", just specify "example.com".',
-        }),
-    )
-    .optional(),
-  formulaNamespace: z.string().optional().refine(validateNamespace, {
-    message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
-  }),
-  systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
-  formulas: z
-    .array(formulaMetadataSchema)
-    .max(Limits.BuildingBlockCountPerType)
-    .optional()
-    .default([])
+  const syncFormulaSchema = zodCompleteObject<
+    Omit<SyncFormula<any, any, ParamDefs, ObjectSchema<any, any>>, 'execute' | 'executeUpdate'>
+  >({
+    schema: arrayPropertySchema.optional(),
+    resultType: z.any(),
+    isSyncFormula: z.literal(true),
+    maxUpdateBatchSize: z.number().min(1).max(Limits.UpdateBatchSize).optional(),
+    supportsUpdates: z.boolean().optional(),
+    ...commonPackFormulaSchema,
+  });
+
+  const baseSyncTableSchema = {
+    name: z
+      .string()
+      .nonempty()
+      .max(Limits.BuildingBlockName)
+      .regex(regexFormulaName, 'Sync Table names can only contain alphanumeric characters and underscores.'),
+    description: z.string().max(Limits.BuildingBlockDescription).optional(),
+    schema: genericObjectSchema,
+    getter: syncFormulaSchema,
+    entityName: z.string().optional(),
+    defaultAddDynamicColumns: z.boolean().optional(),
+    // TODO(patrick): Make identityName non-optional after SDK v1.0.0 is required
+    identityName: z
+      .string()
+      .min(1)
+      .max(Limits.BuildingBlockName)
+      .optional()
+      .refine(
+        val => !val || !SystemColumnNames.includes(val),
+        `This property name is reserved for internal use by Coda and can't be used as an identityName, sorry!`,
+      ),
+    namedAutocompletes: z
+      .record(formulaMetadataSchema)
+      .optional()
+      .default({})
+      .superRefine((data, context) => {
+        if (Object.keys(data).length > Limits.BuildingBlockName) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Too many autocomplete formulas for sync table. Max allowed is "${Limits.BuildingBlockName}".`,
+          });
+        }
+      }),
+  };
+
+  type GenericSyncTableDef = SyncTableDef<any, any, ParamDefs, ObjectSchema<any, any>>;
+
+  const genericSyncTableSchema = zodCompleteObject<GenericSyncTableDef & {isDynamic?: false}>({
+    ...baseSyncTableSchema,
+    // Add a fake discriminant here so that we can flag union errors as related to a non-matching discriminant
+    // and filter them out. A real regular sync table wouldn't specify `isDynamic` at all here, but including
+    // it in the validator like this helps zod flag it in the way we need.
+    isDynamic: zodDiscriminant(false).optional(),
+    getSchema: formulaMetadataSchema.optional(),
+  }).strict();
+
+  const genericDynamicSyncTableSchema = zodCompleteObject<
+    DynamicSyncTableDef<any, any, ParamDefs, ObjectSchema<any, any>>
+  >({
+    ...baseSyncTableSchema,
+    isDynamic: zodDiscriminant(true),
+    getName: formulaMetadataSchema,
+    getDisplayUrl: formulaMetadataSchema,
+    listDynamicUrls: formulaMetadataSchema.optional(),
+    searchDynamicUrls: formulaMetadataSchema.optional(),
+    getSchema: formulaMetadataSchema,
+    autocomplete: objectPackFormulaSchema.optional(),
+  }).strict();
+
+  const syncTableSchema = z
+    .union([genericDynamicSyncTableSchema, genericSyncTableSchema])
     .superRefine((data, context) => {
-      const formulaNames = data.map(formulaDef => formulaDef.name);
-      for (const dupe of getNonUniqueElements(formulaNames)) {
+      const syncTable = data as SyncTable;
+
+      if (syncTable.getter.varargParameters && syncTable.getter.varargParameters.length > 0) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Formula names must be unique. Found duplicate name "${dupe}".`,
+          path: ['getter', 'varargParameters'],
+          message: 'Sync table formulas do not currently support varargParameters.',
         });
       }
+    });
+
+  // Make sure to call the refiners on this after removing legacyPackMetadataSchema.
+  // (Zod doesn't let you call .extends() after you've called .refine(), so we're only refining the top-level
+  // schema we actually use.)
+  const unrefinedPackVersionMetadataSchema = zodCompleteObject<PackVersionMetadata>({
+    version: z
+      .string()
+      .regex(/^\d+(\.\d+){0,2}$/, 'Pack versions must use semantic versioning, e.g. "1", "1.0" or "1.0.0".')
+      .refine(
+        // Version numbers must not be bigger than a postgres integer.
+        version => version.split('.').filter(part => Number(part) > 2_147_483_647).length === 0,
+        'Pack version number too large',
+      ),
+    defaultAuthentication: z.union(zodUnionInput(Object.values(defaultAuthenticationValidators))).optional(),
+    networkDomains: z
+      .array(
+        z
+          .string()
+          .max(Limits.NetworkDomainUrl)
+          .refine(domain => !(domain.startsWith('http:') || domain.startsWith('https:') || domain.indexOf('/') >= 0), {
+            message: 'Invalid network domain. Instead of "https://www.example.com", just specify "example.com".',
+          }),
+      )
+      .optional(),
+    formulaNamespace: z.string().optional().refine(validateNamespace, {
+      message: 'Formula namespaces can only contain alphanumeric characters and underscores.',
     }),
-  formats: z
-    .array(formatMetadataSchema)
-    .max(Limits.BuildingBlockCountPerType)
-    .optional()
-    .default([])
-    .superRefine((data, context) => {
-      const formatNames = data.map(formatDef => formatDef.name);
-      for (const dupe of getNonUniqueElements(formatNames)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Format names must be unique. Found duplicate name "${dupe}".`,
-        });
-      }
-    }),
-  syncTables: z
-    .array(syncTableSchema)
-    .max(Limits.BuildingBlockCountPerType)
-    .optional()
-    .default([])
-    .superRefine((data, context) => {
-      const identityNames: string[] = [];
-      for (const tableDef of data) {
-        if (tableDef.identityName && tableDef.schema.identity?.name) {
-          if (tableDef.identityName !== tableDef.schema.identity.name) {
+    systemConnectionAuthentication: z.union(zodUnionInput(systemAuthenticationValidators)).optional(),
+    formulas: z
+      .array(formulaMetadataSchema)
+      .max(Limits.BuildingBlockCountPerType)
+      .optional()
+      .default([])
+      .superRefine((data, context) => {
+        const formulaNames = data.map(formulaDef => formulaDef.name);
+        for (const dupe of getNonUniqueElements(formulaNames)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Formula names must be unique. Found duplicate name "${dupe}".`,
+          });
+        }
+      }),
+    formats: z
+      .array(formatMetadataSchema)
+      .max(Limits.BuildingBlockCountPerType)
+      .optional()
+      .default([])
+      .superRefine((data, context) => {
+        const formatNames = data.map(formatDef => formatDef.name);
+        for (const dupe of getNonUniqueElements(formatNames)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Format names must be unique. Found duplicate name "${dupe}".`,
+          });
+        }
+      }),
+    syncTables: z
+      .array(syncTableSchema)
+      .max(Limits.BuildingBlockCountPerType)
+      .optional()
+      .default([])
+      .superRefine((data, context) => {
+        const identityNames: string[] = [];
+        for (const tableDef of data) {
+          if (tableDef.identityName && tableDef.schema.identity?.name) {
+            if (tableDef.identityName !== tableDef.schema.identity.name) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `Sync table "${tableDef.name}" defines identityName "${tableDef.identityName}" that conflicts with its schema's identity.name "${tableDef.schema.identity.name}".`,
+              });
+            }
+          }
+          // only add identity names that are not undefined to check for dupes
+          if (tableDef.schema.identity) {
+            identityNames.push(tableDef.schema.identity?.name);
+          }
+        }
+        for (const dupe of getNonUniqueElements(identityNames)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
+          });
+        }
+        const tableNames = data.map(tableDef => tableDef.name);
+        for (const dupe of getNonUniqueElements(tableNames)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Sync table names must be unique. Found duplicate name "${dupe}".`,
+          });
+        }
+      }),
+  });
+
+  function validateNamespace(namespace: string | undefined): boolean {
+    if (typeof namespace === 'undefined') {
+      return true;
+    }
+    return validateFormulaName(namespace);
+  }
+
+  function validateFormulaName(value: string): boolean {
+    return regexFormulaName.test(value);
+  }
+
+  function validateFormulas(schema: z.ZodObject<any>) {
+    return schema
+      .refine(
+        data => {
+          if (data.formulas && data.formulas.length > 0) {
+            return data.formulaNamespace;
+          }
+          return true;
+        },
+        {message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace']},
+      )
+      .refine(
+        untypedMetadata => {
+          const metadata = untypedMetadata as PackVersionMetadata;
+          if (metadata.defaultAuthentication?.type !== AuthenticationType.CodaApiHeaderBearerToken) {
+            return true;
+          }
+
+          const codaDomains = ['coda.io', 'localhost'];
+
+          const hasNonCodaNetwork = metadata.networkDomains?.some((domain: string) => !codaDomains.includes(domain));
+          if (!hasNonCodaNetwork) {
+            return true;
+          }
+
+          const authDomains = getAuthNetworkDomains(metadata);
+          if (!authDomains?.length) {
+            // A non-Coda network domain without auth domain restriction isn't allowed.
+            return false;
+          }
+
+          const hasNonCodaAuthDomain = authDomains.some((domain: string) => !codaDomains.includes(domain));
+
+          // A non-coda auth domain is always an issue.
+          return !hasNonCodaAuthDomain;
+        },
+        {
+          message:
+            'CodaApiHeaderBearerToken can only be used for coda.io domains. Restrict `defaultAuthentication.networkDomain` to coda.io',
+          path: ['defaultAuthentication.networkDomain'],
+        },
+      )
+      .superRefine((data, context) => {
+        if (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) {
+          return;
+        }
+
+        // if the pack has no default authentication, make sure all formulas don't set connection requirements.
+        ((data.formulas || []) as PackFormulaMetadata[]).forEach((formula, i) => {
+          if (formula.connectionRequirement && formula.connectionRequirement !== ConnectionRequirement.None) {
             context.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `Sync table "${tableDef.name}" defines identityName "${tableDef.identityName}" that conflicts with its schema's identity.name "${tableDef.schema.identity.name}".`,
+              path: ['formulas', i],
+              message: 'Formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
             });
           }
-        }
-        // only add identity names that are not undefined to check for dupes
-        if (tableDef.schema.identity) {
-          identityNames.push(tableDef.schema.identity?.name);
-        }
-      }
-      for (const dupe of getNonUniqueElements(identityNames)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
         });
-      }
-      const tableNames = data.map(tableDef => tableDef.name);
-      for (const dupe of getNonUniqueElements(tableNames)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Sync table names must be unique. Found duplicate name "${dupe}".`,
-        });
-      }
-    }),
-});
 
-function validateNamespace(namespace: string | undefined): boolean {
-  if (typeof namespace === 'undefined') {
-    return true;
-  }
-  return validateFormulaName(namespace);
-}
-
-function validateFormulaName(value: string): boolean {
-  return regexFormulaName.test(value);
-}
-
-function validateFormulas(schema: z.ZodObject<any>) {
-  return schema
-    .refine(
-      data => {
-        if (data.formulas && data.formulas.length > 0) {
-          return data.formulaNamespace;
-        }
-        return true;
-      },
-      {message: 'A formula namespace must be provided whenever formulas are defined.', path: ['formulaNamespace']},
-    )
-    .refine(
-      untypedMetadata => {
-        const metadata = untypedMetadata as PackVersionMetadata;
-        if (metadata.defaultAuthentication?.type !== AuthenticationType.CodaApiHeaderBearerToken) {
-          return true;
-        }
-
-        const codaDomains = ['coda.io', 'localhost'];
-
-        const hasNonCodaNetwork = metadata.networkDomains?.some((domain: string) => !codaDomains.includes(domain));
-        if (!hasNonCodaNetwork) {
-          return true;
-        }
-
-        const authDomains = getAuthNetworkDomains(metadata);
-        if (!authDomains?.length) {
-          // A non-Coda network domain without auth domain restriction isn't allowed.
-          return false;
-        }
-
-        const hasNonCodaAuthDomain = authDomains.some((domain: string) => !codaDomains.includes(domain));
-
-        // A non-coda auth domain is always an issue.
-        return !hasNonCodaAuthDomain;
-      },
-      {
-        message:
-          'CodaApiHeaderBearerToken can only be used for coda.io domains. Restrict `defaultAuthentication.networkDomain` to coda.io',
-        path: ['defaultAuthentication.networkDomain'],
-      },
-    )
-    .superRefine((data, context) => {
-      if (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) {
-        return;
-      }
-
-      // if the pack has no default authentication, make sure all formulas don't set connection requirements.
-      ((data.formulas || []) as PackFormulaMetadata[]).forEach((formula, i) => {
-        if (formula.connectionRequirement && formula.connectionRequirement !== ConnectionRequirement.None) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['formulas', i],
-            message: 'Formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
-          });
-        }
-      });
-
-      ((data.syncTables as SyncTable[]) || []).forEach((syncTable, i) => {
-        const connectionRequirement = syncTable.getter.connectionRequirement;
-        if (connectionRequirement && connectionRequirement !== ConnectionRequirement.None) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['syncTables', i, 'getter', 'connectionRequirement'],
-            message:
-              'Sync table formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
-          });
-        }
-      });
-    })
-    .superRefine((data, context) => {
-      const formulas = (data.formulas || []) as PackFormulaMetadata[];
-      ((data.formats as any[]) || []).forEach((format, i) => {
-        const formula = formulas.find(f => f.name === format.formulaName);
-        if (!formula) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['formats', i],
-            message:
-              'Could not find a formula definition for this format. Each format must reference the name of a formula defined in this pack.',
-          });
-        } else {
-          let hasError = !formula.parameters?.length;
-          const [_, ...extraParams] = formula.parameters || [];
-          for (const extraParam of extraParams) {
-            if (!extraParam.optional) {
-              hasError = true;
-            }
+        ((data.syncTables as SyncTable[]) || []).forEach((syncTable, i) => {
+          const connectionRequirement = syncTable.getter.connectionRequirement;
+          if (connectionRequirement && connectionRequirement !== ConnectionRequirement.None) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['syncTables', i, 'getter', 'connectionRequirement'],
+              message:
+                'Sync table formulas cannot set a connectionRequirement when the Pack does not use user authentication.',
+            });
           }
-          if (hasError) {
+        });
+      })
+      .superRefine((data, context) => {
+        const formulas = (data.formulas || []) as PackFormulaMetadata[];
+        ((data.formats as any[]) || []).forEach((format, i) => {
+          const formula = formulas.find(f => f.name === format.formulaName);
+          if (!formula) {
             context.addIssue({
               code: z.ZodIssueCode.custom,
               path: ['formats', i],
-              message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
+              message:
+                'Could not find a formula definition for this format. Each format must reference the name of a formula defined in this pack.',
             });
+          } else {
+            let hasError = !formula.parameters?.length;
+            const [_, ...extraParams] = formula.parameters || [];
+            for (const extraParam of extraParams) {
+              if (!extraParam.optional) {
+                hasError = true;
+              }
+            }
+            if (hasError) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['formats', i],
+                message: 'Formats can only be implemented using formulas that take exactly one required parameter.',
+              });
+            }
+          }
+        });
+      });
+  }
+
+  function validateFormatMatcher(value: string): boolean {
+    try {
+      const parsed = value.match(PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX);
+      if (!parsed) {
+        return false;
+      }
+      const [, pattern, flags] = parsed;
+      new RegExp(pattern, flags);
+      return true;
+    } catch (error: any) {
+      return false;
+    }
+  }
+
+  // We temporarily allow our legacy packs to provide non-versioned data until we sufficiently migrate them.
+  // But all fields must be optional, because this is the top-level object we use for validation,
+  // so we must be able to pass validation while providing only fields from PackVersionMetadata.
+  const legacyPackMetadataSchema = validateFormulas(
+    unrefinedPackVersionMetadataSchema.extend({
+      id: z.number().optional(),
+      name: z.string().nonempty().optional(),
+      shortDescription: z.string().nonempty().optional(),
+      description: z.string().nonempty().optional(),
+      permissionsDescription: z.string().optional(),
+      category: z.nativeEnum(PackCategory).optional(),
+      logoPath: z.string().optional(),
+      exampleImages: z.array(z.string()).optional(),
+      exampleVideoIds: z.array(z.string()).optional(),
+      minimumFeatureSet: z.nativeEnum(FeatureSet).optional(),
+      quotas: z.any().optional(),
+      rateLimits: z.any().optional(),
+      isSystem: z.boolean().optional(),
+    }),
+  )
+    .superRefine((data, context) => {
+      ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
+        if (!syncTable.schema?.identity) {
+          return;
+        }
+
+        const identityName = syncTable.schema.identity.name;
+        if (syncTable.schema.properties[identityName]) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['syncTables', i, 'schema', 'properties', identityName],
+            message: "Cannot have a sync table property with the same name as the sync table's schema identity.",
+          });
+        }
+      });
+    })
+    .superRefine((data, context) => {
+      ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
+        const packId = data.id as number | undefined;
+        const getterName = syncTable.getter.name as string;
+        if (packId && SyncTableGetterNameExemptions.has(exemptionKey(packId, getterName))) {
+          return;
+        }
+
+        if (!validateFormulaName(getterName)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['syncTables', i, 'getter', 'name'],
+            message: 'Formula names can only contain alphanumeric characters and underscores.',
+          });
+        }
+      });
+    })
+    .superRefine((data, context) => {
+      ((data.formulas as any[]) || []).forEach((formula, i) => {
+        // We have to validate regular formula names here as a superRefine because formulas share
+        // a validator with sync table getters, and we need pack ids to exempt certain legacy
+        // formula getters with spaces in their names.
+        if (!validateFormulaName(formula.name)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['formulas', i, 'name'],
+            message: 'Formula names can only contain alphanumeric characters and underscores.',
+          });
+        }
+      });
+    })
+    .refine(
+      data => {
+        const usesAuthentication =
+          (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) ||
+          data.systemConnectionAuthentication;
+        if (!usesAuthentication || data.networkDomains?.length || data.defaultAuthentication?.requiresEndpointUrl) {
+          return true;
+        }
+
+        // Various is an internal authentication type that's only applicable to whitelisted Pack Ids.
+        // Skipping validation here to let it exempt from network domains.
+        if (data.defaultAuthentication?.type === AuthenticationType.Various) {
+          return true;
+        }
+
+        return false;
+      },
+      {
+        message:
+          'This pack uses authentication but did not declare a network domain. ' +
+          "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+        path: ['networkDomains'],
+      },
+    )
+    .superRefine((untypedData, context) => {
+      const data = untypedData as PackVersionMetadata;
+
+      const authNetworkDomains = getAuthNetworkDomains(data);
+
+      if (!isDefined(authNetworkDomains)) {
+        // This is a Various or None auth pack.
+        return;
+      }
+
+      // Auth network domains must match pack network domains.
+      for (const authNetworkDomain of authNetworkDomains) {
+        if (!data.networkDomains?.includes(authNetworkDomain)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['defaultAuthentication.networkDomain'],
+            message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
+          });
+          return;
+        }
+      }
+    })
+    .superRefine((untypedData, context) => {
+      const data = untypedData as PackVersionMetadata;
+
+      const authNetworkDomains = getAuthNetworkDomains(data);
+
+      if (!isDefined(authNetworkDomains)) {
+        // This is a Various or None auth pack.
+        return;
+      }
+
+      // A pack with multiple networks and auth must choose which domain(s) get auth on them.
+      if (!authNetworkDomains?.length) {
+        if (data.networkDomains && data.networkDomains.length > 1) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['defaultAuthentication.networkDomain'],
+            message:
+              'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
+          });
+        }
+        return;
+      }
+    })
+    .superRefine((untypedData, context) => {
+      const data = untypedData as PackVersionMetadata;
+
+      (data.syncTables || []).forEach((syncTable, i) => {
+        const schema: ObjectSchema<any, any> = syncTable.schema;
+        for (const [propertyName, childSchema] of Object.entries(schema.properties)) {
+          const autocomplete = maybeSchemaAutocompleteValue(childSchema);
+          if (!autocomplete || Array.isArray(autocomplete)) {
+            continue;
+          }
+          if (typeof autocomplete !== 'string' || !(autocomplete in (syncTable.namedAutocompletes || {}))) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['syncTables', i, 'properties', propertyName, 'autocomplete'],
+              message:
+                autocomplete === AutocompleteType.Dynamic
+                  ? `Sync table ${syncTable.name} must define "autocomplete" for this property to use AutocompleteType.Dynamic`
+                  : `"${autocomplete}" is not registered as an autocomplete function for this sync table.`,
+            });
+            continue;
           }
         }
       });
     });
+
+  return {legacyPackMetadataSchema, variousSupportedAuthenticationValidators, arrayPropertySchema};
 }
 
-function validateFormatMatcher(value: string): boolean {
-  try {
-    const parsed = value.match(PACKS_VALID_COLUMN_FORMAT_MATCHER_REGEX);
-    if (!parsed) {
-      return false;
-    }
-    const [, pattern, flags] = parsed;
-    new RegExp(pattern, flags);
-    return true;
-  } catch (error: any) {
-    return false;
-  }
-}
-
-// We temporarily allow our legacy packs to provide non-versioned data until we sufficiently migrate them.
-// But all fields must be optional, because this is the top-level object we use for validation,
-// so we must be able to pass validation while providing only fields from PackVersionMetadata.
-const legacyPackMetadataSchema = validateFormulas(
-  unrefinedPackVersionMetadataSchema.extend({
-    id: z.number().optional(),
-    name: z.string().nonempty().optional(),
-    shortDescription: z.string().nonempty().optional(),
-    description: z.string().nonempty().optional(),
-    permissionsDescription: z.string().optional(),
-    category: z.nativeEnum(PackCategory).optional(),
-    logoPath: z.string().optional(),
-    exampleImages: z.array(z.string()).optional(),
-    exampleVideoIds: z.array(z.string()).optional(),
-    minimumFeatureSet: z.nativeEnum(FeatureSet).optional(),
-    quotas: z.any().optional(),
-    rateLimits: z.any().optional(),
-    isSystem: z.boolean().optional(),
-  }),
-)
-  .superRefine((data, context) => {
-    ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
-      if (!syncTable.schema?.identity) {
-        return;
-      }
-
-      const identityName = syncTable.schema.identity.name;
-      if (syncTable.schema.properties[identityName]) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['syncTables', i, 'schema', 'properties', identityName],
-          message: "Cannot have a sync table property with the same name as the sync table's schema identity.",
-        });
-      }
-    });
-  })
-  .superRefine((data, context) => {
-    ((data.syncTables as any[]) || []).forEach((syncTable, i) => {
-      const packId = data.id as number | undefined;
-      const getterName = syncTable.getter.name as string;
-      if (packId && SyncTableGetterNameExemptions.has(exemptionKey(packId, getterName))) {
-        return;
-      }
-
-      if (!validateFormulaName(getterName)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['syncTables', i, 'getter', 'name'],
-          message: 'Formula names can only contain alphanumeric characters and underscores.',
-        });
-      }
-    });
-  })
-  .superRefine((data, context) => {
-    ((data.formulas as any[]) || []).forEach((formula, i) => {
-      // We have to validate regular formula names here as a superRefine because formulas share
-      // a validator with sync table getters, and we need pack ids to exempt certain legacy
-      // formula getters with spaces in their names.
-      if (!validateFormulaName(formula.name)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['formulas', i, 'name'],
-          message: 'Formula names can only contain alphanumeric characters and underscores.',
-        });
-      }
-    });
-  })
-  .refine(
-    data => {
-      const usesAuthentication =
-        (data.defaultAuthentication && data.defaultAuthentication.type !== AuthenticationType.None) ||
-        data.systemConnectionAuthentication;
-      if (!usesAuthentication || data.networkDomains?.length || data.defaultAuthentication?.requiresEndpointUrl) {
-        return true;
-      }
-
-      // Various is an internal authentication type that's only applicable to whitelisted Pack Ids.
-      // Skipping validation here to let it exempt from network domains.
-      if (data.defaultAuthentication?.type === AuthenticationType.Various) {
-        return true;
-      }
-
-      return false;
-    },
-    {
-      message:
-        'This pack uses authentication but did not declare a network domain. ' +
-        "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
-      path: ['networkDomains'],
-    },
-  )
-  .superRefine((untypedData, context) => {
-    const data = untypedData as PackVersionMetadata;
-
-    const authNetworkDomains = getAuthNetworkDomains(data);
-
-    if (!isDefined(authNetworkDomains)) {
-      // This is a Various or None auth pack.
-      return;
-    }
-
-    // Auth network domains must match pack network domains.
-    for (const authNetworkDomain of authNetworkDomains) {
-      if (!data.networkDomains?.includes(authNetworkDomain)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['defaultAuthentication.networkDomain'],
-          message: 'The `networkDomain` in setUserAuthentication() must match a previously declared network domain.',
-        });
-        return;
-      }
-    }
-  })
-  .superRefine((untypedData, context) => {
-    const data = untypedData as PackVersionMetadata;
-
-    const authNetworkDomains = getAuthNetworkDomains(data);
-
-    if (!isDefined(authNetworkDomains)) {
-      // This is a Various or None auth pack.
-      return;
-    }
-
-    // A pack with multiple networks and auth must choose which domain(s) get auth on them.
-    if (!authNetworkDomains?.length) {
-      if (data.networkDomains && data.networkDomains.length > 1) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['defaultAuthentication.networkDomain'],
-          message:
-            'This pack uses multiple network domains and must set one as a `networkDomain` in setUserAuthentication()',
-        });
-      }
-      return;
-    }
-  })
-  .superRefine((untypedData, context) => {
-    const data = untypedData as PackVersionMetadata;
-
-    (data.syncTables || []).forEach((syncTable, i) => {
-      const schema: ObjectSchema<any, any> = syncTable.schema;
-      for (const [propertyName, childSchema] of Object.entries(schema.properties)) {
-        const autocomplete = maybeSchemaAutocompleteValue(childSchema);
-        if (!autocomplete || Array.isArray(autocomplete)) {
-          continue;
-        }
-        if (typeof autocomplete !== 'string' || !(autocomplete in (syncTable.namedAutocompletes || {}))) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['syncTables', i, 'properties', propertyName, 'autocomplete'],
-            message:
-              autocomplete === AutocompleteType.Dynamic
-                ? `Sync table ${syncTable.name} must define "autocomplete" for this property to use AutocompleteType.Dynamic`
-                : `"${autocomplete}" is not registered as an autocomplete function for this sync table.`,
-          });
-          continue;
-        }
-      }
-    });
-  });
 interface SchemaExtension {
   versionRange: string;
   schemaExtend: (schema: z.ZodType<Partial<PackVersionMetadata>>) => z.ZodType<Partial<PackVersionMetadata>>;
@@ -1821,6 +1851,23 @@ const packMetadataSchemaBySdkVersion: SchemaExtension[] = [
             });
           });
         }
+      });
+    },
+  },
+  {
+    versionRange: '>1.4.0',
+    schemaExtend: schema => {
+      return schema.superRefine((untypedData, context) => {
+        const data = untypedData as PackVersionMetadata;
+        data.syncTables.forEach((syncTable, i) => {
+          const schemaPathPrefix = ['syncTables', i, 'schema'];
+          validateSchemaDeprecatedFields(syncTable.schema, schemaPathPrefix, context);
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['syncTables', i, 'schema'],
+            message: 'Needs SelectList codaType',
+          });
+        });
       });
     },
   },

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -201,7 +201,7 @@ export function validateVariousAuthenticationMetadata(
 // Note: This is called within Coda for validating the result of getSchema calls for dynamic sync tables.
 export function validateSyncTableSchema(
   schema: any,
-  options: BuildMetadataSchemaArgs,
+  options: BuildMetadataSchemaArgs & Required<Pick<BuildMetadataSchemaArgs, 'sdkVersion'>>,
 ): ArraySchema<ObjectSchema<any, any>> {
   const {arrayPropertySchema} = buildMetadataSchema(options);
   const validated = arrayPropertySchema.safeParse(schema);

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -369,7 +369,11 @@ interface buildMetadataSchemaArgs {
   sdkVersion?: string;
   warningMode?: boolean;
 }
-function buildMetadataSchema({sdkVersion}: buildMetadataSchemaArgs) {
+function buildMetadataSchema({sdkVersion}: buildMetadataSchemaArgs): {
+  legacyPackMetadataSchema: z.ZodType<Partial<PackVersionMetadata>>;
+  variousSupportedAuthenticationValidators: z.ZodTypeAny[];
+  arrayPropertySchema: z.ZodTypeAny;
+} {
   const singleAuthDomainSchema = z
     .string()
     .nonempty()


### PR DESCRIPTION
This adds more performance/memory overhead, but the flexibility to do different validation based on SDK version seems important and validation doesn't happen all that frequently. Just when running `getSchema` for sync tables that use it and during pack upload

Also conditions the recently added `You must set "codaType" to ValueHintType.SelectList or ValueHintType.Reference when setting an "autocomplete" property.` on an SDK version greater than 1.4.0

Corresponding PR: https://github.com/coda/coda/pull/93495