### PR TITLE
Add --allowOlderSdkVersion param to `coda upload` to bypass upcoming constraint on SDK versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Added
+
+- For CLI development, there is now a `--allowOlderSdkVersion` param for the `coda upload` command that builds a new version. Coda will soon default to preventing a Pack build to have an older SDK version than the prior version, under the assumption that it most often happens when multiple dev environments conflict with each other. This new option is a bypass for that protection, for the rare case when you actually want to downgrade the SDK.
+
 ## [1.5.1] - 2023-07-31
 
 ### Fixed

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -179,6 +179,13 @@ if (require.main === module) {
         },
         apiToken: ApiTokenArg,
         codaApiEndpoint: CodaApiEndpointArg,
+        allowOlderSdkVersion: {
+          boolean: true,
+          desc:
+            'Not recommended. Allows uploading a Pack build that uses an older version of the ' +
+            'SDK than the prior Pack build.',
+          default: false,
+        },
       },
       handler: handleUpload as any,
     })

--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -55,6 +55,7 @@ export async function handleUpload({
   notes,
   timerStrategy,
   apiToken,
+  allowOlderSdkVersion,
 }: ArgumentsCamelCase<UploadArgs>) {
   const logger = console;
   function printAndExit(message: string): never {
@@ -167,7 +168,7 @@ export async function handleUpload({
         packId,
         packVersion,
         {},
-        {notes, source: PublicApiPackSource.Cli},
+        {notes, source: PublicApiPackSource.Cli, allowOlderSdkVersion: Boolean(allowOlderSdkVersion)},
       );
     } catch (err: any) {
       if (isResponseError(err)) {

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -179,6 +179,12 @@ if (require.main === module) {
             },
             apiToken: ApiTokenArg,
             codaApiEndpoint: CodaApiEndpointArg,
+            allowOlderSdkVersion: {
+                boolean: true,
+                desc: 'Not recommended. Allows uploading a Pack build that uses an older version of the ' +
+                    'SDK than the prior Pack build.',
+                default: false,
+            },
         },
         handler: upload_1.handleUpload,
     })

--- a/dist/cli/upload.d.ts
+++ b/dist/cli/upload.d.ts
@@ -8,5 +8,5 @@ interface UploadArgs {
     timerStrategy: TimerShimStrategy;
     apiToken?: string;
 }
-export declare function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, }: ArgumentsCamelCase<UploadArgs>): Promise<undefined>;
+export declare function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, allowOlderSdkVersion, }: ArgumentsCamelCase<UploadArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -57,7 +57,7 @@ function cleanup(intermediateOutputDirectory, logger) {
         logger.info(`Intermediate files are moved to ${tempDirectory}`);
     }
 }
-async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, }) {
+async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApiEndpoint, notes, timerStrategy, apiToken, allowOlderSdkVersion, }) {
     const logger = console;
     function printAndExit(message) {
         cleanup(intermediateOutputDirectory, logger);
@@ -143,7 +143,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
         logger.info('Validating upload...');
         let uploadCompleteResponse;
         try {
-            uploadCompleteResponse = await client.packVersionUploadComplete(packId, packVersion, {}, { notes, source: v1_1.PublicApiPackSource.Cli });
+            uploadCompleteResponse = await client.packVersionUploadComplete(packId, packVersion, {}, { notes, source: v1_1.PublicApiPackSource.Cli, allowOlderSdkVersion: Boolean(allowOlderSdkVersion) });
         }
         catch (err) {
             if ((0, coda_1.isResponseError)(err)) {

--- a/dist/helpers/external-api/v1.d.ts
+++ b/dist/helpers/external-api/v1.d.ts
@@ -3494,6 +3494,12 @@ export interface PublicApiCreatePackVersionRequest {
     notes?: string;
     source?: PublicApiPackSource;
     /**
+     * By default, Coda prevents a new pack version from using an older SDK version than the prior version,
+     * assuming that there are multiple dev environments trampling each other. In the rare case that you
+     * actually need to use the older SDK, use this flag.
+     */
+    allowOlderSdkVersion?: boolean;
+    /**
      * Internal field for cross-environment pack import.
      */
     dangerouslyAllowCrossEnvPack?: boolean;

--- a/helpers/external-api/v1.ts
+++ b/helpers/external-api/v1.ts
@@ -3766,6 +3766,12 @@ export interface PublicApiCreatePackVersionRequest {
   notes?: string;
   source?: PublicApiPackSource;
   /**
+   * By default, Coda prevents a new pack version from using an older SDK version than the prior version,
+   * assuming that there are multiple dev environments trampling each other. In the rare case that you
+   * actually need to use the older SDK, use this flag.
+   */
+  allowOlderSdkVersion?: boolean;
+  /**
    * Internal field for cross-environment pack import.
    */
   dangerouslyAllowCrossEnvPack?: boolean;


### PR DESCRIPTION
For more context see https://github.com/coda/coda/pull/98327