### PR TITLE
Update elliptic due to critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
       "eslint-plugin-local@1.0.0": "patches/eslint-plugin-local@1.0.0.patch"
     },
     "overrides": {
-      "cross-spawn": ">=7.0.6"
+      "cross-spawn": ">=7.0.6",
+      "elliptic@<=6.6.0": ">=6.6.1"
     },
     "packageExtensions": {
       "isolated-vm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   cross-spawn: '>=7.0.6'
+  elliptic@<=6.6.0: '>=6.6.1'
 
 packageExtensionsChecksum: 380851e2db75863824bdde5716c4ef00
 
@@ -2341,8 +2342,8 @@ packages:
   electron-to-chromium@1.5.41:
     resolution: {integrity: sha512-dfdv/2xNjX0P8Vzme4cfzHqnPm5xsZXwsolTYr0eyW18IUmNyG08vL+fttvinTfhKfIKdRoqkDIC9e9iWQCNYQ==}
 
-  elliptic@6.6.0:
-    resolution: {integrity: sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==}
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -6722,7 +6723,7 @@ snapshots:
       browserify-rsa: 4.1.1
       create-hash: 1.2.0
       create-hmac: 1.1.7
-      elliptic: 6.6.0
+      elliptic: 6.6.1
       hash-base: 3.0.4
       inherits: 2.0.4
       parse-asn1: 5.1.7
@@ -7050,7 +7051,7 @@ snapshots:
   create-ecdh@4.0.4:
     dependencies:
       bn.js: 4.12.0
-      elliptic: 6.6.0
+      elliptic: 6.6.1
 
   create-hash@1.2.0:
     dependencies:
@@ -7327,7 +7328,7 @@ snapshots:
 
   electron-to-chromium@1.5.41: {}
 
-  elliptic@6.6.0:
+  elliptic@6.6.1:
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0


### PR DESCRIPTION
This should probably be released ASAP if this affects us.  Let me know if you want me to update the release version in here or do anything else.  

Note: there are other moderate octokit issues as well that should be addressed.  There are problems upgrading the `coda` repo which might also be problems here.

PTAL @jonathan-codaio @patrick-codaio 