### PR TITLE
CB-2904 Remove canSyncPermissions

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -4849,19 +4849,12 @@ export type SystemAuthenticationDef = AsAuthDef<HeaderBearerTokenAuthentication>
  * @ignore
  */
 export type VariousSupportedAuthentication = NoAuthentication | HeaderBearerTokenAuthentication | CustomHeaderTokenAuthentication | MultiHeaderTokenAuthentication | QueryParamTokenAuthentication | MultiQueryParamTokenAuthentication | WebBasicAuthentication;
-export type AdminAuthenticationDefinition = AllowedAuthentication & {
-	/**
-	 * If true, this authentication can be used to sync permissions associated with data
-	 * in addition to the data itself.
-	 */
-	canSyncPermissions?: boolean;
-};
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-	authentication: AdminAuthenticationDefinition;
+	authentication: AllowedAuthentication;
 	/**
 	 * A unique identifier for this authentication configuration. Coda will pass it into formulas via
 	 * the execution context. Users will not see this value.

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -4285,11 +4285,6 @@ export interface BaseAuthentication {
 	 * Using multiple authenticated network domains is uncommon and requires Coda approval.
 	 */
 	networkDomain?: string | string[];
-	/**
-	 * If true, this authentication can be used to sync permissions associated with data
-	 * in addition to the data itself.
-	 */
-	canSyncPermissions?: boolean;
 }
 /**
  * Authenticate using an HTTP header of the form `Authorization: Bearer <token>`.
@@ -4854,12 +4849,19 @@ export type SystemAuthenticationDef = AsAuthDef<HeaderBearerTokenAuthentication>
  * @ignore
  */
 export type VariousSupportedAuthentication = NoAuthentication | HeaderBearerTokenAuthentication | CustomHeaderTokenAuthentication | MultiHeaderTokenAuthentication | QueryParamTokenAuthentication | MultiQueryParamTokenAuthentication | WebBasicAuthentication;
+export type AdminAuthenticationDefinition = AllowedAuthentication & {
+	/**
+	 * If true, this authentication can be used to sync permissions associated with data
+	 * in addition to the data itself.
+	 */
+	canSyncPermissions?: boolean;
+};
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-	authentication: AllowedAuthentication;
+	authentication: AdminAuthenticationDefinition;
 	/**
 	 * A unique identifier for this authentication configuration. Coda will pass it into formulas via
 	 * the execution context. Users will not see this value.

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -404,7 +404,6 @@ function buildMetadataSchema({ sdkVersion }) {
         // The items are technically a discriminated union type but that union currently only has one member.
         postSetup: z.array(setEndpointPostSetupValidator).optional(),
         networkDomain: z.union([singleAuthDomainSchema, z.array(singleAuthDomainSchema).nonempty()]).optional(),
-        canSyncPermissions: z.boolean().optional(),
     };
     const defaultAuthenticationValidators = {
         [types_1.AuthenticationType.None]: zodCompleteStrictObject({
@@ -604,10 +603,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     const reservedAuthenticationNames = Object.values(types_5.ReservedAuthenticationNames).map(value => value.toString());
     const adminAuthenticationValidator = zodCompleteObject({
         authentication: z
-            .union(zodUnionInput(Object.values(adminAuthenticationValidators)))
-            .refine(auth => Boolean(auth.canSyncPermissions), {
-            message: 'All admin authentications must set "canSyncPermissions:true"',
-        }),
+            .union(zodUnionInput(Object.values(adminAuthenticationValidators))),
         name: z
             .string()
             .min(1)
@@ -1718,7 +1714,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                 }
             }
         })
-            .superRefine((data, context) => {
+            .superRefine((data, _context) => {
             const metadata = data;
             const { syncTables } = metadata;
             const authentications = getAuthentications(metadata);
@@ -1739,7 +1735,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                     allowedAuthenticationNames = authNames;
                 }
                 for (const auth of authentications) {
-                    const { name, authentication } = auth;
+                    const { name } = auth;
                     // If a sync table explicitly excludes an authentication, don't require it to
                     // be permission-capable.
                     if (allowedAuthenticationNames && !allowedAuthenticationNames.includes(name)) {
@@ -1749,15 +1745,6 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                     // requesting permissions.
                     if (reservedAuthenticationNames.includes(name)) {
                         continue;
-                    }
-                    // Admin authentications are required to be permission-capable.
-                    // TODO(patrick/alan): better typing
-                    if (!authentication.canSyncPermissions) {
-                        context.addIssue({
-                            code: z.ZodIssueCode.custom,
-                            path: [syncTable.name, 'allowedAuthenticationNames'],
-                            message: `Authentication ${name} must have 'canSyncPermissions:true' to be used in a sync table with executeGetPermissions`,
-                        });
                     }
                 }
             }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1751,7 +1751,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                         continue;
                     }
                     // Admin authentications are required to be permission-capable.
-                    // TODO(patrick): better typing
+                    // TODO(patrick/alan): better typing
                     if (!authentication.canSyncPermissions) {
                         context.addIssue({
                             code: z.ZodIssueCode.custom,

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -889,19 +889,12 @@ export declare enum ReservedAuthenticationNames {
      */
     System = "systemAuthentication"
 }
-export type AdminAuthenticationDefinition = AllowedAuthentication & {
-    /**
-     * If true, this authentication can be used to sync permissions associated with data
-     * in addition to the data itself.
-     */
-    canSyncPermissions?: boolean;
-};
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-    authentication: AdminAuthenticationDefinition;
+    authentication: AllowedAuthentication;
     /**
      * A unique identifier for this authentication configuration. Coda will pass it into formulas via
      * the execution context. Users will not see this value.

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -280,11 +280,6 @@ export interface BaseAuthentication {
      * Using multiple authenticated network domains is uncommon and requires Coda approval.
      */
     networkDomain?: string | string[];
-    /**
-     * If true, this authentication can be used to sync permissions associated with data
-     * in addition to the data itself.
-     */
-    canSyncPermissions?: boolean;
 }
 /**
  * Authenticate using an HTTP header of the form `Authorization: Bearer <token>`.
@@ -894,12 +889,19 @@ export declare enum ReservedAuthenticationNames {
      */
     System = "systemAuthentication"
 }
+export type AdminAuthenticationDefinition = AllowedAuthentication & {
+    /**
+     * If true, this authentication can be used to sync permissions associated with data
+     * in addition to the data itself.
+     */
+    canSyncPermissions?: boolean;
+};
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-    authentication: AllowedAuthentication;
+    authentication: AdminAuthenticationDefinition;
     /**
      * A unique identifier for this authentication configuration. Coda will pass it into formulas via
      * the execution context. Users will not see this value.

--- a/docs/reference/sdk/interfaces/core.AWSAccessKeyAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.AWSAccessKeyAuthentication.md
@@ -22,19 +22,6 @@ Authenticate to Amazon Web Services using an IAM access key id & secret access k
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.AWSAssumeRoleAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.AWSAssumeRoleAuthentication.md
@@ -23,19 +23,6 @@ Authenticate to Amazon Web Services by assuming an IAM role.
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.BaseAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.BaseAuthentication.md
@@ -36,15 +36,6 @@ Base interface for authentication definitions.
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.CodaApiBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CodaApiBearerTokenAuthentication.md
@@ -38,19 +38,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### deferConnectionSetup
 
 • `Optional` **deferConnectionSetup**: `boolean`

--- a/docs/reference/sdk/interfaces/core.CustomAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CustomAuthentication.md
@@ -79,19 +79,6 @@ execute: async function([], context) {
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.CustomHeaderTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.CustomHeaderTokenAuthentication.md
@@ -33,19 +33,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.HeaderBearerTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.HeaderBearerTokenAuthentication.md
@@ -31,19 +31,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.MultiHeaderTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.MultiHeaderTokenAuthentication.md
@@ -31,19 +31,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.MultiQueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.MultiQueryParamTokenAuthentication.md
@@ -38,19 +38,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
+++ b/docs/reference/sdk/interfaces/core.OAuth2Authentication.md
@@ -63,19 +63,6 @@ they may be specified using [additionalParams](core.OAuth2Authentication.md#addi
 
 ___
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-BaseOAuthAuthentication.canSyncPermissions
-
-___
-
 ### credentialsLocation
 
 • `Optional` **credentialsLocation**: [`TokenExchangeCredentialsLocation`](../enums/core.TokenExchangeCredentialsLocation.md)

--- a/docs/reference/sdk/interfaces/core.OAuth2ClientCredentialsAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.OAuth2ClientCredentialsAuthentication.md
@@ -30,19 +30,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-BaseOAuthAuthentication.canSyncPermissions
-
-___
-
 ### credentialsLocation
 
 • `Optional` **credentialsLocation**: [`TokenExchangeCredentialsLocation`](../enums/core.TokenExchangeCredentialsLocation.md)

--- a/docs/reference/sdk/interfaces/core.QueryParamTokenAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.QueryParamTokenAuthentication.md
@@ -35,19 +35,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/docs/reference/sdk/interfaces/core.WebBasicAuthentication.md
+++ b/docs/reference/sdk/interfaces/core.WebBasicAuthentication.md
@@ -37,19 +37,6 @@ pack.setUserAuthentication({
 
 ## Properties
 
-### canSyncPermissions
-
-• `Optional` **canSyncPermissions**: `boolean`
-
-If true, this authentication can be used to sync permissions associated with data
-in addition to the data itself.
-
-#### Inherited from
-
-[BaseAuthentication](core.BaseAuthentication.md).[canSyncPermissions](core.BaseAuthentication.md#cansyncpermissions)
-
-___
-
 ### endpointDomain
 
 • `Optional` **endpointDomain**: `string`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.4",
+  "version": "1.8.5-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1,9 +1,9 @@
 import type {AWSAccessKeyAuthentication} from '../types';
 import type {AWSAssumeRoleAuthentication} from '../types';
 import type {AdminAuthentication} from '../types';
+import type {AdminAuthenticationDefinition} from '../types';
 import type {AdminAuthenticationTypes} from '../types';
 import {AllPrecannedDates} from '../api_types';
-import type {AllowedAuthentication} from '../types';
 import type {ArraySchema} from '../schema';
 import {AttributionNodeType} from '../schema';
 import type {AuthenticationMetadata} from '../compiled_types';
@@ -2184,8 +2184,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
               continue;
             }
             // Admin authentications are required to be permission-capable.
-            // TODO(patrick): better typing
-            if (!(authentication as AllowedAuthentication).canSyncPermissions) {
+            // TODO(patrick/alan): better typing
+            if (!(authentication as AdminAuthenticationDefinition).canSyncPermissions) {
               context.addIssue({
                 code: z.ZodIssueCode.custom,
                 path: [syncTable.name, 'allowedAuthenticationNames'],

--- a/types.ts
+++ b/types.ts
@@ -1004,20 +1004,12 @@ export enum ReservedAuthenticationNames {
   System = 'systemAuthentication',
 }
 
-export type AdminAuthenticationDefinition = AllowedAuthentication & {
-  /**
-   * If true, this authentication can be used to sync permissions associated with data
-   * in addition to the data itself.
-   */
-  canSyncPermissions?: boolean;
-};
-
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-  authentication: AdminAuthenticationDefinition;
+  authentication: AllowedAuthentication;
 
   /**
    * A unique identifier for this authentication configuration. Coda will pass it into formulas via

--- a/types.ts
+++ b/types.ts
@@ -295,12 +295,6 @@ export interface BaseAuthentication {
    * Using multiple authenticated network domains is uncommon and requires Coda approval.
    */
   networkDomain?: string | string[];
-
-  /**
-   * If true, this authentication can be used to sync permissions associated with data
-   * in addition to the data itself.
-   */
-  canSyncPermissions?: boolean;
 }
 
 /**
@@ -1010,12 +1004,20 @@ export enum ReservedAuthenticationNames {
   System = 'systemAuthentication',
 }
 
+export type AdminAuthenticationDefinition = AllowedAuthentication & {
+  /**
+   * If true, this authentication can be used to sync permissions associated with data
+   * in addition to the data itself.
+   */
+  canSyncPermissions?: boolean;
+};
+
 /**
  * TODO(patrick): Unhide this.
  * @hidden
  */
 export interface AdminAuthentication {
-  authentication: AllowedAuthentication;
+  authentication: AdminAuthenticationDefinition;
 
   /**
    * A unique identifier for this authentication configuration. Coda will pass it into formulas via


### PR DESCRIPTION
As discussed in https://github.com/coda/coda/pull/120132#discussion_r1842933123, if a sync table uses meta-sync we want to _only_ use admin authentications, not the default authentication. So this PR moves `canSyncPermissions` into the authentications definition that lives in adminAuthentications. 