### PR TITLE
Validate the formula example results must be defined

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -481,7 +481,9 @@ function buildMetadataSchema({ sdkVersion }) {
                 // to accept it here.
                 z.null(),
             ])),
-            result: z.any(),
+            result: z.any().refine(result => {
+                return !(0, object_utils_2.isNil)(result);
+            }, { message: "Pack formulas can't return null or undefined." }),
         }))
             .optional(),
         parameters: z.array(paramDefValidator).refine(params => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -612,7 +612,12 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
               z.null(),
             ]),
           ),
-          result: z.any(),
+          result: z.any().refine(
+            result => {
+              return !isNil(result);
+            },
+            {message: "Pack formulas can't return null or undefined."},
+          ),
         }),
       )
       .optional(),


### PR DESCRIPTION
Apparently z.any() accepts undefined, so need to add additional validation to make sure that the example results are not falsy.