### PR TITLE
Disable collapsing of `execute` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the CLI `execute` command to output the full JSON of a returned object, without any collapsing of deep objects or long arrays.
+
 ## [1.7.4] - 2024-01-04
 
 ### Fixed

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -68,7 +68,7 @@ function resolveFormulaNameWithNamespace(formulaNameWithNamespace) {
     }
     return name;
 }
-async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, syncUpdates, { validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true,
+async function findAndExecutePackFunction(params, formulaSpec, manifest, executionContext, syncUpdates, { validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true, 
 // TODO(alexd): Switch this to false or remove when we launch 1.0.0
 useDeprecatedResultNormalization = true, } = {}) {
     var _a, _b;
@@ -235,8 +235,8 @@ function makeFormulaSpec(manifest, formulaNameInput) {
             };
         }
     }
-    const syncFormula = (0, helpers_7.tryFindSyncFormula)(manifest, formulaOrSyncName);
-    const standardFormula = (0, helpers_6.tryFindFormula)(manifest, formulaOrSyncName);
+    const syncFormula = (0, helpers_8.tryFindSyncFormula)(manifest, formulaOrSyncName);
+    const standardFormula = (0, helpers_7.tryFindFormula)(manifest, formulaOrSyncName);
     if (!(syncFormula || standardFormula)) {
         throw new Error(`Could not find a formula or sync named "${formulaOrSyncName}".`);
     }

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -42,12 +42,13 @@ const mocks_1 = require("./mocks");
 const mocks_2 = require("./mocks");
 const path = __importStar(require("path"));
 const helpers_5 = require("./helpers");
+const helpers_6 = require("./helpers");
 const auth_1 = require("./auth");
 const auth_2 = require("./auth");
 const thunk = __importStar(require("../runtime/thunk/thunk"));
 const handler_templates_1 = require("../handler_templates");
-const helpers_6 = require("../runtime/common/helpers");
 const helpers_7 = require("../runtime/common/helpers");
+const helpers_8 = require("../runtime/common/helpers");
 const util_1 = __importDefault(require("util"));
 const validation_1 = require("./validation");
 const validation_2 = require("./validation");
@@ -131,8 +132,8 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
             ? (0, fetcher_2.newFetcherSyncExecutionContext)(buildUpdateCredentialsCallback(manifestPath), (0, helpers_3.getPackAuth)(manifest), manifest.networkDomains, credentials)
             : (0, mocks_2.newMockSyncExecutionContext)();
         executionContext.sync.dynamicUrl = dynamicUrl || undefined;
-        const syncFormula = (0, helpers_7.tryFindSyncFormula)(manifest, formulaName);
-        const formula = (0, helpers_6.tryFindFormula)(manifest, formulaName);
+        const syncFormula = (0, helpers_8.tryFindSyncFormula)(manifest, formulaName);
+        const formula = (0, helpers_7.tryFindFormula)(manifest, formulaName);
         if (!(syncFormula || formula)) {
             throw new Error(`Could not find a formula or sync named "${formulaName}".`);
         }
@@ -163,7 +164,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
             if (result.length > maxRows) {
                 result = result.slice(0, maxRows);
             }
-            (0, helpers_5.print)(result);
+            (0, helpers_6.printFull)(result);
         }
         else {
             const result = vm
@@ -175,7 +176,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
                     executionContext,
                 })
                 : await executeFormulaOrSyncWithRawParams({ formulaSpecification, params, manifest, executionContext });
-            (0, helpers_5.print)(result);
+            (0, helpers_6.printFull)(result);
         }
     }
     catch (err) {
@@ -187,7 +188,7 @@ exports.executeFormulaOrSyncFromCLI = executeFormulaOrSyncFromCLI;
 // This method is used to execute a (sync) formula in testing with VM. Don't use it in lambda or calc service.
 async function executeFormulaOrSyncWithVM({ formulaName, params, bundlePath, executionContext = (0, mocks_2.newMockSyncExecutionContext)(), }) {
     const manifest = await (0, helpers_4.importManifest)(bundlePath);
-    const syncFormula = (0, helpers_7.tryFindSyncFormula)(manifest, formulaName);
+    const syncFormula = (0, helpers_8.tryFindSyncFormula)(manifest, formulaName);
     const formulaSpecification = {
         type: syncFormula ? types_1.FormulaType.Sync : types_1.FormulaType.Standard,
         formulaName,

--- a/dist/testing/helpers.d.ts
+++ b/dist/testing/helpers.d.ts
@@ -15,6 +15,7 @@ export declare const printError: {
     (...data: any[]): void;
     (message?: any, ...optionalParams: any[]): void;
 };
+export declare function printFull(value: any): void;
 export declare function printAndExit(msg: string, exitCode?: number): never;
 export declare function promptForInput(prompt: string, { mask, options, yesOrNo }?: {
     mask?: boolean;

--- a/dist/testing/helpers.js
+++ b/dist/testing/helpers.js
@@ -26,9 +26,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.processVmError = exports.getExpirationDate = exports.writeJSONFile = exports.readJSONFile = exports.readFile = exports.promptForInput = exports.printAndExit = exports.printError = exports.printWarn = exports.print = exports.getManifestFromModule = void 0;
+exports.processVmError = exports.getExpirationDate = exports.writeJSONFile = exports.readJSONFile = exports.readFile = exports.promptForInput = exports.printAndExit = exports.printFull = exports.printError = exports.printWarn = exports.print = exports.getManifestFromModule = void 0;
 const ensure_1 = require("../helpers/ensure");
 const fs_1 = __importDefault(require("fs"));
+const util_1 = require("util");
 const path_1 = __importDefault(require("path"));
 const readlineSync = __importStar(require("readline-sync"));
 const source_map_1 = require("../runtime/common/source_map");
@@ -48,6 +49,23 @@ exports.print = console.log;
 exports.printWarn = console.warn;
 // eslint-disable-next-line no-console
 exports.printError = console.error;
+function printFull(value) {
+    if (typeof value === 'object') {
+        // eslint-disable-next-line no-console
+        console.log((0, util_1.inspect)(value, {
+            depth: null,
+            maxArrayLength: null,
+            maxStringLength: null,
+            colors: true,
+        }));
+    }
+    else {
+        // Fallback to console.log for backwards compatibility.
+        // eslint-disable-next-line no-console
+        console.log(value);
+    }
+}
+exports.printFull = printFull;
 function printAndExit(msg, exitCode = 1) {
     (0, exports.print)(msg);
     return process.exit(exitCode);

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -424,10 +424,10 @@ describe('Execution', () => {
   });
 
   describe('CLI execution', () => {
-    let mockPrint: sinon.SinonStub;
+    let mockPrintFull: sinon.SinonStub;
 
     beforeEach(() => {
-      mockPrint = sinon.stub(helpers, 'print');
+      mockPrintFull = sinon.stub(helpers, 'printFull');
     });
 
     afterEach(() => {
@@ -447,7 +447,7 @@ describe('Execution', () => {
             bundlePath,
             contextOptions: {useRealFetcher: false},
           });
-          sinon.assert.calledOnceWithExactly(mockPrint, 25);
+          sinon.assert.calledOnceWithExactly(mockPrintFull, 25);
         });
 
         it('sync works', async () => {
@@ -461,7 +461,7 @@ describe('Execution', () => {
             bundlePath,
             contextOptions: {useRealFetcher: false},
           });
-          const result = mockPrint.args[0][0];
+          const result = mockPrintFull.args[0][0];
           // WTF? Why is this different in VM?
           if (vm) {
             assert.deepEqual(result, [{name: 'Alice'}, {name: 'Bob'}, {name: 'Chris'}, {name: 'Diana'}]);
@@ -484,7 +484,7 @@ describe('Execution', () => {
             bundlePath,
             contextOptions: {useRealFetcher: false},
           });
-          const result = mockPrint.args[0][0];
+          const result = mockPrintFull.args[0][0];
           assert.deepEqual(result, {result: [{outcome: 'success', finalValue: {name: 'Alice Smith'}}]});
         });
 
@@ -499,7 +499,7 @@ describe('Execution', () => {
             bundlePath,
             contextOptions: {useRealFetcher: false},
           });
-          const result = mockPrint.args[0][0];
+          const result = mockPrintFull.args[0][0];
           assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
         });
 
@@ -514,7 +514,7 @@ describe('Execution', () => {
             bundlePath,
             contextOptions: {useRealFetcher: false},
           });
-          const result = mockPrint.args[0][0];
+          const result = mockPrintFull.args[0][0];
           assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
         });
       });

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -27,6 +27,7 @@ import {newMockExecutionContext} from './mocks';
 import {newMockSyncExecutionContext} from './mocks';
 import * as path from 'path';
 import {print} from './helpers';
+import {printFull} from './helpers';
 import {readCredentialsFile} from './auth';
 import {storeCredential} from './auth';
 import * as thunk from '../runtime/thunk/thunk';
@@ -234,7 +235,7 @@ export async function executeFormulaOrSyncFromCLI({
       if (result.length > maxRows) {
         result = result.slice(0, maxRows);
       }
-      print(result);
+      printFull(result);
     } else {
       const result = vm
         ? await executeFormulaOrSyncWithRawParamsInVM({
@@ -245,7 +246,7 @@ export async function executeFormulaOrSyncFromCLI({
             executionContext,
           })
         : await executeFormulaOrSyncWithRawParams({formulaSpecification, params, manifest, executionContext});
-      print(result);
+        printFull(result);
     }
   } catch (err: any) {
     print(err);

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -1,6 +1,7 @@
 import type {PackVersionDefinition} from '../types';
 import {ensureNonEmptyString} from '../helpers/ensure';
 import fs from 'fs';
+import { inspect } from 'util';
 import path from 'path';
 import * as readlineSync from 'readline-sync';
 import {translateErrorStackFromVM} from '../runtime/common/source_map';
@@ -21,6 +22,22 @@ export const print = console.log;
 export const printWarn = console.warn;
 // eslint-disable-next-line no-console
 export const printError = console.error;
+
+export function printFull(value: any){
+  if (typeof value === 'object') {
+    // eslint-disable-next-line no-console
+    console.log(inspect(value, {
+      depth: null,
+      maxArrayLength: null,
+      maxStringLength: null,
+      colors: true,
+    }));
+  } else {
+    // Fallback to console.log for backwards compatibility.
+    // eslint-disable-next-line no-console
+    console.log(value);
+  }
+}
 
 export function printAndExit(msg: string, exitCode: number = 1): never {
   print(msg);


### PR DESCRIPTION
The CLI `execute` command used `console.log` to output the results, with for objects routed to `console.inspect` to generate the output. That function by default collapses deep objects or long arrays, which isn't ideal when you are testing your Pack and want to see the full output.

This PR adds a new `printFull` helper function with for object output manually calls `console.inspect` with the collapsing turned off. `console.log` is used for other data types to preserve backwards compatibility.

### Before

![image](https://github.com/coda/packs-sdk/assets/88106038/fd5e6943-8728-422e-adf5-76da455510e6)


### After

![image](https://github.com/coda/packs-sdk/assets/88106038/d628aab4-67ef-470f-ad9e-c03451ff4003)
