### PR TITLE
Bump the package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.9.2-prerelease.3",
+  "version": "1.9.2-prerelease.4",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Bump the version to `1.9.2-prerelease.4` from `1.9.2-prerelease.3`.
This is necessary followup for changes merged from https://github.com/coda/packs-sdk/pull/3165 to avoid breaking the build process. The change is adding `AuthorityNormProperty` and `PopularityNormProperty` (renaming of `PopularityRankProperty`) to the Brain Pack schema for boost signal indexing to enhance Brain search ranking.