### PR TITLE
Document two-way behavior with `fromKey`

### DIFF
--- a/docs/guides/blocks/sync-tables/two-way.md
+++ b/docs/guides/blocks/sync-tables/two-way.md
@@ -183,7 +183,7 @@ When possible, utilize the `fromKey` field of property schemas to allow Coda to 
           let task = update.newValue;
           // The new value looks like: {"id": "123", "content": "Bar"}
           // Coda automatically mapped "name" property back to "content".
-          task = await updateTask(context, newValue);
+          task = await updateTask(context, task);
           // The final value will look like: {"id": "123", "content": "Bar"}
           // Once again, Coda will automatically map "content" to "name".
           return {
@@ -227,7 +227,7 @@ In cases where `fromKey` is not sufficient and you must manually transform API r
           // The new value looks like: {"id": "123", "name": "Bar"}
           // Manually map the "name" property back to "content" before sending it to the API.
           let task = formatTaskForApi(row);
-          task = await updateTask(context, newValue);
+          task = await updateTask(context, task);
           // The final value will look like: {"id": "123", "content": "Bar"}
           // Once again, manually map "content" to "name" before returning it.
           row = formatTaskForSchema(task);

--- a/docs/guides/blocks/sync-tables/two-way.md
+++ b/docs/guides/blocks/sync-tables/two-way.md
@@ -456,4 +456,3 @@ If your Pack uses [OAuth authentication][oauth] it may require that the user to 
 [parameters_autocomplete]: ../../basics/parameters/autocomplete.md
 [oauth]: ../../basics/authentication/oauth2.md
 [incremental_two_way]: ../../basics/authentication/oauth2.md#incremental-two-way
-[schemas_object_mapping]: ../../advanced/schemas.md#object-mapping


### PR DESCRIPTION
Addressing feedback from @alexd-codaio:

> One minor nit (and may only be applicable to me and these weird dynamic tables) - the keyspaces of the `previousValue`, `newValue` and `updatedFields` is that of the "fromKey" (e.g. pretransformed state rather than the post-transformed state of the schema itself).

Updated the two-way sync guide to mention this behavior, and talk about tactics for transforming between API results and row schemas more generally.