### PR TITLE
Pin gitpython to 3.1.50 to fix CVE-2026-42284

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,9 @@ mkdocs-simple-hooks = "==0.1.5"
 mkdocs-site-urls = "==0.3.1"
 pillow = "==12.1.1"
 urllib3 = "==2.6.0"
+# Pulled in transitively (by mkdocs-rss-plugin). Pinned to a patched version
+# to address CVE-2026-42284 (fixed in 3.1.47).
+gitpython = "==3.1.50"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b6abafbfc410e1a7da38971ee4287e3210ee68872950dc1fbd301917eb825cc7"
+            "sha256": "d77410ecd20003b4bf3555636909525ce49d5d41990ae9468e6c30eca05c4c87"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -363,11 +363,12 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f",
-                "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058"
+                "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc",
+                "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.46"
+            "version": "==3.1.50"
         },
         "hjson": {
             "hashes": [
@@ -1116,11 +1117,11 @@
         },
         "smmap": {
             "hashes": [
-                "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5",
-                "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"
+                "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c",
+                "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.0.2"
+            "version": "==5.0.3"
         },
         "soupsieve": {
             "hashes": [


### PR DESCRIPTION
## Summary

  CVE-2026-42284 reports a vulnerability in gitpython versions before 3.1.47.
  We were pulling it in transitively via mkdocs-rss-plugin at 3.1.46.

  ## Detail

  - Add a top-level `gitpython = "==3.1.50"` pin in `Pipfile` to force resolution past the fix (3.1.47 is the minimum; 3.1.50 matches what coda/coda uses).
  - Regenerated lockfile entry via `pipenv upgrade gitpython==3.1.50`. smmap (a transitive dep of gitpython) bumped 5.0.2 → 5.0.3 as part of the upgrade.

  ## Other notes

  - Lockfile was generated with Python 3.13 locally (Pipfile requires 3.12). The diff is minimal because I used `pipenv upgrade` rather than a full `pipenv lock`. A maintainer with Python 3.12 may want to re-lock cleanly before merge.
  - Once this merges and a new packs-sdk version is cut, coda/coda will pick up the fix on its next packs-sdk bump.