### PR TITLE
Bump path-to-regexp in SDK.

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
       "sharp@<0.32.6": ">=0.32.6",
       "fast-xml-parser@=4.2.4": ">=4.2.5",
       "semver@>=7.0.0 <7.5.2": ">=7.5.2",
-      "elliptic@<6.6.0": ">=6.6.0"
+      "elliptic@<6.6.0": ">=6.6.0",
+      "path-to-regexp@<0.1.12": "^0.1.12"
     },
     "packageExtensions": {
       "isolated-vm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   fast-xml-parser@=4.2.4: '>=4.2.5'
   semver@>=7.0.0 <7.5.2: '>=7.5.2'
   elliptic@<6.6.0: '>=6.6.0'
+  path-to-regexp@<0.1.12: ^0.1.12
 
 packageExtensionsChecksum: 380851e2db75863824bdde5716c4ef00
 
@@ -4746,7 +4747,7 @@ packages:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.10
+      path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -6853,8 +6854,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@0.1.10:
-    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+  /path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
   /path-to-regexp@8.2.0:


### PR DESCRIPTION
Addresses https://github.com/coda/packs-sdk/security/dependabot/122

PTAL @neal-codaio @dweitzman-codaio @coda/packs 