### PR TITLE
Remove hardcoded docker version from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,7 @@ jobs:
       - run:
           name: 'Validate samples'
           command: make validate-samples
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - run:
           name: 'Ensure clean dist diff'
           command: make validate-no-changes


### PR DESCRIPTION
circleci is giving a warning about this: https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176