### PR TITLE
Add warning when running a Pack with multiple domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 - Added `forceCache` to `FetchRequest` to support caching non-GET requests.
 - Updated upload validation to correctly throw errors when formula examples are missing the `result` field.
 
+### Changed
+
+- Running `coda execute` on a Pack that uses multiple network domains will fail with a warning unless the new flag `--allowMultipleNetworkDomains` is included. This acts as an early warning to Pack makers and hopefully encourages them to file for approval early before investing too much time into development.
+
 ## [1.7.3] - 2023-12-15
 
 ### Added

--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -67,6 +67,11 @@ if (require.main === module) {
           default: DEFAULT_MAX_ROWS,
           desc: 'For a sync table, the maximum number of rows to sync.',
         },
+        allowMultipleNetworkDomains: {
+          boolean: true,
+          default: false,
+          desc: 'Allow executing Packs that use multiple network domains. You must get approval from Coda before you can upload these Packs.',
+        },
       },
     })
     .command({

--- a/cli/execute.ts
+++ b/cli/execute.ts
@@ -16,6 +16,7 @@ export interface ExecuteArgs {
   dynamicUrl?: string;
   timerStrategy: TimerShimStrategy;
   maxRows?: number;
+  allowMultipleNetworkDomains?: boolean;
 }
 
 export async function handleExecute({
@@ -27,6 +28,7 @@ export async function handleExecute({
   dynamicUrl,
   timerStrategy,
   maxRows,
+  allowMultipleNetworkDomains,
 }: ArgumentsCamelCase<ExecuteArgs>) {
   if (vm && !tryGetIvm()) {
     return printAndExit(
@@ -41,6 +43,9 @@ export async function handleExecute({
     timerStrategy,
   });
   const manifest = await importManifest(bundlePath);
+  if (manifest.networkDomains && manifest.networkDomains.length > 1 && !allowMultipleNetworkDomains) {
+    return printAndExit('Using multiple network domains requires approval from Coda. Visit https://coda.io/packs/build/latest/support#approvals to make a request. Disable this warning by including the flag: --allowMultipleNetworkDomains');
+  }
   await executeFormulaOrSyncFromCLI({
     formulaName,
     params,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -68,6 +68,11 @@ if (require.main === module) {
                 default: execution_1.DEFAULT_MAX_ROWS,
                 desc: 'For a sync table, the maximum number of rows to sync.',
             },
+            allowMultipleNetworkDomains: {
+                boolean: true,
+                default: false,
+                desc: 'Allow executing Packs that use multiple network domains. You must get approval from Coda before you can upload these Packs.',
+            },
         },
     })
         .command({

--- a/dist/cli/execute.d.ts
+++ b/dist/cli/execute.d.ts
@@ -9,5 +9,6 @@ export interface ExecuteArgs {
     dynamicUrl?: string;
     timerStrategy: TimerShimStrategy;
     maxRows?: number;
+    allowMultipleNetworkDomains?: boolean;
 }
-export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timerStrategy, maxRows, }: ArgumentsCamelCase<ExecuteArgs>): Promise<undefined>;
+export declare function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timerStrategy, maxRows, allowMultipleNetworkDomains, }: ArgumentsCamelCase<ExecuteArgs>): Promise<undefined>;

--- a/dist/cli/execute.js
+++ b/dist/cli/execute.js
@@ -7,7 +7,7 @@ const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const helpers_3 = require("../testing/helpers");
 const ivm_wrapper_1 = require("../testing/ivm_wrapper");
-async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timerStrategy, maxRows, }) {
+async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dynamicUrl, timerStrategy, maxRows, allowMultipleNetworkDomains, }) {
     if (vm && !(0, ivm_wrapper_1.tryGetIvm)()) {
         return (0, helpers_3.printAndExit)('The --vm flag was specified, but the isolated-vm package is not installed, likely because this package is not ' +
             'compatible with your platform. Try again but omitting the --vm flag.');
@@ -19,6 +19,9 @@ async function handleExecute({ manifestPath, formulaName, params, fetch, vm, dyn
         timerStrategy,
     });
     const manifest = await (0, helpers_1.importManifest)(bundlePath);
+    if (manifest.networkDomains && manifest.networkDomains.length > 1 && !allowMultipleNetworkDomains) {
+        return (0, helpers_3.printAndExit)('Using multiple network domains requires approval from Coda. Visit https://coda.io/packs/build/latest/support#approvals to make a request. Disable this warning by including the flag: --allowMultipleNetworkDomains');
+    }
     await (0, execution_1.executeFormulaOrSyncFromCLI)({
         formulaName,
         params,

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -593,5 +593,5 @@ There are services however where each account is associated with a distinct doma
 [MultiQueryParamToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#multiqueryparamtoken
 [CodaApiHeaderBearerToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#codaapiheaderbearertoken
 [AWSAccessKey]: ../../../reference/sdk/enums/core.AuthenticationType.md#awsaccesskey
-[support_network_domain]: ../../../support/index.md#network-domains
+[support_network_domain]: ../../../support/index.md#approvals
 [MultiHeaderToken]: ../../../reference/sdk/enums/core.AuthenticationType.md#multiheadertoken

--- a/docs/guides/basics/authentication/oauth2.md
+++ b/docs/guides/basics/authentication/oauth2.md
@@ -303,7 +303,7 @@ Like with the Authorization Code flow, a variety of other advanced options are a
 [oauth2_client]: https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
 [extraOAuthScopes]: ../../../reference/sdk/interfaces/core.BaseFormulaDef.md#extraoauthscopes
 [support]: ../../../support/index.md
-[support_network_domains]: ../../../support/index.md#network-domains
+[support_network_domains]: ../../../support/index.md#approvals
 [sample_oauth2]: ../../../samples/topic/authentication.md#oauth2
 [sample_apis]: ../../../samples/topic/apis.md
 [tutorial_oauth2]: ../../../tutorials/build/oauth.md

--- a/docs/guides/basics/fetcher.md
+++ b/docs/guides/basics/fetcher.md
@@ -407,7 +407,7 @@ dig +short egress.coda.io
 [samples]: ../../samples/topic/fetcher.md
 [addNetworkDomain]: ../../reference/sdk/classes/core.PackDefinitionBuilder.md#addnetworkdomain
 [support]: ../../support/index.md
-[support_network_domains]: ../../support/index.md#network-domains
+[support_network_domains]: ../../support/index.md#approvals
 [ExecutionContext]: ../../reference/sdk/interfaces/core.ExecutionContext/
 [fetch]: ../../reference/sdk/interfaces/core.Fetcher.md#fetch
 [FetchRequest]: ../../reference/sdk/interfaces/core.FetchRequest.md

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -34,7 +34,9 @@ If you are experiencing a problem with your Pack or have identified a bug you ca
 [Send email][support_email]{: .md-button .md-button--primary}
 
 
-## Approvals and exemptions {: #network-domains}
+## Approvals and exemptions {: #approvals}
+
+<a name="network-domains"></a><!-- Keep for backwards compatibility -->
 
 Certain Pack features are restricted by default and require approval before you can use them. Coda enforces these restrictions when you attempt to create a new version of your Pack. This means you can test your Pack locally using the CLI, but will need to have the approval granted before you can test in a real doc.
 


### PR DESCRIPTION
This change is based on feedback from Pack makers who became frustrated when they sunk a lot of time into developing a Pack only to realize at the end that it required Coda approval since it uses multiple domains.