### PR TITLE
Add user agent and improve IP info

### DIFF
--- a/docs/guides/basics/fetcher.md
+++ b/docs/guides/basics/fetcher.md
@@ -448,13 +448,21 @@ Making a request to an external API can be expensive, either due to quotas, comp
 You can set a total rate limit across all users of your Pack, or if your Pack uses [authentication][authentication] you can also set a per-user rate limit. When the limit is reached your formula will pause for a bit to see if more quota becomes available, and if not eventually fail with an error.
 
 
-## IP addresses
+## Identifying requests
 
-HTTP requests originating from Packs can come from a few different IP addresses. While we strive to keep the set of addresses consistent, they may be subject to change over time. You can query the current set of IP addresses by doing a DNS lookup on the domain `egress.coda.io`.
+HTTP requests originating from Packs can come from a few different IP addresses. You can query the current set of IP addresses by doing a DNS lookup on the domain `egress.coda.io`.
 
 ```sh
 dig +short egress.coda.io
 ```
+
+While we strive to keep the set of addresses consistent, they may be subject to change over time. As of {{today()}} they are:
+
+```
+{{ "\n".join(resolveIps("egress.coda.io")) }}
+```
+
+You can also identify HTTP requests originating from Packs by the `User-Agent` header on the request, which will be set to `Coda-Server-Fetcher`.
 
 
 [Fetcher]: ../../reference/sdk/interfaces/core.Fetcher.md

--- a/documentation/scripts/mkdocs_macros.py
+++ b/documentation/scripts/mkdocs_macros.py
@@ -1,7 +1,18 @@
 import os
+import socket
+from datetime import date
 
 def define_env(env):
   @env.macro
   def getRelativePath(page, rootPage):
     rootDirectory = os.path.dirname(rootPage.file.src_uri)
     return os.path.relpath(page.file.src_uri, rootDirectory)
+
+  @env.macro
+  def resolveIps(host):
+    results = socket.gethostbyname_ex(host)
+    return results[2]
+
+  @env.macro
+  def today():
+    return date.today()


### PR DESCRIPTION
Adding information about the User Agent header to the documentation. While there, also improved the information about IP addresses, to display the current set of IPs on the page directly (powered by a Python macro).

![Screenshot 2024-04-22 at 11 10 05 AM](https://github.com/coda/packs-sdk/assets/88106038/ca3af349-d161-4b1a-8a56-2914e808039f)
