### PR TITLE
Adjust snippets that use schemas

### DIFF
--- a/docs/embedded-snippets/samples/snippets/formula/object_formula.html
+++ b/docs/embedded-snippets/samples/snippets/formula/object_formula.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: $3$MySchema$,\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});",
+          value: "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: $3$ThingSchema$,\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/embedded-snippets/samples/snippets/sync_table.html
+++ b/docs/embedded-snippets/samples/snippets/sync_table.html
@@ -16,7 +16,7 @@
 
       require(['vs/editor/editor.main'], function () {
         var editor = monaco.editor.create(document.getElementById('container'), {
-          value: "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"$1\",\n  schema: $3$MySchema$,\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});",
+          value: "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"${3:Thing}\",\n  schema: $3$ThingSchema$,\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});",
           language: 'javascript',
           minimap: {enabled: false},
           readOnly: true,

--- a/docs/samples/topic/data-type.md
+++ b/docs/samples/topic/data-type.md
@@ -110,7 +110,7 @@ pack.addFormula({
     // TODO: Add parameters.
   ],
   resultType: coda.ValueType.Object,
-  schema: MySchema,
+  schema: ThingSchema,
   execute: async function (args, context) {
     // TODO: Unpack the parameter values.
     let [] = args;

--- a/docs/samples/topic/sync-table.md
+++ b/docs/samples/topic/sync-table.md
@@ -19,8 +19,8 @@ The basic structure of a sync table.
 pack.addSyncTable({
   name: "MyThings",
   description: "Table description.",
-  identityName: "$1",
-  schema: MySchema,
+  identityName: "Thing",
+  schema: ThingSchema,
   formula: {
     name: "Sync$1",
     description: "Syncs the data.",

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -375,7 +375,7 @@
       {
         "name": "Template",
         "content": "The basic structure of a sync table.",
-        "code": "pack.addSyncTable({\n  name: \"MyThings\",\n  description: \"Table description.\",\n  identityName: \"$1\",\n  schema: MySchema,\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});"
+        "code": "pack.addSyncTable({\n  name: \"MyThings\",\n  description: \"Table description.\",\n  identityName: \"Thing\",\n  schema: ThingSchema,\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});"
       },
       {
         "name": "With parameter",
@@ -472,7 +472,7 @@
       {
         "name": "Template (Object)",
         "content": "The basic structure of a formula that returns an object.",
-        "code": "pack.addFormula({\n  name: \"MyFormula\",\n  description: \"My description.\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: MySchema,\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});"
+        "code": "pack.addFormula({\n  name: \"MyFormula\",\n  description: \"My description.\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: ThingSchema,\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});"
       },
       {
         "name": "Percent",

--- a/documentation/generated/pack.code-snippets
+++ b/documentation/generated/pack.code-snippets
@@ -26,7 +26,7 @@
   "addFormula:object": {
     "prefix": "/addFormula:object",
     "description": "Adds a Coda formula which will return an object in the doc.",
-    "body": "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: ${3:MySchema},\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});",
+    "body": "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: ${3:ThingSchema},\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});",
     "scope": "javascript,typescript"
   },
   "addFormula:action": {
@@ -236,7 +236,7 @@
   "addSyncTable": {
     "prefix": "/addSyncTable",
     "description": "Adds a sync table.",
-    "body": "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"$1\",\n  schema: ${3:MySchema},\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});",
+    "body": "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"${3:Thing}\",\n  schema: ${3:ThingSchema},\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});",
     "scope": "javascript,typescript"
   },
   "addDynamicSyncTable": {

--- a/documentation/generated/snippets.json
+++ b/documentation/generated/snippets.json
@@ -48,7 +48,7 @@
       "ObjectFormula"
     ],
     "content": "Adds a Coda formula which will return an object in the doc.",
-    "code": "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: ${3:MySchema},\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});"
+    "code": "pack.addFormula({\n  name: \"${1:MyFormula}\",\n  description: \"${2:My description.}\",\n  parameters: [\n    // TODO: Add parameters.\n  ],\n  resultType: coda.ValueType.Object,\n  schema: ${3:ThingSchema},\n  execute: async function (args, context) {\n    // TODO: Unpack the parameter values.\n    let [] = args;\n    // TODO: Compute the result.\n    return {};\n  },\n});"
   },
   {
     "triggerTokens": [
@@ -362,7 +362,7 @@
       "SyncTable"
     ],
     "content": "Adds a sync table.",
-    "code": "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"$1\",\n  schema: ${3:MySchema},\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});"
+    "code": "pack.addSyncTable({\n  name: \"${1:MyThings}\",\n  description: \"${2:Table description.}\",\n  identityName: \"${3:Thing}\",\n  schema: ${3:ThingSchema},\n  formula: {\n    name: \"Sync$1\",\n    description: \"Syncs the data.\",\n    parameters: [\n      // TODO: Add parameters.\n    ],\n    execute: async function (args, context) {\n      // TODO: Unpack the parameter values.\n      let [] = args;\n      // TODO: Fetch the rows.\n      let rows = [];\n      for (let row of rows) {\n        // TODO: If required, adjust the row to match the schema.\n      }\n      return {\n        result: rows,\n      };\n    },\n  },\n});"
   },
   {
     "triggerTokens": [

--- a/documentation/samples/snippets/formula/object_formula.ts
+++ b/documentation/samples/snippets/formula/object_formula.ts
@@ -2,7 +2,7 @@ import * as coda from "@codahq/packs-sdk";
 
 const pack = coda.newPack();
 
-const $3$MySchema$ = undefined;
+const $3$ThingSchema$ = undefined;
 
 // BEGIN
 
@@ -13,7 +13,7 @@ pack.addFormula({
     // TODO: Add parameters.
   ],
   resultType: coda.ValueType.Object,
-  schema: $3$MySchema$,
+  schema: $3$ThingSchema$,
   execute: async function (args, context) {
     // TODO: Unpack the parameter values.
     let [] = args;

--- a/documentation/samples/snippets/sync_table.ts
+++ b/documentation/samples/snippets/sync_table.ts
@@ -2,15 +2,15 @@ import * as coda from "@codahq/packs-sdk";
 
 const pack = coda.newPack();
 
-const $3$MySchema$ = undefined;
+const $3$ThingSchema$ = undefined;
 
 // BEGIN
 
 pack.addSyncTable({
   name: "${1:MyThings}",
   description: "${2:Table description.}",
-  identityName: "$1",
-  schema: $3$MySchema$,
+  identityName: "${3:Thing}",
+  schema: $3$ThingSchema$,
   formula: {
     name: "Sync$1",
     description: "Syncs the data.",


### PR DESCRIPTION
The snippets that create a schema use the name `ThingSchema`, so this bring this inline. Also while having the sync table name and identity be one placeholder was convenient, I worry it will set a bad precedent, since the identity name should ideally be singular and the sync table name plural. Assigning to on-call.