### PR TITLE
packs-sdk: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - Added `updateOptions.extraOAuthScopes` to sync tables to support incremental OAuth with 2-way sync.
+
+## [1.7.1] - 2023-11-15
+
+### Added
+
 - Added `OAuth2ClientCredentials` authentication type as a system authentication type.
 
 ## [1.7.0] - 2023-10-24
@@ -634,7 +639,8 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.7.0...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/coda/packs-sdk/compare/v1.6.0...v1.7.1
 [1.7.0]: https://github.com/coda/packs-sdk/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/coda/packs-sdk/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/coda/packs-sdk/compare/v1.4.1...v1.5.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
### Added

- Added `OAuth2ClientCredentials` authentication type as a system authentication type.

PTAL @coda/packs 