### PR TITLE
Get the pnpm version from package.json

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,18 +15,6 @@
       allowedVersions: '<5.0.0',
     },
 
-    // isolated-vm 4.4.2 has a known issue that should be fixed in 4.4.3
-    {
-      packageNames: ['isolated-vm'],
-      allowedVersions: '!/^4\\.4\\.2$/',
-    },
-
-    // pnpm 8.6.0 moves to a new lockfile version.
-    {
-      packageNames: ['pnpm'],
-      allowedVersions: '<8.6.0',
-    },
-
     // see https://github.com/coda/packs-sdk/pull/2642
     {
       packageNames: ['open'],

--- a/scripts/dev/install-pnpm.sh
+++ b/scripts/dev/install-pnpm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# We can't install pnpm using node because pnpm 8 isn't compatible with node 14, which is what
-# we use on lambda. Instead, we can install a standalone binary that doesn't depend on node.
+PNPM_VERSION=$(jq -r .engines.pnpm package.json)
 
-npm install --prefix=./.pnpm_install -g @pnpm/exe@~8.5.1
+# Install in a local directory to avoid conflicts with the local or global node_modules/
+npm install --prefix=./.pnpm_install -g "@pnpm/exe@${PNPM_VERSION}"


### PR DESCRIPTION
This PR also re-enables pnpm upgrades, since pnpm is now a standalone install and won't conflict with other global node installations