### PR TITLE
Make a prerelease version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.1",
+  "version": "1.7.2-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
The usual reason

Last time we did this: https://github.com/coda/packs-sdk/pull/2704