### PR TITLE
Add option to cache non-GET requests in the `FetchRequest` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Added
+
+- Added `cachePOSTRequest` to `FetchRequest` to support caching POST requests.
+- Updated upload validation to correctly throw errors when formula examples are missing the `result` field.
+
 ## [1.7.3] - 2023-12-15
 
 ### Added
@@ -15,11 +20,11 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Added
 
 - Added `updateOptions.extraOAuthScopes` to sync tables to support incremental OAuth with 2-way sync.
-- Added `width`, `height`, and `shapeStyle` to `ImageSchema`
+- Added `width`, `height`, and `shapeStyle` to `ImageSchema`.
 
 ### Fixed
 
-- Fixed failing CLI commands when the optional isolated-vm dependency was not present
+- Fixed failing CLI commands when the optional isolated-vm dependency was not present.
 
 ## [1.7.1] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ### Added
 
-- Added `cachePOSTRequest` to `FetchRequest` to support caching POST requests.
+- Added `forceCache` to `FetchRequest` to support caching non-GET requests.
 - Updated upload validation to correctly throw errors when formula examples are missing the `result` field.
 
 ## [1.7.3] - 2023-12-15

--- a/api_types.ts
+++ b/api_types.ts
@@ -580,8 +580,6 @@ export interface FetchRequest {
    * If true, Coda will cache the POST request and return the same response for subsequent requests.
    * This is mainly used for POST requests that do not have side effects, such as querying a
    * GraphQL API.
-   *
-   * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
    */
   cachePOSTRequest?: boolean;
 }

--- a/api_types.ts
+++ b/api_types.ts
@@ -576,6 +576,14 @@ export interface FetchRequest {
    * You may inspect the `Location` header of the response to observe the indicated redirect URL.
    */
   ignoreRedirects?: boolean;
+  /**
+   * If true, Coda will cache the POST request and return the same response for subsequent requests.
+   * This is mainly used for POST requests that do not have side effects, such as querying a
+   * GraphQL API.
+   *
+   * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
+   */
+  cachePOSTRequest?: boolean;
 }
 
 /**

--- a/api_types.ts
+++ b/api_types.ts
@@ -556,8 +556,20 @@ export interface FetchRequest {
    * instead of making the HTTP request. If left unspecified, Coda will automatically
    * cache all GET requests for approximately 5 minutes. To disable the default caching,
    * set this value to `0`.
+   *
+   * If you are trying to cache a POST, PUT, PATCH, or DELETE request, you must also
+   * set {@link FetchRequest.forceCache} to true.
    */
   cacheTtlSecs?: number;
+  /**
+   * If true, Coda will cache the request (including POST, PUT, PATCH, and DELETE) and return the
+   * same response for subsequent requests. This option does *not* need to be specified to cache
+   * GET requests.
+   *
+   * This is mainly used for POST requests that do not have side effects, such as querying a
+   * GraphQL API.
+   */
+  forceCache?: boolean;
   /**
    * Indicates that you expect the response to be binary data, instructing Coda
    * not to attempt to parse the response in any way. Otherwise, Coda may attempt
@@ -576,12 +588,6 @@ export interface FetchRequest {
    * You may inspect the `Location` header of the response to observe the indicated redirect URL.
    */
   ignoreRedirects?: boolean;
-  /**
-   * If true, Coda will cache the POST request and return the same response for subsequent requests.
-   * This is mainly used for POST requests that do not have side effects, such as querying a
-   * GraphQL API.
-   */
-  cachePOSTRequest?: boolean;
 }
 
 /**

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -463,8 +463,6 @@ export interface FetchRequest {
      * If true, Coda will cache the POST request and return the same response for subsequent requests.
      * This is mainly used for POST requests that do not have side effects, such as querying a
      * GraphQL API.
-     *
-     * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
      */
     cachePOSTRequest?: boolean;
 }

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -439,8 +439,20 @@ export interface FetchRequest {
      * instead of making the HTTP request. If left unspecified, Coda will automatically
      * cache all GET requests for approximately 5 minutes. To disable the default caching,
      * set this value to `0`.
+     *
+     * If you are trying to cache a POST, PUT, PATCH, or DELETE request, you must also
+     * set {@link FetchRequest.forceCache} to true.
      */
     cacheTtlSecs?: number;
+    /**
+     * If true, Coda will cache the request (including POST, PUT, PATCH, and DELETE) and return the
+     * same response for subsequent requests. This option does *not* need to be specified to cache
+     * GET requests.
+     *
+     * This is mainly used for POST requests that do not have side effects, such as querying a
+     * GraphQL API.
+     */
+    forceCache?: boolean;
     /**
      * Indicates that you expect the response to be binary data, instructing Coda
      * not to attempt to parse the response in any way. Otherwise, Coda may attempt
@@ -459,12 +471,6 @@ export interface FetchRequest {
      * You may inspect the `Location` header of the response to observe the indicated redirect URL.
      */
     ignoreRedirects?: boolean;
-    /**
-     * If true, Coda will cache the POST request and return the same response for subsequent requests.
-     * This is mainly used for POST requests that do not have side effects, such as querying a
-     * GraphQL API.
-     */
-    cachePOSTRequest?: boolean;
 }
 /**
  * The response of a call to {@link Fetcher.fetch}.

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -459,6 +459,14 @@ export interface FetchRequest {
      * You may inspect the `Location` header of the response to observe the indicated redirect URL.
      */
     ignoreRedirects?: boolean;
+    /**
+     * If true, Coda will cache the POST request and return the same response for subsequent requests.
+     * This is mainly used for POST requests that do not have side effects, such as querying a
+     * GraphQL API.
+     *
+     * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
+     */
+    cachePOSTRequest?: boolean;
 }
 /**
  * The response of a call to {@link Fetcher.fetch}.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -450,8 +450,6 @@ export interface FetchRequest {
 	 * If true, Coda will cache the POST request and return the same response for subsequent requests.
 	 * This is mainly used for POST requests that do not have side effects, such as querying a
 	 * GraphQL API.
-	 *
-	 * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
 	 */
 	cachePOSTRequest?: boolean;
 }

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -446,6 +446,14 @@ export interface FetchRequest {
 	 * You may inspect the `Location` header of the response to observe the indicated redirect URL.
 	 */
 	ignoreRedirects?: boolean;
+	/**
+	 * If true, Coda will cache the POST request and return the same response for subsequent requests.
+	 * This is mainly used for POST requests that do not have side effects, such as querying a
+	 * GraphQL API.
+	 *
+	 * You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
+	 */
+	cachePOSTRequest?: boolean;
 }
 /**
  * The response of a call to {@link Fetcher.fetch}.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -426,8 +426,20 @@ export interface FetchRequest {
 	 * instead of making the HTTP request. If left unspecified, Coda will automatically
 	 * cache all GET requests for approximately 5 minutes. To disable the default caching,
 	 * set this value to `0`.
+	 *
+	 * If you are trying to cache a POST, PUT, PATCH, or DELETE request, you must also
+	 * set {@link FetchRequest.forceCache} to true.
 	 */
 	cacheTtlSecs?: number;
+	/**
+	 * If true, Coda will cache the request (including POST, PUT, PATCH, and DELETE) and return the
+	 * same response for subsequent requests. This option does *not* need to be specified to cache
+	 * GET requests.
+	 *
+	 * This is mainly used for POST requests that do not have side effects, such as querying a
+	 * GraphQL API.
+	 */
+	forceCache?: boolean;
 	/**
 	 * Indicates that you expect the response to be binary data, instructing Coda
 	 * not to attempt to parse the response in any way. Otherwise, Coda may attempt
@@ -446,12 +458,6 @@ export interface FetchRequest {
 	 * You may inspect the `Location` header of the response to observe the indicated redirect URL.
 	 */
 	ignoreRedirects?: boolean;
-	/**
-	 * If true, Coda will cache the POST request and return the same response for subsequent requests.
-	 * This is mainly used for POST requests that do not have side effects, such as querying a
-	 * GraphQL API.
-	 */
-	cachePOSTRequest?: boolean;
 }
 /**
  * The response of a call to {@link Fetcher.fetch}.

--- a/docs/reference/sdk/interfaces/core.FetchRequest.md
+++ b/docs/reference/sdk/interfaces/core.FetchRequest.md
@@ -24,16 +24,6 @@ If you are sending a JSON payload, make sure to call `JSON.stringify()` on the o
 
 ___
 
-### cachePOSTRequest
-
-• `Optional` **cachePOSTRequest**: `boolean`
-
-If true, Coda will cache the POST request and return the same response for subsequent requests.
-This is mainly used for POST requests that do not have side effects, such as querying a
-GraphQL API.
-
-___
-
 ### cacheTtlSecs
 
 • `Optional` **cacheTtlSecs**: `number`
@@ -45,6 +35,9 @@ instead of making the HTTP request. If left unspecified, Coda will automatically
 cache all GET requests for approximately 5 minutes. To disable the default caching,
 set this value to `0`.
 
+If you are trying to cache a POST, PUT, PATCH, or DELETE request, you must also
+set [forceCache](core.FetchRequest.md#forcecache) to true.
+
 ___
 
 ### disableAuthentication
@@ -54,6 +47,19 @@ ___
 If true, Coda will not apply authentication credentials even if this pack is
 configured to use authentication. This is very rare, but sometimes you may
 wish to make an unauthenticated supporting request as part of a formula implementation.
+
+___
+
+### forceCache
+
+• `Optional` **forceCache**: `boolean`
+
+If true, Coda will cache the request (including POST, PUT, PATCH, and DELETE) and return the
+same response for subsequent requests. This option does *not* need to be specified to cache
+GET requests.
+
+This is mainly used for POST requests that do not have side effects, such as querying a
+GraphQL API.
 
 ___
 

--- a/docs/reference/sdk/interfaces/core.FetchRequest.md
+++ b/docs/reference/sdk/interfaces/core.FetchRequest.md
@@ -32,8 +32,6 @@ If true, Coda will cache the POST request and return the same response for subse
 This is mainly used for POST requests that do not have side effects, such as querying a
 GraphQL API.
 
-You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
-
 ___
 
 ### cacheTtlSecs

--- a/docs/reference/sdk/interfaces/core.FetchRequest.md
+++ b/docs/reference/sdk/interfaces/core.FetchRequest.md
@@ -24,6 +24,18 @@ If you are sending a JSON payload, make sure to call `JSON.stringify()` on the o
 
 ___
 
+### cachePOSTRequest
+
+• `Optional` **cachePOSTRequest**: `boolean`
+
+If true, Coda will cache the POST request and return the same response for subsequent requests.
+This is mainly used for POST requests that do not have side effects, such as querying a
+GraphQL API.
+
+You will also need to set `cacheTtlSecs` to a non-zero value for this to work.
+
+___
+
 ### cacheTtlSecs
 
 • `Optional` **cacheTtlSecs**: `number`


### PR DESCRIPTION
We don't allow caching non-`GET` requests by default, but some makers may want to cache the requests for non-side-effecting requests (for example, querying a GraphQL API). Adds the option to cache these results here when making those fetch calls.