### PR TITLE
Call executeGetPermissions with actual sync from cli

### DIFF
--- a/cli/execute.ts
+++ b/cli/execute.ts
@@ -36,6 +36,7 @@ export async function handleExecute({
         'compatible with your platform. Try again but omitting the --vm flag.',
     );
   }
+
   const fullManifestPath = makeManifestFullPath(manifestPath);
   const {bundlePath, bundleSourceMapPath} = await compilePackBundle({
     manifestPath: fullManifestPath,
@@ -44,7 +45,9 @@ export async function handleExecute({
   });
   const manifest = await importManifest(bundlePath);
   if (manifest.networkDomains && manifest.networkDomains.length > 1 && !allowMultipleNetworkDomains) {
-    return printAndExit('Using multiple network domains requires approval from Coda. Visit https://coda.io/packs/build/latest/support#approvals to make a request. Disable this warning by including the flag: --allowMultipleNetworkDomains');
+    return printAndExit(
+      'Using multiple network domains requires approval from Coda. Visit https://coda.io/packs/build/latest/support#approvals to make a request. Disable this warning by including the flag: --allowMultipleNetworkDomains',
+    );
   }
   await executeFormulaOrSyncFromCLI({
     formulaName,

--- a/dist/runtime/types.d.ts
+++ b/dist/runtime/types.d.ts
@@ -70,4 +70,5 @@ export interface PropertyAutocompleteFormulaSpecification {
     search: string;
 }
 export type FormulaSpecification = StandardFormulaSpecification | SyncFormulaSpecification | SyncUpdateFormulaSpecification | MetadataFormulaSpecification | ParameterAutocompleteMetadataFormulaSpecification | PostSetupMetadataFormulaSpecification | SyncMetadataFormulaSpecification | PropertyAutocompleteFormulaSpecification | GetPermissionsFormulaSpecification;
+export type ChainedCommandFormulaSpecification = GetPermissionsFormulaSpecification;
 export type PackFunctionResponse<T extends FormulaSpecification> = T extends SyncFormulaSpecification ? GenericSyncFormulaResult : T extends SyncUpdateFormulaSpecification ? GenericSyncUpdateResultMarshaled : PackFormulaResult;

--- a/dist/testing/helpers.d.ts
+++ b/dist/testing/helpers.d.ts
@@ -28,3 +28,11 @@ export declare function readJSONFile(fileName: string): any | undefined;
 export declare function writeJSONFile(fileName: string, payload: any, mode?: fs.Mode): void;
 export declare function getExpirationDate(expiresInSeconds: number): Date;
 export declare function processVmError(vmError: Error, bundlePath: string): Promise<Error>;
+/**
+ * This function splits an array into chunks of a maximum size.
+ *
+ * @param array The flat list of values
+ * @param size The maximum chunk size
+ * @returns A list of chunks of the input array
+ */
+export declare function chunkArray<T>(array: T[], size: number): T[][];

--- a/dist/testing/helpers.js
+++ b/dist/testing/helpers.js
@@ -26,7 +26,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.processVmError = exports.getExpirationDate = exports.writeJSONFile = exports.readJSONFile = exports.readFile = exports.promptForInput = exports.printAndExit = exports.printFull = exports.printError = exports.printWarn = exports.print = exports.getManifestFromModule = void 0;
+exports.chunkArray = exports.processVmError = exports.getExpirationDate = exports.writeJSONFile = exports.readJSONFile = exports.readFile = exports.promptForInput = exports.printAndExit = exports.printFull = exports.printError = exports.printWarn = exports.print = exports.getManifestFromModule = void 0;
 const ensure_1 = require("../helpers/ensure");
 const fs_1 = __importDefault(require("fs"));
 const util_1 = require("util");
@@ -144,3 +144,18 @@ async function processVmError(vmError, bundlePath) {
     return err;
 }
 exports.processVmError = processVmError;
+/**
+ * This function splits an array into chunks of a maximum size.
+ *
+ * @param array The flat list of values
+ * @param size The maximum chunk size
+ * @returns A list of chunks of the input array
+ */
+function chunkArray(array, size) {
+    const chunks = [];
+    for (let i = 0; i < array.length; i += size) {
+        chunks.push(array.slice(i, i + size));
+    }
+    return chunks;
+}
+exports.chunkArray = chunkArray;

--- a/runtime/thunk/thunk.ts
+++ b/runtime/thunk/thunk.ts
@@ -92,7 +92,6 @@ function getSelectedAuthentication(manifest: BasicPackDefinition, authentication
   );
 }
 
-
 async function doFindAndExecutePackFunction<T extends FormulaSpecification>({
   params,
   formulaSpec,

--- a/runtime/types.ts
+++ b/runtime/types.ts
@@ -97,6 +97,8 @@ export type FormulaSpecification =
   | PropertyAutocompleteFormulaSpecification
   | GetPermissionsFormulaSpecification;
 
+export type ChainedCommandFormulaSpecification = GetPermissionsFormulaSpecification;
+
 export type PackFunctionResponse<T extends FormulaSpecification> = T extends SyncFormulaSpecification
   ? GenericSyncFormulaResult
   : T extends SyncUpdateFormulaSpecification

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -504,6 +504,67 @@ describe('Execution', () => {
           }
         });
 
+        it('sync with includePermissions works', async () => {
+          await executeFormulaOrSyncFromCLI({
+            vm,
+            formulaName: 'Students>permissions',
+            params: ['Cunningham'],
+            manifest: fakePack,
+            manifestPath: '',
+            bundleSourceMapPath,
+            bundlePath,
+            contextOptions: {useRealFetcher: false},
+          });
+          const result = mockPrintFull.args[0][0];
+
+          assert.deepEqual(
+            result,
+            [
+              {name: 'Albert'},
+              {name: 'Brenda'},
+              {name: 'Cory'},
+              {name: 'Dylan'},
+              {name: 'Ethan'},
+              {name: 'Fiona'},
+              {name: 'Gina'},
+              {name: 'Hank'},
+              {name: 'Ivy'},
+              {name: 'Jack'},
+              {name: 'Kyle'},
+              {name: 'Liam'},
+              {name: 'Mia'},
+              {name: 'Noah'},
+              {name: 'Olivia'},
+              {name: 'Pam'},
+              {name: 'Quinn'},
+              {name: 'Ryan'},
+              {name: 'Sam'},
+              {name: 'Tia'},
+              {name: 'Uma'},
+              {name: 'Vince'},
+              {name: 'Wendy'},
+              {name: 'Xavier'},
+              {name: 'Yara'},
+              {name: 'Zack'},
+              {name: 'Aaron'},
+              {name: 'Bella'},
+              {name: 'Charlie'},
+              {name: 'Diana'},
+              {name: 'Easton'},
+              {name: 'Frank'},
+              {name: 'Greg'},
+              {name: 'Hannah'},
+              {name: 'Ian'},
+              {name: 'Julia'},
+            ].map(student => {
+              return {
+                rowId: student.name,
+                permissions: [{permissionType: PermissionType.Direct, principal: {type: 'user', userId: 1}}],
+              };
+            }),
+          );
+        });
+
         it('sync update works', async () => {
           const syncUpdates: GenericSyncUpdate[] = [
             {previousValue: {name: 'Alice'}, newValue: {name: 'Alice Smith'}, updatedFields: ['name']},
@@ -632,7 +693,7 @@ describe('Execution', () => {
           assert.equal(exitValue, 1);
         });
 
-        it('CLI errors don\'t print stacktrace', async () => {
+        it("CLI errors don't print stacktrace", async () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'NotRealFormula',

--- a/test/packs/fake.ts
+++ b/test/packs/fake.ts
@@ -169,6 +169,57 @@ export const manifest: PackDefinition = createFakePack({
                   result: [{name: 'Christina'}, {name: 'Donald'}],
                 };
               }
+            case 'Cunningham':
+              if (!page || page === 1) {
+                return {
+                  result: [
+                    {name: 'Albert'},
+                    {name: 'Brenda'},
+                    {name: 'Cory'},
+                    {name: 'Dylan'},
+                    {name: 'Ethan'},
+                    {name: 'Fiona'},
+                    {name: 'Gina'},
+                    {name: 'Hank'},
+                    {name: 'Ivy'},
+                    {name: 'Jack'},
+                    {name: 'Kyle'},
+                    {name: 'Liam'},
+                    {name: 'Mia'},
+                    {name: 'Noah'},
+                    {name: 'Olivia'},
+                    {name: 'Pam'},
+                    {name: 'Quinn'},
+                    {name: 'Ryan'},
+                    {name: 'Sam'},
+                    {name: 'Tia'},
+                    {name: 'Uma'},
+                    {name: 'Vince'},
+                  ],
+                  continuation: {page: 2},
+                };
+              }
+              if (page === 2) {
+                return {
+                  result: [
+                    {name: 'Wendy'},
+                    {name: 'Xavier'},
+                    {name: 'Yara'},
+                    {name: 'Zack'},
+                    {name: 'Aaron'},
+                    {name: 'Bella'},
+                    {name: 'Charlie'},
+                    {name: 'Diana'},
+                    {name: 'Easton'},
+                    {name: 'Frank'},
+                    {name: 'Greg'},
+                    {name: 'Hannah'},
+                    {name: 'Ian'},
+                    {name: 'Julia'},
+                  ],
+                };
+              }
+
             default:
               return {} as any;
           }

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -23,15 +23,17 @@ export const printWarn = console.warn;
 // eslint-disable-next-line no-console
 export const printError = console.error;
 
-export function printFull(value: any){
+export function printFull(value: any) {
   if (typeof value === 'object') {
     // eslint-disable-next-line no-console
-    console.log(inspect(value, {
-      depth: null,
-      maxArrayLength: null,
-      maxStringLength: null,
-      colors: true,
-    }));
+    console.log(
+      inspect(value, {
+        depth: null,
+        maxArrayLength: null,
+        maxStringLength: null,
+        colors: true,
+      }),
+    );
   } else {
     // Fallback to console.log for backwards compatibility.
     // eslint-disable-next-line no-console
@@ -116,4 +118,19 @@ export async function processVmError(vmError: Error, bundlePath: string): Promis
   const messageSuffix = err.message ? `: ${err.message}` : '';
   err.stack = `${err.constructor.name}${messageSuffix}\n${translatedStacktrace}`;
   return err;
+}
+
+/**
+ * This function splits an array into chunks of a maximum size.
+ *
+ * @param array The flat list of values
+ * @param size The maximum chunk size
+ * @returns A list of chunks of the input array
+ */
+export function chunkArray<T>(array: T[], size: number): T[][] {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
 }


### PR DESCRIPTION
This PR adds the ability to get rowAccessDefinitions for a sync table from the CLI.

Previously, we had the ability to explicitly fetch permissions for rows, but you had to give the rows in a json parameter. This mode of Sync will instead do the sync fetching, pipe those into GetPermissions, and then return the result.


Screencast: https://coda.d.pr/v/3H3gwW