### PR TITLE
packs-sdk: release v1.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.7.15] - 2024-09-04
+
 ### Changed
 
 - Internal change to completion
@@ -718,7 +720,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.7.13...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.7.15...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -755,3 +757,5 @@ await myHelper(context);
 [1.7.11]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.11
 [1.7.10]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.10
 [1.7.13]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.13
+
+[1.7.15]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.7.14-prerelease.2",
+  "version": "1.7.15",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Mis-published v1.7.14 due to being on main branch, so straight to 1.7.15.

PTAL @coda/packs 