### PR TITLE
Fix schema validation to allow for arrays of strings when indexing properties

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1237,10 +1237,14 @@ function buildMetadataSchema({ sdkVersion }) {
             const indexedProperty = properties[i];
             const objectPath = ['index', 'properties', i];
             if (typeof indexedProperty === 'string') {
-                validatePropertyValue(indexedProperty, 'properties', indexedPropertySchema => indexedPropertySchema.type === schema_15.ValueType.String, `must refer to a "ValueType.String" property.`, objectPath);
+                validatePropertyValue(indexedProperty, 'properties', indexedPropertySchema => indexedPropertySchema.type === schema_15.ValueType.String ||
+                    (indexedPropertySchema.type === schema_15.ValueType.Array &&
+                        indexedPropertySchema.items.type === schema_15.ValueType.String), `must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.`, objectPath);
             }
             else {
-                validatePropertyValue(indexedProperty.property, 'properties', indexedPropertySchema => indexedPropertySchema.type === schema_15.ValueType.String, `must refer to a "ValueType.String" property.`, [...objectPath, 'property']);
+                validatePropertyValue(indexedProperty.property, 'properties', indexedPropertySchema => indexedPropertySchema.type === schema_15.ValueType.String ||
+                    (indexedPropertySchema.type === schema_15.ValueType.Array &&
+                        indexedPropertySchema.items.type === schema_15.ValueType.String), `must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.`, [...objectPath, 'property']);
             }
         }
         if (contextProperties) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.12",
+  "version": "1.7.12-prelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -3153,9 +3153,10 @@ describe('Pack metadata Validation', async () => {
             properties: {
               name: {type: ValueType.String},
               value: {type: ValueType.Number},
+              attachments: {type: ValueType.Array, items: {type: ValueType.String}},
             },
             index: {
-              properties: ['name'],
+              properties: ['name', 'attachments'],
               contextProperties: ['value'],
             },
           });
@@ -3170,10 +3171,12 @@ describe('Pack metadata Validation', async () => {
               value: {type: ValueType.Number},
             },
             index: {
-              properties: [{
-                property: 'name',
-                strategy: IndexingStrategy.Raw,
-              }],
+              properties: [
+                {
+                  property: 'name',
+                  strategy: IndexingStrategy.Raw,
+                },
+              ],
             },
           });
           await validateJson(metadata);
@@ -3184,17 +3187,24 @@ describe('Pack metadata Validation', async () => {
             type: ValueType.Object,
             properties: {
               num: {type: ValueType.Number},
+              values: {type: ValueType.Array, items: {type: ValueType.Number}},
             },
             index: {
-              properties: ['num'],
+              properties: ['num', 'values'],
               contextProperties: ['value'],
             },
           });
           const err = await validateJsonAndAssertFails(metadata);
           assert.deepEqual(err.validationErrors, [
             {
-              message: 'The "properties" field name "Num" must refer to a "ValueType.String" property.',
+              message:
+                'The "properties" field name "Num" must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.',
               path: 'formulas[0].schema.index.properties[0]',
+            },
+            {
+              message:
+                'The "properties" field name "Values" must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.',
+              path: 'formulas[0].schema.index.properties[1]',
             },
             {
               message: 'The "contextProperties" path "Value" does not exist in the "properties" object.',
@@ -3211,10 +3221,12 @@ describe('Pack metadata Validation', async () => {
               value: {type: ValueType.Number},
             },
             index: {
-              properties: [{
-                property: 'blah',
-                strategy: IndexingStrategy.Raw,
-              }],
+              properties: [
+                {
+                  property: 'blah',
+                  strategy: IndexingStrategy.Raw,
+                },
+              ],
             },
           });
           const err = await validateJsonAndAssertFails(metadata);
@@ -4825,7 +4837,7 @@ describe('Pack metadata Validation', async () => {
       assert.deepEqual(err.validationErrors, [
         {
           message: 'Array must contain at least 1 element(s)',
-          path: 'defaultAuthentication.scopes'
+          path: 'defaultAuthentication.scopes',
         },
       ]);
     });
@@ -4851,7 +4863,7 @@ describe('Pack metadata Validation', async () => {
       assert.deepEqual(err.validationErrors, [
         {
           message: 'Array must contain at least 1 element(s)',
-          path: 'defaultAuthentication.scopes'
+          path: 'defaultAuthentication.scopes',
         },
       ]);
     });

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1579,16 +1579,22 @@ function buildMetadataSchema({sdkVersion}: BuildMetadataSchemaArgs): {
             validatePropertyValue(
               indexedProperty,
               'properties',
-              indexedPropertySchema => indexedPropertySchema.type === ValueType.String,
-              `must refer to a "ValueType.String" property.`,
+              indexedPropertySchema =>
+                indexedPropertySchema.type === ValueType.String ||
+                (indexedPropertySchema.type === ValueType.Array &&
+                  indexedPropertySchema.items.type === ValueType.String),
+              `must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.`,
               objectPath,
             );
           } else {
             validatePropertyValue(
               indexedProperty.property,
               'properties',
-              indexedPropertySchema => indexedPropertySchema.type === ValueType.String,
-              `must refer to a "ValueType.String" property.`,
+              indexedPropertySchema =>
+                indexedPropertySchema.type === ValueType.String ||
+                (indexedPropertySchema.type === ValueType.Array &&
+                  indexedPropertySchema.items.type === ValueType.String),
+              `must refer to a "ValueType.String" property or a "ValueType.Array" array of "ValueType.String" properties.`,
               [...objectPath, 'property'],
             );
           }


### PR DESCRIPTION
@chris-codaio @sam-codaio @jonathan-codaio PTAL

Missed this in the initial PR.