### PR TITLE
easy packs-sdk validate parameters feedback

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -102,7 +102,7 @@ export class UserVisibleError extends Error {
 /**
  * An error that occurs when validating parameters.
  */
-export interface ParameterError {
+export interface ParameterValidationDetail {
   /** The error message for the parameter. */
   message: string;
   /** The name of the parameter that caused the error. */
@@ -116,13 +116,13 @@ export interface InvalidParameterValidationResult {
   /**
    * The parameters that were invalid, alongside a message describing the error for the parameter.
    */
-  errors: ParameterError[];
+  errors?: ParameterValidationDetail[];
   /**
    * Whether the parameters are valid.
    */
   isValid: false;
   /**
-   * The message to display to the user. Each ParameterError will also have a message.
+   * The message to display to the user. Each ParameterValidationDetail will also have a message.
    */
   message: string;
 }

--- a/index.ts
+++ b/index.ts
@@ -131,7 +131,7 @@ export {Type} from './api_types';
 export type {TypedPackFormula} from './api';
 export type {Formula} from './api';
 export {UserVisibleError} from './api';
-export {ParameterError} from './api';
+export {ParameterValidationDetail} from './api';
 export {LegacyDefaultMetadataReturnType} from './api';
 export {ValidParameterValidationResult} from './api';
 export {InvalidParameterValidationResult} from './api';


### PR DESCRIPTION
- Remove Error from naming to avoid confusion that you do not throw a ParameterError.
- make errors optional, will update coda support to treat this by just showing the `message` which is required