### PR TITLE
[CLI] Open the Superhuman token page during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Fixed
+
+- The `packs register` and `coda register` commands now open the Superhuman Docs account page when creating a Pack-scoped API token.
+
 ### Changed
 
 - `MCPServer.endpointUrl` now accepts a root-relative path (e.g. `/mcp`) that is resolved against the connection's endpoint when the pack's authentication provides one — via `requiresEndpointUrl` or `endpointKey` — mirroring the `authorizationUrl` / `tokenUrl` convention. This also applies to packs that use `setSystemAuthentication` instead of a per-user default authentication. Absolute `https` URLs continue to work unchanged.

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -1,4 +1,5 @@
 import type {ArgumentsCamelCase} from 'yargs';
+import {DEFAULT_API_ENDPOINT} from './config_storage';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {isResponseError} from '../helpers/external-api/coda';
@@ -13,17 +14,26 @@ interface RegisterArgs {
   apiEndpoint: string;
 }
 
+const DEFAULT_ACCOUNT_ENDPOINT = 'https://docs.superhuman.com';
+
+export function getApiTokenCreationUrl(apiEndpoint: string): string {
+  const normalizedEndpoint = apiEndpoint.replace(/\/+$/, '');
+  const accountEndpoint = normalizedEndpoint === DEFAULT_API_ENDPOINT ? DEFAULT_ACCOUNT_ENDPOINT : normalizedEndpoint;
+  return `${accountEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`;
+}
+
 export async function handleRegister({apiToken, apiEndpoint}: ArgumentsCamelCase<RegisterArgs>) {
   const formattedEndpoint = formatEndpoint(apiEndpoint);
   if (!apiToken) {
     // TODO: deal with auto-open on devbox setups
-    const shouldOpenBrowser = promptForInput('No API token provided. Do you want to visit Coda to create one (y/N)? ', {
-      yesOrNo: true,
-    });
+    const shouldOpenBrowser = promptForInput(
+      'No API token provided. Do you want to open your account page to create one (y/N)? ',
+      {yesOrNo: true},
+    );
     if (shouldOpenBrowser !== 'yes') {
       return process.exit(1);
     }
-    await open(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`);
+    await open(getApiTokenCreationUrl(formattedEndpoint));
     apiToken = promptForInput('Please paste the token here: ', {mask: true});
   }
 

--- a/dist/cli/register.d.ts
+++ b/dist/cli/register.d.ts
@@ -3,5 +3,6 @@ interface RegisterArgs {
     apiToken?: string;
     apiEndpoint: string;
 }
+export declare function getApiTokenCreationUrl(apiEndpoint: string): string;
 export declare function handleRegister({ apiToken, apiEndpoint }: ArgumentsCamelCase<RegisterArgs>): Promise<never>;
 export {};

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -3,26 +3,32 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.handleRegister = void 0;
+exports.handleRegister = exports.getApiTokenCreationUrl = void 0;
+const config_storage_1 = require("./config_storage");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
 const open_1 = __importDefault(require("open"));
 const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
-const config_storage_1 = require("./config_storage");
+const config_storage_2 = require("./config_storage");
 const errors_1 = require("./errors");
+const DEFAULT_ACCOUNT_ENDPOINT = 'https://docs.superhuman.com';
+function getApiTokenCreationUrl(apiEndpoint) {
+    const normalizedEndpoint = apiEndpoint.replace(/\/+$/, '');
+    const accountEndpoint = normalizedEndpoint === config_storage_1.DEFAULT_API_ENDPOINT ? DEFAULT_ACCOUNT_ENDPOINT : normalizedEndpoint;
+    return `${accountEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`;
+}
+exports.getApiTokenCreationUrl = getApiTokenCreationUrl;
 async function handleRegister({ apiToken, apiEndpoint }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(apiEndpoint);
     if (!apiToken) {
         // TODO: deal with auto-open on devbox setups
-        const shouldOpenBrowser = (0, helpers_4.promptForInput)('No API token provided. Do you want to visit Coda to create one (y/N)? ', {
-            yesOrNo: true,
-        });
+        const shouldOpenBrowser = (0, helpers_4.promptForInput)('No API token provided. Do you want to open your account page to create one (y/N)? ', { yesOrNo: true });
         if (shouldOpenBrowser !== 'yes') {
             return process.exit(1);
         }
-        await (0, open_1.default)(`${formattedEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`);
+        await (0, open_1.default)(getApiTokenCreationUrl(formattedEndpoint));
         apiToken = (0, helpers_4.promptForInput)('Please paste the token here: ', { mask: true });
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
@@ -36,7 +42,7 @@ async function handleRegister({ apiToken, apiEndpoint }) {
         const errors = [`Unexpected error while checking validity of API token: ${err}`, (0, errors_1.tryParseSystemError)(err)];
         return (0, helpers_3.printAndExit)(errors.join('\n'));
     }
-    (0, config_storage_1.storeCodaApiKey)(apiToken, process.env.PWD, apiEndpoint);
+    (0, config_storage_2.storeCodaApiKey)(apiToken, process.env.PWD, apiEndpoint);
     (0, helpers_3.printAndExit)(`API key validated and stored successfully!`, 0);
 }
 exports.handleRegister = handleRegister;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.1-prerelease.1",
+  "version": "1.17.1-prerelease.2",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -2,6 +2,7 @@ import type {PackVersionDefinition} from '../types';
 import {PublicApiType} from '../helpers/external-api/v1';
 import {compilePackMetadata} from '../helpers/metadata';
 import {formatWhoami} from '../cli/whoami';
+import {getApiTokenCreationUrl} from '../cli/register';
 import {parsePackIdOrUrl} from '../cli/link';
 
 describe('CLI', () => {
@@ -42,6 +43,26 @@ describe('CLI', () => {
       assert.equal(parsePackIdOrUrl('https://codadoc.io/p/1234'), null);
       assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo'), null);
       assert.equal(parsePackIdOrUrl('https://coda.io/packs/foo-1234/5678'), null);
+    });
+  });
+
+  describe('API token creation URL', () => {
+    it('uses Superhuman Docs for the default API endpoint', () => {
+      assert.equal(
+        getApiTokenCreationUrl('https://coda.io'),
+        'https://docs.superhuman.com/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings',
+      );
+      assert.equal(
+        getApiTokenCreationUrl('https://coda.io/'),
+        'https://docs.superhuman.com/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings',
+      );
+    });
+
+    it('preserves custom API endpoints', () => {
+      assert.equal(
+        getApiTokenCreationUrl('https://tenant.example.com/'),
+        'https://tenant.example.com/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Make `coda register` and `packs register` open the Superhuman Docs account page when they use the default API endpoint, instead of the retired Coda account domain.
- Preserve custom and single-tenant API endpoints so their registration flow continues to open the matching account host.
- Cover default, trailing-slash, and custom-endpoint URL generation with focused unit tests.
- Advance the SDK prerelease version to `1.17.1-prerelease.2`, as required for manual changes in this repository.

| Registration endpoint | Before | After |
| --- | --- | --- |
| Default (`https://coda.io`) | Opens `coda.io/account` | Opens `docs.superhuman.com/account` |
| Custom endpoint | Opens that endpoint's account page | Unchanged |

For example, running `coda register` with the default endpoint now opens `https://docs.superhuman.com/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`.

## Test plan

- [x] `./scripts/dev/check-version-updated.sh`
- [x] `make test-file FILE=test/cli_test.ts` (6 passing)
- [x] `make build`
- [ ] GitHub CI passes on the final commit

## Other notes

- The generated CLI JavaScript and declarations are updated alongside the TypeScript source.

<!-- pr-metadata:head:47da88c6da0516919086ff8e00a8bd0bd9e9b906 -->
<!-- pr-metadata:ready:47da88c6da0516919086ff8e00a8bd0bd9e9b906:revision:43449de660219f6c4273c41f71be5695962baff19f79e82c37c6c65bd05c07d5 -->
