### PR TITLE
Support endpoint for OAuth2 in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where running `coda auth` with the CLI failed to honor the auth options `endpointKey` and `postSetup` for `OAuth2` authentication. For `postSetup` `SetEndpoint` steps it will prompt for the endpoint URL directly rather than list them out.
+
 ## [1.7.5] - 2024-02-08
 
 ### Added

--- a/dist/testing/oauth_server.d.ts
+++ b/dist/testing/oauth_server.d.ts
@@ -4,6 +4,9 @@ interface AfterTokenOAuthAuthorizationCodeExchangeParams {
     accessToken: string;
     refreshToken?: string;
     expires?: string;
+    data?: {
+        [key: string]: string;
+    };
 }
 export type AfterAuthorizationCodeTokenExchangeCallback = (params: AfterTokenOAuthAuthorizationCodeExchangeParams) => void;
 export declare function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }: {

--- a/dist/testing/oauth_server.js
+++ b/dist/testing/oauth_server.js
@@ -12,7 +12,7 @@ const helpers_1 = require("./helpers");
 const oauth_helpers_2 = require("./oauth_helpers");
 const url_1 = require("../helpers/url");
 function launchOAuthServerFlow({ clientId, clientSecret, authDef, port, afterTokenExchange, scopes, }) {
-    // TODO: Handle endpointKey.
+    // TODO: Handle PKCE.
     const { authorizationUrl, tokenUrl, additionalParams, scopeDelimiter, nestedResponseKey, scopeParamName } = authDef;
     // Use the manifest's scopes as a default.
     const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
@@ -68,7 +68,7 @@ class OAuthServerContainer {
                 const tokenData = await this._tokenCallback(code);
                 const { accessToken, refreshToken, data } = tokenData;
                 const expires = (0, oauth_helpers_1.getTokenExpiry)(data);
-                this._afterTokenExchange({ accessToken, refreshToken, expires });
+                this._afterTokenExchange({ accessToken, refreshToken, expires, data });
                 return res.send('OAuth authentication is complete! You can close this browser tab.');
             }
             return res.send(`Invalid authorization code received: ${code}`);

--- a/testing/auth.ts
+++ b/testing/auth.ts
@@ -286,7 +286,7 @@ class CredentialHandler {
         const {accessToken, refreshToken, expires, data} = token;
         let endpointUrl;
         if (endpointKey) {
-          endpointUrl = data[endpointKey];
+          endpointUrl = data?.[endpointKey];
         } else {
           endpointUrl = this.maybePromptForEndpointUrl();
         }

--- a/testing/oauth_server.ts
+++ b/testing/oauth_server.ts
@@ -13,7 +13,7 @@ interface AfterTokenOAuthAuthorizationCodeExchangeParams {
   accessToken: string;
   refreshToken?: string;
   expires?: string;
-  data: {[key: string]: string};
+  data?: {[key: string]: string};
 }
 
 interface AuthorizationCodeTokenCallbackResponse {

--- a/testing/oauth_server.ts
+++ b/testing/oauth_server.ts
@@ -13,6 +13,7 @@ interface AfterTokenOAuthAuthorizationCodeExchangeParams {
   accessToken: string;
   refreshToken?: string;
   expires?: string;
+  data: {[key: string]: string};
 }
 
 interface AuthorizationCodeTokenCallbackResponse {
@@ -39,7 +40,7 @@ export function launchOAuthServerFlow({
   afterTokenExchange: AfterAuthorizationCodeTokenExchangeCallback;
   scopes?: string[];
 }) {
-  // TODO: Handle endpointKey.
+  // TODO: Handle PKCE.
   const {authorizationUrl, tokenUrl, additionalParams, scopeDelimiter, nestedResponseKey, scopeParamName} = authDef;
   // Use the manifest's scopes as a default.
   const requestedScopes = scopes && scopes.length > 0 ? scopes : authDef.scopes;
@@ -114,7 +115,7 @@ class OAuthServerContainer {
         const tokenData = await this._tokenCallback(code);
         const {accessToken, refreshToken, data} = tokenData;
         const expires = getTokenExpiry(data);
-        this._afterTokenExchange({accessToken, refreshToken, expires});
+        this._afterTokenExchange({accessToken, refreshToken, expires, data});
         return res.send('OAuth authentication is complete! You can close this browser tab.');
       }
 


### PR DESCRIPTION
Pack maker Troy recently raised the issue that endpoint URL features supported by OAuth2 authorization (`postSetup` and `endpointKey`) weren't be handled when auth'ing via the CLI. This PR does the following:

- Fully handles `endpointKey`
- Detects `postSetup` and prompts the developer to manually enter the endpoint URL.

Aside: I noticed while testing this feature that the CLI doesn't support PKCE, so swapped in a TODO for that.