### PR TITLE
Bump sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.5.2",
+  "version": "1.5.2-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Once again, this is to avoid a lint performance regression

Same as https://github.com/coda/packs-sdk/pull/2662