### PR TITLE
add supportsIncrementalSync in ParamDef to support incremental sync

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -339,6 +339,14 @@ export interface ParamDef<T extends UnionType> {
   // TODO(patrick): Unhide this
   /** @hidden */
   crawlStrategy?: CrawlStrategy;
+
+  /**
+   * Whether this parameter is compatible with incremental sync.
+   * If not, it will be hidden from the Coda Brain setup UI.
+   */
+  // TODO(ebo): Unhide this
+  /** @hidden */
+  supportsIncrementalSync?: boolean;
 }
 
 /**

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -252,6 +252,12 @@ export interface ParamDef<T extends UnionType> {
     suggestedValue?: SuggestedValueType<T>;
     /** @hidden */
     crawlStrategy?: CrawlStrategy;
+    /**
+     * Whether this parameter is compatible with incremental sync.
+     * If not, it will be hidden from the Coda Brain setup UI.
+     */
+    /** @hidden */
+    supportsIncrementalSync?: boolean;
 }
 /**
  * Marker type for an optional {@link ParamDef}, used internally.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -230,6 +230,12 @@ export interface ParamDef<T extends UnionType> {
 	suggestedValue?: SuggestedValueType<T>;
 	/** @hidden */
 	crawlStrategy?: CrawlStrategy;
+	/**
+	 * Whether this parameter is compatible with incremental sync.
+	 * If not, it will be hidden from the Coda Brain setup UI.
+	 */
+	/** @hidden */
+	supportsIncrementalSync?: boolean;
 }
 /**
  * Marker type for an optional {@link ParamDef}, used internally.

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -578,7 +578,10 @@ function buildMetadataSchema({ sdkVersion }) {
         defaultValue: z.unknown().optional(),
         suggestedValue: z.unknown().optional(),
         crawlStrategy: z.unknown().optional(),
-    });
+        supportsIncrementalSync: z.boolean().optional().default(true),
+    }).refine(param => {
+        return param.optional || param.supportsIncrementalSync;
+    }, { message: 'Required params should support incremental sync.' });
     const commonPackFormulaSchema = {
         // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables
         // whose getter names violate the validator, and those exemptions require the pack id, so this has to be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.8",
+  "version": "1.7.8-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -4471,6 +4471,37 @@ describe('Pack metadata Validation', async () => {
         },
       ]);
     });
+
+    it('rejects required param does not support incremental sync', async () => {
+      const formula = makeFormula({
+        resultType: ValueType.String,
+        name: 'Hi',
+        description: 'A',
+        examples: [],
+        parameters: [
+          makeParameter({
+            type: ParameterType.String,
+            name: 'myParam',
+            description: '',
+            optional: false,
+            supportsIncrementalSync: false,
+          }),
+        ],
+        execute: () => '',
+      });
+
+      const metadata = createFakePackVersionMetadata({
+        formulas: [formula],
+        formulaNamespace: 'MyNamespace',
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: `Required params should support incremental sync.`,
+          path: 'formulas[0].parameters[0]',
+        },
+      ]);
+    });
   });
 
   describe('deprecation warnings', () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -717,7 +717,13 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
     defaultValue: z.unknown().optional(),
     suggestedValue: z.unknown().optional(),
     crawlStrategy: z.unknown().optional(),
-  });
+    supportsIncrementalSync: z.boolean().optional().default(true),
+  }).refine(
+    param => {
+      return param.optional || param.supportsIncrementalSync;
+    },
+    {message: 'Required params should support incremental sync.'},
+  );
 
   const commonPackFormulaSchema = {
     // It would be preferable to use validateFormulaName here, but we have to exempt legacy packs with sync tables


### PR DESCRIPTION
Discussion thread: https://github.com/coda/packs/pull/4161#discussion_r1645195276

For incremental sync, some parameters are not compatible with the sync token, for example `orderBy`, `q`, etc. in Google Calendar API:

![image](https://github.com/coda/packs-sdk/assets/102989081/1dd8daf8-84f1-4ab9-9124-07bcada77cd9)


Adding supportsIncrementalSync in ParamDef so that we can exclude params that does not support incremental sync in CSB


