### PR TITLE
Add syntax for executing metadata formulas and sync updates from the CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Added
+
+- `coda execute` now allows for executing metadata formulas and sync updates.
+
 ## [1.7.4] - 2024-01-04
 
 ### Fixed

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -34,6 +34,7 @@ export declare function executeFormulaOrSyncFromCLI({ formulaName, params, manif
     bundlePath: string;
     contextOptions?: ContextOptions;
 }): Promise<void>;
+export declare function makeFormulaSpec(manifest: BasicPackDefinition, formulaNameInput: string): FormulaSpecification;
 export declare function executeFormulaOrSyncWithVM<T extends PackFormulaResult | GenericSyncFormulaResult = any>({ formulaName, params, bundlePath, executionContext, }: {
     formulaName: string;
     params: ParamValues<ParamDefs>;

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -1,13 +1,13 @@
 /// <reference types="node" />
 import type { BasicPackDefinition } from '../types';
 import type { ExecutionContext } from '../api_types';
+import type { FormulaSpecification } from '../runtime/types';
 import type { GenericSyncFormulaResult } from '../api';
 import type { MetadataContext } from '../api';
 import type { MetadataFormula } from '../api';
 import type { PackFormulaResult } from '../api_types';
 import type { ParamDefs } from '../api_types';
 import type { ParamValues } from '../api_types';
-import type { StandardFormulaSpecification } from '../runtime/types';
 import type { SyncExecutionContext } from '../api_types';
 import type { SyncFormulaSpecification } from '../runtime/types';
 import util from 'util';
@@ -47,7 +47,7 @@ export declare class VMError {
     constructor(name: string, message: string, stack: string);
     [util.inspect.custom](): string;
 }
-export declare function executeFormulaOrSyncWithRawParams<T extends StandardFormulaSpecification | SyncFormulaSpecification>({ formulaSpecification, params: rawParams, manifest, executionContext, }: {
+export declare function executeFormulaOrSyncWithRawParams<T extends FormulaSpecification>({ formulaSpecification, params: rawParams, manifest, executionContext, }: {
     formulaSpecification: T;
     params: string[];
     manifest: BasicPackDefinition;

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -332,7 +332,8 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
             break;
         }
         case types_1.FormulaType.SyncUpdate: {
-            params = rawParams;
+            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+            params = (0, coercion_1.coerceParams)(syncFormula, rawParams);
             break;
         }
         default:
@@ -362,7 +363,8 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
             break;
         }
         case types_1.FormulaType.SyncUpdate: {
-            params = rawParams;
+            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+            params = (0, coercion_1.coerceParams)(syncFormula, rawParams);
             break;
         }
         default:

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -333,7 +333,10 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
             break;
         }
         case types_1.FormulaType.Metadata: {
-            params = parseMetadataFormulaParams(rawParams);
+            // Interstingly we don't need special handling for the formula context dict (the optional second arg
+            // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
+            // JSON string anyway which is already parsed by the compiled pack definition.
+            params = rawParams;
             break;
         }
         case types_1.FormulaType.SyncUpdate: {
@@ -364,7 +367,10 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
             break;
         }
         case types_1.FormulaType.Metadata: {
-            params = parseMetadataFormulaParams(rawParams);
+            // Interstingly we don't need special handling for the formula context dict (the optional second arg
+            // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
+            // JSON string anyway which is already parsed by the compiled pack definition.
+            params = rawParams;
             break;
         }
         case types_1.FormulaType.SyncUpdate: {
@@ -377,10 +383,6 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
     return findAndExecutePackFunction(params, formulaSpecification, manifest, executionContext, syncUpdates);
 }
 exports.executeFormulaOrSyncWithRawParams = executeFormulaOrSyncWithRawParams;
-function parseMetadataFormulaParams(rawParams) {
-    const [search = '', formulaContext = '{}'] = rawParams;
-    return [search, JSON.parse(formulaContext)];
-}
 /**
  * Executes multiple iterations of a sync formula in a loop until there is no longer
  * a `continuation` returned, aggregating each page of results and returning an array

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -333,7 +333,7 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
             break;
         }
         case types_1.FormulaType.Metadata: {
-            // Interstingly we don't need special handling for the formula context dict (the optional second arg
+            // Interestingly we don't need special handling for the formula context dict (the optional second arg
             // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
             // JSON string anyway which is already parsed by the compiled pack definition.
             params = rawParams;
@@ -367,7 +367,7 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
             break;
         }
         case types_1.FormulaType.Metadata: {
-            // Interstingly we don't need special handling for the formula context dict (the optional second arg
+            // Interestingly we don't need special handling for the formula context dict (the optional second arg
             // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
             // JSON string anyway which is already parsed by the compiled pack definition.
             params = rawParams;

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -2,6 +2,7 @@ import {testHelper} from './test_helper';
 import {AuthenticationType} from '../types';
 import type {Formula} from '../api';
 import {FormulaType} from '../runtime/types';
+import type {GenericSyncUpdate} from '../api';
 import {MetadataFormulaType} from '../runtime/types';
 import type {PackDefinitionBuilder} from '../builder';
 import {ParameterType} from '../api_types';
@@ -468,36 +469,54 @@ describe('Execution', () => {
             assert.deepEqual(result, [{Name: 'Alice'}, {Name: 'Bob'}, {Name: 'Chris'}, {Name: 'Diana'}]);
           }
         });
-      });
 
-      it('autocomplete', async () => {
-        await executeFormulaOrSyncFromCLI({
-          vm,
-          formulaName: 'Lookup:autocomplete:query',
-          params: ['fo'],
-          manifest: fakePack,
-          manifestPath: '',
-          bundleSourceMapPath,
-          bundlePath,
-          contextOptions: {useRealFetcher: false},
+        it('sync update works', async () => {
+          const syncUpdates: GenericSyncUpdate[] = [
+            {previousValue: {name: 'Alice'}, newValue: {name: 'Alice Smith'}, updatedFields: ['name']},
+          ];
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'Students:update',
+            params: ['Smith', JSON.stringify(syncUpdates)],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const result = mockPrint.args[0][0];
+          assert.deepEqual(result, {result: [{outcome: 'success', finalValue: {name: 'Alice Smith'}}]});
         });
-        const result = mockPrint.args[0][0];
-        assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
-      });
 
-      it('autocomplete with formula context', async () => {
-        await executeFormulaOrSyncFromCLI({
-          vm,
-          formulaName: 'Lookup:autocomplete:query',
-          params: ['fo', JSON.stringify({blah: 'bar'})],
-          manifest: fakePack,
-          manifestPath: '',
-          bundleSourceMapPath,
-          bundlePath,
-          contextOptions: {useRealFetcher: false},
+        it('autocomplete', async () => {
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'Lookup:autocomplete:query',
+            params: ['fo'],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const result = mockPrint.args[0][0];
+          assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
         });
-        const result = mockPrint.args[0][0];
-        assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
+
+        it('autocomplete with formula context', async () => {
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'Lookup:autocomplete:query',
+            params: ['fo', JSON.stringify({blah: 'bar'})],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const result = mockPrint.args[0][0];
+          assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
+        });
       });
     }
   });

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -151,6 +151,9 @@ export const manifest: PackDefinition = createFakePack({
               return {} as any;
           }
         },
+        executeUpdate: async (_params, updates, _context) => {
+          return {result: updates.map(u => u.newValue)};
+        },
         parameters: [makeStringParameter('teacher', 'teacher name')],
         examples: [],
       },

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -1,4 +1,5 @@
 import type {PackDefinition} from '../../types';
+import {ParameterType} from '../../api_types';
 import {ValueType} from '../../schema';
 import {createFakePack} from '../test_utils';
 import {makeFormula} from '../../api';
@@ -6,6 +7,7 @@ import {makeNumericFormula} from '../../api';
 import {makeNumericParameter} from '../../api';
 import {makeObjectFormula} from '../../api';
 import {makeObjectSchema} from '../../schema';
+import {makeParameter} from '../../api';
 import {makeStringFormula} from '../../api';
 import {makeStringParameter} from '../../api';
 import {makeSyncTable} from '../../api';
@@ -51,7 +53,14 @@ export const manifest: PackDefinition = createFakePack({
       name: 'Lookup',
       description: 'Lookup a value from a remote service',
       examples: [],
-      parameters: [makeStringParameter('query', 'A query to look up.')],
+      parameters: [
+        makeParameter({
+          type: ParameterType.String,
+          name: 'query',
+          description: 'A query to look up.',
+          autocomplete: ['foo', 'bar'],
+        }),
+      ],
       execute: async ([query], context) => {
         const url = withQueryParams('https://example.com/lookup', {query});
         const response = await context.fetcher.fetch({method: 'GET', url});

--- a/test/packs/fake_v2.ts
+++ b/test/packs/fake_v2.ts
@@ -66,7 +66,10 @@ pack.addFormula({
     coda.makeParameter({
       type: coda.ParameterType.String,
       name: 'name',
-      description: 'the name of the pereson',
+      description: 'the name of the person',
+      autocomplete: async (_context, _search, formulaContext) => {
+        return [{display: formulaContext!.foo, value: formulaContext!.bar}];
+      },
     }),
   ],
   resultType: coda.ValueType.Object,

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -449,7 +449,8 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       break;
     }
     case FormulaType.SyncUpdate: {
-      params = rawParams as ParamValues<ParamDefs>;
+      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(syncFormula, rawParams as any);
       break;
     }
     default:
@@ -491,7 +492,8 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       break;
     }
     case FormulaType.SyncUpdate: {
-      params = rawParams as ParamValues<ParamDefs>;
+      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(syncFormula, rawParams as any);
       break;
     }
     default:

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -456,7 +456,7 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       break;
     }
     case FormulaType.Metadata: {
-      // Interstingly we don't need special handling for the formula context dict (the optional second arg
+      // Interestingly we don't need special handling for the formula context dict (the optional second arg
       // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
       // JSON string anyway which is already parsed by the compiled pack definition.
       params = rawParams as ParamValues<ParamDefs>;
@@ -507,7 +507,7 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       break;
     }
     case FormulaType.Metadata: {
-      // Interstingly we don't need special handling for the formula context dict (the optional second arg
+      // Interestingly we don't need special handling for the formula context dict (the optional second arg
       // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
       // JSON string anyway which is already parsed by the compiled pack definition.
       params = rawParams as ParamValues<ParamDefs>;

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -278,10 +278,11 @@ function invert<K extends string | number | symbol, V extends string | number | 
   return Object.fromEntries(Object.entries(obj).map(([key, value]) => [value, key]));
 }
 
-function makeFormulaSpec(manifest: BasicPackDefinition, formulaNameInput: string): FormulaSpecification {
+// Exported for tests.
+export function makeFormulaSpec(manifest: BasicPackDefinition, formulaNameInput: string): FormulaSpecification {
   const [formulaOrSyncName, ...parts] = formulaNameInput.split(':');
 
-  if (formulaOrSyncName === 'Auth') {
+  if (formulaOrSyncName === 'Auth' && parts.length > 0) {
     if (parts.length === 1) {
       const metadataFormulaTypeStr = parts[0];
       if (!manifest.defaultAuthentication) {
@@ -446,7 +447,7 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       break;
     }
     case FormulaType.Metadata: {
-      params = rawParams as ParamValues<ParamDefs>;
+      params = parseMetadataFormulaParams(rawParams) as ParamValues<ParamDefs>;
       break;
     }
     case FormulaType.SyncUpdate: {
@@ -488,7 +489,7 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       break;
     }
     case FormulaType.Metadata: {
-      params = rawParams as ParamValues<ParamDefs>;
+      params = parseMetadataFormulaParams(rawParams) as ParamValues<ParamDefs>;
       break;
     }
     case FormulaType.SyncUpdate: {
@@ -499,6 +500,11 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       ensureUnreachable(formulaSpecification);
   }
   return findAndExecutePackFunction(params, formulaSpecification, manifest, executionContext);
+}
+
+function parseMetadataFormulaParams(rawParams: string[]): string[] {
+  const [search = '', formulaContext = '{}'] = rawParams;
+  return [search, JSON.parse(formulaContext)];
 }
 
 /**

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -456,7 +456,10 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       break;
     }
     case FormulaType.Metadata: {
-      params = parseMetadataFormulaParams(rawParams) as ParamValues<ParamDefs>;
+      // Interstingly we don't need special handling for the formula context dict (the optional second arg
+      // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
+      // JSON string anyway which is already parsed by the compiled pack definition.
+      params = rawParams as ParamValues<ParamDefs>;
       break;
     }
     case FormulaType.SyncUpdate: {
@@ -504,7 +507,10 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       break;
     }
     case FormulaType.Metadata: {
-      params = parseMetadataFormulaParams(rawParams) as ParamValues<ParamDefs>;
+      // Interstingly we don't need special handling for the formula context dict (the optional second arg
+      // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
+      // JSON string anyway which is already parsed by the compiled pack definition.
+      params = rawParams as ParamValues<ParamDefs>;
       break;
     }
     case FormulaType.SyncUpdate: {
@@ -515,11 +521,6 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       ensureUnreachable(formulaSpecification);
   }
   return findAndExecutePackFunction(params, formulaSpecification, manifest, executionContext, syncUpdates);
-}
-
-function parseMetadataFormulaParams(rawParams: string[]): string[] {
-  const [search = '', formulaContext = '{}'] = rawParams;
-  return [search, JSON.parse(formulaContext)];
 }
 
 /**

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -6,15 +6,21 @@ import {FormulaType} from '../runtime/types';
 import type {GenericSyncFormulaResult} from '../api';
 import type {MetadataContext} from '../api';
 import type {MetadataFormula} from '../api';
+import type {MetadataFormulaSpecification} from '../runtime/types';
+import {MetadataFormulaType} from '../runtime/types';
 import {Buffer as NonNativeBuffer} from 'buffer/';
 import type {PackFormulaResult} from '../api_types';
 import type {ParamDefs} from '../api_types';
 import type {ParamValues} from '../api_types';
+import type {PostSetupMetadataFormulaSpecification} from '../runtime/types';
 import type {StandardFormulaSpecification} from '../runtime/types';
 import type {SyncExecutionContext} from '../api_types';
 import type {SyncFormulaSpecification} from '../runtime/types';
+import type {SyncMetadataFormulaSpecification} from '../runtime/types';
 import type {TypedPackFormula} from '../api';
 import {coerceParams} from './coercion';
+import {ensureExists} from '../helpers/ensure';
+import {ensureUnreachable} from '../helpers/ensure';
 import {executeThunk} from '../runtime/bootstrap';
 import {findFormula} from '../runtime/common/helpers';
 import {findSyncFormula} from '../runtime/common/helpers';
@@ -198,15 +204,7 @@ export async function executeFormulaOrSyncFromCLI({
       : newMockSyncExecutionContext();
     executionContext.sync.dynamicUrl = dynamicUrl || undefined;
 
-    const syncFormula = tryFindSyncFormula(manifest, formulaName);
-    const formula = tryFindFormula(manifest, formulaName);
-    if (!(syncFormula || formula)) {
-      throw new Error(`Could not find a formula or sync named "${formulaName}".`);
-    }
-    const formulaSpecification: SyncFormulaSpecification | StandardFormulaSpecification = {
-      type: syncFormula ? FormulaType.Sync : FormulaType.Standard,
-      formulaName,
-    };
+    const formulaSpecification = makeFormulaSpec(manifest, formulaName);
 
     if (formulaSpecification.type === FormulaType.Sync) {
       let result = [];
@@ -253,6 +251,132 @@ export async function executeFormulaOrSyncFromCLI({
   }
 }
 
+type SyncMetadataFormulaType = SyncMetadataFormulaSpecification['metadataFormulaType'];
+type GlobalMetadataFormulaType = MetadataFormulaSpecification['metadataFormulaType'];
+type PostSetupMetadataFormulaType = PostSetupMetadataFormulaSpecification['metadataFormulaType'];
+
+const SyncMetadataFormulaTokens: Record<SyncMetadataFormulaType, string> = Object.freeze({
+  [MetadataFormulaType.SyncListDynamicUrls]: 'listDynamicUrls',
+  [MetadataFormulaType.SyncSearchDynamicUrls]: 'searchDynamicUrls',
+  [MetadataFormulaType.SyncGetDisplayUrl]: 'getDisplayUrl',
+  [MetadataFormulaType.SyncGetTableName]: 'getName',
+  [MetadataFormulaType.SyncGetSchema]: 'getSchema',
+});
+
+const GlobalMetadataFormulaTokens: Record<GlobalMetadataFormulaType, string> = Object.freeze({
+  [MetadataFormulaType.GetConnectionName]: 'getConnectionName',
+  [MetadataFormulaType.GetConnectionUserId]: 'getConnectionUserId',
+});
+
+const PostSetupMetadataFormulaTokens: Record<PostSetupMetadataFormulaType, string> = Object.freeze({
+  [MetadataFormulaType.PostSetupSetEndpoint]: 'setEndpoint',
+});
+
+function invert<K extends string | number | symbol, V extends string | number | symbol>(
+  obj: Record<K, V>,
+): Record<V, K> {
+  return Object.fromEntries(Object.entries(obj).map(([key, value]) => [value, key]));
+}
+
+function makeFormulaSpec(manifest: BasicPackDefinition, formulaNameInput: string): FormulaSpecification {
+  const [formulaOrSyncName, ...parts] = formulaNameInput.split(':');
+
+  if (formulaOrSyncName === 'Auth') {
+    if (parts.length === 1) {
+      const metadataFormulaTypeStr = parts[0];
+      if (!manifest.defaultAuthentication) {
+        throw new Error(`Pack definition has no user authentication.`);
+      }
+      const authFormulaType = invert(GlobalMetadataFormulaTokens)[metadataFormulaTypeStr];
+      if (!authFormulaType) {
+        throw new Error(`Unrecognized authentication metadata formula type "${metadataFormulaTypeStr}".`);
+      }
+      return {
+        type: FormulaType.Metadata,
+        metadataFormulaType: authFormulaType,
+      };
+    } else if (parts.length >= 2) {
+      if (parts[0] !== 'postSetup') {
+        throw new Error(`Unrecognized formula type "${parts[0]}", expected "postSetup".`);
+      }
+      const setupStepTypeStr = parts[1];
+      const setupStepType = invert(PostSetupMetadataFormulaTokens)[setupStepTypeStr];
+      if (!setupStepType) {
+        throw new Error(`Unrecognized setup step type "${setupStepTypeStr}".`);
+      }
+      const stepName = parts[2];
+      if (!stepName) {
+        throw new Error(`Expected a step name after "${setupStepTypeStr}".`);
+      }
+      return {
+        type: FormulaType.Metadata,
+        metadataFormulaType: setupStepType,
+        stepName,
+      };
+    }
+  }
+
+  const syncFormula = tryFindSyncFormula(manifest, formulaOrSyncName);
+  const standardFormula = tryFindFormula(manifest, formulaOrSyncName);
+  if (!(syncFormula || standardFormula)) {
+    throw new Error(`Could not find a formula or sync named "${formulaOrSyncName}".`);
+  }
+
+  const formula = ensureExists(syncFormula || standardFormula);
+
+  if (parts.length === 0) {
+    return {
+      type: syncFormula ? FormulaType.Sync : FormulaType.Standard,
+      formulaName: formulaOrSyncName,
+    };
+  }
+
+  if (parts.length === 1) {
+    const metadataFormulaTypeStr = parts[0];
+    if (metadataFormulaTypeStr === 'update') {
+      if (!syncFormula) {
+        throw new Error(`Update metadata formula "${metadataFormulaTypeStr}" is only supported for sync formulas.`);
+      }
+      return {
+        type: FormulaType.SyncUpdate,
+        formulaName: formulaOrSyncName,
+      };
+    }
+    const metadataFormulaType = invert(SyncMetadataFormulaTokens)[metadataFormulaTypeStr];
+    if (!metadataFormulaType) {
+      throw new Error(`Unrecognized metadata formula type "${metadataFormulaTypeStr}".`);
+    }
+    if (!syncFormula) {
+      throw new Error(`Metadata formula "${metadataFormulaTypeStr}" is only supported for sync formulas.`);
+    }
+    return {
+      type: FormulaType.Metadata,
+      metadataFormulaType,
+      syncTableName: formulaOrSyncName,
+    };
+  }
+
+  if (parts.length === 2) {
+    if (parts[0] !== 'autocomplete') {
+      throw new Error(`Unrecognized formula type "${parts[0]}", expected "autocomplete".`);
+    }
+    const parameterName = parts[1];
+    const paramDef = formula.parameters.find(p => p.name === parameterName);
+    if (!paramDef) {
+      throw new Error(`Formula "${formulaOrSyncName}" has no parameter named "${parameterName}".`);
+    }
+    return {
+      type: FormulaType.Metadata,
+      metadataFormulaType: MetadataFormulaType.ParameterAutocomplete,
+      parentFormulaName: formulaOrSyncName,
+      parentFormulaType: syncFormula ? FormulaType.Sync : FormulaType.Standard,
+      parameterName,
+    };
+  }
+
+  throw new Error(`Unrecognized execution command: "${formulaNameInput}".`);
+}
+
 // This method is used to execute a (sync) formula in testing with VM. Don't use it in lambda or calc service.
 export async function executeFormulaOrSyncWithVM<T extends PackFormulaResult | GenericSyncFormulaResult = any>({
   formulaName,
@@ -293,9 +417,7 @@ export class VMError {
   }
 }
 
-async function executeFormulaOrSyncWithRawParamsInVM<
-  T extends SyncFormulaSpecification | StandardFormulaSpecification,
->({
+async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecification>({
   formulaSpecification,
   params: rawParams,
   bundlePath,
@@ -312,20 +434,32 @@ async function executeFormulaOrSyncWithRawParamsInVM<
 
   const manifest = await importManifest(bundlePath);
   let params: ParamValues<ParamDefs>;
-  if (formulaSpecification.type === FormulaType.Standard) {
-    const formula = findFormula(manifest, formulaSpecification.formulaName);
-    params = coerceParams(formula, rawParams as any);
-  } else {
-    const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
-    params = coerceParams(syncFormula, rawParams as any);
+  switch (formulaSpecification.type) {
+    case FormulaType.Standard: {
+      const formula = findFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(formula, rawParams as any);
+      break;
+    }
+    case FormulaType.Sync: {
+      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(syncFormula, rawParams as any);
+      break;
+    }
+    case FormulaType.Metadata: {
+      params = rawParams as ParamValues<ParamDefs>;
+      break;
+    }
+    case FormulaType.SyncUpdate: {
+      params = rawParams as ParamValues<ParamDefs>;
+      break;
+    }
+    default:
+      ensureUnreachable(formulaSpecification);
   }
-
   return executeThunk(ivmContext, {params, formulaSpec: formulaSpecification}, bundlePath, bundleSourceMapPath);
 }
 
-export async function executeFormulaOrSyncWithRawParams<
-  T extends StandardFormulaSpecification | SyncFormulaSpecification,
->({
+export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecification>({
   formulaSpecification,
   params: rawParams,
   manifest,
@@ -342,14 +476,28 @@ export async function executeFormulaOrSyncWithRawParams<
   global.Buffer = NonNativeBuffer as unknown as BufferConstructor;
 
   let params: ParamValues<ParamDefs>;
-  if (formulaSpecification.type === FormulaType.Standard) {
-    const formula = findFormula(manifest, formulaSpecification.formulaName);
-    params = coerceParams(formula, rawParams as any);
-  } else {
-    const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
-    params = coerceParams(syncFormula, rawParams as any);
+  switch (formulaSpecification.type) {
+    case FormulaType.Standard: {
+      const formula = findFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(formula, rawParams as any);
+      break;
+    }
+    case FormulaType.Sync: {
+      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      params = coerceParams(syncFormula, rawParams as any);
+      break;
+    }
+    case FormulaType.Metadata: {
+      params = rawParams as ParamValues<ParamDefs>;
+      break;
+    }
+    case FormulaType.SyncUpdate: {
+      params = rawParams as ParamValues<ParamDefs>;
+      break;
+    }
+    default:
+      ensureUnreachable(formulaSpecification);
   }
-
   return findAndExecutePackFunction(params, formulaSpecification, manifest, executionContext);
 }
 


### PR DESCRIPTION
Now supporting:

```bash
coda execute MyFormula:autocomplete:paramName [query] [formula context json]
coda execute MySync:autocomplete:paramName [query] [formula context json]
coda execute MySync:update [sync params] [sync update array json]
coda execute MyDynamicSync:getName
coda execute MyDynamicSync:getDisplayUrl
coda execute MyDynamicSync:getSchema
coda execute MyDynamicSync:listDynamicUrls [parentUrl]
coda execute MyDynamicSync:searchDynamicUrls [query]
coda execute Auth:getConnectionName
coda execute Auth:getConnectionUserId
coda execute Auth:postSetup:setEndpoint:stepName
```

Haven't considered PropertyOptions yet but think it could fit into this fairly naturally especially given it only works on top-level schema fields.

PTAL @ekoleda-codaio @coda/packs 