### PR TITLE
Add information about HTTP debug logs

### DIFF
--- a/docs/guides/development/troubleshooting.md
+++ b/docs/guides/development/troubleshooting.md
@@ -30,6 +30,17 @@ The Packs runtime only includes a subset of the [full `console` methods][mdn_con
 - `console.warn()`
 
 
+## HTTP request logs
+
+For Packs that make HTTP requests to external services and APIs it can be useful to see the details of the outgoing and request and incoming response. Whenever a Pack is run in a Coda doc the HTTP requests are automatically logged and can be inspected in the [Pack maker tools][pmt_http].
+
+When executing a Pack locally using the Pack CLI, you can use Node's built-in HTTP debug logs to see the raw requests and responses. To enable this logging, set the environment variable `NODE_DEBUG=http`. This can be done for a single execution by adding it before the execute command.
+
+```sh
+NODE_DEBUG=http npx coda execute pack.ts Hello "World"
+```
+
+
 ## Debugging
 
 When developing using the Pack CLI you can connect a JavaScript debugger to your Pack code. This allows you to set breakpoints, examine variables, and step through your code line by line. It requires a bit more setup than simply logging values but is much more flexible.
@@ -90,4 +101,5 @@ The Pack CLI uses the `esbuild` library to compile your local code, and [this er
 [isolated_vm_requirements]: https://github.com/laverdet/isolated-vm#requirements
 [actions_create]: ../blocks/actions.md#creating-actions
 [pmt]: pack-maker-tools.md
+[pmt_http]: pack-maker-tools.md#http-requests
 [esbuild_error]: https://github.com/evanw/esbuild/issues/2183

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -34,13 +34,6 @@ Although Google includes an exception for apps that don't own the domain of thei
 With enough persistence you should be able to get your Pack verified. The process may take a week or more to complete, so plan accordingly.
 
 
-## Can you add my company's icon as an option in Coda?
-
-Building a template or demo document is an important part of creating a Pack, as it shows users how to apply you Pack to real problems. Many Pack makers wish to use their company's branding on that document for visual consistency.
-
-Coda supports both document- and page-level icons, from a library we source from an external provider. While some this library includes the icons for some popular brands, it's not comprehensive and your brand may not be present. At the moment we don't have a process for adding new icons to the library, nor do we support using custom icons within a document. This is something we hope to address in the future, but for the time being we recommend using a generic icon.
-
-
 ## Can formulas return dynamic schemas?
 
 No, unfortunately they can't. While [dynamic sync tables][dynamic_sync_tables] can flex their schema based upon the specific data source being connected to, this option isn't available for formulas. The schema for a formula must be declared statically, and there is no equivalent `getSchema()` function that formulas can provide.


### PR DESCRIPTION
Also deletes a section of the FAQ about icons which is obsolete with the introduction of custom icons.