### PR TITLE
Adding sync state service to get latest row version based on given row ids

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -781,6 +781,29 @@ export interface TemporaryBlobStorage {
   ): Promise<string>;
 }
 
+
+/**
+ * A service for retrieving the sync state in Coda Brain.
+ * @hidden
+ *
+ * TODO(ebo): unhide this
+ */
+export interface SyncStateService {
+  /**
+   * Retrieve the latest version of rows with the given row ids and returns a mapping of row ids to
+   * their latest version, e.g. {"Id-123": "1.0.0"}.
+   *
+   * If the row id is not found, it will not be included in the response.
+   *
+   * If the row version is not defined, it will be set to an empty string.
+   *
+   * @hidden
+   *
+   * TODO(ebo): unhide this
+   */
+  getLatestRowVersions(rowIds: string[]): Promise<{[rowId: string]: string}>;
+}
+
 /**
  * TODO(patrick): Unhide this
  * @hidden
@@ -1062,6 +1085,14 @@ export interface SyncExecutionContext<
    * Information about state of the current sync.
    */
   readonly sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
+
+  /**
+   * A service for retrieving the sync state in Coda Brain.
+   * @hidden
+   *
+   * TODO(ebo): unhide this
+   */
+  readonly syncState: SyncStateService;
 }
 
 /**
@@ -1100,6 +1131,14 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
    * Information about state of the current sync.
    */
   readonly sync: UpdateSync;
+
+  /**
+   * A service for retrieving the sync state in Coda Brain.
+   * @hidden
+   *
+   * TODO(ebo): unhide this
+   */
+  readonly syncState: SyncStateService;
 }
 
 /**

--- a/api_types.ts
+++ b/api_types.ts
@@ -1092,14 +1092,14 @@ export interface SyncExecutionContext<
    *
    * TODO(ebo): unhide this
    */
-  readonly syncState: SyncStateService;
+  readonly syncStateService: SyncStateService;
 }
 
 /**
  * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.
  */
 export function isSyncExecutionContext(context: ExecutionContext): context is SyncExecutionContext {
-  return context.hasOwnProperty('sync') && context.hasOwnProperty('syncState');
+  return context.hasOwnProperty('sync') && context.hasOwnProperty('syncStateService');
 }
 
 /**

--- a/api_types.ts
+++ b/api_types.ts
@@ -1096,6 +1096,13 @@ export interface SyncExecutionContext<
 }
 
 /**
+ * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.
+ */
+export function isSyncExecutionContext(context: ExecutionContext): context is SyncExecutionContext {
+  return context.hasOwnProperty('sync') && context.hasOwnProperty('syncState');
+}
+
+/**
  * Sub-class of {@link SyncExecutionContext} that is passed to the `options` function of
  * mutable sync tables for properties with `options` enabled.
  */
@@ -1131,14 +1138,6 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
    * Information about state of the current sync.
    */
   readonly sync: UpdateSync;
-
-  /**
-   * A service for retrieving the sync state in Coda Brain.
-   * @hidden
-   *
-   * TODO(ebo): unhide this
-   */
-  readonly syncState: SyncStateService;
 }
 
 /**

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -912,7 +912,7 @@ export interface SyncExecutionContext<ContinuationT = Continuation, IncrementalC
      *
      * TODO(ebo): unhide this
      */
-    readonly syncState: SyncStateService;
+    readonly syncStateService: SyncStateService;
 }
 /**
  * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -915,6 +915,10 @@ export interface SyncExecutionContext<ContinuationT = Continuation, IncrementalC
     readonly syncState: SyncStateService;
 }
 /**
+ * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.
+ */
+export declare function isSyncExecutionContext(context: ExecutionContext): context is SyncExecutionContext;
+/**
  * Sub-class of {@link SyncExecutionContext} that is passed to the `options` function of
  * mutable sync tables for properties with `options` enabled.
  */
@@ -948,13 +952,6 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
      * Information about state of the current sync.
      */
     readonly sync: UpdateSync;
-    /**
-     * A service for retrieving the sync state in Coda Brain.
-     * @hidden
-     *
-     * TODO(ebo): unhide this
-     */
-    readonly syncState: SyncStateService;
 }
 /**
  * Context provided to GetPermissionExecution calls

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -648,6 +648,29 @@ export interface TemporaryBlobStorage {
     }): Promise<string>;
 }
 /**
+ * A service for retrieving the sync state in Coda Brain.
+ * @hidden
+ *
+ * TODO(ebo): unhide this
+ */
+export interface SyncStateService {
+    /**
+     * Retrieve the latest version of rows with the given row ids and returns a mapping of row ids to
+     * their latest version, e.g. {"Id-123": "1.0.0"}.
+     *
+     * If the row id is not found, it will not be included in the response.
+     *
+     * If the row version is not defined, it will be set to an empty string.
+     *
+     * @hidden
+     *
+     * TODO(ebo): unhide this
+     */
+    getLatestRowVersions(rowIds: string[]): Promise<{
+        [rowId: string]: string;
+    }>;
+}
+/**
  * TODO(patrick): Unhide this
  * @hidden
  */
@@ -883,6 +906,13 @@ export interface SyncExecutionContext<ContinuationT = Continuation, IncrementalC
      * Information about state of the current sync.
      */
     readonly sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
+    /**
+     * A service for retrieving the sync state in Coda Brain.
+     * @hidden
+     *
+     * TODO(ebo): unhide this
+     */
+    readonly syncState: SyncStateService;
 }
 /**
  * Sub-class of {@link SyncExecutionContext} that is passed to the `options` function of
@@ -918,6 +948,13 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
      * Information about state of the current sync.
      */
     readonly sync: UpdateSync;
+    /**
+     * A service for retrieving the sync state in Coda Brain.
+     * @hidden
+     *
+     * TODO(ebo): unhide this
+     */
+    readonly syncState: SyncStateService;
 }
 /**
  * Context provided to GetPermissionExecution calls

--- a/dist/api_types.js
+++ b/dist/api_types.js
@@ -261,7 +261,7 @@ var InvocationSource;
  * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.
  */
 function isSyncExecutionContext(context) {
-    return context.hasOwnProperty('sync') && context.hasOwnProperty('syncState');
+    return context.hasOwnProperty('sync') && context.hasOwnProperty('syncStateService');
 }
 exports.isSyncExecutionContext = isSyncExecutionContext;
 // A mapping exists in coda that allows these to show up in the UI.

--- a/dist/api_types.js
+++ b/dist/api_types.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.TableRole = exports.OptionsType = exports.FutureLiveDates = exports.PastLiveDates = exports.AllPrecannedDates = exports.PrecannedDate = exports.FromNowDateRanges = exports.PastLiveDateRanges = exports.UntilNowDateRanges = exports.PrecannedDateRange = exports.InvocationSource = exports.InvocationErrorType = exports.PermissionSyncMode = exports.ValidFetchMethods = exports.NetworkConnection = exports.ConnectionRequirement = exports.ParameterTypeInputMap = exports.ParameterType = exports.fileArray = exports.imageArray = exports.htmlArray = exports.dateArray = exports.booleanArray = exports.numberArray = exports.stringArray = exports.isArrayType = exports.Type = void 0;
+exports.TableRole = exports.OptionsType = exports.FutureLiveDates = exports.PastLiveDates = exports.AllPrecannedDates = exports.PrecannedDate = exports.FromNowDateRanges = exports.PastLiveDateRanges = exports.UntilNowDateRanges = exports.PrecannedDateRange = exports.isSyncExecutionContext = exports.InvocationSource = exports.InvocationErrorType = exports.PermissionSyncMode = exports.ValidFetchMethods = exports.NetworkConnection = exports.ConnectionRequirement = exports.ParameterTypeInputMap = exports.ParameterType = exports.fileArray = exports.imageArray = exports.htmlArray = exports.dateArray = exports.booleanArray = exports.numberArray = exports.stringArray = exports.isArrayType = exports.Type = void 0;
 /**
  * Markers used internally to represent data types for parameters and return values.
  * It should not be necessary to ever use these values directly.
@@ -257,6 +257,13 @@ var InvocationSource;
     InvocationSource["Doc"] = "Doc";
     InvocationSource["NativeIntegration"] = "NativeIntegration";
 })(InvocationSource || (exports.InvocationSource = InvocationSource = {}));
+/**
+ * A function to check if a given {@link ExecutionContext} is a {@link SyncExecutionContext}.
+ */
+function isSyncExecutionContext(context) {
+    return context.hasOwnProperty('sync') && context.hasOwnProperty('syncState');
+}
+exports.isSyncExecutionContext = isSyncExecutionContext;
 // A mapping exists in coda that allows these to show up in the UI.
 // If adding new values here, add them to that mapping and vice versa.
 /**

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -910,13 +910,6 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
 	 * Information about state of the current sync.
 	 */
 	readonly sync: UpdateSync;
-	/**
-	 * A service for retrieving the sync state in Coda Brain.
-	 * @hidden
-	 *
-	 * TODO(ebo): unhide this
-	 */
-	readonly syncState: SyncStateService;
 }
 /**
  * Context provided to GetPermissionExecution calls

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -632,6 +632,29 @@ export interface TemporaryBlobStorage {
 		downloadFilename?: string;
 	}): Promise<string>;
 }
+/**
+ * A service for retrieving the sync state in Coda Brain.
+ * @hidden
+ *
+ * TODO(ebo): unhide this
+ */
+export interface SyncStateService {
+	/**
+	 * Retrieve the latest version of rows with the given row ids and returns a mapping of row ids to
+	 * their latest version, e.g. {"Id-123": "1.0.0"}.
+	 *
+	 * If the row id is not found, it will not be included in the response.
+	 *
+	 * If the row version is not defined, it will be set to an empty string.
+	 *
+	 * @hidden
+	 *
+	 * TODO(ebo): unhide this
+	 */
+	getLatestRowVersions(rowIds: string[]): Promise<{
+		[rowId: string]: string;
+	}>;
+}
 declare enum PermissionSyncMode {
 	Personal = "Personal",
 	PermissionAware = "PermissionAware"
@@ -845,6 +868,13 @@ export interface SyncExecutionContext<ContinuationT = Continuation, IncrementalC
 	 * Information about state of the current sync.
 	 */
 	readonly sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
+	/**
+	 * A service for retrieving the sync state in Coda Brain.
+	 * @hidden
+	 *
+	 * TODO(ebo): unhide this
+	 */
+	readonly syncState: SyncStateService;
 }
 /**
  * Sub-class of {@link SyncExecutionContext} that is passed to the `options` function of
@@ -880,6 +910,13 @@ export interface UpdateSyncExecutionContext extends ExecutionContext {
 	 * Information about state of the current sync.
 	 */
 	readonly sync: UpdateSync;
+	/**
+	 * A service for retrieving the sync state in Coda Brain.
+	 * @hidden
+	 *
+	 * TODO(ebo): unhide this
+	 */
+	readonly syncState: SyncStateService;
 }
 /**
  * Context provided to GetPermissionExecution calls

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -874,7 +874,7 @@ export interface SyncExecutionContext<ContinuationT = Continuation, IncrementalC
 	 *
 	 * TODO(ebo): unhide this
 	 */
-	readonly syncState: SyncStateService;
+	readonly syncStateService: SyncStateService;
 }
 /**
  * Sub-class of {@link SyncExecutionContext} that is passed to the `options` function of

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -112,6 +112,7 @@ export type { SyncExecutionContext } from './api_types';
 export type { SyncFormulaResult } from './api';
 export type { SyncTableDef } from './api';
 export type { SyncTableOptions } from './api';
+export type { SyncStateService } from './api_types';
 export type { TemporaryBlobStorage } from './api_types';
 export { Type } from './api_types';
 export type { TypedPackFormula } from './api';

--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -52,7 +52,7 @@ export declare function injectExecutionContext({ context, fetcher, temporaryBlob
     context: Context;
     fetcher: Fetcher;
     temporaryBlobStorage: TemporaryBlobStorage;
-    syncState: SyncStateService;
+    syncState: SyncStateService | undefined;
     logger: Logger;
 } & ExecutionContextPrimitives): Promise<void>;
 export declare function registerBundle(isolate: Isolate, context: Context, path: string, stubName: string, requiresManualClosure?: boolean): Promise<void>;

--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -11,6 +11,7 @@ import type { Logger } from '../../api_types';
 import type { PackFunctionResponse } from '../types';
 import type { ParamDefs } from '../../api_types';
 import type { ParamValues } from '../../api_types';
+import type { SyncStateService } from '../../api_types';
 import type { SyncUpdate } from '../../api';
 import type { TemporaryBlobStorage } from '../../api_types';
 export type { Context } from 'isolated-vm';
@@ -47,10 +48,11 @@ export type ExecutionContextPrimitives = Omit<ExecutionContext, 'fetcher' | 'tem
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }: {
+export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncState, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }: {
     context: Context;
     fetcher: Fetcher;
     temporaryBlobStorage: TemporaryBlobStorage;
+    syncState: SyncStateService;
     logger: Logger;
 } & ExecutionContextPrimitives): Promise<void>;
 export declare function registerBundle(isolate: Isolate, context: Context, path: string, stubName: string, requiresManualClosure?: boolean): Promise<void>;

--- a/dist/runtime/bootstrap/index.d.ts
+++ b/dist/runtime/bootstrap/index.d.ts
@@ -48,11 +48,11 @@ export type ExecutionContextPrimitives = Omit<ExecutionContext, 'fetcher' | 'tem
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncState, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }: {
+export declare function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncStateService, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }: {
     context: Context;
     fetcher: Fetcher;
     temporaryBlobStorage: TemporaryBlobStorage;
-    syncState: SyncStateService | undefined;
+    syncStateService: SyncStateService | undefined;
     logger: Logger;
 } & ExecutionContextPrimitives): Promise<void>;
 export declare function registerBundle(isolate: Isolate, context: Context, path: string, stubName: string, requiresManualClosure?: boolean): Promise<void>;

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -150,12 +150,13 @@ exports.injectSerializer = injectSerializer;
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }) {
+async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncState, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }) {
     (0, ensure_1.ensureNever)();
     // Inject all of the primitives into a global we'll access when we execute the pack function.
     const executionContextPrimitives = {
         fetcher: {},
         temporaryBlobStorage: {},
+        syncState: {},
         logger: {},
         endpoint,
         invocationLocation,
@@ -180,6 +181,7 @@ async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, 
     await injectLogFunction(context, 'console.log', logger.info.bind(logger));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeBlob', temporaryBlobStorage.storeBlob.bind(temporaryBlobStorage));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeUrl', temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage));
+    await injectAsyncFunction(context, 'executionContext.syncState.getLatestRowVersions', syncState.getLatestRowVersions.bind(syncState));
 }
 exports.injectExecutionContext = injectExecutionContext;
 async function registerBundle(isolate, context, path, stubName, requiresManualClosure = true) {

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -181,7 +181,9 @@ async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, 
     await injectLogFunction(context, 'console.log', logger.info.bind(logger));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeBlob', temporaryBlobStorage.storeBlob.bind(temporaryBlobStorage));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeUrl', temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage));
-    await injectAsyncFunction(context, 'executionContext.syncState.getLatestRowVersions', syncState.getLatestRowVersions.bind(syncState));
+    if (syncState) {
+        await injectAsyncFunction(context, 'executionContext.syncState.getLatestRowVersions', syncState.getLatestRowVersions.bind(syncState));
+    }
 }
 exports.injectExecutionContext = injectExecutionContext;
 async function registerBundle(isolate, context, path, stubName, requiresManualClosure = true) {

--- a/dist/runtime/bootstrap/index.js
+++ b/dist/runtime/bootstrap/index.js
@@ -150,13 +150,13 @@ exports.injectSerializer = injectSerializer;
 /**
  * Injects the ExecutionContext object, including stubs for network calls, into the isolate.
  */
-async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncState, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }) {
+async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, syncStateService, logger, endpoint, invocationLocation, timezone, invocationToken, sync, authenticationName, executionId, previousAttemptError, ...rest }) {
     (0, ensure_1.ensureNever)();
     // Inject all of the primitives into a global we'll access when we execute the pack function.
     const executionContextPrimitives = {
         fetcher: {},
         temporaryBlobStorage: {},
-        syncState: {},
+        syncStateService: {},
         logger: {},
         endpoint,
         invocationLocation,
@@ -181,8 +181,8 @@ async function injectExecutionContext({ context, fetcher, temporaryBlobStorage, 
     await injectLogFunction(context, 'console.log', logger.info.bind(logger));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeBlob', temporaryBlobStorage.storeBlob.bind(temporaryBlobStorage));
     await injectAsyncFunction(context, 'executionContext.temporaryBlobStorage.storeUrl', temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage));
-    if (syncState) {
-        await injectAsyncFunction(context, 'executionContext.syncState.getLatestRowVersions', syncState.getLatestRowVersions.bind(syncState));
+    if (syncStateService) {
+        await injectAsyncFunction(context, 'executionContext.syncStateService.getLatestRowVersions', syncStateService.getLatestRowVersions.bind(syncStateService));
     }
 }
 exports.injectExecutionContext = injectExecutionContext;

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -45,7 +45,7 @@ export declare function executeFormulaOrSyncWithVM<T extends PackFormulaResult |
     formulaName: string;
     params: ParamValues<ParamDefs>;
     bundlePath: string;
-    executionContext?: ExecutionContext;
+    executionContext?: SyncExecutionContext;
 }): Promise<T>;
 export declare class VMError {
     name: string;

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -45,7 +45,7 @@ export declare function executeFormulaOrSyncWithVM<T extends PackFormulaResult |
     formulaName: string;
     params: ParamValues<ParamDefs>;
     bundlePath: string;
-    executionContext?: SyncExecutionContext;
+    executionContext?: ExecutionContext;
 }): Promise<T>;
 export declare class VMError {
     name: string;

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -555,8 +555,7 @@ function newRealFetcherExecutionContext(packDef, manifestPath) {
 }
 exports.newRealFetcherExecutionContext = newRealFetcherExecutionContext;
 function newRealFetcherSyncExecutionContext(packDef, manifestPath) {
-    const context = newRealFetcherExecutionContext(packDef, manifestPath);
-    return { ...context, sync: {} };
+    return (0, fetcher_2.newFetcherSyncExecutionContext)(buildUpdateCredentialsCallback(manifestPath), (0, helpers_3.getPackAuth)(packDef), packDef.networkDomains, getCredentials(manifestPath));
 }
 exports.newRealFetcherSyncExecutionContext = newRealFetcherSyncExecutionContext;
 const SyncUpdateSchema = z.object({

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -547,6 +547,14 @@ class AuthenticatingBlobStorage {
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${(0, uuid_1.v4)()}`;
     }
 }
+class AuthenticatingSyncStateService {
+    async getLatestRowVersions(rowIds) {
+        return rowIds.reduce((acc, rowId) => {
+            acc[rowId] = '1.0.0';
+            return acc;
+        }, {});
+    }
+}
 function newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials) {
     const invocationToken = (0, uuid_1.v4)();
     const fetcher = new AuthenticatingFetcher(updateCredentialsCallback, authDef, networkDomains, credentials, invocationToken);
@@ -564,7 +572,7 @@ function newFetcherExecutionContext(updateCredentialsCallback, authDef, networkD
 exports.newFetcherExecutionContext = newFetcherExecutionContext;
 function newFetcherSyncExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials) {
     const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-    return { ...context, sync: {} };
+    return { ...context, sync: {}, syncState: new AuthenticatingSyncStateService() };
 }
 exports.newFetcherSyncExecutionContext = newFetcherSyncExecutionContext;
 function addQueryParam(url, param, value) {

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -572,7 +572,7 @@ function newFetcherExecutionContext(updateCredentialsCallback, authDef, networkD
 exports.newFetcherExecutionContext = newFetcherExecutionContext;
 function newFetcherSyncExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials) {
     const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-    return { ...context, sync: {}, syncState: new FakeSyncStateService() };
+    return { ...context, sync: {}, syncStateService: new FakeSyncStateService() };
 }
 exports.newFetcherSyncExecutionContext = newFetcherSyncExecutionContext;
 function addQueryParam(url, param, value) {

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -547,7 +547,7 @@ class AuthenticatingBlobStorage {
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${(0, uuid_1.v4)()}`;
     }
 }
-class AuthenticatingSyncStateService {
+class FakeSyncStateService {
     async getLatestRowVersions(rowIds) {
         return rowIds.reduce((acc, rowId) => {
             acc[rowId] = '1.0.0';
@@ -572,7 +572,7 @@ function newFetcherExecutionContext(updateCredentialsCallback, authDef, networkD
 exports.newFetcherExecutionContext = newFetcherExecutionContext;
 function newFetcherSyncExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials) {
     const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-    return { ...context, sync: {}, syncState: new AuthenticatingSyncStateService() };
+    return { ...context, sync: {}, syncState: new FakeSyncStateService() };
 }
 exports.newFetcherSyncExecutionContext = newFetcherSyncExecutionContext;
 function addQueryParam(url, param, value) {

--- a/dist/testing/ivm_helper.d.ts
+++ b/dist/testing/ivm_helper.d.ts
@@ -1,3 +1,3 @@
+import type { ExecutionContext } from '../api_types';
 import type { Context as IVMContext } from 'isolated-vm';
-import type { SyncExecutionContext } from '../api_types';
-export declare function setupIvmContext(bundlePath: string, executionContext: SyncExecutionContext): Promise<IVMContext>;
+export declare function setupIvmContext(bundlePath: string, executionContext: ExecutionContext): Promise<IVMContext>;

--- a/dist/testing/ivm_helper.d.ts
+++ b/dist/testing/ivm_helper.d.ts
@@ -1,3 +1,3 @@
-import type { ExecutionContext } from '../api';
 import type { Context as IVMContext } from 'isolated-vm';
-export declare function setupIvmContext(bundlePath: string, executionContext: ExecutionContext): Promise<IVMContext>;
+import type { SyncExecutionContext } from '../api_types';
+export declare function setupIvmContext(bundlePath: string, executionContext: SyncExecutionContext): Promise<IVMContext>;

--- a/dist/testing/ivm_helper.js
+++ b/dist/testing/ivm_helper.js
@@ -57,7 +57,7 @@ async function setupIvmContext(bundlePath, executionContext) {
         authenticationName: executionContext.authenticationName,
         executionId: executionContext.executionId,
         previousAttemptError: executionContext.previousAttemptError,
-        syncState: (0, api_types_1.isSyncExecutionContext)(executionContext) ? executionContext.syncState : undefined,
+        syncStateService: (0, api_types_1.isSyncExecutionContext)(executionContext) ? executionContext.syncStateService : undefined,
     });
     return ivmContext;
 }

--- a/dist/testing/ivm_helper.js
+++ b/dist/testing/ivm_helper.js
@@ -11,6 +11,7 @@ const ivm_wrapper_1 = require("./ivm_wrapper");
 const bootstrap_2 = require("../runtime/bootstrap");
 const bootstrap_3 = require("../runtime/bootstrap");
 const bootstrap_4 = require("../runtime/bootstrap");
+const api_types_1 = require("../api_types");
 const path_1 = __importDefault(require("path"));
 const bootstrap_5 = require("../runtime/bootstrap");
 const IsolateMemoryLimit = 128;
@@ -56,7 +57,7 @@ async function setupIvmContext(bundlePath, executionContext) {
         authenticationName: executionContext.authenticationName,
         executionId: executionContext.executionId,
         previousAttemptError: executionContext.previousAttemptError,
-        syncState: executionContext.syncState,
+        syncState: (0, api_types_1.isSyncExecutionContext)(executionContext) ? executionContext.syncState : undefined,
     });
     return ivmContext;
 }

--- a/dist/testing/ivm_helper.js
+++ b/dist/testing/ivm_helper.js
@@ -56,6 +56,7 @@ async function setupIvmContext(bundlePath, executionContext) {
         authenticationName: executionContext.authenticationName,
         executionId: executionContext.executionId,
         previousAttemptError: executionContext.previousAttemptError,
+        syncState: executionContext.syncState,
     });
     return ivmContext;
 }

--- a/dist/testing/mocks.d.ts
+++ b/dist/testing/mocks.d.ts
@@ -4,6 +4,7 @@ import type { FetchRequest } from '../api_types';
 import type { FetchResponse } from '../api_types';
 import type { Sync } from '../api_types';
 import type { SyncExecutionContext } from '../api_types';
+import type { SyncStateService } from '../api_types';
 import type { TemporaryBlobStorage } from '../api_types';
 import sinon from 'sinon';
 export type SinonFunctionSpy<T extends (...args: any[]) => any> = T extends (...args: infer ArgsT) => infer RetT ? sinon.SinonSpy<ArgsT, RetT> : never;
@@ -19,6 +20,9 @@ export interface MockExecutionContext extends ExecutionContext {
 }
 export interface MockSyncExecutionContext<ContinuationT = Continuation, IncrementalContinuationT = ContinuationT, IncrementalSyncContinuationT = ContinuationT> extends MockExecutionContext {
     sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
+    syncState: {
+        getLatestRowVersions: SinonFunctionStub<SyncStateService['getLatestRowVersions']>;
+    };
 }
 /** Mock type of the specified `SyncExecutionContext`. */
 export type SyncExecutionContextAsMock<T extends SyncExecutionContext> = T extends SyncExecutionContext<infer ContinuationT, infer IncrementalContinuationT, infer IncrementalSyncContinuationT> ? MockSyncExecutionContext<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT> : never;

--- a/dist/testing/mocks.d.ts
+++ b/dist/testing/mocks.d.ts
@@ -20,7 +20,7 @@ export interface MockExecutionContext extends ExecutionContext {
 }
 export interface MockSyncExecutionContext<ContinuationT = Continuation, IncrementalContinuationT = ContinuationT, IncrementalSyncContinuationT = ContinuationT> extends MockExecutionContext {
     sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
-    syncState: {
+    syncStateService: {
         getLatestRowVersions: SinonFunctionStub<SyncStateService['getLatestRowVersions']>;
     };
 }

--- a/dist/testing/mocks.js
+++ b/dist/testing/mocks.js
@@ -10,7 +10,7 @@ function newMockSyncExecutionContext(overrides) {
     return {
         ...newMockExecutionContext(),
         sync: {},
-        syncState: { getLatestRowVersions: sinon_1.default.stub() },
+        syncStateService: { getLatestRowVersions: sinon_1.default.stub() },
         ...overrides,
     };
 }

--- a/dist/testing/mocks.js
+++ b/dist/testing/mocks.js
@@ -7,7 +7,12 @@ exports.newJsonFetchResponse = exports.newMockExecutionContext = exports.newMock
 const sinon_1 = __importDefault(require("sinon"));
 const uuid_1 = require("uuid");
 function newMockSyncExecutionContext(overrides) {
-    return { ...newMockExecutionContext(), sync: {}, ...overrides };
+    return {
+        ...newMockExecutionContext(),
+        sync: {},
+        syncState: { getLatestRowVersions: sinon_1.default.stub() },
+        ...overrides,
+    };
 }
 exports.newMockSyncExecutionContext = newMockSyncExecutionContext;
 function newMockExecutionContext(overrides) {

--- a/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
+++ b/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
@@ -22,7 +22,7 @@ search:
 | :------ | :------ |
 | `«destructured»` | `Object` |
 | › `bundlePath` | `string` |
-| › `executionContext?` | [`ExecutionContext`](../interfaces/core.ExecutionContext.md) |
+| › `executionContext?` | [`SyncExecutionContext`](../interfaces/core.SyncExecutionContext.md)<[`Continuation`](../interfaces/core.Continuation.md), [`Continuation`](../interfaces/core.Continuation.md), [`Continuation`](../interfaces/core.Continuation.md)\> |
 | › `formulaName` | `string` |
 | › `params` | [`ParamValues`](../types/core.ParamValues.md)<[`ParamDefs`](../types/core.ParamDefs.md)\> |
 

--- a/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
+++ b/docs/reference/sdk/functions/testing.executeFormulaOrSyncWithVM.md
@@ -22,7 +22,7 @@ search:
 | :------ | :------ |
 | `«destructured»` | `Object` |
 | › `bundlePath` | `string` |
-| › `executionContext?` | [`SyncExecutionContext`](../interfaces/core.SyncExecutionContext.md)<[`Continuation`](../interfaces/core.Continuation.md), [`Continuation`](../interfaces/core.Continuation.md), [`Continuation`](../interfaces/core.Continuation.md)\> |
+| › `executionContext?` | [`ExecutionContext`](../interfaces/core.ExecutionContext.md) |
 | › `formulaName` | `string` |
 | › `params` | [`ParamValues`](../types/core.ParamValues.md)<[`ParamDefs`](../types/core.ParamDefs.md)\> |
 

--- a/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
@@ -103,6 +103,18 @@ Information about state of the current sync. Only populated if this is a sync ta
 
 ___
 
+### syncState
+
+• **syncState**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `getLatestRowVersions` | `SinonStub`<[rowIds: string[]], `Promise`<{ `[rowId: string]`: `string`;  }\>\> |
+
+___
+
 ### temporaryBlobStorage
 
 • **temporaryBlobStorage**: `Object`

--- a/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
+++ b/docs/reference/sdk/interfaces/testing.MockSyncExecutionContext.md
@@ -103,9 +103,9 @@ Information about state of the current sync. Only populated if this is a sync ta
 
 ___
 
-### syncState
+### syncStateService
 
-• **syncState**: `Object`
+• **syncStateService**: `Object`
 
 #### Type declaration
 

--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,7 @@ export type {SyncExecutionContext} from './api_types';
 export type {SyncFormulaResult} from './api';
 export type {SyncTableDef} from './api';
 export type {SyncTableOptions} from './api';
+export type {SyncStateService} from './api_types';
 export type {TemporaryBlobStorage} from './api_types';
 export {Type} from './api_types';
 export type {TypedPackFormula} from './api';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.8.6-prerelease.2",
+  "version": "1.8.6-prerelease.3",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -229,7 +229,7 @@ export async function injectExecutionContext({
   context,
   fetcher,
   temporaryBlobStorage,
-  syncState,
+  syncStateService,
   logger,
   endpoint,
   invocationLocation,
@@ -244,7 +244,7 @@ export async function injectExecutionContext({
   context: Context;
   fetcher: Fetcher;
   temporaryBlobStorage: TemporaryBlobStorage;
-  syncState: SyncStateService | undefined;
+  syncStateService: SyncStateService | undefined;
   logger: Logger;
 } & ExecutionContextPrimitives): Promise<void> {
   ensureNever<keyof typeof rest>();
@@ -252,7 +252,7 @@ export async function injectExecutionContext({
   const executionContextPrimitives = {
     fetcher: {},
     temporaryBlobStorage: {},
-    syncState: {},
+    syncStateService: {},
     logger: {},
     endpoint,
     invocationLocation,
@@ -291,11 +291,11 @@ export async function injectExecutionContext({
     temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage),
   );
 
-  if (syncState) {
+  if (syncStateService) {
     await injectAsyncFunction(
       context,
-      'executionContext.syncState.getLatestRowVersions',
-      syncState.getLatestRowVersions.bind(syncState),
+      'executionContext.syncStateService.getLatestRowVersions',
+      syncStateService.getLatestRowVersions.bind(syncStateService),
     );
   }
 }

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -244,7 +244,7 @@ export async function injectExecutionContext({
   context: Context;
   fetcher: Fetcher;
   temporaryBlobStorage: TemporaryBlobStorage;
-  syncState: SyncStateService;
+  syncState: SyncStateService | undefined;
   logger: Logger;
 } & ExecutionContextPrimitives): Promise<void> {
   ensureNever<keyof typeof rest>();
@@ -291,11 +291,13 @@ export async function injectExecutionContext({
     temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage),
   );
 
-  await injectAsyncFunction(
-    context,
-    'executionContext.syncState.getLatestRowVersions',
-    syncState.getLatestRowVersions.bind(syncState),
-  );
+  if (syncState) {
+    await injectAsyncFunction(
+      context,
+      'executionContext.syncState.getLatestRowVersions',
+      syncState.getLatestRowVersions.bind(syncState),
+    );
+  }
 }
 
 export async function registerBundle(

--- a/runtime/bootstrap/index.ts
+++ b/runtime/bootstrap/index.ts
@@ -11,6 +11,7 @@ import type {Logger} from '../../api_types';
 import type {PackFunctionResponse} from '../types';
 import type {ParamDefs} from '../../api_types';
 import type {ParamValues} from '../../api_types';
+import type {SyncStateService} from '../../api_types';
 import type {SyncUpdate} from '../../api';
 import type {TemporaryBlobStorage} from '../../api_types';
 import {ensureNever} from '../../helpers/ensure';
@@ -228,6 +229,7 @@ export async function injectExecutionContext({
   context,
   fetcher,
   temporaryBlobStorage,
+  syncState,
   logger,
   endpoint,
   invocationLocation,
@@ -242,6 +244,7 @@ export async function injectExecutionContext({
   context: Context;
   fetcher: Fetcher;
   temporaryBlobStorage: TemporaryBlobStorage;
+  syncState: SyncStateService;
   logger: Logger;
 } & ExecutionContextPrimitives): Promise<void> {
   ensureNever<keyof typeof rest>();
@@ -249,6 +252,7 @@ export async function injectExecutionContext({
   const executionContextPrimitives = {
     fetcher: {},
     temporaryBlobStorage: {},
+    syncState: {},
     logger: {},
     endpoint,
     invocationLocation,
@@ -285,6 +289,12 @@ export async function injectExecutionContext({
     context,
     'executionContext.temporaryBlobStorage.storeUrl',
     temporaryBlobStorage.storeUrl.bind(temporaryBlobStorage),
+  );
+
+  await injectAsyncFunction(
+    context,
+    'executionContext.syncState.getLatestRowVersions',
+    syncState.getLatestRowVersions.bind(syncState),
   );
 }
 

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -432,7 +432,7 @@ export async function executeFormulaOrSyncWithVM<T extends PackFormulaResult | G
   formulaName: string;
   params: ParamValues<ParamDefs>;
   bundlePath: string;
-  executionContext?: SyncExecutionContext;
+  executionContext?: ExecutionContext;
 }): Promise<T> {
   const manifest = await importManifest(bundlePath);
   const syncFormula = tryFindSyncFormula(manifest, formulaName);

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -432,7 +432,7 @@ export async function executeFormulaOrSyncWithVM<T extends PackFormulaResult | G
   formulaName: string;
   params: ParamValues<ParamDefs>;
   bundlePath: string;
-  executionContext?: ExecutionContext;
+  executionContext?: SyncExecutionContext;
 }): Promise<T> {
   const manifest = await importManifest(bundlePath);
   const syncFormula = tryFindSyncFormula(manifest, formulaName);
@@ -858,8 +858,12 @@ export function newRealFetcherSyncExecutionContext(
   packDef: BasicPackDefinition,
   manifestPath: string,
 ): SyncExecutionContext {
-  const context = newRealFetcherExecutionContext(packDef, manifestPath);
-  return {...context, sync: {}};
+  return newFetcherSyncExecutionContext(
+    buildUpdateCredentialsCallback(manifestPath),
+    getPackAuth(packDef),
+    packDef.networkDomains,
+    getCredentials(manifestPath),
+  );
 }
 
 const SyncUpdateSchema = z.object({

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -25,6 +25,7 @@ import {STSClient} from '@aws-sdk/client-sts';
 import {Sha256} from '@aws-crypto/sha256-js';
 import {SignatureV4} from '@aws-sdk/signature-v4';
 import type {SyncExecutionContext} from '../api_types';
+import type {SyncStateService} from '../api_types';
 import type {TemporaryBlobStorage} from '../api_types';
 import type {TokenCredentials} from './auth_types';
 import {URL} from 'url';
@@ -703,6 +704,15 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
   }
 }
 
+class AuthenticatingSyncStateService implements SyncStateService {
+  async getLatestRowVersions(rowIds: string[]): Promise<{[rowId: string]: string}> {
+    return rowIds.reduce((acc, rowId) => {
+      acc[rowId] = '1.0.0';
+      return acc;
+    }, {} as {[rowId: string]: string});
+  }
+}
+
 export function newFetcherExecutionContext(
   updateCredentialsCallback: (newCreds: Credentials) => void | undefined,
   authDef: Authentication | undefined,
@@ -736,7 +746,7 @@ export function newFetcherSyncExecutionContext(
   credentials?: Credentials,
 ): SyncExecutionContext {
   const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-  return {...context, sync: {}};
+  return {...context, sync: {}, syncState: new AuthenticatingSyncStateService()};
 }
 
 function addQueryParam(url: string, param: string, value: string): string {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -704,7 +704,7 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
   }
 }
 
-class AuthenticatingSyncStateService implements SyncStateService {
+class FakeSyncStateService implements SyncStateService {
   async getLatestRowVersions(rowIds: string[]): Promise<{[rowId: string]: string}> {
     return rowIds.reduce((acc, rowId) => {
       acc[rowId] = '1.0.0';
@@ -746,7 +746,7 @@ export function newFetcherSyncExecutionContext(
   credentials?: Credentials,
 ): SyncExecutionContext {
   const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-  return {...context, sync: {}, syncState: new AuthenticatingSyncStateService()};
+  return {...context, sync: {}, syncState: new FakeSyncStateService()};
 }
 
 function addQueryParam(url: string, param: string, value: string): string {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -746,7 +746,7 @@ export function newFetcherSyncExecutionContext(
   credentials?: Credentials,
 ): SyncExecutionContext {
   const context = newFetcherExecutionContext(updateCredentialsCallback, authDef, networkDomains, credentials);
-  return {...context, sync: {}, syncState: new FakeSyncStateService()};
+  return {...context, sync: {}, syncStateService: new FakeSyncStateService()};
 }
 
 function addQueryParam(url: string, param: string, value: string): string {

--- a/testing/ivm_helper.ts
+++ b/testing/ivm_helper.ts
@@ -1,5 +1,5 @@
-import type {ExecutionContext} from '../api';
 import type {Context as IVMContext} from 'isolated-vm';
+import type {SyncExecutionContext} from '../api_types';
 import {build as buildBundle} from '../cli/build';
 import {createIsolateContext} from '../runtime/bootstrap';
 import fs from 'fs';
@@ -17,7 +17,7 @@ const IsolateMemoryLimit = 128;
 const CompiledHelperBundlePath = getThunkPath();
 const HelperTsSourceFile = `${__dirname}/../runtime/thunk/thunk.ts`;
 
-export async function setupIvmContext(bundlePath: string, executionContext: ExecutionContext): Promise<IVMContext> {
+export async function setupIvmContext(bundlePath: string, executionContext: SyncExecutionContext): Promise<IVMContext> {
   const ivm = getIvm();
   // creating an isolate with 128M memory limit.
   const isolate = new ivm.Isolate({memoryLimit: IsolateMemoryLimit});
@@ -58,6 +58,7 @@ export async function setupIvmContext(bundlePath: string, executionContext: Exec
     authenticationName: executionContext.authenticationName,
     executionId: executionContext.executionId,
     previousAttemptError: executionContext.previousAttemptError,
+    syncState: executionContext.syncState,
   });
 
   return ivmContext;

--- a/testing/ivm_helper.ts
+++ b/testing/ivm_helper.ts
@@ -1,5 +1,5 @@
+import type {ExecutionContext} from '../api_types';
 import type {Context as IVMContext} from 'isolated-vm';
-import type {SyncExecutionContext} from '../api_types';
 import {build as buildBundle} from '../cli/build';
 import {createIsolateContext} from '../runtime/bootstrap';
 import fs from 'fs';
@@ -7,6 +7,7 @@ import {getIvm} from './ivm_wrapper';
 import {getThunkPath} from '../runtime/bootstrap';
 import {injectExecutionContext} from '../runtime/bootstrap';
 import {injectSerializer} from '../runtime/bootstrap';
+import { isSyncExecutionContext} from '../api_types';
 import path from 'path';
 import {registerBundles} from '../runtime/bootstrap';
 
@@ -17,7 +18,7 @@ const IsolateMemoryLimit = 128;
 const CompiledHelperBundlePath = getThunkPath();
 const HelperTsSourceFile = `${__dirname}/../runtime/thunk/thunk.ts`;
 
-export async function setupIvmContext(bundlePath: string, executionContext: SyncExecutionContext): Promise<IVMContext> {
+export async function setupIvmContext(bundlePath: string, executionContext: ExecutionContext): Promise<IVMContext> {
   const ivm = getIvm();
   // creating an isolate with 128M memory limit.
   const isolate = new ivm.Isolate({memoryLimit: IsolateMemoryLimit});
@@ -58,7 +59,7 @@ export async function setupIvmContext(bundlePath: string, executionContext: Sync
     authenticationName: executionContext.authenticationName,
     executionId: executionContext.executionId,
     previousAttemptError: executionContext.previousAttemptError,
-    syncState: executionContext.syncState,
+    syncState: isSyncExecutionContext(executionContext) ? executionContext.syncState : undefined,
   });
 
   return ivmContext;

--- a/testing/ivm_helper.ts
+++ b/testing/ivm_helper.ts
@@ -59,7 +59,7 @@ export async function setupIvmContext(bundlePath: string, executionContext: Exec
     authenticationName: executionContext.authenticationName,
     executionId: executionContext.executionId,
     previousAttemptError: executionContext.previousAttemptError,
-    syncState: isSyncExecutionContext(executionContext) ? executionContext.syncState : undefined,
+    syncStateService: isSyncExecutionContext(executionContext) ? executionContext.syncStateService : undefined,
   });
 
   return ivmContext;

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -4,6 +4,7 @@ import type {FetchRequest} from '../api_types';
 import type {FetchResponse} from '../api_types';
 import type {Sync} from '../api_types';
 import type {SyncExecutionContext} from '../api_types';
+import type {SyncStateService} from '../api_types';
 import type {TemporaryBlobStorage} from '../api_types';
 import sinon from 'sinon';
 import {v4} from 'uuid';
@@ -32,6 +33,9 @@ export interface MockSyncExecutionContext<
   IncrementalSyncContinuationT = ContinuationT,
 > extends MockExecutionContext {
   sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
+  syncState: {
+    getLatestRowVersions: SinonFunctionStub<SyncStateService['getLatestRowVersions']>;
+  };
 }
 
 /** Mock type of the specified `SyncExecutionContext`. */
@@ -46,7 +50,12 @@ export type SyncExecutionContextAsMock<T extends SyncExecutionContext> = T exten
 export function newMockSyncExecutionContext<T extends SyncExecutionContext<any>>(
   overrides?: Partial<T>,
 ): SyncExecutionContextAsMock<T> {
-  return {...newMockExecutionContext(), sync: {}, ...overrides} as SyncExecutionContextAsMock<T>;
+  return {
+    ...newMockExecutionContext(),
+    sync: {},
+    syncState: {getLatestRowVersions: sinon.stub()},
+    ...overrides,
+  } as SyncExecutionContextAsMock<T>;
 }
 
 export function newMockExecutionContext(overrides?: Partial<MockExecutionContext>): MockExecutionContext {

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -33,7 +33,7 @@ export interface MockSyncExecutionContext<
   IncrementalSyncContinuationT = ContinuationT,
 > extends MockExecutionContext {
   sync: Sync<ContinuationT, IncrementalContinuationT, IncrementalSyncContinuationT>;
-  syncState: {
+  syncStateService: {
     getLatestRowVersions: SinonFunctionStub<SyncStateService['getLatestRowVersions']>;
   };
 }
@@ -53,7 +53,7 @@ export function newMockSyncExecutionContext<T extends SyncExecutionContext<any>>
   return {
     ...newMockExecutionContext(),
     sync: {},
-    syncState: {getLatestRowVersions: sinon.stub()},
+    syncStateService: {getLatestRowVersions: sinon.stub()},
     ...overrides,
   } as SyncExecutionContextAsMock<T>;
 }


### PR DESCRIPTION
Discussion: https://coda.io/d/go-brainwriteups_dQYLHXsHZWS/Pack-SDK-Get-item-versions-interface_suFrdPVO?utm_source=slack#_luPjCMl1

Follow up: update `item ids` to `row ids` for ingestion related variables 

PTAL: @patrick-codaio @erickoledadevrel  @jonathan-codaio 