### PR TITLE
Fix incorrect link

### DIFF
--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -4911,8 +4911,8 @@ export interface HeaderBearerTokenAuthentication extends BaseAuthentication {
  * });
  * ```
  *
- * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#coda-api-token)
- * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#coda-api-token)
+ * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#superhuman-docs-api-token)
+ * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#superhuman-docs-api-token)
  */
 export interface CodaApiBearerTokenAuthentication extends BaseAuthentication {
 	/** Identifies this as CodaApiHeaderBearerToken authentication. */

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -315,8 +315,8 @@ export interface HeaderBearerTokenAuthentication extends BaseAuthentication {
  * });
  * ```
  *
- * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#coda-api-token)
- * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#coda-api-token)
+ * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#superhuman-docs-api-token)
+ * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#superhuman-docs-api-token)
  */
 export interface CodaApiBearerTokenAuthentication extends BaseAuthentication {
     /** Identifies this as CodaApiHeaderBearerToken authentication. */

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -551,7 +551,7 @@ There are services however where each account is associated with a distinct doma
 [sample_automatic_endpoint]: ../../../samples/topic/authentication.md#automatic-endpoint
 [sample_selected_endpoint]: ../../../samples/topic/authentication.md#user-selected-endpoint
 [sample_connection_name]: ../../../samples/topic/authentication.md#oauth2
-[sample_coda_api]: ../../../samples/topic/authentication.md#coda-api-token
+[sample_coda_api]: ../../../samples/topic/authentication.md#superhuman-docs-api-token
 [sample_custom]: ../../../samples/topic/authentication.md#custom-tokens
 [sample_multiple_query_params]: ../../../samples/topic/authentication.md#multiple-query-parameters
 [sample_multiple_headers]: ../../../samples/topic/authentication.md#multiple-headers

--- a/docs/reference/sdk/core/interfaces/CodaApiBearerTokenAuthentication.md
+++ b/docs/reference/sdk/core/interfaces/CodaApiBearerTokenAuthentication.md
@@ -29,8 +29,8 @@ pack.setUserAuthentication({
 
 ## See
 
- - [Authenticating with other services - Superhuman Docs API token]({{ config.site_url }}guides/basics/authentication/#coda-api-token)
- - [Authentication samples - Superhuman Docs API token]({{ config.site_url }}samples/topic/authentication/#coda-api-token)
+ - [Authenticating with other services - Superhuman Docs API token]({{ config.site_url }}guides/basics/authentication/#superhuman-docs-api-token)
+ - [Authentication samples - Superhuman Docs API token]({{ config.site_url }}samples/topic/authentication/#superhuman-docs-api-token)
 
 ## Extends
 

--- a/types.ts
+++ b/types.ts
@@ -332,8 +332,8 @@ export interface HeaderBearerTokenAuthentication extends BaseAuthentication {
  * });
  * ```
  *
- * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#coda-api-token)
- * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#coda-api-token)
+ * @see [Authenticating with other services - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/guides/basics/authentication/#superhuman-docs-api-token)
+ * @see [Authentication samples - Superhuman Docs API token](https://docs.superhuman.com/packs/build/latest/samples/topic/authentication/#superhuman-docs-api-token)
  */
 export interface CodaApiBearerTokenAuthentication extends BaseAuthentication {
   /** Identifies this as CodaApiHeaderBearerToken authentication. */


### PR DESCRIPTION
The section was renamed as part of the rebrand, but some links to it were using the old hash.