### PR TITLE
Update documentation to mention compatibility with ES2022

### DIFF
--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -95,7 +95,7 @@ sequenceDiagram
   Pack-->>-Doc: Result
 ```
 
-Packs are run in a custom JavaScript execution environment created by Coda, compatible with the [ES2020 standard][mdn_ecmascript]. You can use all the modern JavaScript features, but browser- and Node-specific objects are not available (`window`, `fs`, etc).
+Packs are run in a custom JavaScript execution environment created by Coda, compatible with the [ES2022 standard][mdn_ecmascript]. You can use all the modern JavaScript features, but browser- and Node-specific objects are not available (`window`, `fs`, etc).
 
 
 


### PR DESCRIPTION
Update the overview page to mention support for ES2022 language features, now that the Packs runtime has been updated to run on Node 18.

I tried updating `compile.ts` to target ES2022 directly, but ran into some errors. This is fine though, as esbuild will just downlevel any newer features.