### PR TITLE
Allow setting a cache time when storing URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to specify the `cacheTtlSecs` option when using `TemporaryBlobStorage.storeUrl`.
+
 ## [1.8.2] - 2024-11-08
 
 ### Added

--- a/api_types.ts
+++ b/api_types.ts
@@ -721,7 +721,7 @@ export interface TemporaryBlobStorage {
   storeUrl(
     url: string,
     opts?: {expiryMs?: number; downloadFilename?: string; contentType?: string},
-    fetchOpts?: Pick<FetchRequest, 'disableAuthentication' | 'headers'>,
+    fetchOpts?: Pick<FetchRequest, 'disableAuthentication' | 'headers' | 'cacheTtlSecs'>,
   ): Promise<string>;
   /**
    * Stores the given data as a file with the given content type in Coda-hosted temporary storage.

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -594,7 +594,7 @@ export interface TemporaryBlobStorage {
         expiryMs?: number;
         downloadFilename?: string;
         contentType?: string;
-    }, fetchOpts?: Pick<FetchRequest, 'disableAuthentication' | 'headers'>): Promise<string>;
+    }, fetchOpts?: Pick<FetchRequest, 'disableAuthentication' | 'headers' | 'cacheTtlSecs'>): Promise<string>;
     /**
      * Stores the given data as a file with the given content type in Coda-hosted temporary storage.
      * Returns a URL for the temporary file that you should return in your formula response.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -579,7 +579,7 @@ export interface TemporaryBlobStorage {
 		expiryMs?: number;
 		downloadFilename?: string;
 		contentType?: string;
-	}, fetchOpts?: Pick<FetchRequest, "disableAuthentication" | "headers">): Promise<string>;
+	}, fetchOpts?: Pick<FetchRequest, "disableAuthentication" | "headers" | "cacheTtlSecs">): Promise<string>;
 	/**
 	 * Stores the given data as a file with the given content type in Coda-hosted temporary storage.
 	 * Returns a URL for the temporary file that you should return in your formula response.

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -539,8 +539,8 @@ class AuthenticatingBlobStorage {
     constructor(fetcher) {
         this._fetcher = fetcher;
     }
-    async storeUrl(url, _opts) {
-        await this._fetcher.fetch({ method: 'GET', url, isBinaryResponse: true });
+    async storeUrl(url, _opts, fetchOpts) {
+        await this._fetcher.fetch({ method: 'GET', url, isBinaryResponse: true, ...fetchOpts, });
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${(0, uuid_1.v4)()}`;
     }
     async storeBlob(_blobData, _contentType, _opts) {

--- a/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
+++ b/docs/reference/sdk/interfaces/core.TemporaryBlobStorage.md
@@ -90,7 +90,7 @@ in favor of the provided value.
 | `opts.contentType?` | `string` |
 | `opts.downloadFilename?` | `string` |
 | `opts.expiryMs?` | `number` |
-| `fetchOpts?` | `Pick`<[`FetchRequest`](core.FetchRequest.md), ``"headers"`` \| ``"disableAuthentication"``\> |
+| `fetchOpts?` | `Pick`<[`FetchRequest`](core.FetchRequest.md), ``"headers"`` \| ``"cacheTtlSecs"`` \| ``"disableAuthentication"``\> |
 
 #### Returns
 

--- a/docs/reference/sdk/interfaces/testing.MockExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockExecutionContext.md
@@ -109,7 +109,7 @@ or are too large to return inline. See [TemporaryBlobStorage](core.TemporaryBlob
 | Name | Type |
 | :------ | :------ |
 | `storeBlob` | `SinonStub`<[blobData: Buffer, contentType: string, opts?: Object], `Promise`<`string`\>\> |
-| `storeUrl` | `SinonStub`<[url: string, opts?: Object, fetchOpts?: Pick<FetchRequest, "headers" \| "disableAuthentication"\>], `Promise`<`string`\>\> |
+| `storeUrl` | `SinonStub`<[url: string, opts?: Object, fetchOpts?: Pick<FetchRequest, "headers" \| "cacheTtlSecs" \| "disableAuthentication"\>], `Promise`<`string`\>\> |
 
 #### Overrides
 

--- a/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
@@ -107,7 +107,7 @@ or are too large to return inline. See [TemporaryBlobStorage](core.TemporaryBlob
 | Name | Type |
 | :------ | :------ |
 | `storeBlob` | `SinonStub`<[blobData: Buffer, contentType: string, opts?: Object], `Promise`<`string`\>\> |
-| `storeUrl` | `SinonStub`<[url: string, opts?: Object, fetchOpts?: Pick<FetchRequest, "headers" \| "disableAuthentication"\>], `Promise`<`string`\>\> |
+| `storeUrl` | `SinonStub`<[url: string, opts?: Object, fetchOpts?: Pick<FetchRequest, "headers" \| "cacheTtlSecs" \| "disableAuthentication"\>], `Promise`<`string`\>\> |
 
 #### Inherited from
 

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -689,8 +689,8 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
     this._fetcher = fetcher;
   }
 
-  async storeUrl(url: string, _opts?: {expiryMs?: number}): Promise<string> {
-    await this._fetcher.fetch({method: 'GET', url, isBinaryResponse: true});
+  async storeUrl(url: string, _opts?: {expiryMs?: number}, fetchOpts?: Partial<FetchRequest>): Promise<string> {
+    await this._fetcher.fetch({method: 'GET', url, isBinaryResponse: true, ...fetchOpts,});
     return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${v4()}`;
   }
 


### PR DESCRIPTION
I had wanted to cache some large blobs I was storing, so I didn't have to refetch them on every sync. This PR adjusts signature of `storeUrl` to support a `cacheTtlSecs` fetch option. The implementation already seems to support this (we likely pass through all of the options) but adjusting the typing to indicate it's supported.

I also fixed an issue with the testing fetcher where it wasn't using the fetch options.