### PR TITLE
Move extraOAuthScopes back to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 This changelog keeps track of all changes to the Packs SDK. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+
+- Added `updateOptions.extraOAuthScopes` to sync tables to support incremental OAuth with 2-way sync.
 
 ## [1.7.0] - 2023-10-24
 
 ### Added
 
 - Added `OAuth2ClientCredentials` authentication type to support authenticating with OAuth client credentials.
-- Added `updateOptions.extraOAuthScopes` to sync tables to support incremental OAuth with 2-way sync.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog keeps track of all changes to the Packs SDK. We follow conventions from [keepachangelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
 ### Added
 
 - Added `updateOptions.extraOAuthScopes` to sync tables to support incremental OAuth with 2-way sync.


### PR DESCRIPTION
Moving this doc back to unreleased based on https://github.com/coda/packs-sdk/pull/2801#discussion_r1370850312

PTAL @jonathan-codaio @dweitzman-codaio 