### PR TITLE
Fix publishing the docs to prod

### DIFF
--- a/documentation/scripts/documentation_publisher.ts
+++ b/documentation/scripts/documentation_publisher.ts
@@ -50,7 +50,7 @@ function getS3Bucket(env: string): string {
 }
 
 function getOriginDomainName(env: string): string {
-  const domainName = env !== 'prod' ? `${env}.coda.io` : 'docs.superhuman.com';
+  const domainName = env !== 'prod' ? `${env}.coda.io` : 'coda.io';
   return `origin.${domainName}`;
 }
 


### PR DESCRIPTION
In #3582, my find-and-replace accidentally changed the documentation publishing script, which references CloudFront objects that still use `coda.io`.