### PR TITLE
Drop package.json constraint requesting node versions < 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev/eslint"
   ],
   "engines": {
-    "node": ">=18.0.x <19.0.0",
+    "node": ">=18.0.x",
     "pnpm": ">=8.0.0 <8.6.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
This isn't really necessary and it causes warnings for people using higher node versions