### PR TITLE
Include requirements.txt in postUpgradeTasks artifacts

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -45,6 +45,6 @@
     // NOTE(dweitzman)): _bootstrap-doc-tools doesn't work in the renovate container
     // at the moment so we skip building docs and just compile code.
     commands: ['make _bootstrap-renovate clean compile'],
-    fileFilters: ['**/*.js', '**/*.d.ts'],
+    fileFilters: ['**/*.js', '**/*.d.ts', 'requirements.txt'],
   },
 }


### PR DESCRIPTION
Looks like postUpgradeTasks is running successfully now, but requirements.txt isn't being added to PRs because it wasn't matching the file filters

I'm cautiously optimistic that after this PR, renovate for python will finally be sending out correct PRs