### PR TITLE
Handle getConnectionName, getConnectionUserId for admin authentications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Changed
+
+- Support connection names for admin authentications
+
 ## [1.8.3] - 2024-11-12
 
 ### Added

--- a/builder.ts
+++ b/builder.ts
@@ -1,4 +1,5 @@
 import type {AdminAuthentication} from './types';
+import type {AdminAuthenticationDef} from './types';
 import type {AllowedAuthentication} from './types';
 import type {AllowedAuthenticationDef} from './types';
 import type {Authentication} from './types';
@@ -321,7 +322,7 @@ export class PackDefinitionBuilder implements BasicPackDefinition {
    * TODO(patrick): Unhide this
    * @hidden
    */
-  addAdminAuthentication(adminAuth: AdminAuthentication): this {
+  addAdminAuthentication(adminAuth: AdminAuthenticationDef): this {
     if (!this.adminAuthentications) {
       this.adminAuthentications = [];
     }

--- a/dist/builder.d.ts
+++ b/dist/builder.d.ts
@@ -1,4 +1,5 @@
 import type { AdminAuthentication } from './types';
+import type { AdminAuthenticationDef } from './types';
 import type { Authentication } from './types';
 import type { BasicPackDefinition } from './types';
 import type { DynamicSyncTableOptions } from './api';
@@ -202,7 +203,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
      * TODO(patrick): Unhide this
      * @hidden
      */
-    addAdminAuthentication(adminAuth: AdminAuthentication): this;
+    addAdminAuthentication(adminAuth: AdminAuthenticationDef): this;
     /**
      * Adds the domain that this pack makes HTTP requests to.
      * For example, if your pack makes HTTP requests to "api.example.com",

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -4887,6 +4887,9 @@ export interface AdminAuthentication {
 	 */
 	isServiceAccount?: boolean;
 }
+export interface AdminAuthenticationDef extends Omit<AdminAuthentication, "authentication"> {
+	authentication: AllowedAuthenticationDef;
+}
 /**
  * Definition for a custom column type that users can apply to any column in any Coda table.
  * A column format tells Coda to interpret the value in a cell by executing a formula
@@ -5291,7 +5294,7 @@ export declare class PackDefinitionBuilder implements BasicPackDefinition {
 	 * TODO(patrick): Unhide this
 	 * @hidden
 	 */
-	addAdminAuthentication(adminAuth: AdminAuthentication): this;
+	addAdminAuthentication(adminAuth: AdminAuthenticationDef): this;
 	/**
 	 * Adds the domain that this pack makes HTTP requests to.
 	 * For example, if your pack makes HTTP requests to "api.example.com",

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -6,6 +6,7 @@ const buffer_1 = require("buffer");
 const types_2 = require("../types");
 const types_3 = require("../types");
 const types_4 = require("../../types");
+const types_5 = require("../../types");
 const api_1 = require("../../api");
 const api_2 = require("../../api");
 const ensure_1 = require("../../helpers/ensure");
@@ -40,9 +41,18 @@ async function findAndExecutePackFunction({ shouldWrapError = true, ...args }) {
     }
 }
 exports.findAndExecutePackFunction = findAndExecutePackFunction;
+function getSelectedAuthentication(manifest, authenticationName) {
+    var _a;
+    const { defaultAuthentication, adminAuthentications } = manifest;
+    if (!authenticationName || authenticationName === types_5.ReservedAuthenticationNames.Default) {
+        return defaultAuthentication;
+    }
+    return (0, ensure_1.ensureExists)((_a = adminAuthentications === null || adminAuthentications === void 0 ? void 0 : adminAuthentications.find(auth => auth.name === authenticationName)) === null || _a === void 0 ? void 0 : _a.authentication, `Authentication ${authenticationName} not found`);
+}
 async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, executionContext, updates, getPermissionsRequest, }) {
     var _a, _b;
-    const { syncTables, defaultAuthentication } = manifest;
+    const { syncTables } = manifest;
+    const selectedAuthentication = getSelectedAuthentication(manifest, executionContext.authenticationName);
     switch (formulaSpec.type) {
         case types_2.FormulaType.Standard: {
             const formula = (0, helpers_1.findFormula)(manifest, formulaSpec.formulaName);
@@ -71,17 +81,17 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
         case types_2.FormulaType.Metadata: {
             switch (formulaSpec.metadataFormulaType) {
                 case types_3.MetadataFormulaType.GetConnectionName:
-                    if ((defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.None &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.Various &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.getConnectionName)) {
-                        return defaultAuthentication.getConnectionName.execute(params, executionContext);
+                    if ((selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.None &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.Various &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.getConnectionName)) {
+                        return selectedAuthentication.getConnectionName.execute(params, executionContext);
                     }
                     break;
                 case types_3.MetadataFormulaType.GetConnectionUserId:
-                    if ((defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.None &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.Various &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.getConnectionUserId)) {
-                        return defaultAuthentication.getConnectionUserId.execute(params, executionContext);
+                    if ((selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.None &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.Various &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.getConnectionUserId)) {
+                        return selectedAuthentication.getConnectionUserId.execute(params, executionContext);
                     }
                     break;
                 case types_3.MetadataFormulaType.ParameterAutocomplete:
@@ -137,10 +147,10 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
                     }
                     break;
                 case types_3.MetadataFormulaType.PostSetupSetEndpoint:
-                    if ((defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.None &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.type) !== types_1.AuthenticationType.Various &&
-                        (defaultAuthentication === null || defaultAuthentication === void 0 ? void 0 : defaultAuthentication.postSetup)) {
-                        const setupStep = defaultAuthentication.postSetup.find(step => step.type === types_4.PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
+                    if ((selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.None &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.type) !== types_1.AuthenticationType.Various &&
+                        (selectedAuthentication === null || selectedAuthentication === void 0 ? void 0 : selectedAuthentication.postSetup)) {
+                        const setupStep = selectedAuthentication.postSetup.find(step => step.type === types_4.PostSetupType.SetEndpoint && step.name === formulaSpec.stepName);
                         if (setupStep) {
                             return (0, migration_1.setEndpointHelper)(setupStep).getOptions.execute(params, executionContext);
                         }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -927,6 +927,9 @@ export interface AdminAuthentication {
      */
     isServiceAccount?: boolean;
 }
+export interface AdminAuthenticationDef extends Omit<AdminAuthentication, 'authentication'> {
+    authentication: AllowedAuthenticationDef;
+}
 /**
  * Definition for a custom column type that users can apply to any column in any Coda table.
  * A column format tells Coda to interpret the value in a cell by executing a formula

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.4-prerelease.3",
+  "version": "1.8.4-prerelease.4",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/types.ts
+++ b/types.ts
@@ -1048,6 +1048,10 @@ export interface AdminAuthentication {
   isServiceAccount?: boolean;
 }
 
+export interface AdminAuthenticationDef extends Omit<AdminAuthentication, 'authentication'> {
+  authentication: AllowedAuthenticationDef;
+}
+
 /**
  * Definition for a custom column type that users can apply to any column in any Coda table.
  * A column format tells Coda to interpret the value in a cell by executing a formula


### PR DESCRIPTION
Updating the thunk to properly invoke the correct authentication metadata formulas instead of always using the default.

PTAL @coda/packs / @alan-codaio 

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
