### PR TITLE
Exempting Gitlab on-prem pack from formula name validation

### DIFF
--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1315,6 +1315,10 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     [1083, 'Sync projects', ExemptionType.SyncTableGetterName],
     [1084, 'Ad Groups', ExemptionType.SyncTableGetterName],
     [1093, 'Sync table', ExemptionType.SyncTableGetterName],
+    [11867, 'Sync commits', ExemptionType.SyncTableGetterName],
+    [11867, 'Sync issues', ExemptionType.SyncTableGetterName],
+    [11867, 'Sync merge requests', ExemptionType.SyncTableGetterName],
+    [11867, 'Sync projects', ExemptionType.SyncTableGetterName]
   ];
 
   function exemptionKey(packId: number, entityName: string): string {
@@ -1377,6 +1381,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     contextProperties: contextPropertiesSchema.optional(),
     authorityNormProperty: propertySchema.optional(),
     popularityNormProperty: propertySchema.optional(),
+    popularityRankProperty: propertySchema.optional(),
   });
 
   const identitySchema = zodCompleteObject<Identity>({
@@ -1423,6 +1428,9 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
       userEmailProperty: propertySchema.optional(),
       groupIdProperty: propertySchema.optional(),
       memberGroupIdProperty: propertySchema.optional(),
+      authorityNormProperty: propertySchema.optional(),
+      popularityNormProperty: propertySchema.optional(),
+      popularityRankProperty: propertySchema.optional(),
       versionProperty: propertySchema.optional(),
       options: zodOptionsFieldWithValues(z.object({}).passthrough(), false),
       requireForUpdates: z.boolean().optional(),
@@ -1663,6 +1671,30 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
           );
         };
 
+        const validateAuthorityNormProperty = () => {
+          return validateProperty(
+            'authorityNormProperty',
+            authorityNormPropertySchema => authorityNormPropertySchema.type === ValueType.Number,
+            `must refer to a "ValueType.Number" property.`,
+          );
+        };
+
+        const validatePopularityNormProperty = () => {
+          return validateProperty(
+            'popularityNormProperty',
+            popularityNormPropertySchema => popularityNormPropertySchema.type === ValueType.Number,
+            `must refer to a "ValueType.Number" property.`,
+          );
+        };
+
+        const validatePopularityRankProperty = () => {
+          return validateProperty(
+            'popularityRankProperty',
+            popularityRankPropertySchema => popularityRankPropertySchema.type === ValueType.Number,
+            `must refer to a "ValueType.Number" property.`,
+          );
+        };
+
         const validateVersionProperty = () => {
           return validateProperty(
             'versionProperty',
@@ -1684,6 +1716,9 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         validateUserIdProperty();
         validateGroupIdProperty();
         validateMemberGroupIdProperty();
+        validateAuthorityNormProperty();
+        validatePopularityNormProperty();
+        validatePopularityRankProperty();
         validateVersionProperty();
       })
       .superRefine((data, context) => {
@@ -1713,6 +1748,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
           contextProperties,
           authorityNormProperty,
           popularityNormProperty,
+          popularityRankProperty,
         } = schema.index;
 
         if (authorityNormProperty) {
@@ -1732,6 +1768,16 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             popularityNormPropertySchema => popularityNormPropertySchema.type === ValueType.Number,
             `must refer to a "ValueType.Number" property.`,
             ['index', 'popularityNormProperty'],
+          );
+        }
+
+        if (popularityRankProperty) {
+          validatePropertyValue(
+            popularityRankProperty,
+            'popularityRankProperty',
+            popularityRankPropertySchema => popularityRankPropertySchema.type === ValueType.Number,
+            `must refer to a "ValueType.Number" property.`,
+            ['index', 'popularityRankProperty'],
           );
         }
 


### PR DESCRIPTION
Exempting Gitlab on-prem pack from formula name validation to keep it consistent with the original Gitlab pack