### PR TITLE
Require unique sync formula names

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1207,6 +1207,7 @@ function buildMetadataSchema({ sdkVersion }) {
             .superRefine((data, context) => {
             var _a, _b;
             const identityNames = [];
+            const formulaNames = [];
             for (const tableDef of data) {
                 if (tableDef.identityName && ((_a = tableDef.schema.identity) === null || _a === void 0 ? void 0 : _a.name)) {
                     if (tableDef.identityName !== tableDef.schema.identity.name) {
@@ -1220,11 +1221,18 @@ function buildMetadataSchema({ sdkVersion }) {
                 if (tableDef.schema.identity) {
                     identityNames.push((_b = tableDef.schema.identity) === null || _b === void 0 ? void 0 : _b.name);
                 }
+                formulaNames.push(tableDef.getter.name);
             }
             for (const dupe of getNonUniqueElements(identityNames)) {
                 context.addIssue({
                     code: z.ZodIssueCode.custom,
                     message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
+                });
+            }
+            for (const dupe of getNonUniqueElements(formulaNames)) {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Sync table formula names must be unique. Found duplicate name "${dupe}".`,
                 });
             }
             const tableNames = data.map(tableDef => tableDef.name);

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1323,7 +1323,7 @@ describe('Pack metadata Validation', async () => {
           identityName: 'IdTwo',
           schema: MySchema,
           formula: {
-            name: 'SyncThings',
+            name: 'SyncThings2',
             description: 'Sync some things.',
             parameters: [],
             async execute([]) {
@@ -1763,7 +1763,7 @@ describe('Pack metadata Validation', async () => {
             return '';
           }),
           formula: {
-            name: 'SyncTable',
+            name: 'SyncTable2',
             description: 'Sync table',
             examples: [],
             parameters: [],
@@ -1838,6 +1838,10 @@ describe('Pack metadata Validation', async () => {
             message: 'Sync table identity names must be unique. Found duplicate name "Identity".',
             path: 'syncTables',
           },
+          {
+            message: 'Sync table formula names must be unique. Found duplicate name "SyncTable".',
+            path: 'syncTables',
+          },
         ]);
       });
 
@@ -1874,7 +1878,7 @@ describe('Pack metadata Validation', async () => {
             return '';
           }),
           formula: {
-            name: 'SyncTable',
+            name: 'SyncTable2',
             description: 'Sync table',
             examples: [],
             parameters: [],
@@ -1925,7 +1929,7 @@ describe('Pack metadata Validation', async () => {
             },
           }),
           formula: {
-            name: 'SyncTable',
+            name: 'SyncTable2',
             description: 'A simple sync table',
             async execute([], _context) {
               return {result: []};
@@ -2139,7 +2143,7 @@ describe('Pack metadata Validation', async () => {
                 },
               }),
               formula: {
-                name: 'SyncTable',
+                name: `SyncTable${i}`,
                 description: 'A simple sync table',
                 async execute([], _context) {
                   return {result: []};

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1486,6 +1486,7 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
       .default([])
       .superRefine((data, context) => {
         const identityNames: string[] = [];
+        const formulaNames: string[] = [];
         for (const tableDef of data) {
           if (tableDef.identityName && tableDef.schema.identity?.name) {
             if (tableDef.identityName !== tableDef.schema.identity.name) {
@@ -1499,11 +1500,18 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
           if (tableDef.schema.identity) {
             identityNames.push(tableDef.schema.identity?.name);
           }
+          formulaNames.push(tableDef.getter.name);
         }
         for (const dupe of getNonUniqueElements(identityNames)) {
           context.addIssue({
             code: z.ZodIssueCode.custom,
             message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
+          });
+        }
+        for (const dupe of getNonUniqueElements(formulaNames)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Sync table formula names must be unique. Found duplicate name "${dupe}".`,
           });
         }
         const tableNames = data.map(tableDef => tableDef.name);


### PR DESCRIPTION
There's a bug with autocomplete when multiple sync tables use the same formula name. It's probably possible to fix the autocomplete bug in isolation, but it seems reasonable to just disallow duplicate sync table formula names in the first place.