### PR TITLE
Fix broken links to Buffer docs

### DIFF
--- a/docs/guides/advanced/images.md
+++ b/docs/guides/advanced/images.md
@@ -104,7 +104,7 @@ return coda.SvgConstants.DataUrlPrefixWithDarkModeSupport + encoded;
 [parameters_images]: ../basics/parameters/index.md#images
 [data_types_images]: ../basics/data-types.md#images
 [reference_temporaryblobstorage]: ../../reference/sdk/interfaces/core.TemporaryBlobStorage.md
-[buffer]: https://nodejs.org/en/knowledge/advanced/buffers/how-to-use-buffers/
+[buffer]: https://nodejs.org/api/buffer.html#buffer
 [mdn_data_urls]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [mdn_svg]: https://developer.mozilla.org/en-US/docs/Web/SVG
 [pack_latex]: https://coda.io/packs/latex-1058

--- a/docs/guides/basics/fetcher.md
+++ b/docs/guides/basics/fetcher.md
@@ -478,7 +478,7 @@ You can also identify HTTP requests originating from Packs by the `User-Agent` h
 [fetchresponse]: ../../reference/sdk/interfaces/core.FetchResponse.md
 [xml2js]: https://www.npmjs.com/package/xml2js
 [status_code_error]: ../../reference/sdk/classes/core.StatusCodeError.md
-[buffer]: https://nodejs.org/en/knowledge/advanced/buffers/how-to-use-buffers/
+[buffer]: https://nodejs.org/api/buffer.html#buffer
 [withQueryParams]: ../../reference/sdk/functions/core.withQueryParams.md
 [stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [formula_cache]: ../blocks/formulas.md#caching


### PR DESCRIPTION
Andrea pointed out that the old link 404's. Updated it to a new page.