### PR TITLE
Give up on installing python-y things in postUpgradeTasks for renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,9 @@ _bootstrap-doc-tools:
 
 .PHONY: _bootstrap-renovate
 _bootstrap-renovate:
-	# _bootstrap-doc-tools doesn't work in renovate
-	apt-get install libjpeg-dev
+	$(MAKE) MAKEFLAGS= _bootstrap-install-pnpm
+	$(MAKE) MAKEFLAGS= _bootstrap-node
+	$(MAKE) MAKEFLAGS= _bootstrap-python-requirements
 
 .PHONY: bootstrap
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ _bootstrap-doc-tools:
 .PHONY: _bootstrap-renovate
 _bootstrap-renovate:
 	# _bootstrap-doc-tools doesn't work in renovate
-	sudo apt-get install libjpeg-dev
+	apt-get install libjpeg-dev
 
 .PHONY: bootstrap
 bootstrap:

--- a/renovate.json5
+++ b/renovate.json5
@@ -44,7 +44,7 @@
   postUpgradeTasks: {
     // NOTE(dweitzman)): _bootstrap-doc-tools doesn't work in the renovate container
     // at the moment so we skip building docs and just compile code.
-    commands: ['make _bootstrap-renovate bs clean compile'],
+    commands: ['make _bootstrap-renovate clean compile'],
     fileFilters: ['**/*.js', '**/*.d.ts'],
   },
 }


### PR DESCRIPTION
I tried to figure out how to install pillow & dev-jpeg in the container we have available, but it wasn't going well and I'm ready to surrender. Since we're not building the docs anyway, seems like it's probably fine to just skip installing the python dependencies during the post upgrade tasks