### PR TITLE
Advanced property options feature to ignore properties when caching

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1525,7 +1525,7 @@ interface PropertyOptionsNormalizedResults {
   // Undocumented feature for situations when you might be using an awkward API that
   // only lets you fetch data using an overly-specific property when a more general
   // one would have sufficed.
-  propertiesNotUsed?: string[];
+  unusedProperties?: string[];
 }
 
 function normalizePropertyOptionsResultsArray(

--- a/api.ts
+++ b/api.ts
@@ -1521,6 +1521,11 @@ export type PropertyOptionsResults = PropertyOptionsMetadataResult<any | Propert
 interface PropertyOptionsNormalizedResults {
   cacheTtlSecs?: number;
   results: Array<{display: string | undefined; value: any}>;
+
+  // Undocumented feature for situations when you might be using an awkward API that
+  // only lets you fetch data using an overly-specific property when a more general
+  // one would have sufficed.
+  propertiesNotUsed?: string[];
 }
 
 function normalizePropertyOptionsResultsArray(

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6486,7 +6486,7 @@ module.exports = (() => {
               const normalizedPackResult = normalizePropertyOptionsResults(packResult);
               const result = {
                 packResult: normalizedPackResult,
-                propertiesUsed: normalizedPackResult.propertiesNotUsed?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.propertiesNotUsed?.includes(p)) : cacheKeysUsed,
+                propertiesUsed: normalizedPackResult.unusedProperties?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.unusedProperties?.includes(p)) : cacheKeysUsed,
                 ...contextUsed
               };
               return result;

--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6483,9 +6483,10 @@ module.exports = (() => {
                 params,
                 propertyOptionsExecutionContext
               );
+              const normalizedPackResult = normalizePropertyOptionsResults(packResult);
               const result = {
-                packResult: normalizePropertyOptionsResults(packResult),
-                propertiesUsed: cacheKeysUsed,
+                packResult: normalizedPackResult,
+                propertiesUsed: normalizedPackResult.propertiesNotUsed?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.propertiesNotUsed?.includes(p)) : cacheKeysUsed,
                 ...contextUsed
               };
               return result;

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -930,6 +930,7 @@ export interface PropertyOptionsAnnotatedResult {
     packResult: PropertyOptionsNormalizedResults;
     propertiesUsed: string[];
     searchUsed?: boolean;
+    propertiesNotUsed?: string[];
 }
 /**
  * Formula implementing property options.

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -921,7 +921,7 @@ interface PropertyOptionsNormalizedResults {
         display: string | undefined;
         value: any;
     }>;
-    propertiesNotUsed?: string[];
+    unusedProperties?: string[];
 }
 export declare function normalizePropertyOptionsResults(results: PropertyOptionsResults): PropertyOptionsNormalizedResults;
 /**

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -921,6 +921,7 @@ interface PropertyOptionsNormalizedResults {
         display: string | undefined;
         value: any;
     }>;
+    propertiesNotUsed?: string[];
 }
 export declare function normalizePropertyOptionsResults(results: PropertyOptionsResults): PropertyOptionsNormalizedResults;
 /**
@@ -930,7 +931,6 @@ export interface PropertyOptionsAnnotatedResult {
     packResult: PropertyOptionsNormalizedResults;
     propertiesUsed: string[];
     searchUsed?: boolean;
-    propertiesNotUsed?: string[];
 }
 /**
  * Formula implementing property options.

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6486,7 +6486,7 @@ module.exports = (() => {
               const normalizedPackResult = normalizePropertyOptionsResults(packResult);
               const result = {
                 packResult: normalizedPackResult,
-                propertiesUsed: normalizedPackResult.propertiesNotUsed?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.propertiesNotUsed?.includes(p)) : cacheKeysUsed,
+                propertiesUsed: normalizedPackResult.unusedProperties?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.unusedProperties?.includes(p)) : cacheKeysUsed,
                 ...contextUsed
               };
               return result;

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6483,9 +6483,10 @@ module.exports = (() => {
                 params,
                 propertyOptionsExecutionContext
               );
+              const normalizedPackResult = normalizePropertyOptionsResults(packResult);
               const result = {
-                packResult: normalizePropertyOptionsResults(packResult),
-                propertiesUsed: cacheKeysUsed,
+                packResult: normalizedPackResult,
+                propertiesUsed: normalizedPackResult.propertiesNotUsed?.length ? cacheKeysUsed.filter((p) => !normalizedPackResult.propertiesNotUsed?.includes(p)) : cacheKeysUsed,
                 ...contextUsed
               };
               return result;

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -41,7 +41,7 @@ async function findAndExecutePackFunction({ shouldWrapError = true, ...args }) {
 }
 exports.findAndExecutePackFunction = findAndExecutePackFunction;
 async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, executionContext, updates, }) {
-    var _a;
+    var _a, _b;
     const { syncTables, defaultAuthentication } = manifest;
     switch (formulaSpec.type) {
         case types_2.FormulaType.Standard: {
@@ -117,9 +117,12 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                             },
                         });
                         const packResult = (await optionsFormula.execute(params, propertyOptionsExecutionContext));
+                        const normalizedPackResult = (0, api_4.normalizePropertyOptionsResults)(packResult);
                         const result = {
-                            packResult: (0, api_4.normalizePropertyOptionsResults)(packResult),
-                            propertiesUsed: cacheKeysUsed,
+                            packResult: normalizedPackResult,
+                            propertiesUsed: ((_b = normalizedPackResult.propertiesNotUsed) === null || _b === void 0 ? void 0 : _b.length)
+                                ? cacheKeysUsed.filter(p => { var _a; return !((_a = normalizedPackResult.propertiesNotUsed) === null || _a === void 0 ? void 0 : _a.includes(p)); })
+                                : cacheKeysUsed,
                             ...contextUsed,
                         };
                         return result;

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -120,8 +120,8 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                         const normalizedPackResult = (0, api_4.normalizePropertyOptionsResults)(packResult);
                         const result = {
                             packResult: normalizedPackResult,
-                            propertiesUsed: ((_b = normalizedPackResult.propertiesNotUsed) === null || _b === void 0 ? void 0 : _b.length)
-                                ? cacheKeysUsed.filter(p => { var _a; return !((_a = normalizedPackResult.propertiesNotUsed) === null || _a === void 0 ? void 0 : _a.includes(p)); })
+                            propertiesUsed: ((_b = normalizedPackResult.unusedProperties) === null || _b === void 0 ? void 0 : _b.length)
+                                ? cacheKeysUsed.filter(p => { var _a; return !((_a = normalizedPackResult.unusedProperties) === null || _a === void 0 ? void 0 : _a.includes(p)); })
                                 : cacheKeysUsed,
                             ...contextUsed,
                         };

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -187,9 +187,12 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
               params as any,
               propertyOptionsExecutionContext,
             )) as PropertyOptionsResults;
+            const normalizedPackResult = normalizePropertyOptionsResults(packResult);
             const result: PropertyOptionsAnnotatedResult = {
-              packResult: normalizePropertyOptionsResults(packResult),
-              propertiesUsed: cacheKeysUsed,
+              packResult: normalizedPackResult,
+              propertiesUsed: normalizedPackResult.propertiesNotUsed
+                ? cacheKeysUsed.filter(p => !normalizedPackResult.propertiesNotUsed?.includes(p))
+                : cacheKeysUsed,
               ...contextUsed,
             };
             return result;

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -190,8 +190,8 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
             const normalizedPackResult = normalizePropertyOptionsResults(packResult);
             const result: PropertyOptionsAnnotatedResult = {
               packResult: normalizedPackResult,
-              propertiesUsed: normalizedPackResult.propertiesNotUsed?.length
-                ? cacheKeysUsed.filter(p => !normalizedPackResult.propertiesNotUsed?.includes(p))
+              propertiesUsed: normalizedPackResult.unusedProperties?.length
+                ? cacheKeysUsed.filter(p => !normalizedPackResult.unusedProperties?.includes(p))
                 : cacheKeysUsed,
               ...contextUsed,
             };

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -190,7 +190,7 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
             const normalizedPackResult = normalizePropertyOptionsResults(packResult);
             const result: PropertyOptionsAnnotatedResult = {
               packResult: normalizedPackResult,
-              propertiesUsed: normalizedPackResult.propertiesNotUsed
+              propertiesUsed: normalizedPackResult.propertiesNotUsed?.length
                 ? cacheKeysUsed.filter(p => !normalizedPackResult.propertiesNotUsed?.includes(p))
                 : cacheKeysUsed,
               ...contextUsed,


### PR DESCRIPTION
Normally we do implicit caching where the properties read during the propertyOptions formula are incorporated into the cache key. Some APIs can force packs to make an overly-specific request while getting more general information.

As a hypothetical example, imagine that some API requires you to pass in an email ID when fetching the all labels that your account can use, but the list of labels is actually the same for all emails. You might read `email_id` from the set of properties but then return it in the new `propertiesNotUsed` setting from this PR to prevent it from becoming part of the cache key
   
This feature is undocumented and not an officially-supported API, even at typescript level where it's not exposed to things like vscode autocomplete: for now it's only needed by advanced makers trying to improve caching performance with unusual APIs. If/when there's enough demand we could make it an official feature.