### PR TITLE
Fix default value for `search` argument when executing metadata formulas

### DIFF
--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -352,6 +352,7 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
     return (0, bootstrap_1.executeThunk)(ivmContext, { params, formulaSpec: formulaSpecification, updates: syncUpdates }, bundlePath, bundleSourceMapPath);
 }
 async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params: rawParams, manifest, executionContext, }) {
+    var _a;
     // Use non-native buffer if we're testing this without using isolated-vm, because otherwise
     // we could hit issues like Buffer.isBuffer() returning false if a non-native buffer was created
     // in pack code and we're checking it using native buffers somewhere like node_fetcher.ts
@@ -374,6 +375,8 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
             // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
             // JSON string anyway which is already parsed by the compiled pack definition.
             params = rawParams;
+            // Default the search string (first arg) to an empty string.
+            (_a = params[0]) !== null && _a !== void 0 ? _a : (params[0] = '');
             break;
         }
         case types_1.FormulaType.SyncUpdate: {

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -317,6 +317,7 @@ class VMError {
 }
 exports.VMError = VMError;
 async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, params: rawParams, bundlePath, bundleSourceMapPath, executionContext = (0, mocks_2.newMockSyncExecutionContext)(), }) {
+    var _a;
     const ivmContext = await ivmHelper.setupIvmContext(bundlePath, executionContext);
     const manifest = await (0, helpers_4.importManifest)(bundlePath);
     let params;
@@ -337,6 +338,8 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
             // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
             // JSON string anyway which is already parsed by the compiled pack definition.
             params = rawParams;
+            // Default the search string (first arg) to an empty string.
+            (_a = params[0]) !== null && _a !== void 0 ? _a : (params[0] = '');
             break;
         }
         case types_1.FormulaType.SyncUpdate: {

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -460,6 +460,8 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
       // JSON string anyway which is already parsed by the compiled pack definition.
       params = rawParams as ParamValues<ParamDefs>;
+      // Default the search string (first arg) to an empty string.
+      params[0] ??= '';
       break;
     }
     case FormulaType.SyncUpdate: {

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -513,6 +513,8 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       // to an autocomplete metadata formula), because at execution time it gets passed as a serialized
       // JSON string anyway which is already parsed by the compiled pack definition.
       params = rawParams as ParamValues<ParamDefs>;
+      // Default the search string (first arg) to an empty string.
+      params[0] ??= '';
       break;
     }
     case FormulaType.SyncUpdate: {


### PR DESCRIPTION
The `search` argument of metadata functions should always be defined, but the new support in the `execute` function wasn't setting a default value when it wasn't specified on the command line.

### Before

![image](https://github.com/coda/packs-sdk/assets/88106038/88156a3e-af38-4960-969c-a60cae84e426)

### After

![image](https://github.com/coda/packs-sdk/assets/88106038/b26ad156-e209-4de9-8b1d-f4190c1d2ca0)
