### PR TITLE
Add client credentials auth to coda CLI

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -3787,6 +3787,18 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
 	 */
 	scopes?: string[];
 	/**
+	 * In rare cases, OAuth providers may want the permission scopes in a different query parameter
+	 * than `scope`.
+	 */
+	scopeParamName?: string;
+	/**
+	 * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+	 *
+	 * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+	 * If the API you are using requires a different delimiter, say a comma, specify it here.
+	 */
+	scopeDelimiter?: " " | "," | ";";
+	/**
 	 * The URL that Coda will hit in order to exchange the temporary code for an access token.
 	 */
 	tokenUrl: string;
@@ -3802,11 +3814,6 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
 	 * codes when there is an error in the token exchange.
 	 */
 	credentialsLocation?: TokenExchangeCredentialsLocation;
-	/**
-	 * In rare cases, OAuth providers may want the permission scopes in a different query parameter
-	 * than `scope`.
-	 */
-	scopeParamName?: string;
 	/**
 	 * A custom prefix to be used when passing the access token in the HTTP Authorization
 	 * header when making requests. Typically this prefix is `Bearer` which is what will be
@@ -3852,13 +3859,6 @@ export interface OAuth2Authentication extends BaseOAuthAuthentication {
 	 * they may be specified using {@link additionalParams}.
 	 */
 	authorizationUrl: string;
-	/**
-	 * The delimiter to use when joining {@link scopes} when generating authorization URLs.
-	 *
-	 * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
-	 * If the API you are using requires a different delimiter, say a comma, specify it here.
-	 */
-	scopeDelimiter?: " " | "," | ";";
 	/**
 	 * Option custom URL parameters and values that should be included when redirecting the
 	 * user to the {@link authorizationUrl}.

--- a/dist/testing/auth.d.ts
+++ b/dist/testing/auth.d.ts
@@ -6,7 +6,7 @@ interface SetupAuthOptions {
 }
 export declare const DEFAULT_OAUTH_SERVER_PORT = 3000;
 export declare function setupAuthFromModule(manifestPath: string, manifest: BasicPackDefinition, opts?: SetupAuthOptions): Promise<void>;
-export declare function setupAuth(manifestDir: string, packDef: BasicPackDefinition, opts?: SetupAuthOptions): void;
+export declare function setupAuth(manifestDir: string, packDef: BasicPackDefinition, opts?: SetupAuthOptions): Promise<void>;
 export declare function storeCredential(manifestDir: string, credentials: Credentials): void;
 export declare function readCredentialsFile(manifestDir: string): Credentials | undefined;
 export {};

--- a/dist/testing/auth.js
+++ b/dist/testing/auth.js
@@ -33,6 +33,7 @@ const helpers_1 = require("../cli/helpers");
 const oauth_server_1 = require("./oauth_server");
 const oauth_server_2 = require("./oauth_server");
 const path = __importStar(require("path"));
+const oauth_server_3 = require("./oauth_server");
 const helpers_2 = require("./helpers");
 const helpers_3 = require("./helpers");
 const helpers_4 = require("./helpers");
@@ -75,8 +76,7 @@ function setupAuth(manifestDir, packDef, opts = {}) {
             (0, ensure_2.ensureExists)(packDef.defaultAuthentication, 'OAuth2 only works with defaultAuthentication, not system auth.');
             return handler.handleOAuth2();
         case types_1.AuthenticationType.OAuth2ClientCredentials:
-            // TODO(cqian): Implement this.
-            return (0, helpers_3.printAndExit)('This authentication type is not yet implemented');
+            return handler.handleOAuth2ClientCredentials();
         case types_1.AuthenticationType.AWSAccessKey:
             return handler.handleAWSAccessKey();
         case types_1.AuthenticationType.AWSAssumeRole:
@@ -188,11 +188,7 @@ class CredentialHandler {
         this.storeCredential(credentials);
         (0, helpers_2.print)('Credentials updated!');
     }
-    handleOAuth2() {
-        (0, ensure_1.assertCondition)(this._authDef.type === types_1.AuthenticationType.OAuth2);
-        const existingCredentials = this.checkForExistingCredential();
-        (0, helpers_2.print)(`*** Your application must have ${(0, oauth_server_2.makeRedirectUrl)(this._oauthServerPort)} whitelisted as an OAuth redirect url ` +
-            'in order for this tool to work. ***');
+    _promptOAuth2ClientIdAndSecret(existingCredentials) {
         const clientIdPrompt = existingCredentials
             ? `Enter the OAuth client id for this Pack (or Enter to skip and use existing):\n`
             : `Enter the OAuth client id for this Pack:\n`;
@@ -203,6 +199,14 @@ class CredentialHandler {
         const newClientSecret = (0, helpers_4.promptForInput)(clientSecretPrompt, { mask: true });
         const clientId = (0, ensure_3.ensureNonEmptyString)(newClientId || (existingCredentials === null || existingCredentials === void 0 ? void 0 : existingCredentials.clientId));
         const clientSecret = (0, ensure_3.ensureNonEmptyString)(newClientSecret || (existingCredentials === null || existingCredentials === void 0 ? void 0 : existingCredentials.clientSecret));
+        return { clientId, clientSecret };
+    }
+    handleOAuth2() {
+        (0, ensure_1.assertCondition)(this._authDef.type === types_1.AuthenticationType.OAuth2);
+        const existingCredentials = this.checkForExistingCredential();
+        (0, helpers_2.print)(`*** Your application must have ${(0, oauth_server_2.makeRedirectUrl)(this._oauthServerPort)} whitelisted as an OAuth redirect url ` +
+            'in order for this tool to work. ***');
+        const { clientId, clientSecret } = this._promptOAuth2ClientIdAndSecret(existingCredentials);
         const credentials = {
             clientId,
             clientSecret,
@@ -233,6 +237,39 @@ class CredentialHandler {
                 (0, helpers_2.print)('Access token saved! Shutting down OAuth server and exiting...');
             },
             scopes: requestedScopes,
+        });
+    }
+    handleOAuth2ClientCredentials() {
+        (0, ensure_1.assertCondition)(this._authDef.type === types_1.AuthenticationType.OAuth2ClientCredentials);
+        const existingCredentials = this.checkForExistingCredential();
+        const { clientId, clientSecret } = this._promptOAuth2ClientIdAndSecret(existingCredentials);
+        const credentials = {
+            clientId,
+            clientSecret,
+            accessToken: existingCredentials === null || existingCredentials === void 0 ? void 0 : existingCredentials.accessToken,
+            expires: existingCredentials === null || existingCredentials === void 0 ? void 0 : existingCredentials.expires,
+            scopes: existingCredentials === null || existingCredentials === void 0 ? void 0 : existingCredentials.scopes,
+        };
+        this.storeCredential(credentials);
+        const manifestScopes = this._authDef.scopes || [];
+        const requestedScopes = this._extraOAuthScopes.length > 0 ? [...manifestScopes, ...this._extraOAuthScopes] : manifestScopes;
+        (0, oauth_server_3.performOAuthClientCredentialsServerFlow)({
+            clientId,
+            clientSecret,
+            scopes: requestedScopes,
+            authDef: this._authDef,
+        }).then(({ accessToken, expires }) => {
+            const credentials = {
+                clientId,
+                clientSecret,
+                accessToken,
+                expires,
+                scopes: requestedScopes,
+            };
+            this.storeCredential(credentials);
+            (0, helpers_2.print)('Access token saved!');
+        }).catch(err => {
+            throw err;
         });
     }
     handleAWSAccessKey() {

--- a/dist/testing/auth.js
+++ b/dist/testing/auth.js
@@ -258,17 +258,19 @@ class CredentialHandler {
             clientSecret,
             scopes: requestedScopes,
             authDef: this._authDef,
-        }).then(({ accessToken, expires }) => {
-            const credentials = {
-                clientId,
-                clientSecret,
-                accessToken,
-                expires,
-                scopes: requestedScopes,
-            };
-            this.storeCredential(credentials);
-            (0, helpers_2.print)('Access token saved!');
-        }).catch(err => {
+            afterTokenExchange: ({ accessToken, expires }) => {
+                const credentials = {
+                    clientId,
+                    clientSecret,
+                    accessToken,
+                    expires,
+                    scopes: requestedScopes,
+                };
+                this.storeCredential(credentials);
+                (0, helpers_2.print)('Access token saved!');
+            }
+        })
+            .catch(err => {
             throw err;
         });
     }

--- a/dist/testing/auth_types.d.ts
+++ b/dist/testing/auth_types.d.ts
@@ -29,13 +29,17 @@ export interface MultiQueryParamCredentials extends BaseCredentials {
         [paramName: string]: string;
     };
 }
-export interface OAuth2Credentials extends BaseCredentials {
+export interface BaseOAuth2Credentials extends BaseCredentials {
     clientId: string;
     clientSecret: string;
     accessToken?: string;
-    refreshToken?: string;
     scopes?: string[];
     expires?: string;
+}
+export interface OAuth2Credentials extends BaseOAuth2Credentials {
+    refreshToken?: string;
+}
+export interface OAuth2ClientCredentials extends BaseOAuth2Credentials {
 }
 export interface AWSAccessKeyCredentials extends BaseCredentials {
     accessKeyId: string;
@@ -45,5 +49,18 @@ export interface AWSAssumeRoleCredentials extends BaseCredentials {
     roleArn: string;
     externalId?: string;
 }
-export type Credentials = TokenCredentials | MultiHeaderCredentials | WebBasicCredentials | CustomCredentials | QueryParamCredentials | MultiQueryParamCredentials | OAuth2Credentials | AWSAccessKeyCredentials | AWSAssumeRoleCredentials;
+export type Credentials = TokenCredentials | MultiHeaderCredentials | WebBasicCredentials | CustomCredentials | QueryParamCredentials | MultiQueryParamCredentials | OAuth2Credentials | OAuth2ClientCredentials | AWSAccessKeyCredentials | AWSAssumeRoleCredentials;
+interface BaseOauth2RequestAccessTokenParams {
+    client_id: string;
+    client_secret: string;
+}
+export interface OAuth2RequestAccessTokenParams extends BaseOauth2RequestAccessTokenParams {
+    grant_type: 'authorization_code';
+    code: string;
+    redirect_uri: string;
+}
+export interface OAuth2ClientCredentialsRequestAccessTokenParams extends BaseOauth2RequestAccessTokenParams {
+    grant_type: 'client_credentials';
+    scope?: string;
+}
 export {};

--- a/dist/testing/fetcher.d.ts
+++ b/dist/testing/fetcher.d.ts
@@ -16,6 +16,8 @@ export declare class AuthenticatingFetcher implements Fetcher {
     constructor(updateCredentialsCallback: (newCredentials: Credentials) => void | undefined, authDef: Authentication | undefined, networkDomains: string[] | undefined, credentials: Credentials | undefined, invocationToken: string);
     fetch<T = any>(request: FetchRequest, isRetry?: boolean): Promise<FetchResponse<T>>;
     private _isOAuth401;
+    private _refreshOAuthWithRefreshToken;
+    private _refreshOAuthClientCredentials;
     private _refreshOAuthCredentials;
     private _applyAuthentication;
     private _signAwsRequest;

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -296,7 +296,8 @@ class AuthenticatingFetcher {
                 }
                 return { url, body, form, headers: { ...headers, ...authHeaders } };
             }
-            case types_1.AuthenticationType.OAuth2: {
+            case types_1.AuthenticationType.OAuth2:
+            case types_1.AuthenticationType.OAuth2ClientCredentials: {
                 const { accessToken } = this._credentials;
                 const prefix = (_a = this._authDef.tokenPrefix) !== null && _a !== void 0 ? _a : 'Bearer';
                 const requestHeaders = headers || {};
@@ -314,9 +315,6 @@ class AuthenticatingFetcher {
                     headers: requestHeaders,
                 };
             }
-            case types_1.AuthenticationType.OAuth2ClientCredentials:
-                // TODO(cqian): Implement this.
-                throw new Error('Not yet implemented');
             case types_1.AuthenticationType.AWSAccessKey: {
                 const { accessKeyId, secretAccessKey } = this._credentials;
                 const { service } = this._authDef;

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -18,6 +18,7 @@ const ensure_3 = require("../helpers/ensure");
 const ensure_4 = require("../helpers/ensure");
 const helpers_1 = require("./helpers");
 const node_fetcher_1 = require("./node_fetcher");
+const oauth_server_1 = require("./oauth_server");
 const helpers_2 = require("./helpers");
 const url_parse_1 = __importDefault(require("url-parse"));
 const uuid_1 = require("uuid");
@@ -140,16 +141,25 @@ class AuthenticatingFetcher {
         if (!this._authDef || !this._credentials || !this._updateCredentialsCallback) {
             return false;
         }
-        if (requestFailure.statusCode !== constants_2.HttpStatusCode.Unauthorized || this._authDef.type !== types_1.AuthenticationType.OAuth2) {
+        if (requestFailure.statusCode !== constants_2.HttpStatusCode.Unauthorized ||
+            !([types_1.AuthenticationType.OAuth2, types_1.AuthenticationType.OAuth2ClientCredentials].includes(this._authDef.type))) {
             return false;
         }
-        const { accessToken, refreshToken } = this._credentials;
-        if (!accessToken || !refreshToken) {
-            return false;
+        if (this._authDef.type === types_1.AuthenticationType.OAuth2) {
+            const { accessToken, refreshToken } = this._credentials;
+            if (!accessToken || !refreshToken) {
+                return false;
+            }
+        }
+        else { // Client credentials
+            const { accessToken } = this._credentials;
+            if (!accessToken) {
+                return false;
+            }
         }
         return true;
     }
-    async _refreshOAuthCredentials() {
+    async _refreshOAuthWithRefreshToken() {
         var _a;
         (0, ensure_1.assertCondition)(((_a = this._authDef) === null || _a === void 0 ? void 0 : _a.type) === types_1.AuthenticationType.OAuth2);
         (0, ensure_1.assertCondition)(this._credentials);
@@ -192,14 +202,42 @@ class AuthenticatingFetcher {
             new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
         }
         const { access_token: newAccessToken, refresh_token: newRefreshToken, ...data } = await oauthResponse.json();
-        const newCredentials = {
-            ...this._credentials,
+        return {
+            clientId,
+            clientSecret,
             accessToken: newAccessToken,
             refreshToken: newRefreshToken || refreshToken,
             expires: (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString(),
             scopes,
         };
-        this._credentials = newCredentials;
+    }
+    async _refreshOAuthClientCredentials() {
+        var _a;
+        (0, ensure_1.assertCondition)(((_a = this._authDef) === null || _a === void 0 ? void 0 : _a.type) === types_1.AuthenticationType.OAuth2ClientCredentials);
+        (0, ensure_1.assertCondition)(this._credentials);
+        const credentials = this._credentials;
+        const { clientId, clientSecret, scopes } = credentials;
+        // Refreshing client credentials is just the same as requesting the initial access token
+        const { accessToken, expires } = await (0, oauth_server_1.performOAuthClientCredentialsServerFlow)({ clientId, clientSecret, authDef: this._authDef, scopes });
+        return {
+            clientId,
+            clientSecret,
+            accessToken,
+            expires,
+            scopes
+        };
+    }
+    async _refreshOAuthCredentials() {
+        (0, ensure_1.assertCondition)(this._authDef && [types_1.AuthenticationType.OAuth2, types_1.AuthenticationType.OAuth2ClientCredentials]
+            .includes(this._authDef.type));
+        let credentials;
+        if (this._authDef.type === types_1.AuthenticationType.OAuth2) {
+            credentials = await this._refreshOAuthWithRefreshToken();
+        }
+        else {
+            credentials = await this._refreshOAuthClientCredentials();
+        }
+        this._credentials = credentials;
         this._updateCredentialsCallback(this._credentials);
     }
     async _applyAuthentication({ method, url: rawUrl, headers, body, form, disableAuthentication, }) {

--- a/dist/testing/oauth_helpers.d.ts
+++ b/dist/testing/oauth_helpers.d.ts
@@ -1,0 +1,26 @@
+import type { OAuth2ClientCredentialsAuthentication } from '../types';
+import type { OAuth2ClientCredentialsRequestAccessTokenParams } from './auth_types';
+import type { OAuth2RequestAccessTokenParams } from './auth_types';
+export declare function requestOAuthAccessToken(params: OAuth2RequestAccessTokenParams | OAuth2ClientCredentialsRequestAccessTokenParams, { tokenUrl, nestedResponseKey, scopeParamName }: {
+    tokenUrl: string;
+    nestedResponseKey?: string;
+    scopeParamName?: string;
+}): Promise<{
+    accessToken: any;
+    refreshToken: any;
+    data: any;
+}>;
+export declare function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }: {
+    clientId: string;
+    clientSecret: string;
+    authDef: OAuth2ClientCredentialsAuthentication;
+    scopes?: string[];
+}): Promise<AfterTokenOAuthClientCredentialsExchangeParams>;
+interface AfterTokenOAuthClientCredentialsExchangeParams {
+    accessToken: string;
+    expires?: string;
+}
+export declare function getTokenExpiry(data: {
+    [key: string]: string;
+}): string;
+export {};

--- a/dist/testing/oauth_helpers.js
+++ b/dist/testing/oauth_helpers.js
@@ -1,0 +1,76 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getTokenExpiry = exports.performOAuthClientCredentialsServerFlow = exports.requestOAuthAccessToken = void 0;
+const constants_1 = require("./constants");
+const helpers_1 = require("./helpers");
+async function requestOAuthAccessToken(params, { tokenUrl, nestedResponseKey, scopeParamName }) {
+    const headers = new Headers({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        accept: 'application/json',
+    });
+    const formParams = new URLSearchParams();
+    const formParamsWithSecret = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+            continue;
+        }
+        let paramKey = key;
+        if (key === 'scope' && scopeParamName) {
+            paramKey = scopeParamName;
+        }
+        if (paramKey !== 'client_secret') {
+            formParams.append(paramKey, value.toString());
+        }
+        formParamsWithSecret.append(paramKey, value.toString());
+    }
+    let oauthResponse = await fetch(tokenUrl, {
+        method: 'POST',
+        body: formParamsWithSecret,
+        headers,
+    });
+    if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
+        // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
+        // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
+        // NOT has more than one auth methods.
+        //
+        // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
+        // auth fails with 401. This is the same behavior in production.
+        headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
+        oauthResponse = await fetch(tokenUrl, {
+            method: 'POST',
+            body: formParams,
+            headers,
+        });
+    }
+    if (!oauthResponse.ok) {
+        throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
+    }
+    const responseBody = await oauthResponse.json();
+    const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
+    const { access_token: accessToken, refresh_token: refreshToken, ...data } = tokenContainer;
+    return { accessToken, refreshToken, data };
+}
+exports.requestOAuthAccessToken = requestOAuthAccessToken;
+async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }) {
+    const { tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter } = authDef;
+    // Use the manifest's scopes as a default.
+    const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+    const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
+    const params = {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope,
+    };
+    const { accessToken, data } = await requestOAuthAccessToken(params, {
+        tokenUrl,
+        nestedResponseKey,
+        scopeParamName,
+    });
+    return { accessToken, expires: getTokenExpiry(data) };
+}
+exports.performOAuthClientCredentialsServerFlow = performOAuthClientCredentialsServerFlow;
+function getTokenExpiry(data) {
+    return data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
+}
+exports.getTokenExpiry = getTokenExpiry;

--- a/dist/testing/oauth_server.d.ts
+++ b/dist/testing/oauth_server.d.ts
@@ -1,28 +1,30 @@
 import 'cross-fetch/polyfill';
 import type { OAuth2Authentication } from '../types';
 import type { OAuth2ClientCredentialsAuthentication } from '../types';
-interface AfterTokenExchangeParams {
+interface AfterTokenOAuthAuthorizationCodeExchangeParams {
     accessToken: string;
     refreshToken?: string;
     expires?: string;
 }
-export type AfterTokenExchangeCallback = (params: AfterTokenExchangeParams) => void;
+export type AfterAuthorizationCodeTokenExchangeCallback = (params: AfterTokenOAuthAuthorizationCodeExchangeParams) => void;
+interface AfterTokenOAuthClientCredentialsExchangeParams {
+    accessToken: string;
+    expires?: string;
+}
 export declare function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }: {
     clientId: string;
     clientSecret: string;
     authDef: OAuth2Authentication;
     port: number;
-    afterTokenExchange: AfterTokenExchangeCallback;
+    afterTokenExchange: AfterAuthorizationCodeTokenExchangeCallback;
     scopes?: string[];
 }): void;
 export declare function makeRedirectUrl(port: number): string;
-export declare function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }: {
+export declare function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, afterTokenExchange, }: {
     clientId: string;
     clientSecret: string;
     authDef: OAuth2ClientCredentialsAuthentication;
     scopes?: string[];
-}): Promise<{
-    accessToken: any;
-    expires: string;
-}>;
+    afterTokenExchange?: (params: AfterTokenOAuthClientCredentialsExchangeParams) => void;
+}): Promise<AfterTokenOAuthClientCredentialsExchangeParams>;
 export {};

--- a/dist/testing/oauth_server.d.ts
+++ b/dist/testing/oauth_server.d.ts
@@ -1,16 +1,11 @@
 import 'cross-fetch/polyfill';
 import type { OAuth2Authentication } from '../types';
-import type { OAuth2ClientCredentialsAuthentication } from '../types';
 interface AfterTokenOAuthAuthorizationCodeExchangeParams {
     accessToken: string;
     refreshToken?: string;
     expires?: string;
 }
 export type AfterAuthorizationCodeTokenExchangeCallback = (params: AfterTokenOAuthAuthorizationCodeExchangeParams) => void;
-interface AfterTokenOAuthClientCredentialsExchangeParams {
-    accessToken: string;
-    expires?: string;
-}
 export declare function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }: {
     clientId: string;
     clientSecret: string;
@@ -20,11 +15,4 @@ export declare function launchOAuthServerFlow({ clientId, clientSecret, authDef,
     scopes?: string[];
 }): void;
 export declare function makeRedirectUrl(port: number): string;
-export declare function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, afterTokenExchange, }: {
-    clientId: string;
-    clientSecret: string;
-    authDef: OAuth2ClientCredentialsAuthentication;
-    scopes?: string[];
-    afterTokenExchange?: (params: AfterTokenOAuthClientCredentialsExchangeParams) => void;
-}): Promise<AfterTokenOAuthClientCredentialsExchangeParams>;
 export {};

--- a/dist/testing/oauth_server.d.ts
+++ b/dist/testing/oauth_server.d.ts
@@ -1,5 +1,6 @@
 import 'cross-fetch/polyfill';
 import type { OAuth2Authentication } from '../types';
+import type { OAuth2ClientCredentialsAuthentication } from '../types';
 interface AfterTokenExchangeParams {
     accessToken: string;
     refreshToken?: string;
@@ -15,4 +16,13 @@ export declare function launchOAuthServerFlow({ clientId, clientSecret, authDef,
     scopes?: string[];
 }): void;
 export declare function makeRedirectUrl(port: number): string;
+export declare function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }: {
+    clientId: string;
+    clientSecret: string;
+    authDef: OAuth2ClientCredentialsAuthentication;
+    scopes?: string[];
+}): Promise<{
+    accessToken: any;
+    expires: string;
+}>;
 export {};

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.makeRedirectUrl = exports.launchOAuthServerFlow = void 0;
+exports.performOAuthClientCredentialsServerFlow = exports.makeRedirectUrl = exports.launchOAuthServerFlow = void 0;
 require("cross-fetch/polyfill");
 const constants_1 = require("./constants");
 const child_process_1 = require("child_process");
@@ -11,6 +11,53 @@ const express_1 = __importDefault(require("express"));
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const url_1 = require("../helpers/url");
+async function requestOAuthAccessToken(params, { tokenUrl, nestedResponseKey, scopeParamName }) {
+    const headers = new Headers({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        accept: 'application/json',
+    });
+    const formParams = new URLSearchParams();
+    const formParamsWithSecret = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+            continue;
+        }
+        let paramKey = key;
+        if (key === 'scope' && scopeParamName) {
+            paramKey = scopeParamName;
+        }
+        if (paramKey !== 'client_secret') {
+            formParams.append(paramKey, value.toString());
+        }
+        formParamsWithSecret.append(paramKey, value.toString());
+    }
+    let oauthResponse = await fetch(tokenUrl, {
+        method: 'POST',
+        body: formParamsWithSecret,
+        headers,
+    });
+    if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
+        // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
+        // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
+        // NOT has more than one auth methods.
+        //
+        // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
+        // auth fails with 401. This is the same behavior in production.
+        headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
+        oauthResponse = await fetch(tokenUrl, {
+            method: 'POST',
+            body: formParams,
+            headers,
+        });
+    }
+    if (!oauthResponse.ok) {
+        throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
+    }
+    const responseBody = await oauthResponse.json();
+    const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
+    const { access_token: accessToken, refresh_token: refreshToken, ...data } = tokenContainer;
+    return { accessToken, refreshToken, data };
+}
 function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }) {
     // TODO: Handle endpointKey.
     const { authorizationUrl, tokenUrl, additionalParams, scopeDelimiter, nestedResponseKey, scopeParamName } = authDef;
@@ -23,45 +70,13 @@ function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTok
             grant_type: 'authorization_code',
             code,
             client_id: clientId,
+            client_secret: clientSecret,
             redirect_uri: redirectUri,
         };
-        const headers = new Headers({
-            'Content-Type': 'application/x-www-form-urlencoded',
-            accept: 'application/json',
+        return requestOAuthAccessToken(params, {
+            tokenUrl,
+            nestedResponseKey,
         });
-        const formParams = new URLSearchParams();
-        const formParamsWithSecret = new URLSearchParams();
-        for (const [key, value] of Object.entries(params)) {
-            formParams.append(key, value.toString());
-            formParamsWithSecret.append(key, value.toString());
-        }
-        formParamsWithSecret.append('client_secret', clientSecret);
-        let oauthResponse = await fetch(tokenUrl, {
-            method: 'POST',
-            body: formParamsWithSecret,
-            headers,
-        });
-        if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
-            // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
-            // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
-            // NOT has more than one auth methods.
-            //
-            // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
-            // auth fails with 401. This is the same behavior in production.
-            headers.append('Authorization', `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`);
-            oauthResponse = await fetch(tokenUrl, {
-                method: 'POST',
-                body: formParams,
-                headers,
-            });
-        }
-        if (!oauthResponse.ok) {
-            new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
-        }
-        const responseBody = await oauthResponse.json();
-        const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
-        const { access_token: accessToken, refresh_token: refreshToken, ...data } = tokenContainer;
-        return { accessToken, refreshToken, data };
     };
     const serverContainer = new OAuthServerContainer(callback, afterTokenExchange, port);
     const queryParams = {
@@ -85,6 +100,9 @@ function makeRedirectUrl(port) {
     return `http://localhost:${port}/oauth`;
 }
 exports.makeRedirectUrl = makeRedirectUrl;
+function _getTokenExpiry(data) {
+    return data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
+}
 class OAuthServerContainer {
     constructor(tokenCallback, afterTokenExchange, port) {
         this._tokenCallback = tokenCallback;
@@ -99,7 +117,7 @@ class OAuthServerContainer {
             if (code) {
                 const tokenData = await this._tokenCallback(code);
                 const { accessToken, refreshToken, data } = tokenData;
-                const expires = data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
+                const expires = _getTokenExpiry(data);
                 this._afterTokenExchange({ accessToken, refreshToken, expires });
                 return res.send('OAuth authentication is complete! You can close this browser tab.');
             }
@@ -112,3 +130,22 @@ class OAuthServerContainer {
         (_a = this._server) === null || _a === void 0 ? void 0 : _a.close();
     }
 }
+async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }) {
+    const { tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter } = authDef;
+    // Use the manifest's scopes as a default.
+    const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+    const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
+    const params = {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope,
+    };
+    const { accessToken, data } = await requestOAuthAccessToken(params, {
+        tokenUrl,
+        nestedResponseKey,
+        scopeParamName,
+    });
+    return { accessToken, expires: _getTokenExpiry(data) };
+}
+exports.performOAuthClientCredentialsServerFlow = performOAuthClientCredentialsServerFlow;

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -130,7 +130,7 @@ class OAuthServerContainer {
         (_a = this._server) === null || _a === void 0 ? void 0 : _a.close();
     }
 }
-async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, }) {
+async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, afterTokenExchange, }) {
     const { tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter } = authDef;
     // Use the manifest's scopes as a default.
     const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
@@ -146,6 +146,8 @@ async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret,
         nestedResponseKey,
         scopeParamName,
     });
+    const credentials = { accessToken, expires: _getTokenExpiry(data) };
+    afterTokenExchange === null || afterTokenExchange === void 0 ? void 0 : afterTokenExchange(credentials);
     return { accessToken, expires: _getTokenExpiry(data) };
 }
 exports.performOAuthClientCredentialsServerFlow = performOAuthClientCredentialsServerFlow;

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -3,61 +3,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.performOAuthClientCredentialsServerFlow = exports.makeRedirectUrl = exports.launchOAuthServerFlow = void 0;
+exports.makeRedirectUrl = exports.launchOAuthServerFlow = void 0;
 require("cross-fetch/polyfill");
-const constants_1 = require("./constants");
 const child_process_1 = require("child_process");
 const express_1 = __importDefault(require("express"));
+const oauth_helpers_1 = require("./oauth_helpers");
 const helpers_1 = require("./helpers");
-const helpers_2 = require("./helpers");
+const oauth_helpers_2 = require("./oauth_helpers");
 const url_1 = require("../helpers/url");
-async function requestOAuthAccessToken(params, { tokenUrl, nestedResponseKey, scopeParamName }) {
-    const headers = new Headers({
-        'Content-Type': 'application/x-www-form-urlencoded',
-        accept: 'application/json',
-    });
-    const formParams = new URLSearchParams();
-    const formParamsWithSecret = new URLSearchParams();
-    for (const [key, value] of Object.entries(params)) {
-        if (value === undefined) {
-            continue;
-        }
-        let paramKey = key;
-        if (key === 'scope' && scopeParamName) {
-            paramKey = scopeParamName;
-        }
-        if (paramKey !== 'client_secret') {
-            formParams.append(paramKey, value.toString());
-        }
-        formParamsWithSecret.append(paramKey, value.toString());
-    }
-    let oauthResponse = await fetch(tokenUrl, {
-        method: 'POST',
-        body: formParamsWithSecret,
-        headers,
-    });
-    if (oauthResponse.status === constants_1.HttpStatusCode.Unauthorized) {
-        // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
-        // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
-        // NOT has more than one auth methods.
-        //
-        // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
-        // auth fails with 401. This is the same behavior in production.
-        headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
-        oauthResponse = await fetch(tokenUrl, {
-            method: 'POST',
-            body: formParams,
-            headers,
-        });
-    }
-    if (!oauthResponse.ok) {
-        throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
-    }
-    const responseBody = await oauthResponse.json();
-    const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
-    const { access_token: accessToken, refresh_token: refreshToken, ...data } = tokenContainer;
-    return { accessToken, refreshToken, data };
-}
 function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }) {
     // TODO: Handle endpointKey.
     const { authorizationUrl, tokenUrl, additionalParams, scopeDelimiter, nestedResponseKey, scopeParamName } = authDef;
@@ -73,7 +26,7 @@ function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTok
             client_secret: clientSecret,
             redirect_uri: redirectUri,
         };
-        return requestOAuthAccessToken(params, {
+        return (0, oauth_helpers_2.requestOAuthAccessToken)(params, {
             tokenUrl,
             nestedResponseKey,
         });
@@ -89,7 +42,7 @@ function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTok
     queryParams[scopeKey] = scope;
     const authorizationUri = (0, url_1.withQueryParams)(authorizationUrl, queryParams);
     const launchCallback = () => {
-        (0, helpers_2.print)(`OAuth server running at http://localhost:${port}.\n` +
+        (0, helpers_1.print)(`OAuth server running at http://localhost:${port}.\n` +
             `Complete the auth flow in your browser. If it does not open automatically, visit ${authorizationUri}`);
         (0, child_process_1.exec)(`open "${authorizationUri}"`);
     };
@@ -100,9 +53,6 @@ function makeRedirectUrl(port) {
     return `http://localhost:${port}/oauth`;
 }
 exports.makeRedirectUrl = makeRedirectUrl;
-function _getTokenExpiry(data) {
-    return data.expires_in && (0, helpers_1.getExpirationDate)(Number(data.expires_in)).toString();
-}
 class OAuthServerContainer {
     constructor(tokenCallback, afterTokenExchange, port) {
         this._tokenCallback = tokenCallback;
@@ -117,7 +67,7 @@ class OAuthServerContainer {
             if (code) {
                 const tokenData = await this._tokenCallback(code);
                 const { accessToken, refreshToken, data } = tokenData;
-                const expires = _getTokenExpiry(data);
+                const expires = (0, oauth_helpers_1.getTokenExpiry)(data);
                 this._afterTokenExchange({ accessToken, refreshToken, expires });
                 return res.send('OAuth authentication is complete! You can close this browser tab.');
             }
@@ -130,24 +80,3 @@ class OAuthServerContainer {
         (_a = this._server) === null || _a === void 0 ? void 0 : _a.close();
     }
 }
-async function performOAuthClientCredentialsServerFlow({ clientId, clientSecret, authDef, scopes, afterTokenExchange, }) {
-    const { tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter } = authDef;
-    // Use the manifest's scopes as a default.
-    const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
-    const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
-    const params = {
-        grant_type: 'client_credentials',
-        client_id: clientId,
-        client_secret: clientSecret,
-        scope,
-    };
-    const { accessToken, data } = await requestOAuthAccessToken(params, {
-        tokenUrl,
-        nestedResponseKey,
-        scopeParamName,
-    });
-    const credentials = { accessToken, expires: _getTokenExpiry(data) };
-    afterTokenExchange === null || afterTokenExchange === void 0 ? void 0 : afterTokenExchange(credentials);
-    return { accessToken, expires: _getTokenExpiry(data) };
-}
-exports.performOAuthClientCredentialsServerFlow = performOAuthClientCredentialsServerFlow;

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -367,6 +367,7 @@ function buildMetadataSchema({ sdkVersion }) {
             type: zodDiscriminant(types_1.AuthenticationType.OAuth2ClientCredentials),
             tokenUrl: z.string().url(),
             scopes: z.array(z.string()).optional(),
+            scopeDelimiter: z.enum([' ', ',', ';']).optional(),
             tokenPrefix: z.string().optional(),
             tokenQueryParam: z.string().optional(),
             scopeParamName: z.string().optional(),

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -458,6 +458,18 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
      */
     scopes?: string[];
     /**
+     * In rare cases, OAuth providers may want the permission scopes in a different query parameter
+     * than `scope`.
+     */
+    scopeParamName?: string;
+    /**
+     * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+     *
+     * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+     * If the API you are using requires a different delimiter, say a comma, specify it here.
+     */
+    scopeDelimiter?: ' ' | ',' | ';';
+    /**
      * The URL that Coda will hit in order to exchange the temporary code for an access token.
      */
     tokenUrl: string;
@@ -473,11 +485,6 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
      * codes when there is an error in the token exchange.
      */
     credentialsLocation?: TokenExchangeCredentialsLocation;
-    /**
-     * In rare cases, OAuth providers may want the permission scopes in a different query parameter
-     * than `scope`.
-     */
-    scopeParamName?: string;
     /**
      * A custom prefix to be used when passing the access token in the HTTP Authorization
      * header when making requests. Typically this prefix is `Bearer` which is what will be
@@ -523,13 +530,6 @@ export interface OAuth2Authentication extends BaseOAuthAuthentication {
      * they may be specified using {@link additionalParams}.
      */
     authorizationUrl: string;
-    /**
-     * The delimiter to use when joining {@link scopes} when generating authorization URLs.
-     *
-     * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
-     * If the API you are using requires a different delimiter, say a comma, specify it here.
-     */
-    scopeDelimiter?: ' ' | ',' | ';';
     /**
      * Option custom URL parameters and values that should be included when redirecting the
      * user to the {@link authorizationUrl}.

--- a/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
@@ -209,6 +209,10 @@ The delimiter to use when joining [scopes](core.OAuth2Authentication.md#scopes) 
 The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
 If the API you are using requires a different delimiter, say a comma, specify it here.
 
+#### Inherited from
+
+BaseOAuthAuthentication.scopeDelimiter
+
 ___
 
 ### scopeParamName

--- a/docs/reference/sdk/interfaces/core.OAuth2ClientCredentialsAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.OAuth2ClientCredentialsAuthentication.md
@@ -147,6 +147,21 @@ BaseOAuthAuthentication.requiresEndpointUrl
 
 ___
 
+### scopeDelimiter
+
+• `Optional` **scopeDelimiter**: ``" "`` \| ``","`` \| ``";"``
+
+The delimiter to use when joining [scopes](core.OAuth2ClientCredentialsAuthentication.md#scopes) when generating authorization URLs.
+
+The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+If the API you are using requires a different delimiter, say a comma, specify it here.
+
+#### Inherited from
+
+BaseOAuthAuthentication.scopeDelimiter
+
+___
+
 ### scopeParamName
 
 • `Optional` **scopeParamName**: `string`

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -157,9 +157,16 @@ describe('Auth', () => {
       };
       it('defaultAuthentication', async () => testTokenAuthFlow(createFakePack({defaultAuthentication: auth})));
       it('fails systemAuth', async () => {
-        expect(async () =>
-          testTokenAuthFlow(createFakePack({systemConnectionAuthentication: auth as unknown as SystemAuthentication})),
-        ).to.throw('CodaApiHeaderBearerToken only works with defaultAuthentication, not system auth.');
+        try {
+          await testTokenAuthFlow(
+            createFakePack({systemConnectionAuthentication: auth as unknown as SystemAuthentication})
+          );
+        } catch (err: any) {
+          assert.match(err, /CodaApiHeaderBearerToken only works with defaultAuthentication, not system auth./);
+          return;
+        }
+
+        throw new Error('Promise unexpectedly resolved');
       });
     });
 

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -314,17 +314,19 @@ class CredentialHandler {
       clientSecret,
       scopes: requestedScopes,
       authDef: this._authDef,
-    }).then(({accessToken, expires}) => {
-      const credentials: OAuth2ClientCredentials = {
-        clientId,
-        clientSecret,
-        accessToken,
-        expires,
-        scopes: requestedScopes,
-      };
-      this.storeCredential(credentials);
-      print('Access token saved!');
-    }).catch(err => {
+      afterTokenExchange: ({accessToken, expires}) => {
+        const credentials: OAuth2ClientCredentials = {
+          clientId,
+          clientSecret,
+          accessToken,
+          expires,
+          scopes: requestedScopes,
+        };
+        this.storeCredential(credentials);
+        print('Access token saved!');
+      }
+    })
+    .catch(err => {
       throw err;
     });
   }

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -10,6 +10,7 @@ import type {CustomCredentials} from './auth_types';
 import type {MultiHeaderCredentials} from './auth_types';
 import type {MultiHeaderTokenAuthentication} from '../types';
 import type {MultiQueryParamCredentials} from './auth_types';
+import type {OAuth2ClientCredentials} from './auth_types';
 import type {OAuth2Credentials} from './auth_types';
 import {assertCondition} from '../helpers/ensure';
 import {ensureExists} from '../helpers/ensure';
@@ -19,6 +20,7 @@ import {getPackAuth} from '../cli/helpers';
 import {launchOAuthServerFlow} from './oauth_server';
 import {makeRedirectUrl} from './oauth_server';
 import * as path from 'path';
+import {performOAuthClientCredentialsServerFlow} from './oauth_server';
 import {print} from './helpers';
 import {printAndExit} from './helpers';
 import {promptForInput} from './helpers';
@@ -79,8 +81,7 @@ export function setupAuth(manifestDir: string, packDef: BasicPackDefinition, opt
       ensureExists(packDef.defaultAuthentication, 'OAuth2 only works with defaultAuthentication, not system auth.');
       return handler.handleOAuth2();
     case AuthenticationType.OAuth2ClientCredentials:
-      // TODO(cqian): Implement this.
-      return printAndExit('This authentication type is not yet implemented');
+      return handler.handleOAuth2ClientCredentials();
     case AuthenticationType.AWSAccessKey:
       return handler.handleAWSAccessKey();
     case AuthenticationType.AWSAssumeRole:
@@ -229,6 +230,23 @@ class CredentialHandler {
     print('Credentials updated!');
   }
 
+  private _promptOAuth2ClientIdAndSecret(existingCredentials: OAuth2Credentials | OAuth2ClientCredentials | undefined):
+      {clientId: string, clientSecret: string} {
+    const clientIdPrompt = existingCredentials
+        ? `Enter the OAuth client id for this Pack (or Enter to skip and use existing):\n`
+        : `Enter the OAuth client id for this Pack:\n`;
+    const newClientId = promptForInput(clientIdPrompt);
+    const clientSecretPrompt = existingCredentials
+        ? `Enter the OAuth client secret for this Pack (or Enter to skip and use existing):\n`
+        : `Enter the OAuth client secret for this Pack:\n`;
+    const newClientSecret = promptForInput(clientSecretPrompt, {mask: true});
+
+    const clientId = ensureNonEmptyString(newClientId || existingCredentials?.clientId);
+    const clientSecret = ensureNonEmptyString(newClientSecret || existingCredentials?.clientSecret);
+
+    return {clientId, clientSecret};
+  }
+
   handleOAuth2() {
     assertCondition(this._authDef.type === AuthenticationType.OAuth2);
     const existingCredentials = this.checkForExistingCredential() as OAuth2Credentials | undefined;
@@ -236,17 +254,7 @@ class CredentialHandler {
       `*** Your application must have ${makeRedirectUrl(this._oauthServerPort)} whitelisted as an OAuth redirect url ` +
         'in order for this tool to work. ***',
     );
-    const clientIdPrompt = existingCredentials
-      ? `Enter the OAuth client id for this Pack (or Enter to skip and use existing):\n`
-      : `Enter the OAuth client id for this Pack:\n`;
-    const newClientId = promptForInput(clientIdPrompt);
-    const clientSecretPrompt = existingCredentials
-      ? `Enter the OAuth client secret for this Pack (or Enter to skip and use existing):\n`
-      : `Enter the OAuth client secret for this Pack:\n`;
-    const newClientSecret = promptForInput(clientSecretPrompt, {mask: true});
-
-    const clientId = ensureNonEmptyString(newClientId || existingCredentials?.clientId);
-    const clientSecret = ensureNonEmptyString(newClientSecret || existingCredentials?.clientSecret);
+    const {clientId, clientSecret} = this._promptOAuth2ClientIdAndSecret(existingCredentials);
 
     const credentials: OAuth2Credentials = {
       clientId,
@@ -283,6 +291,44 @@ class CredentialHandler {
       scopes: requestedScopes,
     });
   }
+
+  handleOAuth2ClientCredentials() {
+    assertCondition(this._authDef.type === AuthenticationType.OAuth2ClientCredentials);
+    const existingCredentials = this.checkForExistingCredential() as OAuth2ClientCredentials | undefined;
+    const {clientId, clientSecret} = this._promptOAuth2ClientIdAndSecret(existingCredentials);
+    const credentials: OAuth2ClientCredentials = {
+      clientId,
+      clientSecret,
+      accessToken: existingCredentials?.accessToken,
+      expires: existingCredentials?.expires,
+      scopes: existingCredentials?.scopes,
+    };
+    this.storeCredential(credentials);
+
+    const manifestScopes = this._authDef.scopes || [];
+    const requestedScopes =
+        this._extraOAuthScopes.length > 0 ? [...manifestScopes, ...this._extraOAuthScopes] : manifestScopes;
+
+    performOAuthClientCredentialsServerFlow({
+      clientId,
+      clientSecret,
+      scopes: requestedScopes,
+      authDef: this._authDef,
+    }).then(({accessToken, expires}) => {
+      const credentials: OAuth2ClientCredentials = {
+        clientId,
+        clientSecret,
+        accessToken,
+        expires,
+        scopes: requestedScopes,
+      };
+      this.storeCredential(credentials);
+      print('Access token saved!');
+    }).catch(err => {
+      throw err;
+    });
+  }
+
 
   handleAWSAccessKey() {
     assertCondition(this._authDef.type === AuthenticationType.AWSAccessKey);

--- a/testing/auth_types.ts
+++ b/testing/auth_types.ts
@@ -31,17 +31,22 @@ export interface MultiQueryParamCredentials extends BaseCredentials {
   params: {[paramName: string]: string};
 }
 
-export interface OAuth2Credentials extends BaseCredentials {
+export interface BaseOAuth2Credentials extends BaseCredentials {
   clientId: string;
   clientSecret: string;
   accessToken?: string;
-  refreshToken?: string;
+  scopes?: string[];
   // Optional to not break previously stored credentials.
   // Could make this non-optional in the future.
-  scopes?: string[];
   // Included only for credential debugging purposes
   expires?: string;
 }
+
+export interface OAuth2Credentials extends BaseOAuth2Credentials {
+  refreshToken?: string;
+}
+
+export interface OAuth2ClientCredentials extends BaseOAuth2Credentials {}
 
 export interface AWSAccessKeyCredentials extends BaseCredentials {
   accessKeyId: string;
@@ -61,5 +66,22 @@ export type Credentials =
   | QueryParamCredentials
   | MultiQueryParamCredentials
   | OAuth2Credentials
+  | OAuth2ClientCredentials
   | AWSAccessKeyCredentials
   | AWSAssumeRoleCredentials;
+
+interface BaseOauth2RequestAccessTokenParams {
+  client_id: string;
+  client_secret: string;
+}
+
+export interface OAuth2RequestAccessTokenParams extends BaseOauth2RequestAccessTokenParams {
+  grant_type: 'authorization_code';
+  code: string;
+  redirect_uri: string;
+}
+
+export interface OAuth2ClientCredentialsRequestAccessTokenParams extends BaseOauth2RequestAccessTokenParams {
+  grant_type: 'client_credentials';
+  scope?: string;
+}

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -4,6 +4,7 @@ import {AssumeRoleCommand} from '@aws-sdk/client-sts';
 import type {Authentication} from '../types';
 import {AuthenticationType} from '../types';
 import type {AwsCredentialIdentity} from '@aws-sdk/types';
+import type {BaseOAuth2Credentials} from './auth_types';
 import type {Credentials} from './auth_types';
 import type {CustomCredentials} from './auth_types';
 import {DEFAULT_ALLOWED_GET_DOMAINS_REGEXES} from './constants';
@@ -394,8 +395,9 @@ export class AuthenticatingFetcher implements Fetcher {
         }
         return {url, body, form, headers: {...headers, ...authHeaders}};
       }
-      case AuthenticationType.OAuth2: {
-        const {accessToken} = this._credentials as OAuth2Credentials;
+      case AuthenticationType.OAuth2:
+      case AuthenticationType.OAuth2ClientCredentials: {
+        const {accessToken} = this._credentials as BaseOAuth2Credentials;
         const prefix = this._authDef.tokenPrefix ?? 'Bearer';
         const requestHeaders: {[header: string]: string} = headers || {};
         let requestUrl = url;
@@ -411,9 +413,6 @@ export class AuthenticatingFetcher implements Fetcher {
           headers: requestHeaders,
         };
       }
-      case AuthenticationType.OAuth2ClientCredentials:
-        // TODO(cqian): Implement this.
-        throw new Error('Not yet implemented');
       case AuthenticationType.AWSAccessKey: {
         const {accessKeyId, secretAccessKey} = this._credentials as AWSAccessKeyCredentials;
         const {service} = this._authDef;

--- a/testing/oauth_helpers.ts
+++ b/testing/oauth_helpers.ts
@@ -1,0 +1,106 @@
+import {HttpStatusCode} from './constants';
+import type {OAuth2ClientCredentialsAuthentication} from '../types';
+import type {OAuth2ClientCredentialsRequestAccessTokenParams} from './auth_types';
+import type {OAuth2RequestAccessTokenParams} from './auth_types';
+import {getExpirationDate} from './helpers';
+
+export async function requestOAuthAccessToken(
+    params: OAuth2RequestAccessTokenParams
+        | OAuth2ClientCredentialsRequestAccessTokenParams,
+    {tokenUrl, nestedResponseKey, scopeParamName}:
+        { tokenUrl: string; nestedResponseKey?: string, scopeParamName?: string }
+) {
+    const headers = new Headers({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        accept: 'application/json',
+    });
+
+    const formParams = new URLSearchParams();
+    const formParamsWithSecret = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+            continue;
+        }
+
+        let paramKey = key;
+        if (key === 'scope' && scopeParamName) {
+            paramKey = scopeParamName;
+        }
+        if (paramKey !== 'client_secret') {
+            formParams.append(paramKey, value.toString());
+        }
+
+        formParamsWithSecret.append(paramKey, value.toString());
+    }
+
+    let oauthResponse = await fetch(tokenUrl, {
+        method: 'POST',
+        body: formParamsWithSecret,
+        headers,
+    });
+
+    if (oauthResponse.status === HttpStatusCode.Unauthorized) {
+        // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
+        // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
+        // NOT has more than one auth methods.
+        //
+        // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
+        // auth fails with 401. This is the same behavior in production.
+        headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
+        oauthResponse = await fetch(tokenUrl, {
+            method: 'POST',
+            body: formParams,
+            headers,
+        });
+    }
+
+    if (!oauthResponse.ok) {
+        throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
+    }
+
+    const responseBody = await oauthResponse.json();
+    const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
+    const {access_token: accessToken, refresh_token: refreshToken, ...data} = tokenContainer;
+
+    return {accessToken, refreshToken, data};
+}
+
+export async function performOAuthClientCredentialsServerFlow({
+  clientId,
+  clientSecret,
+  authDef,
+  scopes,
+}: {
+    clientId: string;
+    clientSecret: string;
+    authDef: OAuth2ClientCredentialsAuthentication;
+    scopes?: string[];
+}): Promise<AfterTokenOAuthClientCredentialsExchangeParams> {
+    const {tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter} = authDef;
+    // Use the manifest's scopes as a default.
+    const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+    const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
+    const params: OAuth2ClientCredentialsRequestAccessTokenParams = {
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope,
+    };
+
+    const {accessToken, data} = await requestOAuthAccessToken(params, {
+        tokenUrl,
+        nestedResponseKey,
+        scopeParamName,
+    });
+
+    return {accessToken, expires: getTokenExpiry(data)}
+}
+
+interface AfterTokenOAuthClientCredentialsExchangeParams {
+    accessToken: string;
+    expires?: string;
+}
+
+export function getTokenExpiry(data: { [key: string]: string }) {
+    return data.expires_in && getExpirationDate(Number(data.expires_in)).toString();
+}

--- a/testing/oauth_server.ts
+++ b/testing/oauth_server.ts
@@ -1,6 +1,9 @@
 import 'cross-fetch/polyfill';
 import {HttpStatusCode} from './constants';
 import type {OAuth2Authentication} from '../types';
+import type {OAuth2ClientCredentialsAuthentication} from '../types';
+import type {OAuth2ClientCredentialsRequestAccessTokenParams} from './auth_types';
+import type {OAuth2RequestAccessTokenParams} from './auth_types';
 import {exec} from 'child_process';
 import express from 'express';
 import {getExpirationDate} from './helpers';
@@ -20,6 +23,67 @@ interface TokenCallbackResponse {
   accessToken: string;
   refreshToken?: string;
   data: {[key: string]: string};
+}
+
+async function requestOAuthAccessToken(
+    params: OAuth2RequestAccessTokenParams
+    | OAuth2ClientCredentialsRequestAccessTokenParams,
+    {tokenUrl, nestedResponseKey, scopeParamName}:
+        {tokenUrl: string; nestedResponseKey?: string, scopeParamName?: string}
+) {
+  const headers = new Headers({
+    'Content-Type': 'application/x-www-form-urlencoded',
+    accept: 'application/json',
+  });
+
+  const formParams = new URLSearchParams();
+  const formParamsWithSecret = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    let paramKey = key;
+    if (key === 'scope' && scopeParamName) {
+      paramKey = scopeParamName;
+    }
+    if (paramKey !== 'client_secret') {
+      formParams.append(paramKey, value.toString());
+    }
+
+    formParamsWithSecret.append(paramKey, value.toString());
+  }
+
+  let oauthResponse = await fetch(tokenUrl, {
+    method: 'POST',
+    body: formParamsWithSecret,
+    headers,
+  });
+
+  if (oauthResponse.status === HttpStatusCode.Unauthorized) {
+    // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
+    // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
+    // NOT has more than one auth methods.
+    //
+    // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
+    // auth fails with 401. This is the same behavior in production.
+    headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
+    oauthResponse = await fetch(tokenUrl, {
+      method: 'POST',
+      body: formParams,
+      headers,
+    });
+  }
+
+  if (!oauthResponse.ok) {
+    throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
+  }
+
+  const responseBody = await oauthResponse.json();
+  const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
+  const {access_token: accessToken, refresh_token: refreshToken, ...data} = tokenContainer;
+
+  return {accessToken, refreshToken, data};
 }
 
 export function launchOAuthServerFlow({
@@ -44,57 +108,18 @@ export function launchOAuthServerFlow({
   const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
   const redirectUri = makeRedirectUrl(port);
   const callback = async (code: string): Promise<TokenCallbackResponse> => {
-    const params = {
+    const params: OAuth2RequestAccessTokenParams = {
       grant_type: 'authorization_code',
       code,
       client_id: clientId,
+      client_secret: clientSecret,
       redirect_uri: redirectUri,
     };
 
-    const headers = new Headers({
-      'Content-Type': 'application/x-www-form-urlencoded',
-      accept: 'application/json',
+    return requestOAuthAccessToken(params, {
+      tokenUrl,
+      nestedResponseKey,
     });
-
-    const formParams = new URLSearchParams();
-    const formParamsWithSecret = new URLSearchParams();
-    for (const [key, value] of Object.entries(params)) {
-      formParams.append(key, value.toString());
-      formParamsWithSecret.append(key, value.toString());
-    }
-
-    formParamsWithSecret.append('client_secret', clientSecret);
-
-    let oauthResponse = await fetch(tokenUrl, {
-      method: 'POST',
-      body: formParamsWithSecret,
-      headers,
-    });
-
-    if (oauthResponse.status === HttpStatusCode.Unauthorized) {
-      // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
-      // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
-      // NOT has more than one auth methods.
-      //
-      // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
-      // auth fails with 401. This is the same behavior in production.
-      headers.append('Authorization', `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`);
-      oauthResponse = await fetch(tokenUrl, {
-        method: 'POST',
-        body: formParams,
-        headers,
-      });
-    }
-
-    if (!oauthResponse.ok) {
-      new Error(`OAuth provider returns error ${oauthResponse.status} ${oauthResponse.text}`);
-    }
-
-    const responseBody = await oauthResponse.json();
-    const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
-    const {access_token: accessToken, refresh_token: refreshToken, ...data} = tokenContainer;
-
-    return {accessToken, refreshToken, data};
   };
   const serverContainer = new OAuthServerContainer(callback, afterTokenExchange, port);
 
@@ -124,6 +149,10 @@ export function makeRedirectUrl(port: number): string {
   return `http://localhost:${port}/oauth`;
 }
 
+function _getTokenExpiry(data: {[key: string]: string}) {
+  return  data.expires_in && getExpirationDate(Number(data.expires_in)).toString();
+}
+
 class OAuthServerContainer {
   private readonly _port: number;
   private readonly _afterTokenExchange: AfterTokenExchangeCallback;
@@ -131,9 +160,9 @@ class OAuthServerContainer {
   private _tokenCallback: (code: string) => Promise<TokenCallbackResponse>;
 
   constructor(
-    tokenCallback: (code: string) => Promise<TokenCallbackResponse>,
-    afterTokenExchange: AfterTokenExchangeCallback,
-    port: number,
+      tokenCallback: (code: string) => Promise<TokenCallbackResponse>,
+      afterTokenExchange: AfterTokenExchangeCallback,
+      port: number,
   ) {
     this._tokenCallback = tokenCallback;
     this._port = port;
@@ -150,7 +179,7 @@ class OAuthServerContainer {
       if (code) {
         const tokenData = await this._tokenCallback(code);
         const {accessToken, refreshToken, data} = tokenData;
-        const expires = data.expires_in && getExpirationDate(Number(data.expires_in)).toString();
+        const expires = _getTokenExpiry(data);
         this._afterTokenExchange({accessToken, refreshToken, expires});
         return res.send('OAuth authentication is complete! You can close this browser tab.');
       }
@@ -163,4 +192,35 @@ class OAuthServerContainer {
   shutDown() {
     this._server?.close();
   }
+}
+
+export async function performOAuthClientCredentialsServerFlow({
+  clientId,
+  clientSecret,
+  authDef,
+  scopes,
+}: {
+  clientId: string;
+  clientSecret: string;
+  authDef: OAuth2ClientCredentialsAuthentication;
+  scopes?: string[];
+}) {
+  const {tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter} = authDef;
+  // Use the manifest's scopes as a default.
+  const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
+  const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
+  const params: OAuth2ClientCredentialsRequestAccessTokenParams = {
+    grant_type: 'client_credentials',
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope,
+  };
+
+  const {accessToken, data} = await requestOAuthAccessToken(params, {
+    tokenUrl,
+    nestedResponseKey,
+    scopeParamName,
+  });
+
+  return {accessToken, expires: _getTokenExpiry(data)}
 }

--- a/testing/oauth_server.ts
+++ b/testing/oauth_server.ts
@@ -1,14 +1,12 @@
 import 'cross-fetch/polyfill';
-import {HttpStatusCode} from './constants';
 import type {OAuth2Authentication} from '../types';
-import type {OAuth2ClientCredentialsAuthentication} from '../types';
-import type {OAuth2ClientCredentialsRequestAccessTokenParams} from './auth_types';
 import type {OAuth2RequestAccessTokenParams} from './auth_types';
 import {exec} from 'child_process';
 import express from 'express';
-import {getExpirationDate} from './helpers';
+import {getTokenExpiry} from './oauth_helpers';
 import type * as http from 'http';
 import {print} from './helpers';
+import {requestOAuthAccessToken} from './oauth_helpers';
 import {withQueryParams} from '../helpers/url';
 
 interface AfterTokenOAuthAuthorizationCodeExchangeParams {
@@ -25,72 +23,6 @@ interface AuthorizationCodeTokenCallbackResponse {
 
 export type AfterAuthorizationCodeTokenExchangeCallback =
     (params: AfterTokenOAuthAuthorizationCodeExchangeParams) => void;
-
-interface AfterTokenOAuthClientCredentialsExchangeParams {
-  accessToken: string;
-  expires?: string;
-}
-
-async function requestOAuthAccessToken(
-    params: OAuth2RequestAccessTokenParams
-    | OAuth2ClientCredentialsRequestAccessTokenParams,
-    {tokenUrl, nestedResponseKey, scopeParamName}:
-        {tokenUrl: string; nestedResponseKey?: string, scopeParamName?: string}
-) {
-  const headers = new Headers({
-    'Content-Type': 'application/x-www-form-urlencoded',
-    accept: 'application/json',
-  });
-
-  const formParams = new URLSearchParams();
-  const formParamsWithSecret = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    let paramKey = key;
-    if (key === 'scope' && scopeParamName) {
-      paramKey = scopeParamName;
-    }
-    if (paramKey !== 'client_secret') {
-      formParams.append(paramKey, value.toString());
-    }
-
-    formParamsWithSecret.append(paramKey, value.toString());
-  }
-
-  let oauthResponse = await fetch(tokenUrl, {
-    method: 'POST',
-    body: formParamsWithSecret,
-    headers,
-  });
-
-  if (oauthResponse.status === HttpStatusCode.Unauthorized) {
-    // https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1 doesn't specify how exactly client secret is
-    // passed to the oauth provider. https://datatracker.ietf.org/doc/html/rfc6749#section-2.3 says that client should
-    // NOT has more than one auth methods.
-    //
-    // To workaround with OAuth provider that uses different auth method, we fallback to header auth if body param
-    // auth fails with 401. This is the same behavior in production.
-    headers.append('Authorization', `Basic ${Buffer.from(`${params.client_id}:${params.client_secret}`).toString('base64')}`);
-    oauthResponse = await fetch(tokenUrl, {
-      method: 'POST',
-      body: formParams,
-      headers,
-    });
-  }
-
-  if (!oauthResponse.ok) {
-    throw new Error(`OAuth provider returns error ${oauthResponse.status} ${await oauthResponse.text()}`);
-  }
-
-  const responseBody = await oauthResponse.json();
-  const tokenContainer = nestedResponseKey ? responseBody[nestedResponseKey] : responseBody;
-  const {access_token: accessToken, refresh_token: refreshToken, ...data} = tokenContainer;
-
-  return {accessToken, refreshToken, data};
-}
 
 export function launchOAuthServerFlow({
   clientId,
@@ -155,10 +87,6 @@ export function makeRedirectUrl(port: number): string {
   return `http://localhost:${port}/oauth`;
 }
 
-function _getTokenExpiry(data: {[key: string]: string}) {
-  return  data.expires_in && getExpirationDate(Number(data.expires_in)).toString();
-}
-
 class OAuthServerContainer {
   private readonly _port: number;
   private readonly _afterTokenExchange: AfterAuthorizationCodeTokenExchangeCallback;
@@ -185,7 +113,7 @@ class OAuthServerContainer {
       if (code) {
         const tokenData = await this._tokenCallback(code);
         const {accessToken, refreshToken, data} = tokenData;
-        const expires = _getTokenExpiry(data);
+        const expires = getTokenExpiry(data);
         this._afterTokenExchange({accessToken, refreshToken, expires});
         return res.send('OAuth authentication is complete! You can close this browser tab.');
       }
@@ -200,37 +128,3 @@ class OAuthServerContainer {
   }
 }
 
-export async function performOAuthClientCredentialsServerFlow({
-  clientId,
-  clientSecret,
-  authDef,
-  scopes,
-  afterTokenExchange,
-}: {
-  clientId: string;
-  clientSecret: string;
-  authDef: OAuth2ClientCredentialsAuthentication;
-  scopes?: string[];
-  afterTokenExchange?: (params: AfterTokenOAuthClientCredentialsExchangeParams) => void;
-}): Promise<AfterTokenOAuthClientCredentialsExchangeParams> {
-  const {tokenUrl, nestedResponseKey, scopeParamName, scopeDelimiter} = authDef;
-  // Use the manifest's scopes as a default.
-  const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
-  const scope = requestedScopes ? requestedScopes.join(scopeDelimiter || ' ') : requestedScopes;
-  const params: OAuth2ClientCredentialsRequestAccessTokenParams = {
-    grant_type: 'client_credentials',
-    client_id: clientId,
-    client_secret: clientSecret,
-    scope,
-  };
-
-  const {accessToken, data} = await requestOAuthAccessToken(params, {
-    tokenUrl,
-    nestedResponseKey,
-    scopeParamName,
-  });
-
-  const credentials = {accessToken, expires: _getTokenExpiry(data)};
-  afterTokenExchange?.(credentials);
-  return {accessToken, expires: _getTokenExpiry(data)}
-}

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -480,6 +480,7 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
       type: zodDiscriminant(AuthenticationType.OAuth2ClientCredentials),
       tokenUrl: z.string().url(),
       scopes: z.array(z.string()).optional(),
+      scopeDelimiter: z.enum([' ', ',', ';']).optional(),
       tokenPrefix: z.string().optional(),
       tokenQueryParam: z.string().optional(),
       scopeParamName: z.string().optional(),

--- a/types.ts
+++ b/types.ts
@@ -481,6 +481,18 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
    */
   scopes?: string[];
   /**
+   * In rare cases, OAuth providers may want the permission scopes in a different query parameter
+   * than `scope`.
+   */
+  scopeParamName?: string;
+  /**
+   * The delimiter to use when joining {@link scopes} when generating authorization URLs.
+   *
+   * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
+   * If the API you are using requires a different delimiter, say a comma, specify it here.
+   */
+  scopeDelimiter?: ' ' | ',' | ';';
+  /**
    * The URL that Coda will hit in order to exchange the temporary code for an access token.
    */
   tokenUrl: string;
@@ -496,11 +508,6 @@ export interface BaseOAuthAuthentication extends BaseAuthentication {
    * codes when there is an error in the token exchange.
    */
   credentialsLocation?: TokenExchangeCredentialsLocation;
-  /**
-   * In rare cases, OAuth providers may want the permission scopes in a different query parameter
-   * than `scope`.
-   */
-  scopeParamName?: string;
   /**
    * A custom prefix to be used when passing the access token in the HTTP Authorization
    * header when making requests. Typically this prefix is `Bearer` which is what will be
@@ -547,13 +554,6 @@ export interface OAuth2Authentication extends BaseOAuthAuthentication {
    * they may be specified using {@link additionalParams}.
    */
   authorizationUrl: string;
-  /**
-   * The delimiter to use when joining {@link scopes} when generating authorization URLs.
-   *
-   * The OAuth2 standard is to use spaces to delimit scopes, and Coda will do that by default.
-   * If the API you are using requires a different delimiter, say a comma, specify it here.
-   */
-  scopeDelimiter?: ' ' | ',' | ';';
 
   /**
    * Option custom URL parameters and values that should be included when redirecting the


### PR DESCRIPTION
Adds functionality to request an access token and refresh it from the cli

Video showing execution of fedex pack, using the updated endpoint:
https://coda.d.pr/i/o7ulz7

PTAL @gary-codaio @jonathan-codaio 