### PR TITLE
Notetaker first party auth domains

### DIFF
--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -2040,7 +2040,14 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                 if (authentication.type !== types_1.AuthenticationType.CodaApiHeaderBearerToken) {
                     continue;
                 }
-                const allowedFirstPartyDomains = ['coda.io', 'localhost', 'superhuman.com', 'pp-sh.io', 'qa-sh.io'];
+                const allowedFirstPartyDomains = [
+                    'coda.io',
+                    'localhost',
+                    'superhuman.com',
+                    'pp-sh.io',
+                    'qa-sh.io',
+                    'grammarlyaws.com',
+                ];
                 const isFirstPartyDomain = (domain) => allowedFirstPartyDomains.some(cd => domain === cd || domain.endsWith('.' + cd));
                 const hasNonFirstPartyNetwork = (_a = metadata.networkDomains) === null || _a === void 0 ? void 0 : _a.some((domain) => !isFirstPartyDomain(domain));
                 if (!hasNonFirstPartyNetwork) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.2-prerelease.1",
+  "version": "1.17.2-prerelease.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.17.2-prerelease.1",
+      "version": "1.17.2-prerelease.2",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.2-prerelease.1",
+  "version": "1.17.2-prerelease.2",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -4774,6 +4774,17 @@ describe('Pack metadata Validation', async () => {
       await validateJson(metadata);
     });
 
+    it('CodaApiHeaderBearerToken, valid grammarlyaws.com data-plane domain in auth networkDomain', async () => {
+      const metadata = createFakePackVersionMetadata({
+        defaultAuthentication: {
+          type: AuthenticationType.CodaApiHeaderBearerToken,
+          networkDomain: ['coda.io', 'grammarlyaws.com'],
+        },
+        networkDomains: ['coda.io', 'grammarlyaws.com'],
+      });
+      await validateJson(metadata);
+    });
+
     it('CodaApiHeaderBearerToken, validated even when a non-matching auth is checked first', async () => {
       const metadata = createFakePackVersionMetadata({
         defaultAuthentication: {type: AuthenticationType.None},

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2607,7 +2607,14 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
             continue;
           }
 
-          const allowedFirstPartyDomains = ['coda.io', 'localhost', 'superhuman.com', 'pp-sh.io', 'qa-sh.io'];
+          const allowedFirstPartyDomains = [
+            'coda.io',
+            'localhost',
+            'superhuman.com',
+            'pp-sh.io',
+            'qa-sh.io',
+            'grammarlyaws.com',
+          ];
           const isFirstPartyDomain = (domain: string) =>
             allowedFirstPartyDomains.some(cd => domain === cd || domain.endsWith('.' + cd));
 


### PR DESCRIPTION
Add grammarlyaws.com to the domains, so that Notetaker pack can auth on qa and preprod