### PR TITLE
Add docs and samples for MultiHeaderToken

### DIFF
--- a/docs/embedded-snippets/samples/packs/authentication/copper.html
+++ b/docs/embedded-snippets/samples/packs/authentication/copper.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <!-- Monaco library script is loaded from: https://cdnjs.com/libraries/monaco-editor-->
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.38.0/min/vs/loader.min.js"
+      integrity="sha512-A+6SvPGkIN9Rf0mUXmW4xh7rDvALXf/f0VtOUiHlDUSPknu2kcfz1KzLpOJyL2pO+nZS13hhIjLqVgiQExLJrw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script>
+      require.config({
+        paths: {
+          vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.36.1/min/vs',
+        },
+      });
+
+      require(['vs/editor/editor.main'], function () {
+        var editor = monaco.editor.create(document.getElementById('container'), {
+          value: "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// Per-user authentication to the Copper API, using multiple HTTP headers.\n// See https://developer.copper.com/introduction/requests.html#headers.\npack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"X-PW-AccessToken\", description: \"API key\" },\n    { name: \"X-PW-UserEmail\", description: \"Email address\" },\n  ],\n\n  // Determines the display name of the connected account.\n  getConnectionName: async function (context) {\n    let response = await context.fetcher.fetch({\n      method: \"GET\",\n      url: \"https://api.copper.com/developer_api/v1/account\",\n      headers: {\n        \"X-PW-Application\": \"developer_api\",\n      },\n    });\n    let account = response.body;\n    return account.name;\n  },\n});\n\n// Allow the pack to make requests to Copper.\npack.addNetworkDomain(\"copper.com\");",
+          language: 'javascript',
+          minimap: {enabled: false},
+          readOnly: true,
+          renderValidationDecorations: 'off',
+          wordWrap: 'on',
+          contextmenu: false,
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <div id="container" style="position: absolute; top: 0; right: 16; bottom: 16; left: 0"></div>
+  </body>
+</html>

--- a/docs/embedded-snippets/samples/snippets/authentication/user_multi_header.html
+++ b/docs/embedded-snippets/samples/snippets/authentication/user_multi_header.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <!-- Monaco library script is loaded from: https://cdnjs.com/libraries/monaco-editor-->
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.38.0/min/vs/loader.min.js"
+      integrity="sha512-A+6SvPGkIN9Rf0mUXmW4xh7rDvALXf/f0VtOUiHlDUSPknu2kcfz1KzLpOJyL2pO+nZS13hhIjLqVgiQExLJrw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script>
+      require.config({
+        paths: {
+          vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.36.1/min/vs',
+        },
+      });
+
+      require(['vs/editor/editor.main'], function () {
+        var editor = monaco.editor.create(document.getElementById('container'), {
+          value: "pack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"${1:X-My-Token}\", description: \"${2:My token description}\" },\n    { name: \"${3:X-My-Key}\", description: \"${4:My key description}\" },\n    // TODO: Add more headers, if needed.\n  ],\n  instructionsUrl: \"${5:https://help.example.com/api-tokens}\",\n  getConnectionName: async function (context) {\n    // TODO: Fetch the name of the account.\n    let name = \"\";\n    return name;\n  },\n});",
+          language: 'javascript',
+          minimap: {enabled: false},
+          readOnly: true,
+          renderValidationDecorations: 'off',
+          wordWrap: 'on',
+          contextmenu: false,
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <div id="container" style="position: absolute; top: 0; right: 16; bottom: 16; left: 0"></div>
+  </body>
+</html>

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -129,6 +129,31 @@ Many APIs use tokens or keys for authentication. Per-user tokens are typically g
 
     [View Sample Code][sample_custom_header]{ .md-button }
 
+=== "Multiple headers"
+
+    Use [`MultiHeaderToken`][MultiHeaderToken] authentication for APIs that expect multiple tokens in HTTP headers. For example:
+
+    ```
+    GET /users/me
+    Host: api.example.com
+    X-API-Key: <token>
+    X-API-Secret: <secret>
+    ```
+
+    Can be implemented using:
+
+    ```ts
+    pack.setUserAuthentication({
+      type: coda.AuthenticationType.MultiHeaderToken,
+      headers: [
+        { name: "X-API-Key", description: "The key." },
+        { name: "X-API-Secret", description: "The secret." },
+      ],
+    });
+    ```
+
+    [View Sample Code][sample_multiple_headers]{ .md-button }
+
 === "Query parameter"
 
     Use [`QueryParamToken`][QueryParamToken] authentication for APIs that expect the token in a URL query parameter. For example:
@@ -547,6 +572,7 @@ There are services however where each account is associated with a distinct doma
 [sample_custom]: ../../../samples/topic/authentication.md#custom-tokens
 [sample_multiple_query_params]: ../../../samples/topic/authentication.md#multiple-query-parameters
 [sample_aws]: ../../../samples/topic/authentication.md#aws-signature-version-4
+[sample_multiple_headers]: ../../../samples/topic/authentication.md#multiple-headers
 
 [hc_account_sharing]: https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs
 [account_settings]: https://coda.io/account
@@ -568,3 +594,4 @@ There are services however where each account is associated with a distinct doma
 [CodaApiHeaderBearerToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#codaapiheaderbearertoken
 [AWSAccessKey]: ../../../reference/sdk/enums/core.AuthenticationType.md#awsaccesskey
 [support_network_domain]: ../../../support/index.md#network-domains
+[MultiHeaderToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#multiheadertoken

--- a/docs/samples/topic/apis.md
+++ b/docs/samples/topic/apis.md
@@ -143,6 +143,41 @@ pack.setUserAuthentication({
 pack.addNetworkDomain("coda.io");
 {% endraw %}
 ```
+## Copper API
+The Copper API requires the user to provide an API key and their email address, passed in custom HTTP headers.
+
+```ts
+{% raw %}
+import * as coda from "@codahq/packs-sdk";
+export const pack = coda.newPack();
+
+// Per-user authentication to the Copper API, using multiple HTTP headers.
+// See https://developer.copper.com/introduction/requests.html#headers.
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.MultiHeaderToken,
+  headers: [
+    { name: "X-PW-AccessToken", description: "API key" },
+    { name: "X-PW-UserEmail", description: "Email address" },
+  ],
+
+  // Determines the display name of the connected account.
+  getConnectionName: async function (context) {
+    let response = await context.fetcher.fetch({
+      method: "GET",
+      url: "https://api.copper.com/developer_api/v1/account",
+      headers: {
+        "X-PW-Application": "developer_api",
+      },
+    });
+    let account = response.body;
+    return account.name;
+  },
+});
+
+// Allow the pack to make requests to Copper.
+pack.addNetworkDomain("copper.com");
+{% endraw %}
+```
 ## Dropbox
 The Dropbox API uses OAuth2 to authenticate users, prompting them to approve a specific set of scopes. Additional parameters are requires on the authorization URL to ensure that offline access is granted.
 

--- a/docs/samples/topic/authentication.md
+++ b/docs/samples/topic/authentication.md
@@ -13,26 +13,6 @@ Coda supports a fixed set of authentication types which cover the most common pa
 
 [Learn More](../../../guides/basics/authentication){ .md-button }
 
-## Template (Per-user)
-The basic structure of per-user authentication.
-
-```ts
-{% raw %}
-pack.setUserAuthentication({
-  type: coda.AuthenticationType.$0,
-});
-{% endraw %}
-```
-## Template (System-wide)
-The basic structure of system-wide authentication.
-
-```ts
-{% raw %}
-pack.setSystemAuthentication({
-  type: coda.AuthenticationType.$0,
-});
-{% endraw %}
-```
 ## Authorization header
 Authentication that passes a long-lived token in the Authorization header using the &quot;Bearer&quot; scheme. This sample connects to the Todoist API.
 
@@ -81,6 +61,41 @@ pack.setSystemAuthentication({
 
 // Allow the pack to make requests to RapidAPI.
 pack.addNetworkDomain("rapidapi.com");
+{% endraw %}
+```
+## Multiple headers
+Authentication that passes multiple long-lived token in a HTTP headers. This sample connects to the Copper API.
+
+```ts
+{% raw %}
+import * as coda from "@codahq/packs-sdk";
+export const pack = coda.newPack();
+
+// Per-user authentication to the Copper API, using multiple HTTP headers.
+// See https://developer.copper.com/introduction/requests.html#headers.
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.MultiHeaderToken,
+  headers: [
+    { name: "X-PW-AccessToken", description: "API key" },
+    { name: "X-PW-UserEmail", description: "Email address" },
+  ],
+
+  // Determines the display name of the connected account.
+  getConnectionName: async function (context) {
+    let response = await context.fetcher.fetch({
+      method: "GET",
+      url: "https://api.copper.com/developer_api/v1/account",
+      headers: {
+        "X-PW-Application": "developer_api",
+      },
+    });
+    let account = response.body;
+    return account.name;
+  },
+});
+
+// Allow the pack to make requests to Copper.
+pack.addNetworkDomain("copper.com");
 {% endraw %}
 ```
 ## Query parameter

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -65,16 +65,6 @@
     "content": "Adding authentication to your Pack allows you to pass credentials with your API requests. Simply specify the type of authentication to use and Coda will collect the credentials from the user, store them, and apply them to Fetcher requests. Per-user authentication is the most common, where each user connects to their own account, while system-wide authentication is used in cases where the Pack maker's keys are used for all users.\n\nCoda supports a fixed set of authentication types which cover the most common patterns that APIs use. In addition you can define your own form of custom token authentication to support more complex scenarios. It's not possible to write completely custom authentication code however, as Coda alone has access to the user's credentials.",
     "exampleSnippets": [
       {
-        "name": "Template (Per-user)",
-        "content": "The basic structure of per-user authentication.",
-        "code": "pack.setUserAuthentication({\n  type: coda.AuthenticationType.$0,\n});"
-      },
-      {
-        "name": "Template (System-wide)",
-        "content": "The basic structure of system-wide authentication.",
-        "code": "pack.setSystemAuthentication({\n  type: coda.AuthenticationType.$0,\n});"
-      },
-      {
         "name": "Authorization header",
         "content": "Authentication that passes a long-lived token in the Authorization header using the \"Bearer\" scheme. This sample connects to the Todoist API.",
         "code": "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// Per-user authentication to the Todoist API, using a personal API token in\n// an \"Authorization: Bearer ...\" header.\npack.setUserAuthentication({\n  type: coda.AuthenticationType.HeaderBearerToken,\n  instructionsUrl: \"https://todoist.com/app/settings/integrations\",\n\n  // Determines the display name of the connected account.\n  getConnectionName: async function (context) {\n    let url = coda.withQueryParams(\"https://api.todoist.com/sync/v9/sync\", {\n      resource_types: JSON.stringify([\"user\"]),\n    });\n    let response = await context.fetcher.fetch({\n      method: \"GET\",\n      url: url,\n    });\n    return response.body.user?.full_name;\n  },\n});\n\n// Allow the pack to make requests to Todoist.\npack.addNetworkDomain(\"todoist.com\");"
@@ -83,6 +73,11 @@
         "name": "Custom header",
         "content": "Authentication that passes a long-lived token in a custom header. This sample connects to RapidAPI.",
         "code": "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// System-wide authentication to RapidAPI, using an API key in a custom header.\n// See https://docs.rapidapi.com/docs/keys#how-to-find-your-api-key.\npack.setSystemAuthentication({\n  type: coda.AuthenticationType.CustomHeaderToken,\n  headerName: \"X-RapidAPI-Key\",\n});\n\n// Allow the pack to make requests to RapidAPI.\npack.addNetworkDomain(\"rapidapi.com\");"
+      },
+      {
+        "name": "Multiple headers",
+        "content": "Authentication that passes multiple long-lived token in a HTTP headers. This sample connects to the Copper API.",
+        "code": "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// Per-user authentication to the Copper API, using multiple HTTP headers.\n// See https://developer.copper.com/introduction/requests.html#headers.\npack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"X-PW-AccessToken\", description: \"API key\" },\n    { name: \"X-PW-UserEmail\", description: \"Email address\" },\n  ],\n\n  // Determines the display name of the connected account.\n  getConnectionName: async function (context) {\n    let response = await context.fetcher.fetch({\n      method: \"GET\",\n      url: \"https://api.copper.com/developer_api/v1/account\",\n      headers: {\n        \"X-PW-Application\": \"developer_api\",\n      },\n    });\n    let account = response.body;\n    return account.name;\n  },\n});\n\n// Allow the pack to make requests to Copper.\npack.addNetworkDomain(\"copper.com\");"
       },
       {
         "name": "Query parameter",
@@ -704,6 +699,11 @@
         "name": "Coda API",
         "content": "The Coda API requires the user to provide an API token, passed in an Authorization header. Packs include a specific authentication type optimized for the Coda API.",
         "code": "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// Per-user authentication to the Coda API, using a token in the Authorization\n// header.\n// See https://coda.io/developers/apis/v1\npack.setUserAuthentication({\n  type: coda.AuthenticationType.CodaApiHeaderBearerToken,\n\n  // Creates the token automatically when the Pack is installed.\n  shouldAutoAuthSetup: true,\n});\n\n// Allow the pack to make requests to Coda.\npack.addNetworkDomain(\"coda.io\");"
+      },
+      {
+        "name": "Copper API",
+        "content": "The Copper API requires the user to provide an API key and their email address, passed in custom HTTP headers.",
+        "code": "import * as coda from \"@codahq/packs-sdk\";\nexport const pack = coda.newPack();\n\n// Per-user authentication to the Copper API, using multiple HTTP headers.\n// See https://developer.copper.com/introduction/requests.html#headers.\npack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"X-PW-AccessToken\", description: \"API key\" },\n    { name: \"X-PW-UserEmail\", description: \"Email address\" },\n  ],\n\n  // Determines the display name of the connected account.\n  getConnectionName: async function (context) {\n    let response = await context.fetcher.fetch({\n      method: \"GET\",\n      url: \"https://api.copper.com/developer_api/v1/account\",\n      headers: {\n        \"X-PW-Application\": \"developer_api\",\n      },\n    });\n    let account = response.body;\n    return account.name;\n  },\n});\n\n// Allow the pack to make requests to Copper.\npack.addNetworkDomain(\"copper.com\");"
       },
       {
         "name": "Dropbox",

--- a/documentation/generated/pack.code-snippets
+++ b/documentation/generated/pack.code-snippets
@@ -71,6 +71,12 @@
     "body": "pack.setUserAuthentication({\n  type: coda.AuthenticationType.CustomHeaderToken,\n  headerName: \"${1:MyToken}\",\n  instructionsUrl: \"${2:https://help.example.com/api-tokens}\",\n  getConnectionName: async function (context) {\n    // TODO: Fetch the name of the account.\n    let name = \"\";\n    return name;\n  },\n});",
     "scope": "javascript,typescript"
   },
+  "setUserAuthentication:Headers": {
+    "prefix": "/setUserAuthentication:Headers",
+    "description": "Sets per-user authentication for the Pack, using multiple tokens passed as HTTP headers.",
+    "body": "pack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"${1:X-My-Token}\", description: \"${2:My token description}\" },\n    { name: \"${3:X-My-Key}\", description: \"${4:My key description}\" },\n    // TODO: Add more headers, if needed.\n  ],\n  instructionsUrl: \"${5:https://help.example.com/api-tokens}\",\n  getConnectionName: async function (context) {\n    // TODO: Fetch the name of the account.\n    let name = \"\";\n    return name;\n  },\n});",
+    "scope": "javascript,typescript"
+  },
   "setUserAuthentication:Custom": {
     "prefix": "/setUserAuthentication:Custom",
     "description": "Sets per-user authentication for the Pack, using a set of custom tokens.",

--- a/documentation/generated/snippets.json
+++ b/documentation/generated/snippets.json
@@ -113,6 +113,15 @@
   },
   {
     "triggerTokens": [
+      "setUserAuthentication:Headers",
+      "MultiHeaderToken",
+      "MultiHeaderTokenAuthentication"
+    ],
+    "content": "Sets per-user authentication for the Pack, using multiple tokens passed as HTTP headers.",
+    "code": "pack.setUserAuthentication({\n  type: coda.AuthenticationType.MultiHeaderToken,\n  headers: [\n    { name: \"${1:X-My-Token}\", description: \"${2:My token description}\" },\n    { name: \"${3:X-My-Key}\", description: \"${4:My key description}\" },\n    // TODO: Add more headers, if needed.\n  ],\n  instructionsUrl: \"${5:https://help.example.com/api-tokens}\",\n  getConnectionName: async function (context) {\n    // TODO: Fetch the name of the account.\n    let name = \"\";\n    return name;\n  },\n});"
+  },
+  {
+    "triggerTokens": [
       "setUserAuthentication:Custom",
       "Custom",
       "CustomAuthentication"

--- a/documentation/samples/packs/authentication/copper.ts
+++ b/documentation/samples/packs/authentication/copper.ts
@@ -1,0 +1,28 @@
+import * as coda from "@codahq/packs-sdk";
+export const pack = coda.newPack();
+
+// Per-user authentication to the Copper API, using multiple HTTP headers.
+// See https://developer.copper.com/introduction/requests.html#headers.
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.MultiHeaderToken,
+  headers: [
+    { name: "X-PW-AccessToken", description: "API key" },
+    { name: "X-PW-UserEmail", description: "Email address" },
+  ],
+
+  // Determines the display name of the connected account.
+  getConnectionName: async function (context) {
+    let response = await context.fetcher.fetch({
+      method: "GET",
+      url: "https://api.copper.com/developer_api/v1/account",
+      headers: {
+        "X-PW-Application": "developer_api",
+      },
+    });
+    let account = response.body;
+    return account.name;
+  },
+});
+
+// Allow the pack to make requests to Copper.
+pack.addNetworkDomain("copper.com");

--- a/documentation/samples/snippets/authentication/user_multi_header.ts
+++ b/documentation/samples/snippets/authentication/user_multi_header.ts
@@ -1,0 +1,20 @@
+import * as coda from "@codahq/packs-sdk";
+
+const pack = coda.newPack();
+
+// BEGIN
+
+pack.setUserAuthentication({
+  type: coda.AuthenticationType.MultiHeaderToken,
+  headers: [
+    { name: "${1:X-My-Token}", description: "${2:My token description}" },
+    { name: "${3:X-My-Key}", description: "${4:My key description}" },
+    // TODO: Add more headers, if needed.
+  ],
+  instructionsUrl: "${5:https://help.example.com/api-tokens}",
+  getConnectionName: async function (context) {
+    // TODO: Fetch the name of the account.
+    let name = "";
+    return name;
+  },
+});

--- a/documentation/scripts/documentation_config.ts
+++ b/documentation/scripts/documentation_config.ts
@@ -66,6 +66,11 @@ export const Snippets: AutocompleteSnippet[] = [
     codeFile: './samples/snippets/authentication/user_custom_header.ts',
   },
   {
+    triggerTokens: ['setUserAuthentication:Headers', 'MultiHeaderToken', 'MultiHeaderTokenAuthentication'],
+    content: 'Sets per-user authentication for the Pack, using multiple tokens passed as HTTP headers.',
+    codeFile: './samples/snippets/authentication/user_multi_header.ts',
+  },
+  {
     triggerTokens: ['setUserAuthentication:Custom', 'Custom', 'CustomAuthentication'],
     content: 'Sets per-user authentication for the Pack, using a set of custom tokens.',
     codeFile: './samples/snippets/authentication/user_custom.ts',
@@ -314,16 +319,6 @@ export const Examples: Example[] = [
     },
     exampleSnippets: [
       {
-        name: 'Template (Per-user)',
-        content: 'The basic structure of per-user authentication.',
-        codeFile: './samples/snippets/authentication/user.ts',
-      },
-      {
-        name: 'Template (System-wide)',
-        content: 'The basic structure of system-wide authentication.',
-        codeFile: './samples/snippets/authentication/system.ts',
-      },
-      {
         name: 'Authorization header',
         content:
           'Authentication that passes a long-lived token in the Authorization header using the "Bearer" scheme. This sample connects to the Todoist API.',
@@ -333,6 +328,11 @@ export const Examples: Example[] = [
         name: 'Custom header',
         content: 'Authentication that passes a long-lived token in a custom header. This sample connects to RapidAPI.',
         codeFile: './samples/packs/authentication/rapidapi.ts',
+      },
+      {
+        name: 'Multiple headers',
+        content: 'Authentication that passes multiple long-lived token in a HTTP headers. This sample connects to the Copper API.',
+        codeFile: './samples/packs/authentication/copper.ts',
       },
       {
         name: 'Query parameter',
@@ -948,6 +948,11 @@ export const Examples: Example[] = [
         name: 'Coda API',
         content: 'The Coda API requires the user to provide an API token, passed in an Authorization header. Packs include a specific authentication type optimized for the Coda API.',
         codeFile: './samples/packs/authentication/coda.ts',
+      },
+      {
+        name: 'Copper API',
+        content: 'The Copper API requires the user to provide an API key and their email address, passed in custom HTTP headers.',
+        codeFile: './samples/packs/authentication/copper.ts',
       },
       {
         name: 'Dropbox',


### PR DESCRIPTION
Also removes the "Template" samples from the authentication samples. They confusingly still included the snippet placeholders, and they added little value.

Preview:
- https://coda-packs-sdk--2667.com.readthedocs.build/en/2667/guides/basics/authentication/#simple-tokens
- https://coda-packs-sdk--2667.com.readthedocs.build/en/2667/samples/topic/authentication/#multiple-headers