### PR TITLE
Fix indexing strategy validation for object schemas

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1024,7 +1024,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         .optional();
     const propertySchema = z.union([
         z.string().min(1),
-        zodCompleteObject({
+        zodCompleteStrictObject({
             property: z.string().min(1),
             label: z.string().optional(),
             placeholder: z.string().optional(),
@@ -1032,11 +1032,11 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     ]);
     const contextPropertiesSchema = z.array(propertySchema).min(1);
     const indexedPropertySchema = z.union([
+        propertySchema,
         zodCompleteStrictObject({
             property: propertySchema,
             strategy: z.nativeEnum(schema_9.IndexingStrategy),
         }),
-        propertySchema,
     ]);
     const indexSchema = zodCompleteStrictObject({
         properties: z.array(indexedPropertySchema).min(1),

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1032,11 +1032,11 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     ]);
     const contextPropertiesSchema = z.array(propertySchema).min(1);
     const indexedPropertySchema = z.union([
-        propertySchema,
-        zodCompleteObject({
+        zodCompleteStrictObject({
             property: propertySchema,
             strategy: z.nativeEnum(schema_9.IndexingStrategy),
         }),
+        propertySchema,
     ]);
     const indexSchema = zodCompleteStrictObject({
         properties: z.array(indexedPropertySchema).min(1),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.4-prerelease.2",
+  "version": "1.8.4-prerelease.3",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1265,7 +1265,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
 
   const propertySchema = z.union([
     z.string().min(1),
-    zodCompleteObject<PropertyIdentifier>({
+    zodCompleteStrictObject<PropertyIdentifier>({
       property: z.string().min(1),
       label: z.string().optional(),
       placeholder: z.string().optional(),
@@ -1276,7 +1276,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
 
   const indexedPropertySchema = z.union([
     propertySchema,
-    zodCompleteObject<DetailedIndexedProperty>({
+    zodCompleteStrictObject<DetailedIndexedProperty>({
       property: propertySchema,
       strategy: z.nativeEnum(IndexingStrategy),
     }),


### PR DESCRIPTION
Noticed this while running some experimentation on dev that indexing strategies in pack schemas were being dropped. The strategy property is being ignored since `{property: 'blah', strategy: 'blah'}` still satisfies the property identifier schema without using `strict()`. Add strict so that schemas with `strategy` defined fall through to the `DetailedIndexedProperty` schema validation. Would've also worked by reordering the zod union.
