### PR TITLE
Fix react deprecation warning

### DIFF
--- a/cli/upload.ts
+++ b/cli/upload.ts
@@ -74,7 +74,7 @@ export async function handleUpload({
     logger.info(
       `Existing directory ${intermediateOutputDirectory} detected. Probably left over from previous build. Removing it...`,
     );
-    fs.rmdirSync(intermediateOutputDirectory, {recursive: true});
+    fs.rmSync(intermediateOutputDirectory, {recursive: true, force: true});
   }
 
   // we need to generate the bundle file in the working directory instead of a temp directory in

--- a/dist/cli/upload.js
+++ b/dist/cli/upload.js
@@ -70,7 +70,7 @@ async function handleUpload({ intermediateOutputDirectory, manifestFile, codaApi
     logger.info('Building Pack bundle...');
     if (fs_extra_1.default.existsSync(intermediateOutputDirectory)) {
         logger.info(`Existing directory ${intermediateOutputDirectory} detected. Probably left over from previous build. Removing it...`);
-        fs_extra_1.default.rmdirSync(intermediateOutputDirectory, { recursive: true });
+        fs_extra_1.default.rmSync(intermediateOutputDirectory, { recursive: true, force: true });
     }
     // we need to generate the bundle file in the working directory instead of a temp directory in
     // order to set source map right. The source map tool chain isn't smart enough to resolve a


### PR DESCRIPTION
Cursor added the `force: true` which seems reasonable.  Warning was:
```
(node:49795) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

PTAL @coda/packs 