### PR TITLE
Try removing "sudo" from make _bootstrap-renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ _bootstrap-doc-tools:
 .PHONY: _bootstrap-renovate
 _bootstrap-renovate:
 	# _bootstrap-doc-tools doesn't work in renovate
-	sudo apt-get install libjpeg-dev
+	apt-get install libjpeg-dev
 
 .PHONY: bootstrap
 bootstrap:


### PR DESCRIPTION
It's not working as-is, so pipenv updates are still failing: https://github.com/coda/packs-sdk/pull/2776#issuecomment-1771635874