### PR TITLE
Add internal userId to InvocationLocation for Go agent invocations

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -1202,6 +1202,13 @@ export interface InvocationLocation {
    * @deprecated This will be removed in a future version of the SDK.
    */
   docId?: string;
+
+  /**
+   * The ID of the user this invocation runs on behalf of. Only populated for
+   * Superhuman-created Packs. Superhuman internal use only.
+   * @internal
+   */
+  userId?: string;
 }
 
 /**

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -1027,6 +1027,12 @@ export interface InvocationLocation {
      * @deprecated This will be removed in a future version of the SDK.
      */
     docId?: string;
+    /**
+     * The ID of the user this invocation runs on behalf of. Only populated for
+     * Superhuman-created Packs. Superhuman internal use only.
+     * @internal
+     */
+    userId?: string;
 }
 /**
  * An object passed to the `execute` function of every formula invocation

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -997,6 +997,12 @@ export interface InvocationLocation {
 	 * @deprecated This will be removed in a future version of the SDK.
 	 */
 	docId?: string;
+	/**
+	 * The ID of the user this invocation runs on behalf of. Only populated for
+	 * Superhuman-created Packs. Superhuman internal use only.
+	 * @internal
+	 */
+	userId?: string;
 }
 /**
  * An object passed to the `execute` function of every formula invocation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.16.0-prerelease.1",
+  "version": "1.16.0-prerelease.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.16.0-prerelease.1",
+      "version": "1.16.0-prerelease.2",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.16.0-prerelease.1",
+  "version": "1.16.0-prerelease.2",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Summary
Adds an optional, `@internal` `userId` to `InvocationLocation`: the id of the user an invocation runs on behalf of. It lets first-party agent packs forward the invoking user to user-keyed Grammarly backends — e.g. the AI Detector pack calls CAPI, which routes per-user experiments (AI-detection model selection) off this id.

## Detail
Addressing the concern about identifiable data in the context (the `docId` precedent):
- **`@internal`** — stripped from the generated/public SDK docs; not part of the 3P-facing surface.
- **Populated only for first-party packs.** Coda sets it solely for 1P packs (the AI Detector today); third-party packs never receive it, so this does not broaden the identifiable data available to external pack authors.
- It rides through the existing execution payload as part of `invocationLocation` (copied verbatim into the pack), so there are no runtime/bootstrap changes. Absent when no user is known (e.g. Coda-only accounts with no Grammarly correlation).

## Test plan
Type-only addition to an internal-use interface; no SDK behavior change. `dist/` regenerated via `make compile`.

## Other notes
Prerequisite for the matching Coda change, which populates the field (scoped to 1P packs) and consumes it from the AI Detector pack; Coda repins to a released SDK version that includes it.