### PR TITLE
packs-sdk: release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.8.2] - 2024-11-08
+
 ### Added
 
 - Added support for the authentication type `AWSAssumeRole`, a more secure method of connecting to AWS services.
@@ -779,7 +781,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.8.1...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.8.2...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -823,3 +825,5 @@ await myHelper(context);
 [1.7.17]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.17
 [1.7.16]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.16
 [1.8.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.1
+
+[1.8.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 - Added support for the authentication type `AWSAssumeRole`, a more secure method of connecting to AWS services.
 
+### Changed
+
+- Improve types for sync formula continuation
+- Support onError in sync tables
+- Update isolated-vm
+
 ## [1.8.1] - 2024-10-29
 
 ### Added
@@ -816,5 +822,4 @@ await myHelper(context);
 [1.7.18]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.18
 [1.7.17]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.17
 [1.7.16]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.7.16
-
 [1.8.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.2-prerelease.1",
+  "version": "1.8.2",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Released: https://github.com/coda/packs-sdk/releases/tag/v1.8.2