### PR TITLE
For validateParameters, add search string to params from cli so first argument can just be the metadata context string

### DIFF
--- a/dist/testing/execution.js
+++ b/dist/testing/execution.js
@@ -444,6 +444,10 @@ async function executeFormulaOrSyncWithRawParamsInVM({ formulaSpecification, par
             params = rawParams;
             // Default the search string (first arg) to an empty string.
             (_a = params[0]) !== null && _a !== void 0 ? _a : (params[0] = '');
+            if (formulaSpecification.metadataFormulaType === types_4.MetadataFormulaType.ValidateParameters) {
+                // insert empty string at front of params to use as the search string
+                params.unshift('');
+            }
             break;
         }
         case types_3.FormulaType.SyncUpdate: {
@@ -491,6 +495,10 @@ async function executeFormulaOrSyncWithRawParams({ formulaSpecification, params:
             params = rawParams;
             // Default the search string (first arg) to an empty string.
             (_a = params[0]) !== null && _a !== void 0 ? _a : (params[0] = '');
+            if (formulaSpecification.metadataFormulaType === types_4.MetadataFormulaType.ValidateParameters) {
+                // insert empty string at front of params to use as the search string
+                params.unshift('');
+            }
             break;
         }
         case types_3.FormulaType.SyncUpdate: {

--- a/test/execution_test.ts
+++ b/test/execution_test.ts
@@ -781,7 +781,7 @@ describe('Execution', () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'Students:validateParameters',
-            params: ['', '{"teacher": "Personal"}'],
+            params: ['{"teacher": "Personal"}'],
             manifest: fakePack,
             manifestPath: '',
             bundleSourceMapPath,
@@ -798,7 +798,7 @@ describe('Execution', () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'ValidateParametersFailsDueToNonSync:validateParameters',
-            params: ['', '{}'],
+            params: ['{}'],
             manifest: fakePack,
             manifestPath: '',
             bundleSourceMapPath,
@@ -814,7 +814,7 @@ describe('Execution', () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'ValidateParametersFailsIfParamIsNotPositive:validateParameters',
-            params: ['', '{"value": 0}'],
+            params: ['{"value": 0}'],
             manifest: fakePack,
             manifestPath: '',
             bundleSourceMapPath,
@@ -830,7 +830,7 @@ describe('Execution', () => {
           await executeFormulaOrSyncFromCLI({
             vm,
             formulaName: 'ValidateParametersFailsIfParamIsNotPositive:validateParameters',
-            params: ['', '{"value": 1}'],
+            params: ['{"value": 1}'],
             manifest: fakePack,
             manifestPath: '',
             bundleSourceMapPath,

--- a/testing/execution.ts
+++ b/testing/execution.ts
@@ -598,6 +598,10 @@ async function executeFormulaOrSyncWithRawParamsInVM<T extends FormulaSpecificat
       params = rawParams as ParamValues<ParamDefs>;
       // Default the search string (first arg) to an empty string.
       params[0] ??= '';
+      if (formulaSpecification.metadataFormulaType === MetadataFormulaType.ValidateParameters) {
+        // insert empty string at front of params to use as the search string
+        params.unshift('');
+      }
       break;
     }
     case FormulaType.SyncUpdate: {
@@ -664,6 +668,10 @@ export async function executeFormulaOrSyncWithRawParams<T extends FormulaSpecifi
       params = rawParams as ParamValues<ParamDefs>;
       // Default the search string (first arg) to an empty string.
       params[0] ??= '';
+      if (formulaSpecification.metadataFormulaType === MetadataFormulaType.ValidateParameters) {
+        // insert empty string at front of params to use as the search string
+        params.unshift('');
+      }
       break;
     }
     case FormulaType.SyncUpdate: {


### PR DESCRIPTION
This is so we can do
```
npx coda execute manifest.ts SomeFormula:validateParameters '{"blah":"blah"}'
```
instead of
```
npx coda execute manifest.ts SomeFormula:validateParameters '' '{"blah":"blah"}'
```
in the cli. Let me know if this is actually undesired