### PR TITLE
[Node18] Ensure we build docker images for x86_64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ do-compile-isolated-vm:
 	mkdir build-isolated-vm && \
 		cd build-isolated-vm && \
 		npm init -y && \
-		docker run --rm -v `pwd`:/var/task amazon/aws-sam-cli-build-image-nodejs14.x:latest npm install isolated-vm@${ISOLATED_VM_VERSION}
+		docker run --rm --platform linux/amd64 -v `pwd`:/var/task amazon/aws-sam-cli-build-image-nodejs14.x:latest npm install isolated-vm@${ISOLATED_VM_VERSION}
 	cp build-isolated-vm/node_modules/isolated-vm/package.json runtime/isolated-vm/
 	cp build-isolated-vm/node_modules/isolated-vm/isolated-vm.js runtime/isolated-vm/
 	cp build-isolated-vm/node_modules/isolated-vm/out/isolated_vm.node runtime/isolated-vm/out/


### PR DESCRIPTION
We've been running into problems where we build the SDK from a Mac arm machine, but then try to deploy that build to lambda in AWS which runs x86_64.

For now, this code assumes we always want x86_64.  We may run into Rosetta2 emulator issues when trying to run this on an arm64 dev machine, in which case we'll likely need to have two versions of this compilation step run, then be sure to select the correct one during test time vs. run time.  Will see how that lands and followup as necessary.

PTAL @coda/packs @dweitzman-codaio 