### PR TITLE
CB-2995 Allow identity names to be duplicated if allowedAuthenticationNames is disjoint

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1542,7 +1542,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             .default([])
             .superRefine((data, context) => {
             var _a, _b;
-            const identityNames = [];
+            const identityInfo = new Map();
             const formulaNames = [];
             for (const tableDef of data) {
                 if (tableDef.identityName && ((_a = tableDef.schema.identity) === null || _a === void 0 ? void 0 : _a.name)) {
@@ -1555,16 +1555,12 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                 }
                 // only add identity names that are not undefined to check for dupes
                 if (tableDef.schema.identity) {
-                    identityNames.push((_b = tableDef.schema.identity) === null || _b === void 0 ? void 0 : _b.name);
+                    const allowedAuthenticationNames = identityInfo.get(tableDef.schema.identity.name) || [];
+                    identityInfo.set(tableDef.schema.identity.name, [...allowedAuthenticationNames, ...(((_b = tableDef.getter) === null || _b === void 0 ? void 0 : _b.allowedAuthenticationNames) || [undefined])]);
                 }
                 formulaNames.push(tableDef.getter.name);
             }
-            for (const dupe of getNonUniqueElements(identityNames)) {
-                context.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
-                });
-            }
+            validateIdentityNames(context, identityInfo);
             for (const dupe of getNonUniqueElements(formulaNames)) {
                 context.addIssue({
                     code: z.ZodIssueCode.custom,
@@ -1580,6 +1576,20 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             }
         }),
     });
+    function validateIdentityNames(context, identityInfo) {
+        for (const [identityName, allowedAuthenticationNames] of identityInfo) {
+            const seenAuthNames = new Set();
+            for (const allowedAuthName of allowedAuthenticationNames) {
+                if (seenAuthNames.has(allowedAuthName)) {
+                    context.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: allowedAuthName ? `Identity "${identityName}" is used by multiple sync tables with non-distinct allowedAuthenticationNames: ${allowedAuthName}` : `Sync table identity names must be unique. Found duplicate name "${identityName}".`,
+                    });
+                }
+                seenAuthNames.add(allowedAuthName);
+            }
+        }
+    }
     function validateNamespace(namespace) {
         if (typeof namespace === 'undefined') {
             return true;
@@ -1704,7 +1714,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                     });
                 }
                 for (const allowedAuthenticationName of allowedAuthenticationNames) {
-                    if (!authNames.includes(allowedAuthenticationName)) {
+                    if (!authNames.includes(allowedAuthenticationName) &&
+                        !reservedAuthenticationNames.includes(allowedAuthenticationName)) {
                         context.addIssue({
                             code: z.ZodIssueCode.custom,
                             path: [formula.name, 'allowedAuthenticationNames'],

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1580,7 +1580,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         for (const [identityName, allowedAuthenticationNames] of identityInfo) {
             const seenAuthNames = new Set();
             for (const allowedAuthName of allowedAuthenticationNames) {
-                if (seenAuthNames.has(allowedAuthName)) {
+                // If no allowedAuthName is provided, the sync table is allowed to use any authentication.
+                if (seenAuthNames.has(allowedAuthName) || seenAuthNames.has(undefined)) {
                     context.addIssue({
                         code: z.ZodIssueCode.custom,
                         message: allowedAuthName ? `Identity "${identityName}" is used by multiple sync tables with non-distinct allowedAuthenticationNames: ${allowedAuthName}` : `Sync table identity names must be unique. Found duplicate name "${identityName}".`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.5-prerelease.2",
+  "version": "1.8.5-prerelease.3",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -1916,14 +1916,103 @@ describe('Pack metadata Validation', async () => {
           },
         });
 
-        const metadata = createFakePack({
-          syncTables: [syncTable1, syncTable2],
+        // No violation between 3 and 4 because they use allowedAuthenticationNames and those are disjoint.
+        const syncTable3 = makeSyncTable({
+          name: 'SyncTable3',
+          identityName: 'IdentityAdminAuth',
+          schema: makeObjectSchema({
+            type: ValueType.Object,
+            primary: 'foo',
+            id: 'foo',
+            properties: {
+              Foo: {type: ValueType.String},
+            },
+          }),
+          formula: {
+            name: 'SyncTable3',
+            description: 'A simple sync table',
+            async execute([], _context) {
+              return {result: []};
+            },
+            parameters: [],
+            allowedAuthenticationNames: [ReservedAuthenticationNames.System]
+          },
         });
-        const err = await validateJsonAndAssertFails(metadata);
+        const syncTable4 = makeSyncTable({
+          name: 'SyncTable4',
+          identityName: 'IdentityAdminAuth',
+          schema: makeObjectSchema({
+            type: ValueType.Object,
+            primary: 'foo',
+            id: 'foo',
+            properties: {
+              Foo: {type: ValueType.String},
+            },
+          }),
+          formula: {
+            name: 'SyncTable4',
+            description: 'A simple sync table',
+            async execute([], _context) {
+              return {result: []};
+            },
+            parameters: [],
+            allowedAuthenticationNames: [ReservedAuthenticationNames.Default]
+          },
+        });
+
+
+        let metadata = createFakePack({
+          syncTables: [syncTable1, syncTable2, syncTable3, syncTable4],
+        });
+        let err = await validateJsonAndAssertFails(metadata);
         assert.deepEqual(err.validationErrors, [
           {
             message: 'Sync table identity names must be unique. Found duplicate name "Identity".',
             path: 'syncTables',
+          },
+          {
+            message: 'Sync table formula names must be unique. Found duplicate name "SyncTable".',
+            path: 'syncTables',
+          },
+        ]);
+
+        const syncTable5 = makeSyncTable({
+          name: 'SyncTable5',
+          identityName: 'IdentityAdminAuth',
+          schema: makeObjectSchema({
+            type: ValueType.Object,
+            primary: 'foo',
+            id: 'foo',
+            properties: {
+              Foo: {type: ValueType.String},
+            },
+          }),
+          formula: {
+            name: 'SyncTable5',
+            description: 'A simple sync table',
+            async execute([], _context) {
+              return {result: []};
+            },
+            parameters: [],
+            allowedAuthenticationNames: [ReservedAuthenticationNames.Default, ReservedAuthenticationNames.System]
+          },
+        });
+         metadata = createFakePack({
+          syncTables: [syncTable1, syncTable2, syncTable3, syncTable4, syncTable5],
+        });
+        err = await validateJsonAndAssertFails(metadata);
+        assert.deepEqual(err.validationErrors, [
+          {
+            message: 'Sync table identity names must be unique. Found duplicate name "Identity".',
+            path: 'syncTables',
+          },
+          {
+            message: 'Identity "IdentityAdminAuth" is used by multiple sync tables with non-distinct allowedAuthenticationNames: defaultUserAuthentication',
+            path: 'syncTables'
+          },
+          {
+            message: 'Identity "IdentityAdminAuth" is used by multiple sync tables with non-distinct allowedAuthenticationNames: systemAuthentication',
+            path: 'syncTables'
           },
           {
             message: 'Sync table formula names must be unique. Found duplicate name "SyncTable".',
@@ -4823,6 +4912,25 @@ describe('Pack metadata Validation', async () => {
                 },
                 parameters: [],
                 allowedAuthenticationNames: ['fakeAuthName'],
+              },
+            }),
+            makeSyncTable({
+              name: 'SyncTable2',
+              identityName: 'Identity2',
+              schema: makeObjectSchema({
+                type: ValueType.Object,
+                displayProperty: 'foo',
+                idProperty: 'foo',
+                properties: {foo: {type: ValueType.String}},
+              }),
+              formula: {
+                name: 'SyncTable2',
+                description: '',
+                async execute([], _context) {
+                  return {result: []};
+                },
+                parameters: [],
+                allowedAuthenticationNames: [ReservedAuthenticationNames.System, ReservedAuthenticationNames.Default],
               },
             }),
           ],

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1978,7 +1978,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             const allowedAuthenticationNames = identityInfo.get(tableDef.schema.identity.name) || [];
             identityInfo.set(
               tableDef.schema.identity.name, 
-              [...allowedAuthenticationNames, ...(tableDef.getter?.allowedAuthenticationNames || [undefined])]
+              [...allowedAuthenticationNames, ...(tableDef.getter?.allowedAuthenticationNames || [undefined])],
             );
   
           }
@@ -2006,7 +2006,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     for (const [identityName, allowedAuthenticationNames] of identityInfo) {
       const seenAuthNames = new Set<string | undefined>();
       for (const allowedAuthName of allowedAuthenticationNames) {
-        if (seenAuthNames.has(allowedAuthName)) {
+        // If no allowedAuthName is provided, the sync table is allowed to use any authentication.
+        if (seenAuthNames.has(allowedAuthName) || seenAuthNames.has(undefined)) {
           context.addIssue({
             code: z.ZodIssueCode.custom,
             message: allowedAuthName ?  `Identity "${identityName}" is used by multiple sync tables with non-distinct allowedAuthenticationNames: ${allowedAuthName}`: `Sync table identity names must be unique. Found duplicate name "${identityName}".` ,

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1962,7 +1962,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
       .optional()
       .default([])
       .superRefine((data, context) => {
-        const identityNames: string[] = [];
+        const identityInfo: Map<string, string[]> = new Map();
         const formulaNames: string[] = [];
         for (const tableDef of data) {
           if (tableDef.identityName && tableDef.schema.identity?.name) {
@@ -1975,16 +1975,17 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
           }
           // only add identity names that are not undefined to check for dupes
           if (tableDef.schema.identity) {
-            identityNames.push(tableDef.schema.identity?.name);
+            const allowedAuthenticationNames = identityInfo.get(tableDef.schema.identity.name) || [];
+            identityInfo.set(
+              tableDef.schema.identity.name, 
+              [...allowedAuthenticationNames, ...(tableDef.getter?.allowedAuthenticationNames || [undefined])]
+            );
+  
           }
           formulaNames.push(tableDef.getter.name);
         }
-        for (const dupe of getNonUniqueElements(identityNames)) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Sync table identity names must be unique. Found duplicate name "${dupe}".`,
-          });
-        }
+        
+        validateIdentityNames(context, identityInfo);
         for (const dupe of getNonUniqueElements(formulaNames)) {
           context.addIssue({
             code: z.ZodIssueCode.custom,
@@ -2000,6 +2001,21 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         }
       }),
   });
+
+  function validateIdentityNames(context: z.RefinementCtx, identityInfo: Map<string, string[]>) {
+    for (const [identityName, allowedAuthenticationNames] of identityInfo) {
+      const seenAuthNames = new Set<string | undefined>();
+      for (const allowedAuthName of allowedAuthenticationNames) {
+        if (seenAuthNames.has(allowedAuthName)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: allowedAuthName ?  `Identity "${identityName}" is used by multiple sync tables with non-distinct allowedAuthenticationNames: ${allowedAuthName}`: `Sync table identity names must be unique. Found duplicate name "${identityName}".` ,
+          });
+        }
+        seenAuthNames.add(allowedAuthName);
+      }
+    }
+  }
 
   function validateNamespace(namespace: string | undefined): boolean {
     if (typeof namespace === 'undefined') {
@@ -2136,7 +2152,10 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             });
           }
           for (const allowedAuthenticationName of allowedAuthenticationNames) {
-            if (!authNames.includes(allowedAuthenticationName)) {
+            if (
+              !authNames.includes(allowedAuthenticationName) &&
+              !reservedAuthenticationNames.includes(allowedAuthenticationName)
+            ) {
               context.addIssue({
                 code: z.ZodIssueCode.custom,
                 path: [formula.name, 'allowedAuthenticationNames'],


### PR DESCRIPTION
The premise here is that sync table identities can be duplicated if the allowedAuths are disjoint meaning that only 1 sync _table_ would be used in a certain context (brain, doc, etc) even if multiple identities exist.

Also fixes a validation bug where we throw an error if you try to use a `ReservedAuthenticationName` in the `allowedAuthenticationNames` field.