### PR TITLE
packs-sdk: release v1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.8.5] - 2024-12-04
+
 ### Changed
 
 - Improved `Sync` and `SyncExecutionContext` types to better handle full vs. incremental sync
@@ -801,7 +803,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.8.4...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.8.5...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -848,3 +850,4 @@ await myHelper(context);
 [1.8.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.2
 [1.8.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.3
 [1.8.4]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.4
+[1.8.5]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.5-prerelease.4",
+  "version": "1.8.5",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Released here: https://github.com/coda/packs-sdk/releases/tag/v1.8.5

PTAL @coda/packs 