### PR TITLE
CB-2317 Verify authenticationName is supported when invoking Pack formulas

### DIFF
--- a/bundles/thunk_bundle.js
+++ b/bundles/thunk_bundle.js
@@ -6393,7 +6393,8 @@ module.exports = (() => {
 
   // runtime/common/helpers.ts
   init_buffer_shim();
-  function verifyFormulaSupportsAuthenticationName(formulaName, allowedAuthenticationNames, authenticationName) {
+  function verifyFormulaSupportsAuthenticationName(formula, authenticationName) {
+    const { allowedAuthenticationNames, name: formulaName } = formula;
     if (!allowedAuthenticationNames) {
       return;
     }
@@ -6425,7 +6426,7 @@ module.exports = (() => {
     for (const formula of formulas) {
       if (formula.name === name) {
         if (verifyFormulaForAuthenticationName) {
-          verifyFormulaSupportsAuthenticationName(name, formula.allowedAuthenticationNames, authenticationName);
+          verifyFormulaSupportsAuthenticationName(formula, authenticationName);
         }
         return formula;
       }
@@ -6443,11 +6444,7 @@ module.exports = (() => {
       const syncFormula = syncTable.getter;
       if (syncTable.name === syncFormulaName) {
         if (verifyFormulaForAuthenticationName) {
-          verifyFormulaSupportsAuthenticationName(
-            syncFormulaName,
-            syncFormula.allowedAuthenticationNames,
-            authenticationName
-          );
+          verifyFormulaSupportsAuthenticationName(syncFormula, authenticationName);
         }
         return syncFormula;
       }

--- a/dist/bundles/thunk_bundle.js
+++ b/dist/bundles/thunk_bundle.js
@@ -6393,7 +6393,8 @@ module.exports = (() => {
 
   // runtime/common/helpers.ts
   init_buffer_shim();
-  function verifyFormulaSupportsAuthenticationName(formulaName, allowedAuthenticationNames, authenticationName) {
+  function verifyFormulaSupportsAuthenticationName(formula, authenticationName) {
+    const { allowedAuthenticationNames, name: formulaName } = formula;
     if (!allowedAuthenticationNames) {
       return;
     }
@@ -6425,7 +6426,7 @@ module.exports = (() => {
     for (const formula of formulas) {
       if (formula.name === name) {
         if (verifyFormulaForAuthenticationName) {
-          verifyFormulaSupportsAuthenticationName(name, formula.allowedAuthenticationNames, authenticationName);
+          verifyFormulaSupportsAuthenticationName(formula, authenticationName);
         }
         return formula;
       }
@@ -6443,11 +6444,7 @@ module.exports = (() => {
       const syncFormula = syncTable.getter;
       if (syncTable.name === syncFormulaName) {
         if (verifyFormulaForAuthenticationName) {
-          verifyFormulaSupportsAuthenticationName(
-            syncFormulaName,
-            syncFormula.allowedAuthenticationNames,
-            authenticationName
-          );
+          verifyFormulaSupportsAuthenticationName(syncFormula, authenticationName);
         }
         return syncFormula;
       }

--- a/dist/runtime/common/helpers.d.ts
+++ b/dist/runtime/common/helpers.d.ts
@@ -1,7 +1,11 @@
 import type { BasicPackDefinition } from '../../types';
 import type { Formula } from '../../api';
 import type { GenericSyncFormula } from '../../api';
-export declare function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula;
-export declare function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula;
+export declare function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string, authenticationName: string | undefined, { verifyFormulaForAuthenticationName, }?: {
+    verifyFormulaForAuthenticationName: boolean;
+}): Formula;
+export declare function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string, authenticationName: string | undefined, { verifyFormulaForAuthenticationName, }?: {
+    verifyFormulaForAuthenticationName: boolean;
+}): GenericSyncFormula;
 export declare function tryFindFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula | undefined;
 export declare function tryFindSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula | undefined;

--- a/dist/runtime/common/helpers.js
+++ b/dist/runtime/common/helpers.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.tryFindSyncFormula = exports.tryFindFormula = exports.findSyncFormula = exports.findFormula = void 0;
-function verifyFormulaSupportsAuthenticationName(formulaName, allowedAuthenticationNames, authenticationName) {
+function verifyFormulaSupportsAuthenticationName(formula, authenticationName) {
+    const { allowedAuthenticationNames, name: formulaName } = formula;
     if (!allowedAuthenticationNames) {
         return;
     }
@@ -31,7 +32,7 @@ function findFormula(packDef, formulaNameWithNamespace, authenticationName, { ve
     for (const formula of formulas) {
         if (formula.name === name) {
             if (verifyFormulaForAuthenticationName) {
-                verifyFormulaSupportsAuthenticationName(name, formula.allowedAuthenticationNames, authenticationName);
+                verifyFormulaSupportsAuthenticationName(formula, authenticationName);
             }
             return formula;
         }
@@ -47,7 +48,7 @@ function findSyncFormula(packDef, syncFormulaName, authenticationName, { verifyF
         const syncFormula = syncTable.getter;
         if (syncTable.name === syncFormulaName) {
             if (verifyFormulaForAuthenticationName) {
-                verifyFormulaSupportsAuthenticationName(syncFormulaName, syncFormula.allowedAuthenticationNames, authenticationName);
+                verifyFormulaSupportsAuthenticationName(syncFormula, authenticationName);
             }
             return syncFormula;
         }

--- a/dist/runtime/thunk/thunk.js
+++ b/dist/runtime/thunk/thunk.js
@@ -58,15 +58,15 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
     const selectedAuthentication = getSelectedAuthentication(manifest, executionContext.authenticationName);
     switch (formulaSpec.type) {
         case types_2.FormulaType.Standard: {
-            const formula = (0, helpers_1.findFormula)(manifest, formulaSpec.formulaName);
+            const formula = (0, helpers_1.findFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             return formula.execute(params, executionContext);
         }
         case types_2.FormulaType.Sync: {
-            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName);
+            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             return formula.execute(params, executionContext);
         }
         case types_2.FormulaType.SyncUpdate: {
-            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName);
+            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             if (!formula.executeUpdate) {
                 throw new Error(`No executeUpdate function defined on sync table formula ${formulaSpec.formulaName}`);
             }
@@ -74,7 +74,7 @@ async function doFindAndExecutePackFunction({ params, formulaSpec, manifest, exe
             return parseSyncUpdateResult(response);
         }
         case types_2.FormulaType.GetPermissions: {
-            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName);
+            const formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             if (!formula.executeGetPermissions) {
                 throw new Error(`No executeGetPermissions function defined on sync table formula ${formulaSpec.formulaName}`);
             }

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -76,12 +76,12 @@ useDeprecatedResultNormalization = true, } = {}) {
     let formula;
     switch (formulaSpec.type) {
         case types_1.FormulaType.Standard:
-            formula = (0, helpers_1.findFormula)(manifest, formulaSpec.formulaName);
+            formula = (0, helpers_1.findFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             break;
         case types_1.FormulaType.Sync:
         case types_1.FormulaType.SyncUpdate:
         case types_1.FormulaType.GetPermissions:
-            formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName);
+            formula = (0, helpers_2.findSyncFormula)(manifest, formulaSpec.formulaName, executionContext.authenticationName);
             break;
     }
     if (shouldValidateParams && formula) {
@@ -345,12 +345,12 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
     let permissionRequest;
     switch (formulaSpecification.type) {
         case types_1.FormulaType.Standard: {
-            const formula = (0, helpers_1.findFormula)(manifest, formulaSpecification.formulaName);
+            const formula = (0, helpers_1.findFormula)(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
             params = (0, coercion_1.coerceParams)(formula, rawParams);
             break;
         }
         case types_1.FormulaType.Sync: {
-            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
             params = (0, coercion_1.coerceParams)(syncFormula, rawParams);
             break;
         }
@@ -387,12 +387,12 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
     let permissionRequest;
     switch (formulaSpecification.type) {
         case types_1.FormulaType.Standard: {
-            const formula = (0, helpers_1.findFormula)(manifest, formulaSpecification.formulaName);
+            const formula = (0, helpers_1.findFormula)(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
             params = (0, coercion_1.coerceParams)(formula, rawParams);
             break;
         }
         case types_1.FormulaType.Sync: {
-            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+            const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
             params = (0, coercion_1.coerceParams)(syncFormula, rawParams);
             break;
         }
@@ -432,7 +432,7 @@ exports.executeFormulaOrSyncWithRawParams = executeFormulaOrSyncWithRawParams;
  * For now, use `coda execute --vm` to simulate that level of isolation.
  */
 async function executeSyncFormula(packDef, syncFormulaName, params, context, { validateParams: shouldValidateParams = true, validateResult: shouldValidateResult = true, useDeprecatedResultNormalization = true, } = {}, { useRealFetcher, manifestPath } = {}) {
-    const formula = (0, helpers_2.findSyncFormula)(packDef, syncFormulaName);
+    const formula = (0, helpers_2.findSyncFormula)(packDef, syncFormulaName, context === null || context === void 0 ? void 0 : context.authenticationName);
     if (shouldValidateParams && formula) {
         (0, validation_1.validateParams)(formula, params);
     }
@@ -575,7 +575,7 @@ function parseSyncUpdates(manifest, formulaSpecification, rawParams) {
     if (!parseResult.success) {
         throw new Error(`Invalid sync updates: ${parseResult.error.message}`);
     }
-    const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+    const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName, undefined, { verifyFormulaForAuthenticationName: false });
     return { syncUpdates: parseResult.data, params: (0, coercion_1.coerceParams)(syncFormula, paramsCopy) };
 }
 const GetPermissionSchema = z.object({
@@ -591,6 +591,6 @@ function parseGetPermissionRequest(manifest, formulaSpecification, rawParams) {
     if (!parseResult.success) {
         throw new Error(`Invalid get permission request: ${parseResult.error.message}`);
     }
-    const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName);
+    const syncFormula = (0, helpers_2.findSyncFormula)(manifest, formulaSpecification.formulaName, undefined, { verifyFormulaForAuthenticationName: false });
     return { permissionRequest: parseResult.data, params: (0, coercion_1.coerceParams)(syncFormula, paramsCopy) };
 }

--- a/runtime/common/helpers.ts
+++ b/runtime/common/helpers.ts
@@ -4,10 +4,10 @@ import type {GenericSyncFormula} from '../../api';
 
 
 function verifyFormulaSupportsAuthenticationName(
-  formulaName: string,
-  allowedAuthenticationNames: string[] | undefined,
+  formula: Formula,
   authenticationName: string | undefined,
 ) {
+  const {allowedAuthenticationNames, name: formulaName} = formula;
   if (!allowedAuthenticationNames) {
     return;
   }
@@ -52,7 +52,7 @@ export function findFormula(
   for (const formula of formulas) {
     if (formula.name === name) {
       if (verifyFormulaForAuthenticationName) {
-        verifyFormulaSupportsAuthenticationName(name, formula.allowedAuthenticationNames, authenticationName);
+        verifyFormulaSupportsAuthenticationName(formula, authenticationName);
       }
       return formula;
     }
@@ -76,9 +76,7 @@ export function findSyncFormula(
     const syncFormula = syncTable.getter;
     if (syncTable.name === syncFormulaName) {
       if (verifyFormulaForAuthenticationName) {
-        verifyFormulaSupportsAuthenticationName(
-          syncFormulaName, syncFormula.allowedAuthenticationNames, authenticationName
-        );
+        verifyFormulaSupportsAuthenticationName(syncFormula, authenticationName);
       }
       return syncFormula;
     }

--- a/runtime/common/helpers.ts
+++ b/runtime/common/helpers.ts
@@ -2,7 +2,33 @@ import type {BasicPackDefinition} from '../../types';
 import type {Formula} from '../../api';
 import type {GenericSyncFormula} from '../../api';
 
-export function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula {
+
+function verifyFormulaSupportsAuthenticationName(
+  formulaName: string,
+  allowedAuthenticationNames: string[] | undefined,
+  authenticationName: string | undefined,
+) {
+  if (!allowedAuthenticationNames) {
+    return;
+  }
+
+  if (!authenticationName) {
+    throw new Error(`Formula ${formulaName} requires an authentication but none was provided`);
+  }
+
+  if (!allowedAuthenticationNames.includes(authenticationName)) {
+    throw new Error(`Formula ${formulaName} is not allowed for connection with authentication ${authenticationName}`);
+  }
+}
+
+export function findFormula(
+  packDef: BasicPackDefinition,
+  formulaNameWithNamespace: string,
+  authenticationName: string | undefined,
+  {
+    verifyFormulaForAuthenticationName,
+  }: {verifyFormulaForAuthenticationName: boolean} = {verifyFormulaForAuthenticationName: true}
+): Formula {
   const packFormulas = packDef.formulas;
   if (!packFormulas) {
     throw new Error(`Pack definition has no formulas.`);
@@ -25,13 +51,23 @@ export function findFormula(packDef: BasicPackDefinition, formulaNameWithNamespa
   }
   for (const formula of formulas) {
     if (formula.name === name) {
+      if (verifyFormulaForAuthenticationName) {
+        verifyFormulaSupportsAuthenticationName(name, formula.allowedAuthenticationNames, authenticationName);
+      }
       return formula;
     }
   }
   throw new Error(`Pack definition has no formula "${name}"${namespace ?? ` in namespace "${namespace}"`}.`);
 }
 
-export function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: string): GenericSyncFormula {
+export function findSyncFormula(
+  packDef: BasicPackDefinition,
+  syncFormulaName: string,
+  authenticationName: string | undefined,
+  {
+    verifyFormulaForAuthenticationName,
+  }: {verifyFormulaForAuthenticationName: boolean} = {verifyFormulaForAuthenticationName: true}
+): GenericSyncFormula {
   if (!packDef.syncTables) {
     throw new Error(`Pack definition has no sync tables.`);
   }
@@ -39,6 +75,11 @@ export function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: s
   for (const syncTable of packDef.syncTables) {
     const syncFormula = syncTable.getter;
     if (syncTable.name === syncFormulaName) {
+      if (verifyFormulaForAuthenticationName) {
+        verifyFormulaSupportsAuthenticationName(
+          syncFormulaName, syncFormula.allowedAuthenticationNames, authenticationName
+        );
+      }
       return syncFormula;
     }
   }
@@ -46,9 +87,17 @@ export function findSyncFormula(packDef: BasicPackDefinition, syncFormulaName: s
   throw new Error(`Pack definition has no sync formula "${syncFormulaName}" in its sync tables.`);
 }
 
-export function tryFindFormula(packDef: BasicPackDefinition, formulaNameWithNamespace: string): Formula | undefined {
+export function tryFindFormula(
+  packDef: BasicPackDefinition,
+  formulaNameWithNamespace: string,
+): Formula | undefined {
   try {
-    return findFormula(packDef, formulaNameWithNamespace);
+    return findFormula(
+      packDef,
+      formulaNameWithNamespace,
+      undefined,
+      {verifyFormulaForAuthenticationName: false}
+    );
   } catch (_err) {}
 }
 
@@ -57,6 +106,6 @@ export function tryFindSyncFormula(
   syncFormulaName: string,
 ): GenericSyncFormula | undefined {
   try {
-    return findSyncFormula(packDef, syncFormulaName);
+    return findSyncFormula(packDef, syncFormulaName, undefined, {verifyFormulaForAuthenticationName: false});
   } catch (_err) {}
 }

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -92,6 +92,7 @@ function getSelectedAuthentication(manifest: BasicPackDefinition, authentication
   );
 }
 
+
 async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
   params,
   formulaSpec,
@@ -115,15 +116,15 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
 
   switch (formulaSpec.type) {
     case FormulaType.Standard: {
-      const formula = findFormula(manifest, formulaSpec.formulaName);
+      const formula = findFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       return formula.execute(params, executionContext as ExecutionContext);
     }
     case FormulaType.Sync: {
-      const formula = findSyncFormula(manifest, formulaSpec.formulaName);
+      const formula = findSyncFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       return formula.execute(params, executionContext as SyncExecutionContext);
     }
     case FormulaType.SyncUpdate: {
-      const formula = findSyncFormula(manifest, formulaSpec.formulaName);
+      const formula = findSyncFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       if (!formula.executeUpdate) {
         throw new Error(`No executeUpdate function defined on sync table formula ${formulaSpec.formulaName}`);
       }
@@ -135,7 +136,7 @@ async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
       return parseSyncUpdateResult(response);
     }
     case FormulaType.GetPermissions: {
-      const formula = findSyncFormula(manifest, formulaSpec.formulaName);
+      const formula = findSyncFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       if (!formula.executeGetPermissions) {
         throw new Error(`No executeGetPermissions function defined on sync table formula ${formulaSpec.formulaName}`);
       }

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -101,12 +101,12 @@ async function findAndExecutePackFunction<T extends FormulaSpecification>(
   let formula: TypedPackFormula | undefined;
   switch (formulaSpec.type) {
     case FormulaType.Standard:
-      formula = findFormula(manifest, formulaSpec.formulaName);
+      formula = findFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       break;
     case FormulaType.Sync:
     case FormulaType.SyncUpdate:
     case FormulaType.GetPermissions:
-      formula = findSyncFormula(manifest, formulaSpec.formulaName);
+      formula = findSyncFormula(manifest, formulaSpec.formulaName, executionContext.authenticationName);
       break;
   }
 
@@ -478,12 +478,13 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
   let permissionRequest: GenericExecuteGetPermissionsRequest | undefined;
   switch (formulaSpecification.type) {
     case FormulaType.Standard: {
-      const formula = findFormula(manifest, formulaSpecification.formulaName);
+      const formula = findFormula(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
       params = coerceParams(formula, rawParams as any);
       break;
     }
     case FormulaType.Sync: {
-      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      const syncFormula = findSyncFormula(
+        manifest, formulaSpecification.formulaName, executionContext.authenticationName);
       params = coerceParams(syncFormula, rawParams as any);
       break;
     }
@@ -536,12 +537,13 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
   let permissionRequest: GenericExecuteGetPermissionsRequest | undefined;
   switch (formulaSpecification.type) {
     case FormulaType.Standard: {
-      const formula = findFormula(manifest, formulaSpecification.formulaName);
+      const formula = findFormula(manifest, formulaSpecification.formulaName, executionContext.authenticationName);
       params = coerceParams(formula, rawParams as any);
       break;
     }
     case FormulaType.Sync: {
-      const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+      const syncFormula = findSyncFormula(
+        manifest, formulaSpecification.formulaName, executionContext.authenticationName);
       params = coerceParams(syncFormula, rawParams as any);
       break;
     }
@@ -600,7 +602,7 @@ export async function executeSyncFormula(
   }: ExecuteOptions = {},
   {useRealFetcher, manifestPath}: ContextOptions = {},
 ): Promise<GenericSyncFormulaResult> {
-  const formula = findSyncFormula(packDef, syncFormulaName);
+  const formula = findSyncFormula(packDef, syncFormulaName, context?.authenticationName);
   if (shouldValidateParams && formula) {
     validateParams(formula, params);
   }
@@ -872,7 +874,12 @@ function parseSyncUpdates(
   if (!parseResult.success) {
     throw new Error(`Invalid sync updates: ${parseResult.error.message}`);
   }
-  const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+  const syncFormula = findSyncFormula(
+    manifest,
+    formulaSpecification.formulaName,
+    undefined,
+    {verifyFormulaForAuthenticationName: false},
+  );
   return {syncUpdates: parseResult.data, params: coerceParams(syncFormula, paramsCopy as any)};
 }
 
@@ -899,7 +906,12 @@ function parseGetPermissionRequest(
     throw new Error(`Invalid get permission request: ${parseResult.error.message}`);
   }
 
-  const syncFormula = findSyncFormula(manifest, formulaSpecification.formulaName);
+  const syncFormula = findSyncFormula(
+    manifest,
+    formulaSpecification.formulaName,
+    undefined,
+    {verifyFormulaForAuthenticationName: false},
+  );
 
   return {permissionRequest: parseResult.data, params: coerceParams(syncFormula, paramsCopy as any)};
 }


### PR DESCRIPTION
Adds verification to our thunk so that we don't invoke formulas with connections created with unsupported authentication mechanisms. Will add unit tests