### PR TITLE
Add replacesMcpTools formula option

### DIFF
--- a/api_types.ts
+++ b/api_types.ts
@@ -613,6 +613,16 @@ export interface CommonPackFormulaDef<T extends ParamDefs> {
   readonly purpose?: FormulaPurpose;
 
   /**
+   * Names of MCP tools, exposed by this same pack's MCP server(s), that this formula replaces.
+   * When both this formula and the listed MCP tool(s) resolve for an agent, the MCP tool(s) are
+   * hidden in favor of this purpose-built formula. Use the plain tool name your MCP server
+   * publishes (e.g. `slack_send_message`) — the agent runtime maps it to the internal namespaced
+   * name for you. Used by agents; not for use by packs that are not Superhuman-authored.
+   * @internal
+   */
+  readonly replacesMcpTools?: readonly string[];
+
+  /**
    * OAuth scopes that the formula needs that weren't requested in the pack's overall authentication
    * config. For example, a Slack pack can have one formula that needs admin privileges, but non-admins
    * can use the bulk of the pack without those privileges. The platform will give users help in understanding

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -1634,6 +1634,7 @@ export declare function makeTranslateObjectFormula<ParamDefsT extends ParamDefs,
     isExperimental?: boolean | undefined;
     isSystem?: boolean | undefined;
     purpose?: import("./api_types").FormulaPurpose | undefined;
+    replacesMcpTools?: readonly string[] | undefined;
     extraOAuthScopes?: string[] | undefined;
     allowedAuthenticationNames?: string[] | undefined;
     validateParameters?: MetadataFormulaDef<ExecutionContext, ParameterValidationResult> | undefined;
@@ -1680,6 +1681,7 @@ export declare function makeEmptyFormula<ParamDefsT extends ParamDefs>(definitio
     isExperimental?: boolean | undefined;
     isSystem?: boolean | undefined;
     purpose?: import("./api_types").FormulaPurpose | undefined;
+    replacesMcpTools?: readonly string[] | undefined;
     extraOAuthScopes?: string[] | undefined;
     allowedAuthenticationNames?: string[] | undefined;
     validateParameters?: MetadataFormulaDef<ExecutionContext, ParameterValidationResult> | undefined;

--- a/dist/api_types.d.ts
+++ b/dist/api_types.d.ts
@@ -483,6 +483,15 @@ export interface CommonPackFormulaDef<T extends ParamDefs> {
      */
     readonly purpose?: FormulaPurpose;
     /**
+     * Names of MCP tools, exposed by this same pack's MCP server(s), that this formula replaces.
+     * When both this formula and the listed MCP tool(s) resolve for an agent, the MCP tool(s) are
+     * hidden in favor of this purpose-built formula. Use the plain tool name your MCP server
+     * publishes (e.g. `slack_send_message`) — the agent runtime maps it to the internal namespaced
+     * name for you. Used by agents; not for use by packs that are not Superhuman-authored.
+     * @internal
+     */
+    readonly replacesMcpTools?: readonly string[];
+    /**
      * OAuth scopes that the formula needs that weren't requested in the pack's overall authentication
      * config. For example, a Slack pack can have one formula that needs admin privileges, but non-admins
      * can use the bulk of the pack without those privileges. The platform will give users help in understanding

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -891,6 +891,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         isExperimental: z.boolean().optional(),
         isSystem: z.boolean().optional(),
         purpose: z.nativeEnum(api_types_4.FormulaPurpose).optional(),
+        replacesMcpTools: z.array(z.string()).optional(),
         extraOAuthScopes: z.array(z.string()).optional(),
         allowedAuthenticationNames: z.array(z.string()).optional(),
         // Has to be any to avoid circular dependency.

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -1126,6 +1126,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     isExperimental: z.boolean().optional(),
     isSystem: z.boolean().optional(),
     purpose: z.nativeEnum(FormulaPurpose).optional(),
+    replacesMcpTools: z.array(z.string()).optional(),
     extraOAuthScopes: z.array(z.string()).optional(),
     allowedAuthenticationNames: z.array(z.string()).optional(),
     // Has to be any to avoid circular dependency.


### PR DESCRIPTION
## Summary
Add an `@internal` `replacesMcpTools` field to `CommonPackFormulaDef` so a Superhuman-authored pack formula can declare the agent-facing MCP tool name(s) it replaces. When the formula and the listed MCP tool(s) both resolve for an agent, the agent runtime hides the MCP tool(s) in favor of the purpose-built formula.

## Detail
- Field sits beside the existing agent-facing `instructions`/`purpose`; flows to `PackFormulaMetadata` via the existing `Omit`-based pass-through (no serialization changes).
- Values are the plain tool name the MCP server publishes (e.g. `slack_send_message`); the consuming agent runtime resolves the internal namespacing, so pack authors don't need to know it.
- Adds the matching `commonPackFormulaSchema` entry in `upload_validation.ts` (the `ZodCompleteShape` exhaustiveness guard requires it) and regenerated `dist/`.

## Test plan
CI (`make compile-ts` clean locally). Consuming logic is validated in the front-end-web-monorepo agent-runtime branch.
