### PR TITLE
Add a blog post announcing DCR support

### DIFF
--- a/docs/agents/features/mcp.md
+++ b/docs/agents/features/mcp.md
@@ -66,6 +66,7 @@ Requests to MCP servers use the same [authentication system][authentication] as 
       type: sdk.AuthenticationType.OAuth2,
       useDynamicClientRegistration: true,
       useProofKeyForCodeExchange: true,
+      scopes: ["read", "write"],
     });
     ```
 
@@ -84,6 +85,7 @@ Requests to MCP servers use the same [authentication system][authentication] as 
       authorizationUrl: "https://example.com/authorize",
       tokenUrl: "https://example.com/token",
       useProofKeyForCodeExchange: true,
+      scopes: ["read", "write"],
     });
     ```
 

--- a/docs/blog/posts/dcr_support.md
+++ b/docs/blog/posts/dcr_support.md
@@ -1,0 +1,30 @@
+---
+date: 2026-04-13
+slug: dcr-supported
+description: The SDK now supports Dynamic Client Registration for OAuth2, making it easier to connect to MCP servers and other providers.
+authors:
+  - eric.koleda
+categories:
+  - Updates
+---
+
+# Dynamic Client Registration is now supported
+
+The SDK now supports [Dynamic Client Registration (DCR)][oauth2_dcr] for OAuth2 authentication. With DCR, the platform automatically discovers OAuth endpoints and registers client credentials with the provider, so you no longer need to manually create an application in a developer console or upload a client ID and secret.
+
+This is especially useful when connecting to [MCP servers][mcp], many of which support DCR out of the box. Enabling it is as simple as setting a single flag:
+
+```{.ts hl_lines="3"}
+pack.setUserAuthentication({
+  type: sdk.AuthenticationType.OAuth2,
+  useDynamicClientRegistration: true,
+  useProofKeyForCodeExchange: true,
+  scopes: ["read", "write"],
+});
+```
+
+For more details, including how to combine DCR with manually specified endpoints, see the [OAuth2 authentication guide][oauth2_dcr] and the [MCP guide][mcp].
+
+
+[oauth2_dcr]: ../../guides/basics/authentication/oauth2.md#dcr
+[mcp]: ../../agents/features/mcp.md

--- a/docs/guides/basics/authentication/oauth2.md
+++ b/docs/guides/basics/authentication/oauth2.md
@@ -298,6 +298,7 @@ pack.setUserAuthentication({
   type: sdk.AuthenticationType.OAuth2,
   useDynamicClientRegistration: true,
   useProofKeyForCodeExchange: true,
+  scopes: ["read", "write"],
 });
 ```
 
@@ -310,6 +311,7 @@ pack.setUserAuthentication({
   authorizationUrl: "https://example.com/authorize",
   tokenUrl: "https://api.example.com/token",
   useProofKeyForCodeExchange: true,
+  scopes: ["read", "write"],
 });
 ```
 


### PR DESCRIPTION
Backdating the post to when I documented support, since I should have included it then. Also adds scopes to some other examples, since the DCR support doesn't automatically include all available scopes like other MCP clients.