### PR TITLE
Add network domain validation for MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 - Launched `useDynamicClientRegistration` for OAuth2 authentication, allowing for the automatic discovery of OAuth endpoints and automatic registration of client credentials.
 
+### Changed
+
+- Upload validation now requires Packs that declare MCP servers to also declare a matching network domain, mirroring the existing requirement for authentication.
+
 ## [1.13.3] - 2026-04-09
 
 ### Added

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -2324,6 +2324,17 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
         path: ['networkDomains'],
     })
+        .refine((data) => {
+        var _a, _b;
+        if (((_a = data.networkDomains) === null || _a === void 0 ? void 0 : _a.length) || !((_b = data.mcpServers) === null || _b === void 0 ? void 0 : _b.length)) {
+            return true;
+        }
+        return false;
+    }, {
+        message: 'This pack uses MCP servers but did not declare a network domain. ' +
+            "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+        path: ['networkDomains'],
+    })
         .superRefine((untypedData, context) => {
         var _a;
         const data = untypedData;
@@ -2381,6 +2392,26 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                         return;
                     }
                 }
+            }
+        }
+    })
+        .superRefine((untypedData, context) => {
+        const data = untypedData;
+        if (!data.networkDomains || !data.mcpServers) {
+            return;
+        }
+        for (const [i, server] of data.mcpServers.entries()) {
+            const usedNetworkDomain = (0, url_parse_1.default)(server.endpointUrl).hostname;
+            if (!usedNetworkDomain) {
+                continue;
+            }
+            if (!data.networkDomains.some(domain => domain === usedNetworkDomain || usedNetworkDomain.endsWith('.' + domain))) {
+                context.addIssue({
+                    code: 'custom',
+                    path: [`mcpServers[${i}].endpointUrl`],
+                    message: `Domain ${usedNetworkDomain} is used in MCP server ${server.name} but not declared in the pack's "networkDomains".`,
+                });
+                return;
             }
         }
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.3-prerelease.2",
+  "version": "1.13.3-prerelease.3",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -5471,6 +5471,60 @@ describe('Pack metadata Validation', async () => {
       ]);
     });
 
+    it('missing networkDomains when specifying mcpServers', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: undefined,
+        defaultAuthentication: {type: AuthenticationType.None},
+        mcpServers: [
+          {
+            endpointUrl: 'https://mcp.example.com/mcp',
+            name: 'Example',
+          },
+        ],
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message:
+            "This pack uses MCP servers but did not declare a network domain. Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+          path: 'networkDomains',
+        },
+      ]);
+    });
+
+    it('valid networkDomains when specifying mcpServers', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['mcp.example.com'],
+        defaultAuthentication: {type: AuthenticationType.None},
+        mcpServers: [
+          {
+            endpointUrl: 'https://mcp.example.com/mcp',
+            name: 'Example',
+          },
+        ],
+      });
+      await validateJson(metadata);
+    });
+
+    it('mcpServer endpointUrl domain not covered by networkDomains', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['example.com'],
+        mcpServers: [
+          {
+            endpointUrl: 'https://mcp.canva.com/mcp',
+            name: 'Canva',
+          },
+        ],
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: `Domain mcp.canva.com is used in MCP server Canva but not declared in the pack's "networkDomains".`,
+          path: 'mcpServers[0].endpointUrl',
+        },
+      ]);
+    });
+
     describe('Admin authentication', () => {
       it('validates name', async () => {
         const metadata = createFakePackVersionMetadata({
@@ -6130,7 +6184,7 @@ describe('Pack metadata Validation', async () => {
         ],
         mcpServers: [
           {
-            endpointUrl: 'https://mcp.canva.com/mcp',
+            endpointUrl: 'https://mcp.example.com/mcp',
             name: 'Canva',
           },
         ],
@@ -6209,7 +6263,7 @@ describe('Pack metadata Validation', async () => {
         ],
         mcpServers: [
           {
-            endpointUrl: 'https://mcp.canva.com/mcp',
+            endpointUrl: 'https://mcp.example.com/mcp',
             name: 'Canva',
           },
         ],

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -6185,7 +6185,7 @@ describe('Pack metadata Validation', async () => {
         mcpServers: [
           {
             endpointUrl: 'https://mcp.example.com/mcp',
-            name: 'Canva',
+            name: 'Example',
           },
         ],
       });
@@ -6264,7 +6264,7 @@ describe('Pack metadata Validation', async () => {
         mcpServers: [
           {
             endpointUrl: 'https://mcp.example.com/mcp',
-            name: 'Canva',
+            name: 'Example',
           },
         ],
       });

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -5525,6 +5525,26 @@ describe('Pack metadata Validation', async () => {
       ]);
     });
 
+    it('mcpServer endpointUrl subdomain differs from networkDomains subdomain', async () => {
+      const metadata = createFakePackVersionMetadata({
+        networkDomains: ['api.example.com'],
+        defaultAuthentication: {type: AuthenticationType.None},
+        mcpServers: [
+          {
+            endpointUrl: 'https://mcp.example.com/mcp',
+            name: 'Example',
+          },
+        ],
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: `Domain mcp.example.com is used in MCP server Example but not declared in the pack's "networkDomains".`,
+          path: 'mcpServers[0].endpointUrl',
+        },
+      ]);
+    });
+
     describe('Admin authentication', () => {
       it('validates name', async () => {
         const metadata = createFakePackVersionMetadata({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2908,6 +2908,20 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         path: ['networkDomains'],
       },
     )
+    .refine(
+      (data: any) => {
+        if (data.networkDomains?.length || !data.mcpServers?.length) {
+          return true;
+        }
+        return false;
+      },
+      {
+        message:
+          'This pack uses MCP servers but did not declare a network domain. ' +
+          "Specify the domain that your pack makes http requests to using `networkDomains: ['example.com']`",
+        path: ['networkDomains'],
+      },
+    )
     .superRefine((untypedData, context) => {
       const data = untypedData as PackVersionMetadata;
 
@@ -2977,6 +2991,29 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
               return;
             }
           }
+        }
+      }
+    })
+    .superRefine((untypedData, context) => {
+      const data = untypedData as PackVersionMetadata;
+      if (!data.networkDomains || !data.mcpServers) {
+        return;
+      }
+
+      for (const [i, server] of data.mcpServers.entries()) {
+        const usedNetworkDomain = URLParse(server.endpointUrl).hostname;
+        if (!usedNetworkDomain) {
+          continue;
+        }
+        if (
+          !data.networkDomains.some(domain => domain === usedNetworkDomain || usedNetworkDomain.endsWith('.' + domain))
+        ) {
+          context.addIssue({
+            code: 'custom',
+            path: [`mcpServers[${i}].endpointUrl`],
+            message: `Domain ${usedNetworkDomain} is used in MCP server ${server.name} but not declared in the pack's "networkDomains".`,
+          });
+          return;
         }
       }
     })


### PR DESCRIPTION
A partner and I each ran into the issue where we forgot to declare a network domain or had a mismatch, and it wasn't caught at build time. This PR adds upload validation to ensure that domains in MCP servers are covered by network domains, mirroring the logic used to validate domains used in authentication.

Code written by Claude code and reviewed by me.