### PR TITLE
Bump tmp to 0.2.6 to fix CVE-2026-44705

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13419,16 +13419,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/p-limit/-/p-limit-3.1.0.tgz",
@@ -16448,16 +16438,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.6",
+      "resolved": "https://artifactory.grammarly.io/artifactory/api/npm/common-npm/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.15.0-prerelease.1",
+  "version": "1.15.0-prerelease.2",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,9 @@
       "prettier --write"
     ]
   },
+  "overrides": {
+    "tmp": "0.2.6"
+  },
   "pnpm": {
     "overrides": {
       "@types/estree": "1.0.8",
@@ -151,7 +154,7 @@
       "qs@>=6.7.0 <6.14.2": "6.14.2",
       "serialize-javascript@<=7.0.2": "7.0.4",
       "tar-fs@<2.1.4": "2.1.4",
-      "tmp@<0.2.4": "0.2.4",
+      "tmp@<0.2.6": "0.2.6",
       "webpack@>=5.49.0 <5.104.1": "5.104.1"
     },
     "packageExtensions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   qs@>=6.7.0 <6.14.2: 6.14.2
   serialize-javascript@<=7.0.2: 7.0.4
   tar-fs@<2.1.4: 2.1.4
-  tmp@<0.2.4: 0.2.4
+  tmp@<0.2.6: 0.2.6
   webpack@>=5.49.0 <5.104.1: 5.104.1
 
 packageExtensionsChecksum: sha256-jOFugJbEjo38UV1unLJM/6itxPFBBiGGEtfcaEfSRi4=
@@ -4663,8 +4663,8 @@ packages:
     resolution: {integrity: sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.2.4:
-    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   to-buffer@1.2.1:
@@ -8113,7 +8113,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.4
+      tmp: 0.2.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -10297,7 +10297,7 @@ snapshots:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
-  tmp@0.2.4: {}
+  tmp@0.2.6: {}
 
   to-buffer@1.2.1:
     dependencies:


### PR DESCRIPTION
Path traversal in the tmp package via unsanitized prefix/postfix/dir (GHSA-ph9p-34f9-6g65), fixed in 0.2.6. tmp is a dev-only transitive dep (via external-editor). Widens the existing pnpm override to <0.2.6 and adds the matching npm overrides entry so package-lock.json no longer resolves the vulnerable tmp@0.0.33.