### PR TITLE
packs-sdk: release v1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.13.3] - 2026-04-09
+
+### Added
+
+- Added `DataIndexing` option for sync tables to configure default ingestion behavior.
+- Allow multiple domains for Coda header bearer token authentication.
+
+### Fixed
+
+- Fixed `SourceMapConsumer` memory leak that could cause Lambda hangs under memory pressure.
+
+### Removed
+
+- Removed `DynamicSuggestedPromptTool`.
+
+### Changed
+
+- Updated dependencies and pnpm overrides for security patches.
+
 ## [1.13.2] - 2026-03-09
 
 ### Added
@@ -1006,7 +1025,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.13.2...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.13.3...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -1081,3 +1100,5 @@ await myHelper(context);
 [1.12.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.3
 [1.12.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.2
 [1.12.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.1
+
+[1.13.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.13.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.3-prerelease.4",
+  "version": "1.13.3",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Summary

- Release packs-sdk v1.13.3
- Updates `package.json` version from `1.13.3-prerelease.4` to `1.13.3`
- Adds changelog entries for all changes since v1.13.2

### Changelog

**Added**
- `DataIndexing` option for sync tables to configure default ingestion behavior
- Multiple domains for Coda header bearer token authentication

**Fixed**
- `SourceMapConsumer` memory leak that could cause Lambda hangs under memory pressure

**Removed**
- `DynamicSuggestedPromptTool`

**Changed**
- Updated dependencies and pnpm overrides for security patches

> **Note:** This PR contains a single commit as required by the release process. Merge without squashing to preserve the tagged commit.


Made with [Cursor](https://cursor.com)