### PR TITLE
Validate formula names in the chat and bench initialization skills

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -2193,10 +2193,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             const metadata = data;
             const { formulas = [], skills = [] } = metadata;
             const formulaNames = new Set(formulas.map(f => f.name));
-            // Validate each skill's tools
-            skills.forEach((skill, skillIndex) => {
-                // Validate PackTools that reference the current pack
-                skill.tools.forEach((tool, toolIndex) => {
+            function validateSkillTools(skill, basePath) {
+                (skill.tools || []).forEach((tool, toolIndex) => {
                     // Only validate Pack tools without a packId (i.e., referencing current pack).
                     // Cross-pack tool calls (with packId set) are not validated here, though they will
                     // fail at runtime for third-party packs since only first-party Coda agents can
@@ -2207,14 +2205,25 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                             if (!formulaNames.has(formulaName)) {
                                 context.addIssue({
                                     code: 'custom',
-                                    path: ['skills', skillIndex, 'tools', toolIndex, 'formulas', formulaIndex, 'formulaName'],
+                                    path: [...basePath, 'tools', toolIndex, 'formulas', formulaIndex, 'formulaName'],
                                     message: `Formula "${formulaName}" not found. Pack tool formulas must reference formulas defined in this pack.`,
                                 });
                             }
                         });
                     }
                 });
+            }
+            // Validate each skill's tools
+            skills.forEach((skill, skillIndex) => {
+                validateSkillTools(skill, ['skills', skillIndex]);
             });
+            // Validate chatSkill and benchInitializationSkill tools
+            if (metadata.chatSkill) {
+                validateSkillTools(metadata.chatSkill, ['chatSkill']);
+            }
+            if (metadata.benchInitializationSkill) {
+                validateSkillTools(metadata.benchInitializationSkill, ['benchInitializationSkill']);
+            }
         });
     }
     function validateFormatMatcher(value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.3",
+  "version": "1.13.3-prerelease.1",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -6898,6 +6898,100 @@ describe('Pack metadata Validation', async () => {
       });
       await validateJson(metadata);
     });
+
+    it('fails for chatSkill tool referencing non-existent formula', async () => {
+      const metadata = createFakePackVersionMetadata({
+        formulaNamespace: 'TestPack',
+        formulas: [createFakePackFormulaMetadata({name: 'ExistingFormula'})],
+        chatSkill: {
+          name: 'ChatSkill',
+          displayName: 'Chat Skill',
+          description: 'A chat skill',
+          prompt: 'You are a helpful assistant',
+          tools: [
+            {
+              type: ToolType.Pack,
+              formulas: [{formulaName: 'NonExistentFormula'}],
+            },
+          ],
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          path: 'chatSkill.tools[0].formulas[0].formulaName',
+          message:
+            'Formula "NonExistentFormula" not found. Pack tool formulas must reference formulas defined in this pack.',
+        },
+      ]);
+    });
+
+    it('fails for benchInitializationSkill tool referencing non-existent formula', async () => {
+      const metadata = createFakePackVersionMetadata({
+        formulaNamespace: 'TestPack',
+        formulas: [createFakePackFormulaMetadata({name: 'ExistingFormula'})],
+        benchInitializationSkill: {
+          name: 'BenchSkill',
+          displayName: 'Bench Skill',
+          description: 'A bench initialization skill',
+          prompt: 'You are a helpful assistant',
+          tools: [
+            {
+              type: ToolType.Pack,
+              formulas: [{formulaName: 'NonExistentFormula'}],
+            },
+          ],
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          path: 'benchInitializationSkill.tools[0].formulas[0].formulaName',
+          message:
+            'Formula "NonExistentFormula" not found. Pack tool formulas must reference formulas defined in this pack.',
+        },
+      ]);
+    });
+
+    it('validates chatSkill tool referencing valid formula', async () => {
+      const metadata = createFakePackVersionMetadata({
+        formulaNamespace: 'TestPack',
+        formulas: [createFakePackFormulaMetadata({name: 'ValidFormula'})],
+        chatSkill: {
+          name: 'ChatSkill',
+          displayName: 'Chat Skill',
+          description: 'A chat skill',
+          prompt: 'You are a helpful assistant',
+          tools: [
+            {
+              type: ToolType.Pack,
+              formulas: [{formulaName: 'ValidFormula'}],
+            },
+          ],
+        },
+      });
+      await validateJson(metadata);
+    });
+
+    it('validates benchInitializationSkill tool referencing valid formula', async () => {
+      const metadata = createFakePackVersionMetadata({
+        formulaNamespace: 'TestPack',
+        formulas: [createFakePackFormulaMetadata({name: 'ValidFormula'})],
+        benchInitializationSkill: {
+          name: 'BenchSkill',
+          displayName: 'Bench Skill',
+          description: 'A bench initialization skill',
+          prompt: 'You are a helpful assistant',
+          tools: [
+            {
+              type: ToolType.Pack,
+              formulas: [{formulaName: 'ValidFormula'}],
+            },
+          ],
+        },
+      });
+      await validateJson(metadata);
+    });
   });
 
   describe('validateChatSkill', () => {

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2764,10 +2764,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         const {formulas = [], skills = []} = metadata;
         const formulaNames = new Set(formulas.map(f => f.name));
 
-        // Validate each skill's tools
-        skills.forEach((skill, skillIndex) => {
-          // Validate PackTools that reference the current pack
-          skill.tools.forEach((tool, toolIndex) => {
+        function validateSkillTools(skill: {tools?: Tool[]}, basePath: Array<string | number>) {
+          (skill.tools || []).forEach((tool, toolIndex) => {
             // Only validate Pack tools without a packId (i.e., referencing current pack).
             // Cross-pack tool calls (with packId set) are not validated here, though they will
             // fail at runtime for third-party packs since only first-party Coda agents can
@@ -2778,14 +2776,27 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                 if (!formulaNames.has(formulaName)) {
                   context.addIssue({
                     code: 'custom',
-                    path: ['skills', skillIndex, 'tools', toolIndex, 'formulas', formulaIndex, 'formulaName'],
+                    path: [...basePath, 'tools', toolIndex, 'formulas', formulaIndex, 'formulaName'],
                     message: `Formula "${formulaName}" not found. Pack tool formulas must reference formulas defined in this pack.`,
                   });
                 }
               });
             }
           });
+        }
+
+        // Validate each skill's tools
+        skills.forEach((skill, skillIndex) => {
+          validateSkillTools(skill, ['skills', skillIndex]);
         });
+
+        // Validate chatSkill and benchInitializationSkill tools
+        if (metadata.chatSkill) {
+          validateSkillTools(metadata.chatSkill, ['chatSkill']);
+        }
+        if (metadata.benchInitializationSkill) {
+          validateSkillTools(metadata.benchInitializationSkill, ['benchInitializationSkill']);
+        }
       });
   }
 


### PR DESCRIPTION
Formula name validation was added in https://github.com/coda/packs-sdk/pull/3433, but it didn't include `chatSkill` or `benchInitializationSkill`. This PR extends the validation to those skills as well.

Claude Code was used to generate the code changes, and I reviewed it.