### PR TITLE
Finish PR 2806

### DIFF
--- a/docs/samples/topic/two-way.md
+++ b/docs/samples/topic/two-way.md
@@ -8,6 +8,7 @@ icon: material/card-text
 
 Two-way sync is an optional feature of sync tables that allows users to make edits to row data and push those changes back to the data source. Pack makers enable two-way sync on their tables by annotating their schemas and writing an `executeUpdate` function that handles the update logic.
 
+
 [Learn More](../../../guides/blocks/sync-tables/two-way){ .md-button }
 
 ## Simple two-way sync

--- a/docs/samples/topic/two-way.md
+++ b/docs/samples/topic/two-way.md
@@ -8,9 +8,6 @@ icon: material/card-text
 
 Two-way sync is an optional feature of sync tables that allows users to make edits to row data and push those changes back to the data source. Pack makers enable two-way sync on their tables by annotating their schemas and writing an `executeUpdate` function that handles the update logic.
 
-🚧 This feature is currently only available to a limited group of alpha testers. Email [partners@coda.io](mailto:partners@coda.io) to learn more and request access.
-
-
 [Learn More](../../../guides/blocks/sync-tables/two-way){ .md-button }
 
 ## Simple two-way sync

--- a/documentation/generated/examples.json
+++ b/documentation/generated/examples.json
@@ -835,7 +835,7 @@
     },
     "exampleFooterLink": "https://coda.io/packs/build/latest/guides/blocks/sync-tables/two-way",
     "learnMoreLink": "/guides/blocks/sync-tables/two-way",
-    "content": "Two-way sync is an optional feature of sync tables that allows users to make edits to row data and push those changes back to the data source. Pack makers enable two-way sync on their tables by annotating their schemas and writing an `executeUpdate` function that handles the update logic.\n\n🚧 This feature is currently only available to a limited group of alpha testers. Email [partners@coda.io](mailto:partners@coda.io) to learn more and request access.",
+    "content": "Two-way sync is an optional feature of sync tables that allows users to make edits to row data and push those changes back to the data source. Pack makers enable two-way sync on their tables by annotating their schemas and writing an `executeUpdate` function that handles the update logic.",
     "exampleSnippets": [
       {
         "name": "Simple two-way sync",

--- a/documentation/samples/packs/two-way/README.md
+++ b/documentation/samples/packs/two-way/README.md
@@ -1,3 +1,1 @@
 Two-way sync is an optional feature of sync tables that allows users to make edits to row data and push those changes back to the data source. Pack makers enable two-way sync on their tables by annotating their schemas and writing an `executeUpdate` function that handles the update logic.
-
-🚧 This feature is currently only available to a limited group of alpha testers. Email [partners@coda.io](mailto:partners@coda.io) to learn more and request access.


### PR DESCRIPTION
PR #2806 removes an outdated warning about two-way sync, but didn't make the change at the source. This PR extends that work and modifies the correct source file.

Assigning to on-call.