### PR TITLE
Replace old HC links

### DIFF
--- a/docs/guides/.nav.yml
+++ b/docs/guides/.nav.yml
@@ -7,5 +7,5 @@ nav:
   - advanced
   - development
   - Distribution:
-    - Sharing & publishing: https://help.coda.io/en/articles/5987280-sharing-and-publishing-a-pack
-    - Selling packs: https://help.coda.io/en/articles/6381607-selling-packs-on-coda
+    - Sharing & publishing: https://help.coda.io/hc/en-us/articles/39555880940557-Share-or-publish-a-Pack
+    - Selling packs: https://help.coda.io/hc/en-us/articles/39555971447053-Sell-your-Packs-on-Coda

--- a/docs/guides/advanced/embeds.md
+++ b/docs/guides/advanced/embeds.md
@@ -68,7 +68,7 @@ Once a user clicks the embed they are prompted to approve embedding the URL:
 Once approved, Coda attempts to load the URL int an `<iframe>` element with [sandboxing applied][mdn_iframe_sandbox]. The URL must be secure (begin with `https://`) and must not prevent being loaded in an iframe (via the [`X-Frame-Options`][mdn_xfo] or [`Content-Security-Policy`][mdn_csp] headers).
 
 
-[help_center_embed]: https://help.coda.io/en/articles/1211364-embedding-content-in-your-doc
+[help_center_embed]: https://help.coda.io/hc/en-us/articles/39555949656077-Embed-third-party-content-in-your-doc
 [iframely]: https://iframely.com/
 [iframely_check]: https://iframely.com/embed
 [iframely_docs]: https://iframely.com/docs/webmasters

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -556,7 +556,6 @@ There are services however where each account is associated with a distinct doma
 [sample_multiple_query_params]: ../../../samples/topic/authentication.md#multiple-query-parameters
 [sample_multiple_headers]: ../../../samples/topic/authentication.md#multiple-headers
 
-[hc_account_sharing]: https://help.coda.io/en/articles/4587167-what-can-coda-access-with-packs
 [account_settings]: https://coda.io/account
 [AuthenticationType]: ../../../reference/sdk/core/enumerations/AuthenticationType.md
 [support]: ../../../support/index.md

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -543,8 +543,8 @@ The full set of formatting options for a given value type and hint can be found 
 [unix_epoch]: https://en.wikipedia.org/wiki/Unix_time
 [iframely]: https://iframely.com/
 [oEmbed]: https://oembed.com/
-[embed_force]: https://help.coda.io/en/articles/1211364-embedding-content-in-your-doc#using-the-force-parameter
-[column_formats]: https://help.coda.io/en/articles/1235680-overview-of-column-formats
+[embed_force]: https://help.coda.io/hc/en-us/articles/39555949656077-Embed-third-party-content-in-your-doc#h_01K57937QDYQQRV47NPGVMPRCY
+[column_formats]: https://help.coda.io/hc/en-us/articles/39555851862925-Column-basics
 [actions]: ../blocks/actions.md
 [precision]: ../../reference/sdk/core/interfaces/NumericSchema.md#precision
 [currencyCode]: ../../reference/sdk/core/interfaces/CurrencySchema.md#currencycode

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -190,8 +190,8 @@ Dynamic sync tables have dynamic schemas, and therefore need to use the techniqu
 While there is no solution for the general case, there is for the common case where a button appears in a column of the same table. As long as the `identity.name` of the schema matches that of the dynamic sync table containing the button, the dynamic URL will be automatically populated and the row update will work. Using that same action elsewhere in the doc however will not update the existing row.
 
 
-[help_buttons]: https://help.coda.io/en/articles/2033889-overview-of-buttons
-[help_automations]: https://help.coda.io/en/articles/2423860-automations-in-coda
+[help_buttons]: https://help.coda.io/hc/en-us/articles/39555758072717-Button-basics
+[help_automations]: https://help.coda.io/hc/en-us/articles/39555778179853-Automations-in-Coda
 [fetcher]: ../basics/fetcher.md
 [samples]: ../../samples/topic/action.md
 [formulas]: formulas.md

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -266,7 +266,7 @@ Since the properties themselves may use the [`fromKey`][fromKey] option to load 
     ```
 
 [samples]: ../../../samples/topic/sync-table.md
-[help_center]: https://help.coda.io/en/articles/3213629-using-packs-tables-to-sync-your-data-into-coda
+[help_center]: https://help.coda.io/hc/en-us/articles/39555773352461-Sync-data-with-Pack-tables
 [sample_todoist]: ../../../samples/full/todoist.md
 [schemas]: ../../advanced/schemas.md
 [featured]: ../../../reference/sdk/core/interfaces/ObjectSchemaDefinition.md#featuredproperties
@@ -279,7 +279,7 @@ Since the properties themselves may use the [`fromKey`][fromKey] option to load 
 [actions]: ../actions.md
 [dynamic_sync_tables]: dynamic.md
 [dynamic_sync_tables_schema_only]: dynamic.md#schema-only
-[hc_relations]: https://help.coda.io/en/articles/1385997-connect-tables-with-relation-columns
+[hc_relations]: https://help.coda.io/hc/en-us/articles/39555878926861-Connect-tables-with-relation-columns
 [sample_continuation]: ../../../samples/topic/sync-table.md#with-continuation
 [sample_reference]: ../../../samples/topic/sync-table.md#with-row-references
 [parmeters]: ../../basics/parameters/index.md

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -104,10 +104,10 @@ Packs are run in a custom JavaScript execution environment, compatible with the 
 [packs_why]: https://coda.io/why-build-packs
 [gallery_slack]: https://coda.io/packs/slack-1000
 [formula_list]: https://coda.io/formulas
-[help_buttons]: https://help.coda.io/en/articles/2033889-overview-of-buttons
-[help_automations]: https://help.coda.io/en/articles/2423860-automations-in-coda
-[help_format]: https://help.coda.io/en/articles/1235680-overview-of-column-formats
-[help_pack_table]: https://help.coda.io/en/articles/3213629-using-packs-tables-to-sync-your-data-into-coda
+[help_buttons]: https://help.coda.io/hc/en-us/articles/39555758072717-Button-basics
+[help_automations]: https://help.coda.io/hc/en-us/articles/39555778179853-Automations-in-Coda
+[help_format]: https://help.coda.io/hc/en-us/articles/39555851862925-Column-basics
+[help_pack_table]: https://help.coda.io/hc/en-us/articles/39555773352461-Sync-data-with-Pack-tables
 [codecademy]: https://www.codecademy.com/learn/introduction-to-javascript
 [community]: https://community.coda.io/c/developers-central/making-packs/15
 [quickstart_web]: ../tutorials/get-started/web.md
@@ -119,5 +119,5 @@ Packs are run in a custom JavaScript execution environment, compatible with the 
 [actions]: blocks/actions.md
 [column_formats]: blocks/column-formats.md
 [sync_tables]: blocks/sync-tables/index.md
-[help_admin]: https://help.coda.io/en/articles/5574990-managing-packs-approvals-for-enterprise-admins
+[help_admin]: https://help.coda.io/hc/en-us/articles/39555784421773-Enable-Pack-approvals-and-manage-requests
 [gallery_packs]: https://coda.io/gallery?filter=packs

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -86,4 +86,4 @@ Only the [support][support_email] team can transfer a Pack to another workspace,
 [packs_apps_script]: https://coda.io/packs/apps-script-14470
 [dynamic_sync_tables]: ../guides/blocks/sync-tables/dynamic.md
 [support_email]: mailto:support+packstudio@coda.io
-[hc_selling]: https://help.coda.io/en/articles/6381607-selling-packs-on-coda
+[hc_selling]: https://help.coda.io/hc/en-us/articles/39555971447053-Sell-your-Packs-on-Coda

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -56,7 +56,7 @@ To request approval please fill out the form linked below. Ensure you are signed
 [community_search]: https://community.coda.io/search?q=%23making-packs
 [community_post]: https://community.coda.io/new-topic?category=making-packs
 [support_email]: mailto:care@superhuman.com
-[hc_share]: https://help.coda.io/en/articles/1137949-sharing-your-doc#h_5061fdf96a
+[hc_share]: https://help.coda.io/hc/en-us/articles/39555880940557-Share-or-publish-a-Pack
 [fetcher_network_domains]: ../guides/basics/fetcher.md#network-domains
 [network_domains_form]: https://coda.io/form/Pack-Network-Domains-Request_ddvuAhFq3IZ
 [office_hours]: https://calendly.com/ekoleda/packs-office-hours

--- a/docs/tutorials/get-started/.cli-before.md
+++ b/docs/tutorials/get-started/.cli-before.md
@@ -2,5 +2,5 @@ To create a Pack you will need a Coda account, with [Doc Maker access][hc_doc_ma
 
 The instructions below assume some familiarity with the terminal / command prompt. If you aren't used to using this interface consult the help material for your operating system.
 
-[hc_doc_maker]: https://help.coda.io/en/articles/3388781-members-and-roles
+[hc_doc_maker]: https://help.coda.io/hc/en-us/articles/39556004184077-Roles-in-Coda-Doc-Makers-Admins-and-Editors
 [sign_up]: https://coda.io/signup

--- a/docs/tutorials/get-started/web.md
+++ b/docs/tutorials/get-started/web.md
@@ -91,7 +91,7 @@ You've built your fist Pack, congrats! 🎉 Now that you have some experience wi
 
 
 [coda_sign_up]: https://coda.io/signup
-[hc_doc_maker]: https://help.coda.io/en/articles/3388781-members-and-roles
+[hc_doc_maker]: https://help.coda.io/hc/en-us/articles/39556004184077-Roles-in-Coda-Doc-Makers-Admins-and-Editors
 [coda_home]: https://coda.io/docs
 [samples_hello_world]: ../../samples/full/hello-world.md
 [samples]: ../../samples/topic/formula.md


### PR DESCRIPTION
The HC at help.coda.io migrated earlier this year, and unfortunately, a lot of the old links broke (no redirect). This PR replaced the old links with new ones, using a mapping that the support team provided.