### PR TITLE
Adjust help text for coda build

### DIFF
--- a/cli/coda.ts
+++ b/cli/coda.ts
@@ -140,7 +140,7 @@ if (require.main === module) {
     })
     .command({
       command: 'build <manifestFile>',
-      describe: 'Generate a bundle for your Pack',
+      describe: 'Build your Pack locally (not required; for debugging purposes only)',
       builder: {
         outputDir: {
           string: true,
@@ -165,7 +165,7 @@ if (require.main === module) {
     })
     .command({
       command: 'upload <manifestFile>',
-      describe: 'Upload your Pack version to Coda',
+      describe: 'Build and upload your Pack version to Coda',
       builder: {
         notes: {
           string: true,

--- a/dist/cli/coda.js
+++ b/dist/cli/coda.js
@@ -140,7 +140,7 @@ if (require.main === module) {
     })
         .command({
         command: 'build <manifestFile>',
-        describe: 'Generate a bundle for your Pack',
+        describe: 'Build your Pack locally (not required; for debugging purposes only)',
         builder: {
             outputDir: {
                 string: true,
@@ -165,7 +165,7 @@ if (require.main === module) {
     })
         .command({
         command: 'upload <manifestFile>',
-        describe: 'Upload your Pack version to Coda',
+        describe: 'Build and upload your Pack version to Coda',
         builder: {
             notes: {
                 string: true,


### PR DESCRIPTION
The `coda build` command isn't required for normal usage, but this isn't clear today. This PR adjusts the help text to make this clearer. Snippet from the updated help text:

```
  coda.ts build <manifestFile>              Build your Pack locally (not
                                            required; for debugging purposes
                                            only)
  coda.ts upload <manifestFile>             Build and upload your Pack version
                                            to Coda
```