### PR TITLE
Hide docs for updateOptions which make take some time to implement

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1124,6 +1124,7 @@ export interface SyncFormulaDef<
    *
    * This is useful for specifying OAuth scopes that are only necessary for 2-way writes
    * but not for reads.
+   * @hidden
    */
   updateOptions?: Pick<CommonPackFormulaDef<ParamDefsT>, 'extraOAuthScopes'>;
 }

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -665,6 +665,7 @@ export interface SyncFormulaDef<K extends string, L extends string, ParamDefsT e
      *
      * This is useful for specifying OAuth scopes that are only necessary for 2-way writes
      * but not for reads.
+     * @hidden
      */
     updateOptions?: Pick<CommonPackFormulaDef<ParamDefsT>, 'extraOAuthScopes'>;
 }

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -2666,6 +2666,7 @@ export interface SyncFormulaDef<K extends string, L extends string, ParamDefsT e
 	 *
 	 * This is useful for specifying OAuth scopes that are only necessary for 2-way writes
 	 * but not for reads.
+	 * @hidden
 	 */
 	updateOptions?: Pick<CommonPackFormulaDef<ParamDefsT>, "extraOAuthScopes">;
 }

--- a/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
+++ b/docs/reference/sdk/interfaces/core.SyncFormulaDef.md
@@ -178,17 +178,6 @@ The parameter inputs to the formula, if any.
 
 ___
 
-### updateOptions
-
-• `Optional` **updateOptions**: `Pick`<[`CommonPackFormulaDef`](core.CommonPackFormulaDef.md)<`ParamDefsT`\>, ``"extraOAuthScopes"``\>
-
-Options that only apply [executeUpdate](core.SyncFormulaDef.md#executeupdate) but not [execute](core.SyncFormulaDef.md#execute).
-
-This is useful for specifying OAuth scopes that are only necessary for 2-way writes
-but not for reads.
-
-___
-
 ### varargParameters
 
 • `Optional` `Readonly` **varargParameters**: [`ParamDefs`](../types/core.ParamDefs.md)


### PR DESCRIPTION
This may take longer to implement than anticipated, so it's probably best to hide in the docs until it's ready for use