### PR TITLE
packs-sdk: release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-15
+
 ### Added
 
 - Launched `useDynamicClientRegistration` for OAuth2 authentication, allowing for the automatic discovery of OAuth endpoints and automatic registration of client credentials.
 
+### Fixed
+
+- Fixed `makeParameter` type error (TS2345) when `autocomplete` is an array.
+
 ### Changed
 
 - Upload validation now requires Packs that declare MCP servers to also declare a matching network domain, mirroring the existing requirement for authentication.
+- Removed deprecated `AssistantMessageTool`.
 
 ## [1.13.3] - 2026-04-09
 
@@ -1033,7 +1040,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.13.3...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.14.0...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -1108,5 +1115,5 @@ await myHelper(context);
 [1.12.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.3
 [1.12.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.2
 [1.12.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.1
-
 [1.13.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.13.3
+[1.14.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.13.3",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.13.3-prerelease.5",
+  "version": "1.14.0",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Summary

- Release packs-sdk v1.14.0
- Updates package.json version from 1.13.3-prerelease.5 to 1.14.0
- Adds changelog entries for all changes since v1.13.3

### Changelog

#### Added

- Launched useDynamicClientRegistration for OAuth2 authentication, allowing for the automatic discovery of OAuth endpoints and automatic registration of client credentials. (#3520)

#### Fixed

- Fixed `makeParameter` type error (TS2345) when autocomplete is an array. (#3539)

#### Changed

- Upload validation now requires Packs that declare MCP servers to also declare a matching network domain, mirroring the existing requirement for authentication. (#3540)
- Removed deprecated `AssistantMessageTool`. (#3522)