### PR TITLE
Allow relative tokenUrl for OAuth2ClientCredentials authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Changed
 
 - `MCPServer.endpointUrl` now accepts a root-relative path (e.g. `/mcp`) that is resolved against the connection's endpoint when the pack's authentication provides one — via `requiresEndpointUrl` or `endpointKey` — mirroring the `authorizationUrl` / `tokenUrl` convention. This also applies to packs that use `setSystemAuthentication` instead of a per-user default authentication. Absolute `https` URLs continue to work unchanged.
+- `OAuth2ClientCredentialsAuthentication.tokenUrl` now accepts a root-relative path (e.g. `/token`) that is resolved against the connection's endpoint when the pack's authentication sets `requiresEndpointUrl`, mirroring the OAuth2 authorization-code flow's `tokenUrl` convention. Absolute `https` URLs continue to work unchanged.
 
 ## [1.17.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 ### Changed
 
 - `MCPServer.endpointUrl` now accepts a root-relative path (e.g. `/mcp`) that is resolved against the connection's endpoint when the pack's authentication provides one — via `requiresEndpointUrl` or `endpointKey` — mirroring the `authorizationUrl` / `tokenUrl` convention. This also applies to packs that use `setSystemAuthentication` instead of a per-user default authentication. Absolute `https` URLs continue to work unchanged.
-- `OAuth2ClientCredentialsAuthentication.tokenUrl` now accepts a root-relative path (e.g. `/token`) that is resolved against the connection's endpoint when the pack's authentication sets `requiresEndpointUrl`, mirroring the OAuth2 authorization-code flow's `tokenUrl` convention. Absolute `https` URLs continue to work unchanged.
+- `OAuth2ClientCredentialsAuthentication.tokenUrl` now accepts a root-relative path (e.g. `/token`) that is resolved against the connection's endpoint when the pack's authentication sets `requiresEndpointUrl`, mirroring the OAuth2 authorization-code flow's `tokenUrl` convention. Absolute URLs of any scheme continue to work unchanged.
 
 ## [1.17.0] - 2026-07-08
 

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -5245,7 +5245,13 @@ export type OAuth2Authentication = OAuth2StaticCodeAuthentication | OAuth2Dynami
 export interface OAuth2ClientCredentialsAuthentication extends BaseOAuthAuthentication {
 	/** Identifies this as OAuth2 client credentials authentication. */
 	type: AuthenticationType.OAuth2ClientCredentials;
-	/** The URL that the platform will hit in order to exchange credentials for an access token. */
+	/**
+	 * The URL that the platform will hit in order to exchange credentials for an access token.
+	 *
+	 * If {@link BaseAuthentication.requiresEndpointUrl} is `true`, this may instead be a
+	 * root-relative path (e.g. `/oauth/token`), which the platform resolves against the account's
+	 * endpoint. Absolute URLs are always accepted, with or without `requiresEndpointUrl`.
+	 */
 	tokenUrl: string;
 }
 /**

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -654,7 +654,11 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         }),
         [types_1.AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.OAuth2ClientCredentials),
-            /** Accepts a relative URL when requiresEndpointUrl is true; enforced in the superRefine below. */
+            /**
+             * May be relative or absolute when requiresEndpointUrl is true (enforced in the superRefine
+             * below) — packs already support a manually-entered endpoint alongside a fixed absolute
+             * tokenUrl, so a relative tokenUrl is offered as an additional option, not a requirement.
+             */
             tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
             scopes: z.array(z.string()).optional(),
             scopeDelimiter: z.enum([' ', ',', ';']).optional(),
@@ -667,7 +671,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             credentialsLocation: z.nativeEnum(types_10.TokenExchangeCredentialsLocation).optional(),
             ...baseAuthenticationValidators,
         }).superRefine(({ requiresEndpointUrl, tokenUrl }, context) => {
-            validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, { requiresEndpointUrl }, context);
+            validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, { requiresEndpointUrl, allowEitherWhenEndpointRequired: true }, context);
         }),
         [types_1.AuthenticationType.WebBasic]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.WebBasic),
@@ -2778,16 +2782,25 @@ function validateUrlParsesIfAbsolute(url) {
 /**
  * Validates a field that must be relative exactly when `requiresEndpointUrl` is set (and no
  * `endpointKey` resolves an endpoint instead) — shared by fields evaluated during the auth flow.
+ *
+ * `allowEitherWhenEndpointRequired` relaxes that to accept either a relative or an absolute URL
+ * when an endpoint is required, instead of requiring relative. Some auth types (e.g.
+ * {@link OAuth2ClientCredentialsAuthentication.tokenUrl}) already supported a manually-entered
+ * endpoint alongside a fixed absolute URL (auth at one endpoint, requests to a customer-specific
+ * one), so enforcing relative-only here would be a backwards-incompatible break for those packs.
  */
-function validateUrlIsRelativeOrAbsolute(fieldName, url, { requiresEndpointUrl, endpointKey }, context) {
+function validateUrlIsRelativeOrAbsolute(fieldName, url, { requiresEndpointUrl, endpointKey, allowEitherWhenEndpointRequired, }, context) {
     const expectsRelativeUrl = Boolean(requiresEndpointUrl && !endpointKey);
-    if ((expectsRelativeUrl && !isRootRelativeUrl(url)) || (!expectsRelativeUrl && !isAbsoluteUrl(url))) {
-        const expectedType = expectsRelativeUrl ? 'a relative' : 'an absolute';
-        context.addIssue({
-            code: 'custom',
-            path: [fieldName],
-            message: `${fieldName} must be ${expectedType} URL when \
-${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl !== null && requiresEndpointUrl !== void 0 ? requiresEndpointUrl : 'not true'}`}`,
-        });
+    const allowsRelative = expectsRelativeUrl;
+    const allowsAbsolute = !expectsRelativeUrl || allowEitherWhenEndpointRequired;
+    if ((allowsRelative && isRootRelativeUrl(url)) || (allowsAbsolute && isAbsoluteUrl(url))) {
+        return;
     }
+    const expectedType = allowsRelative && allowsAbsolute ? 'a relative or absolute' : allowsRelative ? 'a relative' : 'an absolute';
+    context.addIssue({
+        code: 'custom',
+        path: [fieldName],
+        message: `${fieldName} must be ${expectedType} URL when \
+${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl !== null && requiresEndpointUrl !== void 0 ? requiresEndpointUrl : 'not true'}`}`,
+    });
 }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -654,17 +654,20 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         }),
         [types_1.AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.OAuth2ClientCredentials),
-            tokenUrl: z.string().url().refine(validateUrlParsesIfAbsolute),
+            /** Accepts a relative URL when requiresEndpointUrl is true; enforced in the superRefine below. */
+            tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
             scopes: z.array(z.string()).optional(),
             scopeDelimiter: z.enum([' ', ',', ';']).optional(),
             tokenPrefix: z.string().optional(),
             tokenQueryParam: z.string().optional(),
-            /** Unlike the authorization code flow, this flow's tokenUrl is absolute-only, so resource must be too. */
+            /** Unlike tokenUrl, resource has no relative-URL exception and must always be absolute. */
             resource: z.string().url().refine(validateUrlParsesIfAbsolute).optional(),
             scopeParamName: z.string().optional(),
             nestedResponseKey: z.string().optional(),
             credentialsLocation: z.nativeEnum(types_10.TokenExchangeCredentialsLocation).optional(),
             ...baseAuthenticationValidators,
+        }).superRefine(({ requiresEndpointUrl, tokenUrl }, context) => {
+            validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, { requiresEndpointUrl }, context);
         }),
         [types_1.AuthenticationType.WebBasic]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.WebBasic),

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -654,12 +654,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         }),
         [types_1.AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.OAuth2ClientCredentials),
-            /**
-             * May be relative or absolute when requiresEndpointUrl is true (enforced in the superRefine
-             * below) — packs already support a manually-entered endpoint alongside a fixed absolute
-             * tokenUrl, so a relative tokenUrl is offered as an additional option, not a requirement.
-             */
-            tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
+            // Absolute (any scheme) always allowed; relative only when requiresEndpointUrl is true — see superRefine.
+            tokenUrl: z.string(),
             scopes: z.array(z.string()).optional(),
             scopeDelimiter: z.enum([' ', ',', ';']).optional(),
             tokenPrefix: z.string().optional(),
@@ -671,7 +667,18 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             credentialsLocation: z.nativeEnum(types_10.TokenExchangeCredentialsLocation).optional(),
             ...baseAuthenticationValidators,
         }).superRefine(({ requiresEndpointUrl, tokenUrl }, context) => {
-            validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, { requiresEndpointUrl, allowEitherWhenEndpointRequired: true }, context);
+            const isValid = requiresEndpointUrl
+                ? isRootRelativeUrl(tokenUrl) || isAbsoluteUrlOfAnyScheme(tokenUrl)
+                : isAbsoluteUrlOfAnyScheme(tokenUrl);
+            if (!isValid) {
+                context.addIssue({
+                    code: 'custom',
+                    path: ['tokenUrl'],
+                    message: requiresEndpointUrl
+                        ? 'tokenUrl must be a relative or absolute URL when requiresEndpointUrl is true'
+                        : 'tokenUrl must be an absolute URL when requiresEndpointUrl is not true',
+                });
+            }
         }),
         [types_1.AuthenticationType.WebBasic]: zodCompleteStrictObject({
             type: zodDiscriminant(types_1.AuthenticationType.WebBasic),
@@ -2763,6 +2770,15 @@ function validateDeprecatedParameterFields(param, pathPrefix, context) {
 function isAbsoluteUrl(url) {
     return url.startsWith('https://');
 }
+/** Unlike {@link isAbsoluteUrl}, accepts any scheme (matching the pre-existing `z.string().url()` check). */
+function isAbsoluteUrlOfAnyScheme(url) {
+    try {
+        return Boolean(new URL(url));
+    }
+    catch {
+        return false;
+    }
+}
 function isRootRelativeUrl(url) {
     return url.startsWith('/') && url[1] !== '/' && url[1] !== '\\';
 }
@@ -2782,25 +2798,16 @@ function validateUrlParsesIfAbsolute(url) {
 /**
  * Validates a field that must be relative exactly when `requiresEndpointUrl` is set (and no
  * `endpointKey` resolves an endpoint instead) — shared by fields evaluated during the auth flow.
- *
- * `allowEitherWhenEndpointRequired` relaxes that to accept either a relative or an absolute URL
- * when an endpoint is required, instead of requiring relative. Some auth types (e.g.
- * {@link OAuth2ClientCredentialsAuthentication.tokenUrl}) already supported a manually-entered
- * endpoint alongside a fixed absolute URL (auth at one endpoint, requests to a customer-specific
- * one), so enforcing relative-only here would be a backwards-incompatible break for those packs.
  */
-function validateUrlIsRelativeOrAbsolute(fieldName, url, { requiresEndpointUrl, endpointKey, allowEitherWhenEndpointRequired, }, context) {
+function validateUrlIsRelativeOrAbsolute(fieldName, url, { requiresEndpointUrl, endpointKey }, context) {
     const expectsRelativeUrl = Boolean(requiresEndpointUrl && !endpointKey);
-    const allowsRelative = expectsRelativeUrl;
-    const allowsAbsolute = !expectsRelativeUrl || allowEitherWhenEndpointRequired;
-    if ((allowsRelative && isRootRelativeUrl(url)) || (allowsAbsolute && isAbsoluteUrl(url))) {
-        return;
-    }
-    const expectedType = allowsRelative && allowsAbsolute ? 'a relative or absolute' : allowsRelative ? 'a relative' : 'an absolute';
-    context.addIssue({
-        code: 'custom',
-        path: [fieldName],
-        message: `${fieldName} must be ${expectedType} URL when \
+    if ((expectsRelativeUrl && !isRootRelativeUrl(url)) || (!expectsRelativeUrl && !isAbsoluteUrl(url))) {
+        const expectedType = expectsRelativeUrl ? 'a relative' : 'an absolute';
+        context.addIssue({
+            code: 'custom',
+            path: [fieldName],
+            message: `${fieldName} must be ${expectedType} URL when \
 ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl !== null && requiresEndpointUrl !== void 0 ? requiresEndpointUrl : 'not true'}`}`,
-    });
+        });
+    }
 }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -649,7 +649,13 @@ export type OAuth2Authentication = OAuth2StaticCodeAuthentication | OAuth2Dynami
 export interface OAuth2ClientCredentialsAuthentication extends BaseOAuthAuthentication {
     /** Identifies this as OAuth2 client credentials authentication. */
     type: AuthenticationType.OAuth2ClientCredentials;
-    /** The URL that the platform will hit in order to exchange credentials for an access token. */
+    /**
+     * The URL that the platform will hit in order to exchange credentials for an access token.
+     *
+     * If {@link BaseAuthentication.requiresEndpointUrl} is `true`, this may instead be a
+     * root-relative path (e.g. `/oauth/token`), which the platform resolves against the account's
+     * endpoint. Absolute URLs are always accepted, with or without `requiresEndpointUrl`.
+     */
     tokenUrl: string;
 }
 /**

--- a/docs/reference/sdk/core/interfaces/OAuth2ClientCredentialsAuthentication.md
+++ b/docs/reference/sdk/core/interfaces/OAuth2ClientCredentialsAuthentication.md
@@ -239,6 +239,10 @@ that should contain the token.
 
 The URL that the platform will hit in order to exchange credentials for an access token.
 
+If [BaseAuthentication.requiresEndpointUrl](BaseAuthentication.md#requiresendpointurl) is `true`, this may instead be a
+root-relative path (e.g. `/oauth/token`), which the platform resolves against the account's
+endpoint. Absolute URLs are always accepted, with or without `requiresEndpointUrl`.
+
 #### Overrides
 
 `BaseOAuthAuthentication.tokenUrl`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.1-prerelease.1",
+  "version": "1.17.1-prerelease.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.17.1-prerelease.0",
+      "version": "1.17.1-prerelease.2",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.1-prerelease.1",
+  "version": "1.17.1-prerelease.2",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -5188,6 +5188,66 @@ describe('Pack metadata Validation', async () => {
       await validateJson(metadata);
     });
 
+    it('OAuth2ClientCredentials, requiresEndpointUrl requires relative tokenUrl', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.OAuth2ClientCredentials,
+          tokenUrl: 'https://example.com/tokenUrl',
+          requiresEndpointUrl: true,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'tokenUrl must be a relative URL when requiresEndpointUrl is true',
+          path: 'defaultAuthentication.tokenUrl',
+        },
+      ]);
+
+      assertCondition(metadata.defaultAuthentication?.type === AuthenticationType.OAuth2ClientCredentials);
+      metadata.defaultAuthentication.tokenUrl = '/tokenUrl';
+      await validateJson(metadata);
+    });
+
+    it('OAuth2ClientCredentials, no requiresEndpointUrl requires absolute tokenUrl', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.OAuth2ClientCredentials,
+          tokenUrl: '/tokenUrl',
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'tokenUrl must be an absolute URL when requiresEndpointUrl is not true',
+          path: 'defaultAuthentication.tokenUrl',
+        },
+      ]);
+
+      assertCondition(metadata.defaultAuthentication?.type === AuthenticationType.OAuth2ClientCredentials);
+      metadata.defaultAuthentication.tokenUrl = 'https://example.com/tokenUrl';
+      await validateJson(metadata);
+    });
+
+    it('OAuth2ClientCredentials, requiresEndpointUrl rejects protocol-relative tokenUrl', async () => {
+      // A protocol-relative URL like "//evil.com/tokenUrl" starts with "/" but resolves to a
+      // different host than the connection endpoint, so it must not be treated as relative.
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.OAuth2ClientCredentials,
+          tokenUrl: '//evil.com/tokenUrl',
+          requiresEndpointUrl: true,
+        },
+      });
+      const err = await validateJsonAndAssertFails(metadata);
+      assert.deepEqual(err.validationErrors, [
+        {
+          message: 'tokenUrl must be a relative URL when requiresEndpointUrl is true',
+          path: 'defaultAuthentication.tokenUrl',
+        },
+      ]);
+    });
+
     it('WebBasic', async () => {
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
@@ -5590,7 +5650,7 @@ describe('Pack metadata Validation', async () => {
       const err = await validateJsonAndAssertFails(metadata, '1.0.0');
       assert.deepEqual(err.validationErrors, [
         {
-          message: 'Invalid URL',
+          message: 'tokenUrl must be an absolute URL when requiresEndpointUrl is not true',
           path: 'defaultAuthentication.tokenUrl',
         },
       ]);

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -5188,7 +5188,10 @@ describe('Pack metadata Validation', async () => {
       await validateJson(metadata);
     });
 
-    it('OAuth2ClientCredentials, requiresEndpointUrl requires relative tokenUrl', async () => {
+    it('OAuth2ClientCredentials, requiresEndpointUrl allows either a relative or absolute tokenUrl', async () => {
+      // Packs already support a manually-entered endpoint alongside a fixed absolute tokenUrl (auth
+      // at one endpoint, requests to a customer-specific one), so a relative tokenUrl is an
+      // additional option here, not a requirement — enforcing relative-only would break those packs.
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2ClientCredentials,
@@ -5196,13 +5199,7 @@ describe('Pack metadata Validation', async () => {
           requiresEndpointUrl: true,
         },
       });
-      const err = await validateJsonAndAssertFails(metadata);
-      assert.deepEqual(err.validationErrors, [
-        {
-          message: 'tokenUrl must be a relative URL when requiresEndpointUrl is true',
-          path: 'defaultAuthentication.tokenUrl',
-        },
-      ]);
+      await validateJson(metadata);
 
       assertCondition(metadata.defaultAuthentication?.type === AuthenticationType.OAuth2ClientCredentials);
       metadata.defaultAuthentication.tokenUrl = '/tokenUrl';
@@ -5231,7 +5228,8 @@ describe('Pack metadata Validation', async () => {
 
     it('OAuth2ClientCredentials, requiresEndpointUrl rejects protocol-relative tokenUrl', async () => {
       // A protocol-relative URL like "//evil.com/tokenUrl" starts with "/" but resolves to a
-      // different host than the connection endpoint, so it must not be treated as relative.
+      // different host than the connection endpoint, so it must not be treated as relative — and
+      // it isn't a valid absolute URL either, so it's rejected even though both shapes are allowed.
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2ClientCredentials,
@@ -5242,7 +5240,7 @@ describe('Pack metadata Validation', async () => {
       const err = await validateJsonAndAssertFails(metadata);
       assert.deepEqual(err.validationErrors, [
         {
-          message: 'tokenUrl must be a relative URL when requiresEndpointUrl is true',
+          message: 'tokenUrl must be a relative or absolute URL when requiresEndpointUrl is true',
           path: 'defaultAuthentication.tokenUrl',
         },
       ]);

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -5189,9 +5189,7 @@ describe('Pack metadata Validation', async () => {
     });
 
     it('OAuth2ClientCredentials, requiresEndpointUrl allows either a relative or absolute tokenUrl', async () => {
-      // Packs already support a manually-entered endpoint alongside a fixed absolute tokenUrl (auth
-      // at one endpoint, requests to a customer-specific one), so a relative tokenUrl is an
-      // additional option here, not a requirement — enforcing relative-only would break those packs.
+      // A fixed absolute tokenUrl remains valid even when requiresEndpointUrl is true.
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2ClientCredentials,
@@ -5206,7 +5204,7 @@ describe('Pack metadata Validation', async () => {
       await validateJson(metadata);
     });
 
-    it('OAuth2ClientCredentials, no requiresEndpointUrl requires absolute tokenUrl', async () => {
+    it('OAuth2ClientCredentials, no requiresEndpointUrl requires absolute tokenUrl, any scheme', async () => {
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2ClientCredentials,
@@ -5221,15 +5219,15 @@ describe('Pack metadata Validation', async () => {
         },
       ]);
 
+      // Non-https absolute URLs must keep working (pre-existing behavior).
       assertCondition(metadata.defaultAuthentication?.type === AuthenticationType.OAuth2ClientCredentials);
-      metadata.defaultAuthentication.tokenUrl = 'https://example.com/tokenUrl';
+      metadata.defaultAuthentication.tokenUrl = 'http://example.com/tokenUrl';
       await validateJson(metadata);
     });
 
     it('OAuth2ClientCredentials, requiresEndpointUrl rejects protocol-relative tokenUrl', async () => {
-      // A protocol-relative URL like "//evil.com/tokenUrl" starts with "/" but resolves to a
-      // different host than the connection endpoint, so it must not be treated as relative — and
-      // it isn't a valid absolute URL either, so it's rejected even though both shapes are allowed.
+      // "//evil.com/tokenUrl" starts with "/" but points at a different host, so it's neither a
+      // valid relative path nor a valid absolute URL.
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {
           type: AuthenticationType.OAuth2ClientCredentials,

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -847,17 +847,20 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     }),
     [AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject<OAuth2ClientCredentialsAuthentication>({
       type: zodDiscriminant(AuthenticationType.OAuth2ClientCredentials),
-      tokenUrl: z.string().url().refine(validateUrlParsesIfAbsolute),
+      /** Accepts a relative URL when requiresEndpointUrl is true; enforced in the superRefine below. */
+      tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
       scopes: z.array(z.string()).optional(),
       scopeDelimiter: z.enum([' ', ',', ';']).optional(),
       tokenPrefix: z.string().optional(),
       tokenQueryParam: z.string().optional(),
-      /** Unlike the authorization code flow, this flow's tokenUrl is absolute-only, so resource must be too. */
+      /** Unlike tokenUrl, resource has no relative-URL exception and must always be absolute. */
       resource: z.string().url().refine(validateUrlParsesIfAbsolute).optional(),
       scopeParamName: z.string().optional(),
       nestedResponseKey: z.string().optional(),
       credentialsLocation: z.nativeEnum(TokenExchangeCredentialsLocation).optional(),
       ...baseAuthenticationValidators,
+    }).superRefine(({requiresEndpointUrl, tokenUrl}, context) => {
+      validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, {requiresEndpointUrl}, context);
     }),
     [AuthenticationType.WebBasic]: zodCompleteStrictObject<WebBasicAuthentication>({
       type: zodDiscriminant(AuthenticationType.WebBasic),

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -847,12 +847,8 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     }),
     [AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject<OAuth2ClientCredentialsAuthentication>({
       type: zodDiscriminant(AuthenticationType.OAuth2ClientCredentials),
-      /**
-       * May be relative or absolute when requiresEndpointUrl is true (enforced in the superRefine
-       * below) — packs already support a manually-entered endpoint alongside a fixed absolute
-       * tokenUrl, so a relative tokenUrl is offered as an additional option, not a requirement.
-       */
-      tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
+      // Absolute (any scheme) always allowed; relative only when requiresEndpointUrl is true — see superRefine.
+      tokenUrl: z.string(),
       scopes: z.array(z.string()).optional(),
       scopeDelimiter: z.enum([' ', ',', ';']).optional(),
       tokenPrefix: z.string().optional(),
@@ -864,12 +860,18 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
       credentialsLocation: z.nativeEnum(TokenExchangeCredentialsLocation).optional(),
       ...baseAuthenticationValidators,
     }).superRefine(({requiresEndpointUrl, tokenUrl}, context) => {
-      validateUrlIsRelativeOrAbsolute(
-        'tokenUrl',
-        tokenUrl,
-        {requiresEndpointUrl, allowEitherWhenEndpointRequired: true},
-        context,
-      );
+      const isValid = requiresEndpointUrl
+        ? isRootRelativeUrl(tokenUrl) || isAbsoluteUrlOfAnyScheme(tokenUrl)
+        : isAbsoluteUrlOfAnyScheme(tokenUrl);
+      if (!isValid) {
+        context.addIssue({
+          code: 'custom',
+          path: ['tokenUrl'],
+          message: requiresEndpointUrl
+            ? 'tokenUrl must be a relative or absolute URL when requiresEndpointUrl is true'
+            : 'tokenUrl must be an absolute URL when requiresEndpointUrl is not true',
+        });
+      }
     }),
     [AuthenticationType.WebBasic]: zodCompleteStrictObject<WebBasicAuthentication>({
       type: zodDiscriminant(AuthenticationType.WebBasic),
@@ -3442,6 +3444,15 @@ function isAbsoluteUrl(url: string): boolean {
   return url.startsWith('https://');
 }
 
+/** Unlike {@link isAbsoluteUrl}, accepts any scheme (matching the pre-existing `z.string().url()` check). */
+function isAbsoluteUrlOfAnyScheme(url: string): boolean {
+  try {
+    return Boolean(new URL(url));
+  } catch {
+    return false;
+  }
+}
+
 function isRootRelativeUrl(url: string): boolean {
   return url.startsWith('/') && url[1] !== '/' && url[1] !== '\\';
 }
@@ -3464,35 +3475,21 @@ function validateUrlParsesIfAbsolute(url: string) {
 /**
  * Validates a field that must be relative exactly when `requiresEndpointUrl` is set (and no
  * `endpointKey` resolves an endpoint instead) — shared by fields evaluated during the auth flow.
- *
- * `allowEitherWhenEndpointRequired` relaxes that to accept either a relative or an absolute URL
- * when an endpoint is required, instead of requiring relative. Some auth types (e.g.
- * {@link OAuth2ClientCredentialsAuthentication.tokenUrl}) already supported a manually-entered
- * endpoint alongside a fixed absolute URL (auth at one endpoint, requests to a customer-specific
- * one), so enforcing relative-only here would be a backwards-incompatible break for those packs.
  */
 function validateUrlIsRelativeOrAbsolute(
   fieldName: string,
   url: string,
-  {
-    requiresEndpointUrl,
-    endpointKey,
-    allowEitherWhenEndpointRequired,
-  }: {requiresEndpointUrl?: boolean; endpointKey?: string; allowEitherWhenEndpointRequired?: boolean},
+  {requiresEndpointUrl, endpointKey}: {requiresEndpointUrl?: boolean; endpointKey?: string},
   context: z.RefinementCtx,
 ) {
   const expectsRelativeUrl = Boolean(requiresEndpointUrl && !endpointKey);
-  const allowsRelative = expectsRelativeUrl;
-  const allowsAbsolute = !expectsRelativeUrl || allowEitherWhenEndpointRequired;
-  if ((allowsRelative && isRootRelativeUrl(url)) || (allowsAbsolute && isAbsoluteUrl(url))) {
-    return;
-  }
-  const expectedType =
-    allowsRelative && allowsAbsolute ? 'a relative or absolute' : allowsRelative ? 'a relative' : 'an absolute';
-  context.addIssue({
-    code: 'custom',
-    path: [fieldName],
-    message: `${fieldName} must be ${expectedType} URL when \
+  if ((expectsRelativeUrl && !isRootRelativeUrl(url)) || (!expectsRelativeUrl && !isAbsoluteUrl(url))) {
+    const expectedType = expectsRelativeUrl ? 'a relative' : 'an absolute';
+    context.addIssue({
+      code: 'custom',
+      path: [fieldName],
+      message: `${fieldName} must be ${expectedType} URL when \
 ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl ?? 'not true'}`}`,
-  });
+    });
+  }
 }

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -847,7 +847,11 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     }),
     [AuthenticationType.OAuth2ClientCredentials]: zodCompleteStrictObject<OAuth2ClientCredentialsAuthentication>({
       type: zodDiscriminant(AuthenticationType.OAuth2ClientCredentials),
-      /** Accepts a relative URL when requiresEndpointUrl is true; enforced in the superRefine below. */
+      /**
+       * May be relative or absolute when requiresEndpointUrl is true (enforced in the superRefine
+       * below) — packs already support a manually-entered endpoint alongside a fixed absolute
+       * tokenUrl, so a relative tokenUrl is offered as an additional option, not a requirement.
+       */
       tokenUrl: z.string().refine(validateUrlParsesIfAbsolute),
       scopes: z.array(z.string()).optional(),
       scopeDelimiter: z.enum([' ', ',', ';']).optional(),
@@ -860,7 +864,12 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
       credentialsLocation: z.nativeEnum(TokenExchangeCredentialsLocation).optional(),
       ...baseAuthenticationValidators,
     }).superRefine(({requiresEndpointUrl, tokenUrl}, context) => {
-      validateUrlIsRelativeOrAbsolute('tokenUrl', tokenUrl, {requiresEndpointUrl}, context);
+      validateUrlIsRelativeOrAbsolute(
+        'tokenUrl',
+        tokenUrl,
+        {requiresEndpointUrl, allowEitherWhenEndpointRequired: true},
+        context,
+      );
     }),
     [AuthenticationType.WebBasic]: zodCompleteStrictObject<WebBasicAuthentication>({
       type: zodDiscriminant(AuthenticationType.WebBasic),
@@ -3455,21 +3464,35 @@ function validateUrlParsesIfAbsolute(url: string) {
 /**
  * Validates a field that must be relative exactly when `requiresEndpointUrl` is set (and no
  * `endpointKey` resolves an endpoint instead) — shared by fields evaluated during the auth flow.
+ *
+ * `allowEitherWhenEndpointRequired` relaxes that to accept either a relative or an absolute URL
+ * when an endpoint is required, instead of requiring relative. Some auth types (e.g.
+ * {@link OAuth2ClientCredentialsAuthentication.tokenUrl}) already supported a manually-entered
+ * endpoint alongside a fixed absolute URL (auth at one endpoint, requests to a customer-specific
+ * one), so enforcing relative-only here would be a backwards-incompatible break for those packs.
  */
 function validateUrlIsRelativeOrAbsolute(
   fieldName: string,
   url: string,
-  {requiresEndpointUrl, endpointKey}: {requiresEndpointUrl?: boolean; endpointKey?: string},
+  {
+    requiresEndpointUrl,
+    endpointKey,
+    allowEitherWhenEndpointRequired,
+  }: {requiresEndpointUrl?: boolean; endpointKey?: string; allowEitherWhenEndpointRequired?: boolean},
   context: z.RefinementCtx,
 ) {
   const expectsRelativeUrl = Boolean(requiresEndpointUrl && !endpointKey);
-  if ((expectsRelativeUrl && !isRootRelativeUrl(url)) || (!expectsRelativeUrl && !isAbsoluteUrl(url))) {
-    const expectedType = expectsRelativeUrl ? 'a relative' : 'an absolute';
-    context.addIssue({
-      code: 'custom',
-      path: [fieldName],
-      message: `${fieldName} must be ${expectedType} URL when \
-${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl ?? 'not true'}`}`,
-    });
+  const allowsRelative = expectsRelativeUrl;
+  const allowsAbsolute = !expectsRelativeUrl || allowEitherWhenEndpointRequired;
+  if ((allowsRelative && isRootRelativeUrl(url)) || (allowsAbsolute && isAbsoluteUrl(url))) {
+    return;
   }
+  const expectedType =
+    allowsRelative && allowsAbsolute ? 'a relative or absolute' : allowsRelative ? 'a relative' : 'an absolute';
+  context.addIssue({
+    code: 'custom',
+    path: [fieldName],
+    message: `${fieldName} must be ${expectedType} URL when \
+${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpointUrl ?? 'not true'}`}`,
+  });
 }

--- a/types.ts
+++ b/types.ts
@@ -679,7 +679,13 @@ export type OAuth2Authentication = OAuth2StaticCodeAuthentication | OAuth2Dynami
 export interface OAuth2ClientCredentialsAuthentication extends BaseOAuthAuthentication {
   /** Identifies this as OAuth2 client credentials authentication. */
   type: AuthenticationType.OAuth2ClientCredentials;
-  /** The URL that the platform will hit in order to exchange credentials for an access token. */
+  /**
+   * The URL that the platform will hit in order to exchange credentials for an access token.
+   *
+   * If {@link BaseAuthentication.requiresEndpointUrl} is `true`, this may instead be a
+   * root-relative path (e.g. `/oauth/token`), which the platform resolves against the account's
+   * endpoint. Absolute URLs are always accepted, with or without `requiresEndpointUrl`.
+   */
   tokenUrl: string;
 }
 


### PR DESCRIPTION
## Summary
`OAuth2ClientCredentialsAuthentication.tokenUrl` now accepts a root-relative path (e.g. `/token`) that's resolved against the connection's endpoint when the pack's authentication sets `requiresEndpointUrl`, mirroring the OAuth2 authorization-code flow's `tokenUrl` convention added in the parent PR. Absolute `https` URLs continue to work unchanged.

## Details
Reuses the shared relative-vs-absolute URL validator from the parent PR rather than duplicating the resolution logic.

## Test plan
`make build && make lint` pass. Added test coverage for relative `tokenUrl` resolution.