### PR TITLE
Don't double-encode paths in AWSAccessKey auth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 - Add `validateParameters` metadata formula to CommonPackFormulaDef
 - Add `ValueHintType.Date` as a valid type for the `FilterableProperty` in `IndexDefinition`.
+- `AWSAccessKey` auth: fixed bug with double-signing of requests where the URL path contains special characters like spaces.
 
 ## [1.9.5] - 2025-05-02
 
@@ -899,11 +900,8 @@ await myHelper(context);
 [1.8.4]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.4
 [1.8.5]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.5
 [1.8.6]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.8.6
-
 [1.9.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.1
 [1.9.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.3
 [1.9.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.2
-
 [1.9.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.2
-
 [1.9.5]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.9.5

--- a/dist/testing/fetcher.js
+++ b/dist/testing/fetcher.js
@@ -458,7 +458,9 @@ class AuthenticatingFetcher {
             body,
             protocol,
             hostname,
-            path: pathname,
+            // signRequest ultimately calls encodeForAwsAuthHeader(), which expects an unencoded path, but
+            // URL().pathname is encoded, so we decode it here so we don't double-encode the path when signing.
+            path: decodeURIComponent(pathname),
             query,
         });
         return result.headers;
@@ -540,7 +542,7 @@ class AuthenticatingBlobStorage {
         this._fetcher = fetcher;
     }
     async storeUrl(url, _opts, fetchOpts) {
-        await this._fetcher.fetch({ method: 'GET', url, isBinaryResponse: true, ...fetchOpts, });
+        await this._fetcher.fetch({ method: 'GET', url, isBinaryResponse: true, ...fetchOpts });
         return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${(0, uuid_1.v4)()}`;
     }
     async storeBlob(_blobData, _contentType, _opts) {

--- a/testing/fetcher.ts
+++ b/testing/fetcher.ts
@@ -588,7 +588,9 @@ export class AuthenticatingFetcher implements Fetcher {
       body,
       protocol,
       hostname,
-      path: pathname,
+      // signRequest ultimately calls encodeForAwsAuthHeader(), which expects an unencoded path, but
+      // URL().pathname is encoded, so we decode it here so we don't double-encode the path when signing.
+      path: decodeURIComponent(pathname),
       query,
     });
 
@@ -691,7 +693,7 @@ class AuthenticatingBlobStorage implements TemporaryBlobStorage {
   }
 
   async storeUrl(url: string, _opts?: {expiryMs?: number}, fetchOpts?: Partial<FetchRequest>): Promise<string> {
-    await this._fetcher.fetch({method: 'GET', url, isBinaryResponse: true, ...fetchOpts,});
+    await this._fetcher.fetch({method: 'GET', url, isBinaryResponse: true, ...fetchOpts});
     return `https://not-a-real-url.s3.amazonaws.com/tempBlob/${v4()}`;
   }
 


### PR DESCRIPTION
Addresses https://staging.coda.io/d/_dEE5xhCKh9I#Bug-Triage_tu9rR8Oj/r7437

PTAL @ekoleda-codaio @coda/packs 

Feel free to merge this yourself, as I'll be OOO by the time this is reviewed.