### PR TITLE
Bumped up version number (1.9.12-prerelease.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.9.11",
+  "version": "1.9.12-prerelease.1",
   "license": "MIT",
   "workspaces": [
     "dev/eslint"


### PR DESCRIPTION
Based on this Slack conversation:
https://grammarly.slack.com/archives/C01835XEBSS/p1752699589963099

This PR updates the packs-sdk semantic version in package.json to avoid a known issue with the Coda linter job.

## Context
We’ve previously observed that when the commit hash changes without a corresponding semantic version bump in the SDK, the Coda linter job can take over an hour to run. The root cause is still unknown, and the issue may still recur.

## Fix
To mitigate this, we follow the practice of always updating the SDK version to a prerelease when bumping the SDK in Coda. This PR bumps the version to:
```
1.9.12-prerelease.1
```
This ensures that the Coda linter job runs as expected and avoids the performance degradation.