### PR TITLE
[CSB]: adding full execution id for pack calls to query item version

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -996,13 +996,22 @@ export interface ExecutionContext {
 
   /**
    * If this invocation is a part of a crawling execution, like in Coda Brain, then this ID will be provided
-   * to all invocations. That includes invocations of sync `execute` and `executeGetPermissions`, as well as
-   * dynamic table features like `listDynamicUrls`, `getSchema`, and `getName`.
+   * to all invocations as incremental execution id. That includes invocations of sync `execute` 
+   * and `executeGetPermissions`, as well as dynamic table features like `listDynamicUrls`,
+   * `getSchema`, and `getName`.
    *
    * TODO(patrick): Unhide this
    * @hidden
    */
   readonly executionId?: string;
+
+  /**
+   * Provided by a crawling execution, like in Coda Brain, this ID will be the full execution id.
+   *
+   * TODO(ebo): Unhide this
+   * @hidden
+   */
+  readonly fullExecutionId?: string;
 
   /**
    * If this invocation is a retry, this will be populated with information about what went wrong

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -826,13 +826,21 @@ export interface ExecutionContext {
     readonly authenticationName?: string;
     /**
      * If this invocation is a part of a crawling execution, like in Coda Brain, then this ID will be provided
-     * to all invocations. That includes invocations of sync `execute` and `executeGetPermissions`, as well as
-     * dynamic table features like `listDynamicUrls`, `getSchema`, and `getName`.
+     * to all invocations as incremental execution id. That includes invocations of sync `execute`
+     * and `executeGetPermissions`, as well as dynamic table features like `listDynamicUrls`,
+     * `getSchema`, and `getName`.
      *
      * TODO(patrick): Unhide this
      * @hidden
      */
     readonly executionId?: string;
+    /**
+     * Provided by a crawling execution, like in Coda Brain, this ID will be the full execution id.
+     *
+     * TODO(ebo): Unhide this
+     * @hidden
+     */
+    readonly fullExecutionId?: string;
     /**
      * If this invocation is a retry, this will be populated with information about what went wrong
      * during the previous attempt.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -788,13 +788,21 @@ export interface ExecutionContext {
 	readonly authenticationName?: string;
 	/**
 	 * If this invocation is a part of a crawling execution, like in Coda Brain, then this ID will be provided
-	 * to all invocations. That includes invocations of sync `execute` and `executeGetPermissions`, as well as
-	 * dynamic table features like `listDynamicUrls`, `getSchema`, and `getName`.
+	 * to all invocations as incremental execution id. That includes invocations of sync `execute`
+	 * and `executeGetPermissions`, as well as dynamic table features like `listDynamicUrls`,
+	 * `getSchema`, and `getName`.
 	 *
 	 * TODO(patrick): Unhide this
 	 * @hidden
 	 */
 	readonly executionId?: string;
+	/**
+	 * Provided by a crawling execution, like in Coda Brain, this ID will be the full execution id.
+	 *
+	 * TODO(ebo): Unhide this
+	 * @hidden
+	 */
+	readonly fullExecutionId?: string;
 	/**
 	 * If this invocation is a retry, this will be populated with information about what went wrong
 	 * during the previous attempt.

--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -47,7 +47,7 @@ export type ExecutionContextPrimitives = Omit<ExecutionContext, 'fetcher' | 'tem
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }: {
+export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, fullExecutionId, previousAttemptError, ...rest }: {
     context: Context;
     fetcher: Fetcher;
     temporaryBlobStorage: TemporaryBlobStorage;

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -150,7 +150,7 @@ exports.injectSerializer = injectSerializer;
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }) {
+async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, fullExecutionId, previousAttemptError, ...rest }) {
     (0, ensure_1.ensureNever)();
     // Inject all of the primitives into a global we'll access when we execute the pack function.
     const executionContextPrimitives = {
@@ -163,6 +163,7 @@ async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, 
         invocationToken,
         sync,
         executionId,
+        fullExecutionId,
         authenticationName,
         previousAttemptError,
     };

--- a/dist/testing/ivm_helper.js
+++ b/dist/testing/ivm_helper.js
@@ -55,6 +55,7 @@ async function setupIvmContext(bundlePath, executionContext) {
         sync: executionContext.sync,
         authenticationName: executionContext.authenticationName,
         executionId: executionContext.executionId,
+        fullExecutionId: executionContext.fullExecutionId,
         previousAttemptError: executionContext.previousAttemptError,
     });
     return ivmContext;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.4-prerelease.3",
+  "version": "1.8.4-prerelease.4",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -236,6 +236,7 @@ export async function injectExecutionContext({
   sync,
   authenticationName,
   executionId,
+  fullExecutionId,
   previousAttemptError,
   ...rest
 }: {
@@ -256,6 +257,7 @@ export async function injectExecutionContext({
     invocationToken,
     sync,
     executionId,
+    fullExecutionId,
     authenticationName,
     previousAttemptError,
   };

--- a/testing/ivm_helper.ts
+++ b/testing/ivm_helper.ts
@@ -57,6 +57,7 @@ export async function setupIvmContext(bundlePath: string, executionContext: Exec
     sync: executionContext.sync,
     authenticationName: executionContext.authenticationName,
     executionId: executionContext.executionId,
+    fullExecutionId: executionContext.fullExecutionId,
     previousAttemptError: executionContext.previousAttemptError,
   });
 


### PR DESCRIPTION
Pack function requires full execution id info to query item version. 

PTAL @coda/snowcoda-platform 