### PR TITLE
Release 1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
-### Changed
-
+- Update `IndexDefinition` to encompass either `CustomIndexDefinition` or `CategorizedIndexDefinition`. `CustomIndexDefinition` will be backwards compatible with releases from before 1.9.4 and refer to the old `IndexDefinition`. The `CategorizedIndexDefinition` will support specific types of indexable content that has been predefined in the sdk.
+- Add a new `filteredProperities` field to `schema.index` to specify additional columns that can be used to filter down query results.
+- Minor documentation updates.
+- Deprecate `PrincipalType.Anyone`.
 - Remove `popularityNormProperty` and `authorityNormProperty` from top-level `schema` since they reside primarily in `schema.index`.
 - Remove deprecated `popularityRankProperty` from `schema`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.9.5] - 2025-05-02
+
 - Update `IndexDefinition` to encompass either `CustomIndexDefinition` or `CategorizedIndexDefinition`. `CustomIndexDefinition` will be backwards compatible with releases from before 1.9.4 and refer to the old `IndexDefinition`. The `CategorizedIndexDefinition` will support specific types of indexable content that has been predefined in the sdk.
 - Add a new `filteredProperities` field to `schema.index` to specify additional columns that can be used to filter down query results.
 - Minor documentation updates.
@@ -841,7 +843,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.9.3...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.9.5...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -896,3 +898,5 @@ await myHelper(context);
 [1.9.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.2
 
 [1.9.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.2
+
+[1.9.5]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [1.9.5] - 2025-05-02
 
+### Changed
+
 - Update `IndexDefinition` to encompass either `CustomIndexDefinition` or `CategorizedIndexDefinition`. `CustomIndexDefinition` will be backwards compatible with releases from before 1.9.4 and refer to the old `IndexDefinition`. The `CategorizedIndexDefinition` will support specific types of indexable content that has been predefined in the sdk.
 - Add a new `filteredProperities` field to `schema.index` to specify additional columns that can be used to filter down query results.
 - Minor documentation updates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.9.4-prerelease.3",
+  "version": "1.9.4",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Releasing new version. Somehow got skipped to 1.9.5 😭 . New tag here
```https://github.com/coda/packs-sdk/releases/new?tag=v1.9.5&title=Release+1.9.5&body=-+Update+%60IndexDefinition%60+to+encompass+either+%60CustomIndexDefinition%60+or+%60CategorizedIndexDefinition%60.+%60CustomIndexDefinition%60+will+be+backwards+compatible+with+releases+from+before+1.9.4+and+refer+to+the+old+%60IndexDefinition%60.+The+%60CategorizedIndexDefinition%60+will+support+specific+types+of+indexable+content+that+has+been+predefined+in+the+sdk.%0A-+Add+a+new+%60filteredProperities%60+field+to+%60schema.index%60+to+specify+additional+columns+that+can+be+used+to+filter+down+query+results.%0A-+Minor+documentation+updates.%0A-+Deprecate+%60PrincipalType.Anyone%60.%0A-+Remove+%60popularityNormProperty%60+and+%60authorityNormProperty%60+from+top-level+%60schema%60+since+they+reside+primarily+in+%60schema.index%60.%0A-+Remove+deprecated+%60popularityRankProperty%60+from+%60schema%60.&prerelease=false```