### PR TITLE
Show stack traces for errors thrown by Pack code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 - SDK requires node version 20 or higher
 - Update `Sync` parameter type names for clarity
 
+### Fixed
+
+- When using `coda execute`, if the Pack fails due to an error the stack trace will be included in the output again.
+
 ## [1.8.6] - 2024-12-13
 
 ### Changed

--- a/dist/testing/execution.d.ts
+++ b/dist/testing/execution.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import type { BasicPackDefinition } from '../types';
 import type { ExecutionContext } from '../api_types';
 import type { FormulaSpecification } from '../runtime/types';
@@ -16,7 +15,6 @@ import type { ParamValues } from '../api_types';
 import type { SyncExecutionContext } from '../api_types';
 import type { SyncFormulaSpecification } from '../runtime/types';
 import type { UpdateSyncExecutionContext } from '../api_types';
-import util from 'util';
 export declare const DEFAULT_MAX_ROWS = 1000;
 export interface ExecuteOptions {
     validateParams?: boolean;
@@ -47,13 +45,6 @@ export declare function executeFormulaOrSyncWithVM<T extends PackFormulaResult |
     bundlePath: string;
     executionContext?: ExecutionContext;
 }): Promise<T>;
-export declare class VMError {
-    name: string;
-    message: string;
-    stack: string;
-    constructor(name: string, message: string, stack: string);
-    [util.inspect.custom](): string;
-}
 export declare function executeFormulaOrSyncWithRawParams<T extends FormulaSpecification>({ formulaSpecification, params: rawParams, manifest, executionContext, }: {
     formulaSpecification: T;
     params: string[];

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -189,7 +189,10 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
         }
     }
     catch (err) {
-        (0, helpers_5.print)(err.message || err);
+        (0, helpers_5.print)(err);
+        if (!vm && !isSourceMapsEnabled()) {
+            (0, helpers_5.print)('\nEnable the Node flag --enable-source-maps to get an accurate stack trace.');
+        }
         process.exit(1);
     }
 }
@@ -596,4 +599,12 @@ function parseGetPermissionRequest(manifest, formulaSpecification, rawParams) {
         verifyFormulaForAuthenticationName: false,
     });
     return { permissionRequest: parseResult.data, params: (0, coercion_1.coerceParams)(syncFormula, paramsCopy) };
+}
+function isSourceMapsEnabled() {
+    var _a, _b;
+    const flags = [
+        ...process.execArgv,
+        ...(_b = (_a = process.env.NODE_OPTIONS) === null || _a === void 0 ? void 0 : _a.split(/\s+/)) !== null && _b !== void 0 ? _b : [],
+    ];
+    return flags.includes('--enable-source-maps');
 }

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -621,9 +621,10 @@ function isSourceMapsEnabled() {
 }
 class DeveloperError extends Error {
     constructor(err) {
-        super('The Pack code threw an error.', {
+        super('The Pack code threw an error: ' + err.message, {
             cause: err,
         });
+        this.stack = err.stack;
         this.name = 'DeveloperError';
         Object.setPrototypeOf(this, DeveloperError.prototype);
     }

--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -96,7 +96,7 @@ useDeprecatedResultNormalization = true, } = {}) {
         });
     }
     catch (err) {
-        throw asDeveloperError(err);
+        throw new DeveloperError(err);
     }
     if (formulaSpec.type === types_1.FormulaType.SyncUpdate) {
         return result;
@@ -191,7 +191,7 @@ async function executeFormulaOrSyncFromCLI({ formulaName, params, manifest, mani
         }
     }
     catch (err) {
-        if (isDeveloperError(err)) {
+        if (err instanceof DeveloperError) {
             // The error came from the Pack code. Print the inner error, including the stack trace.
             (0, helpers_5.print)(err.cause);
             // If source maps are not enabled, print a warning.
@@ -341,7 +341,7 @@ async function executeFormulaOrSyncWithVM({ formulaName, params, bundlePath, exe
         return await (0, bootstrap_1.executeThunk)(ivmContext, { params, formulaSpec: formulaSpecification }, bundlePath, bundlePath + '.map');
     }
     catch (err) {
-        throw asDeveloperError(err);
+        throw new DeveloperError(err);
     }
 }
 exports.executeFormulaOrSyncWithVM = executeFormulaOrSyncWithVM;
@@ -387,7 +387,7 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
         return await (0, bootstrap_1.executeThunk)(ivmContext, { params, formulaSpec: formulaSpecification, updates: syncUpdates, permissionRequest }, bundlePath, bundleSourceMapPath);
     }
     catch (err) {
-        throw asDeveloperError(err);
+        throw new DeveloperError(err);
     }
 }
 async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params: rawParams, manifest, executionContext, }) {
@@ -625,13 +625,6 @@ class DeveloperError extends Error {
             cause: err,
         });
         this.stack = err.stack;
-        this.name = 'DeveloperError';
         Object.setPrototypeOf(this, DeveloperError.prototype);
     }
-}
-function asDeveloperError(err) {
-    throw new DeveloperError(err);
-}
-function isDeveloperError(err) {
-    return err.name === 'DeveloperError';
 }

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -572,7 +572,7 @@ describe('Execution', () => {
           assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
         });
 
-        it('include stacktrace', async () => {
+        it('pack exceptions print stacktrace', async () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'Throw',
@@ -587,6 +587,24 @@ describe('Execution', () => {
           const exitValue = mockExit.args[0][0];
           assert.instanceOf(error, Error);
           assert.include(error.stack, path.join(__dirname, 'packs/fake.ts'));
+          assert.equal(exitValue, 1);
+        });
+
+        it('CLI errors don\'t print stacktrace', async () => {
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'NotRealFormula',
+            params: [],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const message = mockPrint.args[0][0];
+          const exitValue = mockExit.args[0][0];
+          assert.typeOf(message, 'string');
+          assert.notInclude(message, path.join(__dirname, '/packs-sdk/dist/'));
           assert.equal(exitValue, 1);
         });
       });

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -37,6 +37,7 @@ import {newJsonFetchResponse} from '../testing/mocks';
 import {newMockExecutionContext} from '../testing/mocks';
 import {newMockSyncExecutionContext} from '../testing/mocks';
 import {newPack} from '../builder';
+import path from 'path';
 import sinon from 'sinon';
 
 describe('Execution', () => {
@@ -444,10 +445,14 @@ describe('Execution', () => {
   });
 
   describe('CLI execution', () => {
+    let mockPrint: sinon.SinonStub;
     let mockPrintFull: sinon.SinonStub;
+    let mockExit: sinon.SinonStub;
 
     beforeEach(() => {
+      mockPrint = sinon.stub(helpers, 'print');
       mockPrintFull = sinon.stub(helpers, 'printFull');
+      mockExit = sinon.stub(process, 'exit');
     });
 
     afterEach(() => {
@@ -565,6 +570,24 @@ describe('Execution', () => {
           });
           const result = mockPrintFull.args[0][0];
           assert.deepEqual(result, [{value: 'foo', display: 'foo'}]);
+        });
+
+        it('include stacktrace', async () => {
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'Throw',
+            params: [],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const error = mockPrint.args[0][0];
+          const exitValue = mockExit.args[0][0];
+          assert.instanceOf(error, Error);
+          assert.include(error.stack, path.join(__dirname, 'packs/fake.ts'));
+          assert.equal(exitValue, 1);
         });
       });
     }

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -944,9 +944,10 @@ function isSourceMapsEnabled() {
 
 class DeveloperError extends Error {
   constructor(err: Error) {
-    super('The Pack code threw an error.', {
+    super('The Pack code threw an error: ' + err.message, {
       cause: err,
     });
+    this.stack = err.stack;
     this.name = 'DeveloperError';
     Object.setPrototypeOf(this, DeveloperError.prototype);
   }

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -282,7 +282,10 @@ export async function executeFormulaOrSyncFromCLI({
       printFull(result);
     }
   } catch (err: any) {
-    print(err.message || err);
+    print(err);
+    if (!vm && !isSourceMapsEnabled()) {
+      print('\nEnable the Node flag --enable-source-maps to get an accurate stack trace.');
+    }
     process.exit(1);
   }
 }
@@ -923,4 +926,12 @@ function parseGetPermissionRequest(
   });
 
   return {permissionRequest: parseResult.data, params: coerceParams(syncFormula, paramsCopy as any)};
+}
+
+function isSourceMapsEnabled() {
+  const flags = [
+    ...process.execArgv,
+    ...process.env.NODE_OPTIONS?.split(/\s+/) ?? [],
+  ];
+  return flags.includes('--enable-source-maps');
 }

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -130,7 +130,7 @@ async function findAndExecutePackFunction<T extends FormulaSpecification>(
       getPermissionsRequest,
     });
   } catch (err: any) {
-    throw asDeveloperError(err);
+    throw new DeveloperError(err);
   }
 
   if (formulaSpec.type === FormulaType.SyncUpdate) {
@@ -287,7 +287,7 @@ export async function executeFormulaOrSyncFromCLI({
       printFull(result);
     }
   } catch (err: any) {
-    if (isDeveloperError(err)) {
+    if (err instanceof DeveloperError) {
       // The error came from the Pack code. Print the inner error, including the stack trace.
       print(err.cause);
       // If source maps are not enabled, print a warning.
@@ -463,7 +463,7 @@ export async function executeFormulaOrSyncWithVM<T extends PackFormulaResult | G
   try {
     return await executeThunk(ivmContext, {params, formulaSpec: formulaSpecification}, bundlePath, bundlePath + '.map') as T;
   } catch (err: any) {
-    throw asDeveloperError(err);
+    throw new DeveloperError(err);
   }
 }
 
@@ -529,7 +529,7 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       bundleSourceMapPath,
     );
   } catch (err: any) {
-    throw asDeveloperError(err);
+    throw new DeveloperError(err);
   }
 }
 
@@ -948,15 +948,6 @@ class DeveloperError extends Error {
       cause: err,
     });
     this.stack = err.stack;
-    this.name = 'DeveloperError';
     Object.setPrototypeOf(this, DeveloperError.prototype);
   }
-}
-
-function asDeveloperError(err: Error) {
-  throw new DeveloperError(err);
-}
-
-function isDeveloperError(err: Error) {
-  return err.name === 'DeveloperError';
 }


### PR DESCRIPTION
In https://github.com/coda/packs-sdk/pull/2895 the logic was changed to only show the error message if available, hiding the stack trace. This is desirable for errors originating from the CLI itself, but makes it harder to debug when the error comes from Pack code (see [community thread](https://community.coda.io/t/how-to-get-the-stack-trace-when-executing-using-the-coda-cli/53804)).

This PR wraps errors that are thrown from Pack code in a new custom error class, so that later those errors can be detected and the full stack trace printed. It also detects when the Node source maps feature is disabled and logs a warning.

# Before

## Pack error

```sh
❯ node dist/cli/coda.js execute test/packs/fake.ts Throw                                             
here
```

## CLI error

```sh
❯ node dist/cli/coda.js execute test/packs/fake.ts NotARealFormula 
Could not find a formula or sync named "NotARealFormula".
```

# After

## Pack error

### With VM

```sh
❯ node dist/cli/coda.js execute test/packs/fake.ts Throw  --vm=true      
Error: here
    at throwError (../../../../../../private/var/folders/Users/ekoleda/src/packs-sdk/test/packs/fake.ts:33:9)
    at Object.execute (../../../../../../private/var/folders/Users/ekoleda/src/packs-sdk/test/packs/fake.ts:83:9)
    at doFindAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/bundles/thunk_bundle.js:6900:24)
    at Object.findAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/bundles/thunk_bundle.js:6867:20)
    at <unknown> (<isolated-vm>:1:13)
```

### Without VM

#### No source maps

```sh
❯ node dist/cli/coda.js execute test/packs/fake.ts Throw --vm=false
Error: here
    at throwError (/private/var/folders/4q/7k_8hbj11d3fzc4q78jcjbtm0000gr/T/coda-packs-b6915755-d121-4a90-9330-7610d07b7413R8XXfp/bundle.js:31860:23)
    at Object.execute (/private/var/folders/4q/7k_8hbj11d3fzc4q78jcjbtm0000gr/T/coda-packs-b6915755-d121-4a90-9330-7610d07b7413R8XXfp/bundle.js:31912:23)
    at doFindAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/runtime/thunk/thunk.js:62:28)
    at Object.findAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/runtime/thunk/thunk.js:36:22)
    at findAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:88:30)
    at executeFormulaOrSyncWithRawParams (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:433:12)
    at executeFormulaOrSyncFromCLI (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:189:25)
    at Object.handleExecute [as handler] (/Users/ekoleda/src/packs-sdk/dist/cli/execute.js:25:55)

Enable the Node flag --enable-source-maps to get an accurate stack trace. For example:
NODE_OPTIONS="--enable-source-maps" npx coda execute ...
```

#### With source maps

```sh
❯ NODE_OPTIONS="--enable-source-maps" node dist/cli/coda.js execute test/packs/fake.ts Throw --vm=false 
(node:24442) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Error: here
    at throwError (/private/private/var/folders/Users/ekoleda/src/packs-sdk/test/packs/fake.ts:33:9)
    at Object.execute (/private/private/var/folders/Users/ekoleda/src/packs-sdk/test/packs/fake.ts:83:9)
    at doFindAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/runtime/thunk/thunk.js:62:28)
    at Object.findAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/runtime/thunk/thunk.js:36:22)
    at findAndExecutePackFunction (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:88:30)
    at executeFormulaOrSyncWithRawParams (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:433:12)
    at executeFormulaOrSyncFromCLI (/Users/ekoleda/src/packs-sdk/dist/testing/execution.js:189:25)
    at Object.handleExecute [as handler] (/Users/ekoleda/src/packs-sdk/dist/cli/execute.js:25:55)
```

### CLI error

```sh
❯ node dist/cli/coda.js execute test/packs/fake.ts NotARealFormula
Could not find a formula or sync named "NotARealFormula".
```