### PR TITLE
packs-sdk: release v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-05-29
+
 ### Changed
 
 - Renamed the CLI binary from `coda` to `packs`. The `coda` command remains available as an alias for backwards compatibility.
@@ -1044,7 +1046,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.14.0...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.15.0...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -1121,3 +1123,4 @@ await myHelper(context);
 [1.12.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.12.1
 [1.13.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.13.3
 [1.14.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.14.0
+[1.15.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.15.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.14.0-prerelease.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.14.0-prerelease.1",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.14.0-prerelease.1",
+  "version": "1.15.0",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
### Changed

- Renamed the CLI binary from `coda` to `packs`. The `coda` command remains available as an alias for backwards compatibility.