### PR TITLE
Add Domain Principal

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1964,6 +1964,16 @@ export interface GroupPrincipal {
 	groupId: string | number;
 }
 /**
+ * This represents a principal that is anyone in that domain
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DomainPrincipal {
+	type: PrincipalType.Group;
+	domain: string;
+}
+/**
  * This represents a principal corresponding to anyone
  *
  * Generally this would apply to an entity where anyone with access to the url can view the item
@@ -1980,7 +1990,7 @@ export interface AnyonePrincipal {
  * TODO(sam): Unhide this
  * @hidden
  */
-export type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
+export type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal | DomainPrincipal;
 /**
  * This represents the definition of a permission in the external system.
  *

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -1941,7 +1941,8 @@ export interface ObjectSchemaDefinition<K extends string, L extends string> exte
 declare enum PrincipalType {
 	User = "user",
 	Group = "group",
-	Anyone = "anyone"
+	Anyone = "anyone",
+	Domain = "domain"
 }
 /**
  * This represents a principal that is a single user.
@@ -1970,7 +1971,7 @@ export interface GroupPrincipal {
  * @hidden
  */
 export interface DomainPrincipal {
-	type: PrincipalType.Group;
+	type: PrincipalType.Domain;
 	domain: string;
 }
 /**

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -1105,7 +1105,8 @@ export interface ObjectSchemaDefinition<K extends string, L extends string> exte
 export declare enum PrincipalType {
     User = "user",
     Group = "group",
-    Anyone = "anyone"
+    Anyone = "anyone",
+    Domain = "domain"
 }
 /**
  * This represents a principal that is a single user.
@@ -1134,7 +1135,7 @@ export interface GroupPrincipal {
  * @hidden
  */
 export interface DomainPrincipal {
-    type: PrincipalType.Group;
+    type: PrincipalType.Domain;
     domain: string;
 }
 /**

--- a/dist/schema.d.ts
+++ b/dist/schema.d.ts
@@ -1128,6 +1128,16 @@ export interface GroupPrincipal {
     groupId: string | number;
 }
 /**
+ * This represents a principal that is anyone in that domain
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DomainPrincipal {
+    type: PrincipalType.Group;
+    domain: string;
+}
+/**
  * This represents a principal corresponding to anyone
  *
  * Generally this would apply to an entity where anyone with access to the url can view the item
@@ -1144,7 +1154,7 @@ export interface AnyonePrincipal {
  * TODO(sam): Unhide this
  * @hidden
  */
-type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
+type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal | DomainPrincipal;
 /**
  * This represents the definition of a permission in the external system.
  *

--- a/dist/schema.js
+++ b/dist/schema.js
@@ -387,6 +387,7 @@ var PrincipalType;
     PrincipalType["User"] = "user";
     PrincipalType["Group"] = "group";
     PrincipalType["Anyone"] = "anyone";
+    PrincipalType["Domain"] = "domain";
 })(PrincipalType || (exports.PrincipalType = PrincipalType = {}));
 /**
  * The type of content in this attribution node.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.8",
+  "version": "1.7.7-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/schema.ts
+++ b/schema.ts
@@ -1294,6 +1294,17 @@ export interface GroupPrincipal {
 }
 
 /**
+ * This represents a principal that is anyone in that domain
+ *
+ * TODO(sam): Unhide this
+ * @hidden
+ */
+export interface DomainPrincipal {
+  type: PrincipalType.Group;
+  domain: string;
+}
+
+/**
  * This represents a principal corresponding to anyone
  *
  * Generally this would apply to an entity where anyone with access to the url can view the item
@@ -1311,7 +1322,7 @@ export interface AnyonePrincipal {
  * TODO(sam): Unhide this
  * @hidden
  */
-type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal;
+type Principal = UserPrincipal | GroupPrincipal | AnyonePrincipal | DomainPrincipal;
 
 /**
  * This represents the definition of a permission in the external system.

--- a/schema.ts
+++ b/schema.ts
@@ -1269,6 +1269,7 @@ export enum PrincipalType {
   User = 'user',
   Group = 'group',
   Anyone = 'anyone',
+  Domain = 'domain',
 }
 
 /**
@@ -1300,7 +1301,7 @@ export interface GroupPrincipal {
  * @hidden
  */
 export interface DomainPrincipal {
-  type: PrincipalType.Group;
+  type: PrincipalType.Domain;
   domain: string;
 }
 


### PR DESCRIPTION
* Add the domain principal type which will be required in certain packs-sync
* Proposal on adding a type to the user/groups principal types. This will allow us to do special handling for specific group and user types such as avoiding a user mapping table when the user type is email.