### PR TITLE
Try to fix renovate artifact building with pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ _bootstrap-doc-tools:
 	# Image libraries required by the social cards plugin for MkDocs Material.
 	sudo apt-get install libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
 
+.PHONY: _bootstrap-renovate
+_bootstrap-renovate:
+	# _bootstrap-doc-tools doesn't work in renovate
+	sudo apt-get install libjpeg-dev
+
 .PHONY: bootstrap
 bootstrap:
 	$(MAKE) MAKEFLAGS= _bootstrap-install-pnpm

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
   postUpgradeTasks: {
     // NOTE(dweitzman)): _bootstrap-doc-tools doesn't work in the renovate container
     // at the moment so we skip building docs and just compile code.
-    commands: ['make bs clean compile'],
+    commands: ['make _bootstrap-doc-tools bs clean compile'],
     fileFilters: ['**/*.js', '**/*.d.ts'],
   },
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
   postUpgradeTasks: {
     // NOTE(dweitzman)): _bootstrap-doc-tools doesn't work in the renovate container
     // at the moment so we skip building docs and just compile code.
-    commands: ['make _bootstrap-doc-tools bs clean compile'],
+    commands: ['make _bootstrap-renovate bs clean compile'],
     fileFilters: ['**/*.js', '**/*.d.ts'],
   },
 }


### PR DESCRIPTION
Now that we're using the pipfile instead of requirements.txt to power renovate, it's running into trouble installing dependencies.

Example error: https://github.com/coda/packs-sdk/pull/2781#issuecomment-1771461730

Unfortunately I didn't document what the specific renovate error with _bootstrap-doc-tools was when I made https://github.com/coda/packs-sdk/pull/2646, I just linked to a PR exhibiting the error on which renovate has since deleted the comment with the actual error message

This may not work, but I'm having trouble testing renovate on branches other than the repo default branch, so it might be easiest to just merge a PR and see what happens