### PR TITLE
Add contentType override for storeUrl

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -703,10 +703,13 @@ export interface TemporaryBlobStorage {
    *
    * If the `downloadFilename` parameter is specified, when opened in the browser the file will
    * be downloaded with the file name provided.
+   *
+   * If the `contentType` parameter is specified, any Content-Type header on the URL will be ignored
+   * in favor of the provided value.
    */
   storeUrl(
     url: string,
-    opts?: {expiryMs?: number; downloadFilename?: string},
+    opts?: {expiryMs?: number; downloadFilename?: string; contentType?: string},
     fetchOpts?: Pick<FetchRequest, 'disableAuthentication'>,
   ): Promise<string>;
   /**

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -576,10 +576,14 @@ export interface TemporaryBlobStorage {
      *
      * If the `downloadFilename` parameter is specified, when opened in the browser the file will
      * be downloaded with the file name provided.
+     *
+     * If the `contentType` parameter is specified, any Content-Type header on the URL will be ignored
+     * in favor of the provided value.
      */
     storeUrl(url: string, opts?: {
         expiryMs?: number;
         downloadFilename?: string;
+        contentType?: string;
     }, fetchOpts?: Pick<FetchRequest, 'disableAuthentication'>): Promise<string>;
     /**
      * Stores the given data as a file with the given content type in Coda-hosted temporary storage.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -563,10 +563,14 @@ export interface TemporaryBlobStorage {
 	 *
 	 * If the `downloadFilename` parameter is specified, when opened in the browser the file will
 	 * be downloaded with the file name provided.
+	 *
+	 * If the `contentType` parameter is specified, any Content-Type header on the URL will be ignored
+	 * in favor of the provided value.
 	 */
 	storeUrl(url: string, opts?: {
 		expiryMs?: number;
 		downloadFilename?: string;
+		contentType?: string;
 	}, fetchOpts?: Pick<FetchRequest, "disableAuthentication">): Promise<string>;
 	/**
 	 * Stores the given data as a file with the given content type in Coda-hosted temporary storage.

--- a/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
@@ -78,12 +78,16 @@ Coda reserves the right to ignore long expirations.
 If the `downloadFilename` parameter is specified, when opened in the browser the file will
 be downloaded with the file name provided.
 
+If the `contentType` parameter is specified, any Content-Type header on the URL will be ignored
+in favor of the provided value.
+
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `url` | `string` |
 | `opts?` | `Object` |
+| `opts.contentType?` | `string` |
 | `opts.downloadFilename?` | `string` |
 | `opts.expiryMs?` | `number` |
 | `fetchOpts?` | `Pick`<[`FetchRequest`](core.FetchRequest.md), ``"disableAuthentication"``\> |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.13-prerelease.1",
+  "version": "1.7.13-prerelease.2",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
@sam-codaio @neal-codaio PTAL

Already implemented on the `coda` side, just need to document.