### PR TITLE
Create delegated permission capabilities

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1968,15 +1968,43 @@ export interface AnyonePrincipal {
  * @hidden
  */
 export type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
+declare enum PermissionType {
+	/**
+	 * Represents a permission a user, group, or anyone has to view an item.
+	 */
+	Principal = "principal",
+	/**
+	 * Represents a permission that delegates access to permissions on a separate entity.
+	 */
+	Delegated = "delegated"
+}
+/**
+ * This represents a permission that is granted to a principal.
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface PrincipalPermission {
+	type: PermissionType.Principal;
+	principal: Principal;
+}
+/**
+ * This represents a permission that delegates access to another entity
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DelegatedPermission {
+	type: PermissionType.Delegated;
+	delegateRowId: string | number;
+}
 /**
  * This represents the definition of a permission in the external system.
  *
  * TODO(sam): Unhide this
  * @hidden
  */
-export interface Permission {
-	principal: Principal;
-}
+export type Permission = PrincipalPermission | DelegatedPermission;
 /**
  * This represents the list of permissions on a sync table row.
  *

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -1137,14 +1137,48 @@ export interface AnyonePrincipal {
  */
 type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
 /**
+ * The type of permission that is being granted
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export declare enum PermissionType {
+    /**
+     * Represents a permission a user, group, or anyone has to view an item.
+     */
+    Principal = "principal",
+    /**
+     * Represents a permission that delegates access to permissions on a separate entity.
+     */
+    Delegated = "delegated"
+}
+/**
+ * This represents a permission that is granted to a principal.
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface PrincipalPermission {
+    type: PermissionType.Principal;
+    principal: Principal;
+}
+/**
+ * This represents a permission that delegates access to another entity
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DelegatedPermission {
+    type: PermissionType.Delegated;
+    delegateRowId: string | number;
+}
+/**
  * This represents the definition of a permission in the external system.
  *
  * TODO(sam): Unhide this
  * @hidden
  */
-export interface Permission {
-    principal: Principal;
-}
+export type Permission = PrincipalPermission | DelegatedPermission;
 /**
  * This represents the list of permissions on a sync table row.
  *

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.throwOnDynamicSchemaWithJsOptionsFunction = exports.withIdentity = exports.makeReferenceSchemaFromObjectSchema = exports.normalizeObjectSchema = exports.normalizeSchema = exports.normalizePropertyValuePathIntoSchemaPath = exports.normalizeSchemaKeyPath = exports.normalizeSchemaKey = exports.makeObjectSchema = exports.makeSchema = exports.generateSchema = exports.maybeUnwrapArraySchema = exports.maybeSchemaOptionsValue = exports.unwrappedSchemaSupportsOptions = exports.isArray = exports.isObject = exports.makeAttributionNode = exports.AttributionNodeType = exports.PrincipalType = exports.PropertyLabelValueTemplate = exports.SimpleStringHintValueTypes = exports.DurationUnit = exports.ImageShapeStyle = exports.ImageCornerStyle = exports.ImageOutline = exports.LinkDisplayType = exports.EmailDisplayType = exports.ScaleIconSet = exports.CurrencyFormat = exports.AutocompleteHintValueTypes = exports.ObjectHintValueTypes = exports.BooleanHintValueTypes = exports.NumberHintValueTypes = exports.StringHintValueTypes = exports.ValueHintType = exports.ValueType = void 0;
+exports.throwOnDynamicSchemaWithJsOptionsFunction = exports.withIdentity = exports.makeReferenceSchemaFromObjectSchema = exports.normalizeObjectSchema = exports.normalizeSchema = exports.normalizePropertyValuePathIntoSchemaPath = exports.normalizeSchemaKeyPath = exports.normalizeSchemaKey = exports.makeObjectSchema = exports.makeSchema = exports.generateSchema = exports.maybeUnwrapArraySchema = exports.maybeSchemaOptionsValue = exports.unwrappedSchemaSupportsOptions = exports.isArray = exports.isObject = exports.makeAttributionNode = exports.AttributionNodeType = exports.PermissionType = exports.PrincipalType = exports.PropertyLabelValueTemplate = exports.SimpleStringHintValueTypes = exports.DurationUnit = exports.ImageShapeStyle = exports.ImageCornerStyle = exports.ImageOutline = exports.LinkDisplayType = exports.EmailDisplayType = exports.ScaleIconSet = exports.CurrencyFormat = exports.AutocompleteHintValueTypes = exports.ObjectHintValueTypes = exports.BooleanHintValueTypes = exports.NumberHintValueTypes = exports.StringHintValueTypes = exports.ValueHintType = exports.ValueType = void 0;
 const ensure_1 = require("./helpers/ensure");
 const object_utils_1 = require("./helpers/object_utils");
 const ensure_2 = require("./helpers/ensure");
@@ -388,6 +388,23 @@ var PrincipalType;
     PrincipalType["Group"] = "group";
     PrincipalType["Anyone"] = "anyone";
 })(PrincipalType || (exports.PrincipalType = PrincipalType = {}));
+/**
+ * The type of permission that is being granted
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+var PermissionType;
+(function (PermissionType) {
+    /**
+     * Represents a permission a user, group, or anyone has to view an item.
+     */
+    PermissionType["Principal"] = "principal";
+    /**
+     * Represents a permission that delegates access to permissions on a separate entity.
+     */
+    PermissionType["Delegated"] = "delegated";
+})(PermissionType || (exports.PermissionType = PermissionType = {}));
 /**
  * The type of content in this attribution node.
  *

--- a/schema.ts
+++ b/schema.ts
@@ -1303,15 +1303,51 @@ export interface AnyonePrincipal {
 type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
 
 /**
+ * The type of permission that is being granted
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export enum PermissionType {
+  /**
+   * Represents a permission a user, group, or anyone has to view an item.
+   */
+  Principal = 'principal',
+  /**
+   * Represents a permission that delegates access to permissions on a separate entity.
+   */
+  Delegated = 'delegated',
+}
+
+/**
+ * This represents a permission that is granted to a principal.
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface PrincipalPermission {
+  type: PermissionType.Principal;
+  principal: Principal;
+}
+
+/**
+ * This represents a permission that delegates access to another entity
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DelegatedPermission {
+  type: PermissionType.Delegated;
+  delegateRowId: string | number;
+}
+
+/**
  * This represents the definition of a permission in the external system.
  *
  * TODO(sam): Unhide this
  * @hidden
  */
-export interface Permission {
-  principal: Principal;
-}
-
+export type Permission = PrincipalPermission | DelegatedPermission;
 /**
  * This represents the list of permissions on a sync table row.
  *

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -7,6 +7,7 @@ import type {GenericSyncUpdate} from '../api';
 import {MetadataFormulaType} from '../runtime/types';
 import type {PackDefinitionBuilder} from '../builder';
 import {ParameterType} from '../api_types';
+import {PermissionType} from '../schema';
 import {PostSetupType} from '../types';
 import type {ResponseHandlerTemplate} from '../handler_templates';
 import type {Schema} from '../schema';
@@ -508,11 +509,16 @@ describe('Execution', () => {
             rowAccessDefinitions: [
               {
                 rowId: 'Alice',
-                permissions: [{principal: {type: 'user', userId: 1}}],
+                permissions: [
+                  {
+                    type: PermissionType.Principal,
+                    principal: {type: 'user', userId: 1},
+                  },
+                ],
               },
               {
                 rowId: 'Bob',
-                permissions: [{principal: {type: 'user', userId: 1}}],
+                permissions: [{type: PermissionType.Principal, principal: {type: 'user', userId: 1}}],
               },
             ],
           });

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -1,6 +1,7 @@
 import type {PackDefinition} from '../../types';
 import {ParameterType} from '../../api_types';
 import type {Permission} from '../../schema';
+import {PermissionType} from '../../schema';
 import {PrincipalType} from '../../schema';
 import type {RowAccessDefinition} from '../../schema';
 import type {UserPrincipal} from '../../schema';
@@ -172,6 +173,7 @@ export const manifest: PackDefinition = createFakePack({
 
               const permissions: Permission[] = [
                 {
+                  type: PermissionType.Principal,
                   principal,
                 },
               ];


### PR DESCRIPTION
* Creates a new concept of a "Delegated Permission" in which the permission is actually a pointer to the permissions on a separate object.
* Adds permission type and creates a discriminated union to describe the permission type.
* This leaves the door open for more complex permission types in the future