### PR TITLE
make endpoint key available in external metadata

### DIFF
--- a/compiled_types.ts
+++ b/compiled_types.ts
@@ -160,6 +160,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
     oauthAuthorizationUrl?: string;
     oauthTokenUrl?: string;
     networkDomain?: string | string[];
+    endpointKey?: string;
   };
   instructionsUrl?: string;
 

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -4560,6 +4560,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
 		oauthAuthorizationUrl?: string;
 		oauthTokenUrl?: string;
 		networkDomain?: string | string[];
+		endpointKey?: string;
 	};
 	instructionsUrl?: string;
 	formulas?: ExternalPackFormulas;

--- a/dist/compiled_types.d.ts
+++ b/dist/compiled_types.d.ts
@@ -113,6 +113,7 @@ export interface ExternalPackVersionMetadata extends BasePackVersionMetadata {
         oauthAuthorizationUrl?: string;
         oauthTokenUrl?: string;
         networkDomain?: string | string[];
+        endpointKey?: string;
     };
     instructionsUrl?: string;
     formulas?: ExternalPackFormulas;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,24 +2,24 @@
 # If the format has changed, update MIN_PIPENV_VERSION in Makefile
 -i https://pypi.org/simple
 bracex==2.3.post1; python_version >= '3.7'
-cairocffi==1.6.1; python_version >= '3.7'
+cairocffi==1.5.1; python_version >= '3.7'
 cairosvg==2.7.0
-certifi==2023.7.22; python_version >= '3.6'
+certifi==2023.5.7; python_version >= '3.6'
 cffi==1.15.1
-charset-normalizer==3.2.0; python_full_version >= '3.7.0'
+charset-normalizer==3.1.0; python_full_version >= '3.7.0'
 click==8.1.3; python_version >= '3.7'
 colorama==0.4.6; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 cssselect2==0.7.0; python_version >= '3.7'
 defusedxml==0.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 ghp-import==2.1.0
 idna==3.4; python_version >= '3.5'
-importlib-metadata==6.8.0
+importlib-metadata==6.6.0
 jinja2==3.1.2; python_version >= '3.7'
 lxml==4.9.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-markdown==3.4.4; python_version >= '3.6'
+markdown==3.3.7; python_version >= '3.6'
 markupsafe==2.1.2; python_version >= '3.7'
 mergedeep==1.3.4; python_version >= '3.6'
-mkdocs==1.5.2
+mkdocs==1.4.3
 mkdocs-awesome-pages-plugin==2.9.1
 mkdocs-macros-plugin==1.0.1
 mkdocs-material==9.1.15
@@ -40,7 +40,7 @@ requests==2.31.0; python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 termcolor==2.3.0; python_version >= '3.7'
 tinycss2==1.2.1; python_version >= '3.7'
-urllib3==2.0.4; python_version >= '3.7'
+urllib3==2.0.2; python_version >= '3.7'
 watchdog==3.0.0; python_version >= '3.7'
 wcmatch==8.4.1; python_version >= '3.7'
 webencodings==0.5.1


### PR DESCRIPTION
so we can check it when we consider if we want to show oauth as configurable for pack configurations