### PR TITLE
Stop supporting '=' in sync table identity names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - For CLI development, there is now a `--allowOlderSdkVersion` param for the `coda upload` command that builds a new version. Coda will soon default to preventing a Pack build to have an older SDK version than the prior version, under the assumption that it most often happens when multiple dev environments conflict with each other. This new option is a bypass for that protection, for the rare case when you actually want to downgrade the SDK.
+- "=" character is no longer supported in sync table identity names.
 
 ## [1.5.1] - 2023-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - For CLI development, there is now a `--allowOlderSdkVersion` param for the `coda upload` command that builds a new version. Coda will soon default to preventing a Pack build to have an older SDK version than the prior version, under the assumption that it most often happens when multiple dev environments conflict with each other. This new option is a bypass for that protection, for the rare case when you actually want to downgrade the SDK.
+
+### Changed
+
 - "=" character is no longer supported in sync table identity names.
 
 ## [1.5.1] - 2023-07-31

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -732,10 +732,10 @@ function buildMetadataSchema({ sdkVersion }) {
         items: objectPropertyUnionSchema,
         ...basePropertyValidators,
     }));
-    const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
+    const ValidCodaObjectIdRegex = /^[A-Za-z0-9_-]+$/;
     // This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
     function isValidObjectId(component) {
-        return Base64ObjectRegex.test(component);
+        return ValidCodaObjectIdRegex.test(component);
     }
     const SystemColumnNames = ['id', 'value', 'synced', 'connection'];
     let ExemptionType;

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -907,7 +907,7 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
     }),
   );
 
-  const Base64ObjectRegex = /^[A-Za-z0-9=_-]+$/;
+  const Base64ObjectRegex = /^[A-Za-z0-9_-]+$/;
   // This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
   function isValidObjectId(component: string): boolean {
     return Base64ObjectRegex.test(component);

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -907,10 +907,10 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
     }),
   );
 
-  const Base64ObjectRegex = /^[A-Za-z0-9_-]+$/;
+  const ValidCodaObjectIdRegex = /^[A-Za-z0-9_-]+$/;
   // This is ripped off from isValidObjectId in coda. Violating this causes a number of downstream headaches.
   function isValidObjectId(component: string): boolean {
-    return Base64ObjectRegex.test(component);
+    return ValidCodaObjectIdRegex.test(component);
   }
 
   const SystemColumnNames = ['id', 'value', 'synced', 'connection'];


### PR DESCRIPTION
According to my map reduce result, there's no sync tables in all envs that is using a `=` character in their identity name. And the `=` is not a valid character in coda object ids. So let's simply get rid of it. 

PTAL @patrick-codaio @dweitzman-codaio @alan-codaio 

cc @taj-codaio @chris-codaio 