### PR TITLE
Export helpers for creating isolated-vm Isolate

### DIFF
--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -4,7 +4,8 @@ import type { FetchResponse } from '../../api_types';
 import type { Fetcher } from '../../api_types';
 import type { FormulaSpecification } from '../types';
 import type { InvocationLocation } from '../../api_types';
-import type { Isolate } from 'isolated-vm';
+import { Isolate } from 'isolated-vm';
+import type { IsolateOptions } from 'isolated-vm';
 import type { Logger } from '../../api_types';
 import type { PackFunctionResponse } from '../types';
 import type { ParamDefs } from '../../api_types';
@@ -12,6 +13,8 @@ import type { ParamValues } from '../../api_types';
 import type { Sync } from '../../api_types';
 import type { SyncUpdate } from '../../api';
 import type { TemporaryBlobStorage } from '../../api_types';
+export type { Context } from 'isolated-vm';
+export declare function createIsolate(options: IsolateOptions): Isolate;
 /**
  * Setup an isolate context with sufficient globals needed to execute a pack.
  *

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -3,7 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getThunkPath = exports.registerBundles = exports.registerBundle = exports.injectExecutionContext = exports.injectSerializer = exports.executeThunk = exports.injectFetcherFunction = exports.injectLogFunction = exports.injectAsyncFunction = exports.createIsolateContext = void 0;
+exports.getThunkPath = exports.registerBundles = exports.registerBundle = exports.injectExecutionContext = exports.injectSerializer = exports.executeThunk = exports.injectFetcherFunction = exports.injectLogFunction = exports.injectAsyncFunction = exports.createIsolateContext = exports.createIsolate = void 0;
+const isolated_vm_1 = require("isolated-vm");
 const fs_1 = __importDefault(require("fs"));
 const marshaling_1 = require("../common/marshaling");
 const path_1 = __importDefault(require("path"));
@@ -11,6 +12,12 @@ const source_map_1 = require("../common/source_map");
 const marshaling_2 = require("../common/marshaling");
 const marshaling_3 = require("../common/marshaling");
 const v8_1 = __importDefault(require("v8"));
+// This helper avoids the need for other repos to directly depend on isolated-vm and
+// know what version to import.
+function createIsolate(options) {
+    return new isolated_vm_1.Isolate(options);
+}
+exports.createIsolate = createIsolate;
 /**
  * Setup an isolate context with sufficient globals needed to execute a pack.
  *

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -4,7 +4,8 @@ import type {FetchResponse} from '../../api_types';
 import type {Fetcher} from '../../api_types';
 import type {FormulaSpecification} from '../types';
 import type {InvocationLocation} from '../../api_types';
-import type {Isolate} from 'isolated-vm';
+import {Isolate} from 'isolated-vm';
+import type {IsolateOptions} from 'isolated-vm';
 import type {Logger} from '../../api_types';
 import type {PackFunctionResponse} from '../types';
 import type {ParamDefs} from '../../api_types';
@@ -19,6 +20,14 @@ import {translateErrorStackFromVM} from '../common/source_map';
 import {unmarshalValue} from '../common/marshaling';
 import {unwrapError} from '../common/marshaling';
 import v8 from 'v8';
+
+export type {Context} from 'isolated-vm';
+
+// This helper avoids the need for other repos to directly depend on isolated-vm and
+// know what version to import.
+export function createIsolate(options: IsolateOptions): Isolate {
+  return new Isolate(options);
+}
 
 /**
  * Setup an isolate context with sufficient globals needed to execute a pack.


### PR DESCRIPTION
The goal here is to avoid the need to directly import isolated-vm in other repos, which avoids the need to manually upgrade isolated-vm in those repos