### PR TITLE
Fix bug with AWSAssumeRole signing

### DIFF
--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -420,7 +420,10 @@ class AuthenticatingFetcher {
                     method,
                     url,
                     service,
-                    headers: headers || {},
+                    headers: {
+                        ...headers,
+                        host,
+                    },
                     credentials,
                 });
                 return {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -530,7 +530,10 @@ export class AuthenticatingFetcher implements Fetcher {
           method,
           url,
           service,
-          headers: headers || {},
+          headers: {
+            ...headers,
+            host,
+          },
           credentials,
         });
         return {


### PR DESCRIPTION
Similar to https://github.com/coda/packs-sdk/pull/2528, this PR adds the `Host` header to the signature payload for `AWSAssumeRole` auth to fix a bug:

```
403 - "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>AccessDenied</Code><Message>There were headers present in the request which were not signed</Message><HeadersNotSigned>host</HeadersNotSigned><RequestId>MP4AR6GAY20WJ36J</RequestId><HostId>yX2o3qvvxuDzmQ+Cka5cRkfQ1D7yv3eZMfjN4XGRTKkHrckEvysZCj9kZMcjY3a3s/vTyBFbcOo=</HostId></Error>"
```