### PR TITLE
packs-sdk: release v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.17.1] - 2026-07-28
+
 ### Fixed
 
 - The `packs register` and `coda register` commands now open the Superhuman Docs account page when creating a Pack-scoped API token.
@@ -1079,7 +1081,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.17.0...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.17.1...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -1158,3 +1160,4 @@ await myHelper(context);
 [1.15.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.15.0
 [1.16.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.16.0
 [1.17.0]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.0
+[1.17.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.1-prerelease.2",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.17.1-prerelease.2",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.1-prerelease.2",
+  "version": "1.17.1",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Release 1.17.1

### Fixed

- The `packs register` and `coda register` commands now open the Superhuman Docs account page when creating a Pack-scoped API token.

### Changed

- `MCPServer.endpointUrl` now accepts a root-relative path (e.g. `/mcp`) that is resolved against the connection's endpoint when the pack's authentication provides one — via `requiresEndpointUrl` or `endpointKey` — mirroring the `authorizationUrl` / `tokenUrl` convention. This also applies to packs that use `setSystemAuthentication` instead of a per-user default authentication. Absolute `https` URLs continue to work unchanged.
- `OAuth2ClientCredentialsAuthentication.tokenUrl` now accepts a root-relative path (e.g. `/token`) that is resolved against the connection's endpoint when the pack's authentication sets `requiresEndpointUrl`, mirroring the OAuth2 authorization-code flow's `tokenUrl` convention. Absolute URLs of any scheme continue to work unchanged.