### PR TITLE
Remove mkdocs-video plugin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,6 @@ mkdocs-macros-plugin = "*"
 mkdocs-redirects = "*"
 mkdocs-simple-hooks = "*"
 pillow = "==9.5.0"
-mkdocs-video = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "46dd444ec9475f4762895010aba420a078906b2903260de38d2234c4c3c40fc7"
+            "sha256": "e747e71c8c06ac192f707796cdbb3dd1ff95a88bfec0d5fce8efb15562604498"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -469,14 +469,6 @@
             ],
             "index": "pypi",
             "version": "==0.1.5"
-        },
-        "mkdocs-video": {
-            "hashes": [
-                "sha256:0defc018f4b7927f8afffc4d8e039c84dfba636dffc5e25e2bfa8d6350bc8eca",
-                "sha256:b35613d4dacbac2dfa94d8c2600383cda14ad99a1fa1542b5fc4e9c6d19e9fe1"
-            ],
-            "index": "pypi",
-            "version": "==1.5.0"
         },
         "natsort": {
             "hashes": [

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -21,7 +21,7 @@ Packs that support per-user authentication require some additional setup. Users 
 
 The listing for the Pack will display a **Sign in to install** button in place of the usual **Install** button. Upon clicking it the user will immediately be launched into a sign-in flow, which varies depending on the type of authentication used and the service the user is connecting to. After the sign-in flow is complete Coda will ask the user if that connected account should be shared with other users in the same doc.
 
-![type:video](../../../images/auth_sign_in.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of authenticating with a Pack." class="screenshot"><source src="../../../images/auth_sign_in.mp4" type="video/mp4"></source></video>
 
 Users can sign in to additional accounts and change their sharing settings from the **Settings** tab of the Pack's side panel. Accounts can be reused across docs, and  users can manage all of their connected accounts on the [Account settings][account_settings] page.
 

--- a/docs/guides/blocks/sync-tables/dynamic.md
+++ b/docs/guides/blocks/sync-tables/dynamic.md
@@ -14,7 +14,7 @@ Sync tables are designed to bring records from an external data source into Coda
 
 Adding a dynamic sync table to a doc is similar to adding a regular sync table, but with an additional step of selecting the specific dataset to sync from. Start by navigating to {{ coda.pack_panel_clicks }} and clicking on the the table in the side panel. This will expand a section below the table that displays the specific datasets that the user has access to. Then drag one of these datasets onto the page.
 
-![type:video](../../../images/dynamic_sync_table_usage.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of adding a dynamic sync table." class="screenshot"><source src="../../../../images/dynamic_sync_table_usage.mp4" type="video/mp4"></source></video>
 
 
 ## Creating a dynamic sync table

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -14,7 +14,7 @@ Tables are one of the most powerful features of Coda, and many times people use 
 
 Sync tables are added directly to the document, usually by dragging them in from the side panel. Navigate to {{ coda.pack_panel_clicks }} and drag the table into the canvas.
 
-![type:video](../../../images/sync_table_use.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of adding a sync table." class="screenshot"><source src="../../../images/sync_table_use.mp4" type="video/mp4"></source></video>
 
 If the sync table doesn't have any required parameters it will start syncing immediately, otherwise you'll have to configure it first. The data in the table can be synced manually or set up to sync automatically at regular intervals.
 

--- a/docs/guides/blocks/sync-tables/two-way.md
+++ b/docs/guides/blocks/sync-tables/two-way.md
@@ -21,7 +21,7 @@ To enable two-way sync on a sync table that supports it you need to toggle on th
 
 Certain columns of the table will now be editable, and you can change cell values them as you would for a normal Coda table. Use the **Update rows** link to push the changes back to the data source.
 
-![type:video](../../../images/two_way.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of editing a sync table." class="screenshot"><source src="../../../../images/two_way.mp4" type="video/mp4"></source></video>
 
 
 ## Adding two-way sync

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Packs can be created for personal use, shared with a team, or published to the w
 </div>
 
 <div class="landing-item" markdown>
-![type:video](images/home_demo.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Illustration video of using a Pack." class="screenshot"><source src="images/home_demo.mp4" type="video/mp4"></source></video>
 </div>
 
 </section>
@@ -44,7 +44,7 @@ Or for you power users, build a Pack using the `coda` command line tool on your 
 </div>
 
 <div class="landing-item" markdown>
-![type:video](images/web_ide_build.mp4){: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Creating a Pack in the Pack Studio." class="screenshot"><source src="images/web_ide_build.mp4" type="video/mp4"></source></video>
 </div>
 
 </section>

--- a/docs/tutorials/build/formula.md
+++ b/docs/tutorials/build/formula.md
@@ -351,7 +351,7 @@ You should see the name, description, and parameters in the help text, get back 
 ??? tip "Tip: Slash command"
     When you write Packs using the Pack Studio web editor you can use the slash command `/addFormula` to generate the scaffolding for you!
 
-    ![type:video][slash_gif]{: .screenshot}
+    <video style="width:auto" loop muted autoplay alt="Recording of using the addFormula slash command." class="screenshot"><source src="../../../images/tutorial_formula_slash.mp4" type="video/mp4"></source></video>
 
 
 ## :fontawesome-solid-laptop-code: Write the logic
@@ -658,4 +658,3 @@ Now that you have an understanding of how to build formulas, here are some more 
 [parameters]: ../../guides/basics/parameters/index.md
 [data_types]: ../../guides/basics/data-types.md
 [javascript_key_value]: https://javascript.info/object
-[slash_gif]: ../../images/tutorial_formula_slash.mp4

--- a/docs/tutorials/get-started/.cli/core.md
+++ b/docs/tutorials/get-started/.cli/core.md
@@ -109,6 +109,8 @@ Now that you have your Pack up and running let's make a change to how it works.
 
 --8<-- "tutorials/get-started/.rebuild.md"
 
+<video style="width:auto" loop muted autoplay alt="Recording of adding a dynamic sync table." class="screenshot"><source src="../../../images/cli_rebuild.mp4" type="video/mp4"></source></video>
+
 
 ## Next steps
 

--- a/docs/tutorials/get-started/.rebuild.md
+++ b/docs/tutorials/get-started/.rebuild.md
@@ -13,7 +13,5 @@
 
 Your formula result should now be `Howdy World!`.
 
-![type:video][rebuild]{: .screenshot}
-
 !!! tip
     To avoid having to manually refresh the formulas on every update, click the gear icon :material-cog-outline: in the Pack maker toolbar and toggle on the **AUTO-REFRESH**  setting.

--- a/docs/tutorials/get-started/.use.md
+++ b/docs/tutorials/get-started/.use.md
@@ -7,10 +7,7 @@
 
 If everything has gone right you should see the result `Hello World` as the output of your formula.
 
-![type:video][web_ide_use]{: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of using the new Pack." class="screenshot"><source src="../../../images/web_ide_use.mp4" type="video/mp4"></source></video>
 
 !!! tip
     For a more personalized message, try changing the formula to `Hello(User())`.
-
-
-[web_ide_use]: ../../images/web_ide_use.mp4

--- a/docs/tutorials/get-started/github.md
+++ b/docs/tutorials/get-started/github.md
@@ -75,5 +75,4 @@ It may take a few minutes for the codespace to fully initialize and install the 
 [github_new]: https://github.com/new
 [github_use_template]: https://github.com/coda/packs-starter/generate
 [github_packs_starter]: https://github.com/coda/packs-starter
-[rebuild]: ../../images/cli_rebuild.mp4
 [github_codespace_template]: https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace-from-a-template#publishing-to-a-repository-on-github

--- a/docs/tutorials/get-started/gitpod.md
+++ b/docs/tutorials/get-started/gitpod.md
@@ -40,4 +40,3 @@ It may take a few minutes for the workspace to fully initialize. When it's compl
 [gitpod_signup]: https://gitpod.io/workspaces/
 [gitpod_from_github]: https://gitpod.io/#https://github.com/coda/packs-starter
 [github_packs_starter]: https://github.com/coda/packs-starter
-[rebuild]: ../../images/cli_rebuild.mp4

--- a/docs/tutorials/get-started/replit.md
+++ b/docs/tutorials/get-started/replit.md
@@ -47,4 +47,3 @@ If everything works correctly this should output `Hello World!`.
 [replit_signup]: https://replit.com/signup
 [replit_from_github]: https://replit.com/new/github/coda/packs-starter
 [github_packs_starter]: https://github.com/coda/packs-starter
-[rebuild]: ../../images/cli_rebuild.mp4

--- a/docs/tutorials/get-started/web.md
+++ b/docs/tutorials/get-started/web.md
@@ -29,7 +29,7 @@ The Pack Studio is built right in to the Coda application. To get there:
 
 You are now in the Pack Studio, ready to start building!
 
-![type:video][web_ide_navigate]{: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of navigating to the Pack Studio." class="screenshot"><source src="../../../images/web_ide_navigate.mp4" type="video/mp4"></source></video>
 
 
 ## Create a Pack from an example
@@ -50,7 +50,7 @@ Next we'll use the Pack Studio to build that code and get it ready to use:
 
 Your Pack is now built and ready to use!
 
-![type:video][web_ide_build]{: .screenshot}
+<video style="width:auto" loop muted autoplay alt="Recording of building the Pack." class="screenshot"><source src="../../../images/web_ide_build.mp4" type="video/mp4"></source></video>
 
 
 ## Use the Pack
@@ -79,6 +79,8 @@ Now that you have your Pack up and running let's make a change to how it works.
 
 --8<-- "tutorials/get-started/.rebuild.md"
 
+<video style="width:auto" loop muted autoplay alt="Recording of adding a dynamic sync table." class="screenshot"><source src="../../../images/web_ide_rebuild.mp4" type="video/mp4"></source></video>
+
 
 ## Next steps
 
@@ -91,9 +93,6 @@ You've built your fist Pack, congrats! 🎉 Now that you have some experience wi
 [coda_sign_up]: https://coda.io/signup
 [hc_doc_maker]: https://help.coda.io/en/articles/3388781-members-and-roles
 [coda_home]: https://coda.io/docs
-[web_ide_navigate]: ../../images/web_ide_navigate.mp4
-[web_ide_build]: ../../images/web_ide_build.mp4
 [samples_hello_world]: ../../samples/full/hello-world.md
-[rebuild]: ../../images/web_ide_rebuild.mp4
 [samples]: ../../samples/topic/formula.md
 [guides]: ../../guides/blocks/formulas.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,14 +56,6 @@ plugins:
     # Variables in markdown.
     # See: https://squidfunk.github.io/mkdocs-material/reference/variables/
     - macros
-    - mkdocs-video:
-        is_video: True
-        video_autoplay: True
-        video_loop: True
-        video_muted: True
-        video_controls: False
-        css_style:
-          width: "auto"
     - redirects:
         redirect_maps:
           # 2022-01-14: Reorganize guides and tutorials.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ mkdocs-material==9.1.15
 mkdocs-material-extensions==1.1.1 ; python_version >= '3.7'
 mkdocs-redirects==1.2.0
 mkdocs-simple-hooks==0.1.5
-mkdocs-video==1.5.0
 natsort==8.3.1 ; python_version >= '3.7'
 packaging==23.1 ; python_version >= '3.7'
 pillow==9.5.0


### PR DESCRIPTION
MkDocs was failing to build on M2 macs with the following error:

```
[info] Loaded plugin typedoc-plugin-markdown
[info] Documentation generated at ./docs/reference/sdk
Already has frontmatter: /Users/patrick/code/packs-sdk/docs/reference/sdk/index.md
INFO     -  [macros] - Macros arguments: {'module_name': 'main', 'modules': [], 'render_by_default': True, 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '',
            'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '', 'on_undefined': 'keep', 'on_error_fail': False, 'verbose': False}
INFO     -  [macros] - Extra variables (config file): ['social', 'coda']
INFO     -  [macros] - Extra filters (module): ['pretty']
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /Users/patrick/code/packs-sdk/site
ERROR    -  Error reading page 'reference/sdk/interfaces/core.NumericDateTimeSchema.md': Document is empty
Traceback (most recent call last):
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/mkdocs/__main__.py", line 250, in build_command
    build.build(cfg, dirty=not clean)
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/mkdocs/commands/build.py", line 308, in build
    _populate_page(file.page, config, files, dirty)
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/mkdocs/commands/build.py", line 184, in _populate_page
    page.content = config.plugins.run_event(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/mkdocs/plugins.py", line 520, in run_event
    result = method(item, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/mkdocs_video/plugin.py", line 28, in on_page_content
    content = lxml.html.fromstring(html)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/lxml/html/__init__.py", line 873, in fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/patrick/.local/share/virtualenvs/packs-sdk-BVvyaSJI/lib/python3.11/site-packages/lxml/html/__init__.py", line 761, in document_fromstring
    raise etree.ParserError(
lxml.etree.ParserError: Document is empty
make: *** [build-mkdocs] Error 1
```

While it's unclear if `mkdocs-video` is the cause of the error (vs something upstream) removing it also removed the error. Since it's use isn't required, this PR removes the plugin and replaces it with manually-created HTML `<video>` elements.

The switch from markdown paths to HTML paths resulted in some minor rework of some tutorials templates, which were relying on markdown paths flowing into includes, in a way that can't be done through other means.