### PR TITLE
Make it easier to work with images in the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,10 +253,22 @@ view-docs:
 		PYTHONPATH=${ROOTDIR} PIPENV_IGNORE_VIRTUALENVS=1 MK_DOCS_SITE_URL=http://localhost:8000/packs-sdk MK_DOCS_GENERATE_ASSETS=false MK_DOCS_FAVICON='assets/favicon-local.svg' pipenv run mkdocs serve --livereload --watch-theme | grep -v 'mkdocs_site_urls:'; \
 	fi
 
-.PHONY: optimize-images
-optimize-images:
-	# Compress pngs.
-	npx sharp-cli -i docs/images/*.png -o docs/images/ --optimize
+.PHONY: generate-1x-images
+generate-1x-images:
+	# Screenshots are captured at 2x, and each needs a half-size 1x version to
+	# serve as the fallback in the `src` attribute.
+	TEMP_DIR=$$(mktemp -d); \
+	for IMAGE in ${ROOTDIR}/docs/images/*_2x.png; do \
+		[[ -e "$$IMAGE" ]] || continue; \
+		TARGET="$${IMAGE%_2x.png}.png"; \
+		[[ -e "$$TARGET" ]] && continue; \
+		FULL_WIDTH=$$(npx image-dimensions "$$IMAGE" | cut -d x -f 1); \
+		WIDTH=$$(( FULL_WIDTH / 2 )); \
+		echo "Generating $$(basename $$TARGET) at $${WIDTH}px wide"; \
+		npx sharp-cli --input "$$IMAGE" --output "$$TEMP_DIR" resize $$WIDTH > /dev/null; \
+		mv "$$TEMP_DIR/$$(basename $$IMAGE)" "$$TARGET"; \
+	done; \
+	rm -rf "$$TEMP_DIR"
 
 .PHONY: optimize-video
 optimize-video:

--- a/cspell.yml
+++ b/cspell.yml
@@ -74,3 +74,5 @@ ignoreRegExpList:
   - "^icon: .*?$"
   # Markdown attributes
   - "{:.*?}"
+  # MkDocs Macros
+  - "{{.*?}}"

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -27,7 +27,7 @@ Connector logs show the execution of the individual building blocks in a connect
 
     The logs are grouped by the Go session where the connector was used, with the most recent session at the top. To get the latest results, click the refresh button in the upper right of the logs panel.
 
-    <img src="site:images/connector_logs.png" srcset="site:images/connector_logs_2x.png 2x" class="screenshot" alt="A screenshot of the connector logs drawer in Go.">
+    {{screenshot("images/connector_logs.png", "A screenshot of the connector logs drawer in Go.")}}
 
 === ":superhuman-docs: Docs"
 
@@ -39,7 +39,7 @@ Connector logs show the execution of the individual building blocks in a connect
 
     The logs are grouped by invocation, with the latest entries at the top. New log entries are displayed automatically, usually a few seconds after the connector is run — there's no need to refresh the page or reopen the panel.
 
-    <img src="site:images/connector_logs_docs.png" srcset="site:images/connector_logs_docs_2x.png 2x" class="screenshot" alt="A screenshot of the connector logs in Docs.">
+    {{screenshot("images/connector_logs_docs.png", "A screenshot of the connector logs in Docs.")}}
 
     The panel will only show the logs from one connector at a time. To change the selected connector you can click the connector name at the top of the panel and select a new one from the dropdown.
 
@@ -55,7 +55,7 @@ To access the ingestion logs:
 
 Select a table from the **Datasource** dropdown to see the logs for that sync table. You can see the recent syncs for the table, and drill down into individual executions of the sync table and any associated logs.
 
-<img src="site:images/agent_ingestion_logs.png" srcset="site:images/agent_ingestion_logs_2x.png 2x" class="screenshot" alt="A screenshot of the ingestion logs drawer for a connector.">
+{{screenshot("images/agent_ingestion_logs.png", "A screenshot of the ingestion logs drawer for a connector.")}}
 
 
 ## Adding log messages
@@ -92,7 +92,7 @@ However you open them, connector logs share a common structure. This section exp
 
 Every time your connector is run it generates an invocation, which groups together all of the other logs that come from the connector while it was executing.
 
-<img src="site:images/pmt_overview.png" srcset="site:images/pmt_overview_2x.png 2x" class="screenshot" alt="Invocation logs">
+{{screenshot("images/pmt_overview.png", "Invocation logs")}}
 
 Each invocation has a brief description, if it was successful or failed, approximately when it was run, and what version of the connector was run (if not the latest).
 
@@ -110,7 +110,7 @@ A new invocation is logged each time your connector is run, for example when a f
 
 Clicking on an invocation expands it to reveal individual log entries.
 
-<img src="site:images/pmt_entries.png" srcset="site:images/pmt_entries_2x.png 2x" class="screenshot" alt="Log entries">
+{{screenshot("images/pmt_entries.png", "Log entries")}}
 
 The first entry will always be an **Overview** of the invocation. Additional entries are shown in reverse chronological order (latest entries at the top), and are added when your connector makes a fetcher request or [logs a message](#adding-log-messages). If your connector encounters an error the execution will stop and no further log entries will be added.
 
@@ -119,13 +119,13 @@ The first entry will always be an **Overview** of the invocation. Additional ent
 
 Clicking on a log entry expands it to reveal additional details.
 
-<img src="site:images/pmt_details.png" srcset="site:images/pmt_details_2x.png 2x" class="screenshot" alt="Log entry details">
+{{screenshot("images/pmt_details.png", "Log entry details")}}
 
 These details include information you can use directly (**Version**, etc), as well as internal details that may be useful when working with support (**Request ID**, etc). The **Overview** log entry will include a **Duration** field containing the total execution time.
 
 Failed invocations will include some additional detail in the **Overview** entry.
 
-<img src="site:images/pmt_details_error.png" srcset="site:images/pmt_details_error_2x.png 2x" class="screenshot" alt="Log entry details for a failed invocation">
+{{screenshot("images/pmt_details_error.png", "Log entry details for a failed invocation")}}
 
 Specifically the **Error** field will include the error message, and the **Stack trace** field will include the line number where the error happened (`code.ts:18:23` means line 18, character 23).
 
@@ -134,7 +134,7 @@ Specifically the **Error** field will include the error message, and the **Stack
 
 Log entries for fetcher requests include an extra link at the bottom called **Show HTTP request details**. Clicking this link will open a dialog that shows the full details of the request, including the headers and bodies of the request and response.
 
-<img src="site:images/pmt_http.png" srcset="site:images/pmt_http_2x.png 2x" class="screenshot" alt="HTTP request details dialog">
+{{screenshot("images/pmt_http.png", "HTTP request details dialog")}}
 
 Just like in your connector's code, [some headers are redacted][fetcher_headers] as well as any user credentials.
 
@@ -143,7 +143,7 @@ Just like in your connector's code, [some headers are redacted][fetcher_headers]
 
 You can search for logs using the magnifying glass icon at the top of the panel.
 
-<img src="site:images/pmt_search.png" srcset="site:images/pmt_search_2x.png 2x" class="screenshot" alt="Searching for log entries">
+{{screenshot("images/pmt_search.png", "Searching for log entries")}}
 
 Search results are no longer grouped by invocation, but instead a flat list of entries from across all invocations. You can expand an entry and click the **View related logs** link to view all of the log entries from that invocation.
 

--- a/docs/development/versions.md
+++ b/docs/development/versions.md
@@ -44,7 +44,7 @@ There are some restrictions to the version numbers you can select however:
 
 The **History** section in the Pack Studio shows a log of all past versions of your code, including when they were created and by who. For each version you can also download the code at that checkpoint or restore it.
 
-<img src="site:images/versions_restore.png" srcset="site:images/versions_restore_2x.png 2x" class="screenshot" alt="Version history of a Pack">
+{{screenshot("images/versions_restore.png", "Version history of a Pack")}}
 
 Restoring a previous version simply loads the code from that version into the web editor, and you'll need to re-build that code (and hence create a new version) to actually change the state of your Pack.
 
@@ -68,7 +68,7 @@ Each release is just a pointer an existing Pack version, so to release new code 
 
 To determine which version of your Pack a given release corresponds to, visit the **History** section of the Pack Studio. Release numbers will be displayed next to their corresponding version, and the **Released** tab can be used to filter the versions to just those that were released.
 
-<img src="site:images/versions_releases.png" srcset="site:images/versions_releases_2x.png 2x" class="screenshot" alt="Versions tagged with release">
+{{screenshot("images/versions_releases.png", "Versions tagged with release")}}
 
 
 ### Rollout
@@ -115,7 +115,7 @@ You can change which version is used at any time.
         1.  Click the gear icon :octicons-gear-16:.
         1.  Change the **Pack version** option as desired.
 
-    <img src="site:images/agent_version.png" srcset="site:images/agent_version_2x.png 2x" class="screenshot" alt="A screenshot of the dropdown that can switch the version of the Pack used by the connector.">
+    {{screenshot("images/agent_version.png", "A screenshot of the dropdown that can switch the version of the Pack used by the connector.")}}
 
 === ":superhuman-docs: Docs"
 
@@ -125,7 +125,7 @@ You can change which version is used at any time.
     1. Click the gear icon on the panel.
     1. Change the **Installed in this doc** setting as desired.
 
-    <img src="site:images/pmt_settings.png" srcset="site:images/pmt_settings_2x.png 2x" class="screenshot" alt="Changing the version installed in a doc from the Pack maker tools settings">
+    {{screenshot("images/pmt_settings.png", "Changing the version installed in a doc from the Pack maker tools settings")}}
 
     !!! warning "Don't use latest version for published docs"
         The **Latest Version** option is useful while developing and testing, but you must switch to **Latest Release** before you can publish a doc or convert it to a template — and once a doc is published or turned into a template you won't be able to change the version at all. Using **Latest Release** also ensures you don't break your doc as you change your Pack, and that users get the same behavior when they copy it.

--- a/docs/guides/advanced/caching.md
+++ b/docs/guides/advanced/caching.md
@@ -15,7 +15,7 @@ For performance reasons the platform uses a variety of caching techniques to sto
 
 Before the platform executes your [Pack formula][formulas], it first checks a cache of previous formula results. If a matching entry is found, it is returned instead of re-running your code. When a cached result is returned, the logs entry will end with **returned a prior result from the cache** and the **Cache hit** field will be set to **true**.
 
-<img src="site:images/cache_formula_logs.png" srcset="site:images/cache_formula_logs_2x.png 2x" class="screenshot" alt="Cached formula in the logs">
+{{screenshot("images/cache_formula_logs.png", "Cached formula in the logs")}}
 
 Formula result caching is enabled by default for all Pack formulas. You can adjust the caching behavior by setting the [`cacheTtlSecs`][formulas_cacheTtlSecs] field on the formula definition, which specifies for how many seconds the result should be cached. To disable caching for a formula set that value to zero.
 
@@ -30,7 +30,7 @@ The following types of formulas are never cached:
 
 When making an HTTP request with the [fetcher][fetcher], the Packs runtime first checks a cache of previous responses. If a matching entry is found, it is returned instead of making a request to the server. When a cached response is returned, the logs entry will be labeled with **(Cached)** and the **Cache hit** field will be set to **true**.
 
-<img src="site:images/cache_fetcher_logs.png" srcset="site:images/cache_fetcher_logs_2x.png 2x" class="screenshot" alt="Cached fetcher requests in the logs">
+{{screenshot("images/cache_fetcher_logs.png", "Cached fetcher requests in the logs")}}
 
 By default the Packs runtime caches the HTTP responses for `GET` requests, meaning that your code may not always be getting the latest response from the server. You can adjust this behavior by setting the [`cacheTtlSecs`][fetcher_cacheTtlSecs] field in the fetch request, which specifies for how many seconds the response should be cached. To disable caching for a request set that value to zero.
 

--- a/docs/guides/advanced/embeds.md
+++ b/docs/guides/advanced/embeds.md
@@ -60,11 +60,11 @@ pack.addFormula({
 
 A forced embed is initially displayed in a disabled state:
 
-<img src="site:images/embed_force_enable.png" srcset="site:images/embed_force_enable_2x.png 2x" class="screenshot" alt="Force embeds are initially disabled">
+{{screenshot("images/embed_force_enable.png", "Force embeds are initially disabled")}}
 
 Once a user clicks the embed they are prompted to approve embedding the URL:
 
-<img src="site:images/embed_force_approve.png" srcset="site:images/embed_force_approve_2x.png 2x" class="screenshot" alt="Force embeds must be approved">
+{{screenshot("images/embed_force_approve.png", "Force embeds must be approved")}}
 
 !!! info "Embed approval scope"
     This approval is once per-domain, per-user. This means that each user in the document will need to approve the embed in order to see the content, but that approval works across all embeds in that doc or others.

--- a/docs/guides/advanced/errors.md
+++ b/docs/guides/advanced/errors.md
@@ -53,7 +53,7 @@ pack.addFormula({
 
     The user sees a generic error message.
 
-    <img src="site:images/errors_generic.png" srcset="site:images/errors_generic_2x.png 2x" class="screenshot" alt="Generic error message.">
+    {{screenshot("images/errors_generic.png", "Generic error message.")}}
 
 When you want to provide a more specific error message, throw a `UserVisibleError` exception instead.
 
@@ -79,7 +79,7 @@ pack.addFormula({
 
     The message is shown directly to the user.
 
-    <img src="site:images/errors_user_visible.png" srcset="site:images/errors_user_visible_2x.png 2x" class="screenshot" alt="User-visible error message.">
+    {{screenshot("images/errors_user_visible.png", "User-visible error message.")}}
 
 When the error originates from an API or library, you can catch the error and throw a `UserVisibleError` one instead.
 

--- a/docs/guides/advanced/images.md
+++ b/docs/guides/advanced/images.md
@@ -111,7 +111,7 @@ return sdk.SvgConstants.DataUrlPrefixWithDarkModeSupport + encoded;
 
 Chat replies can include images, which will be automatically scaled to fit the width of the side panel.
 
-<img src="site:images/agent_image.png" srcset="site:images/agent_image_2x.png 2x" alt="A screenshot of chat response containing an image." class="screenshot">
+{{screenshot("images/agent_image.png", "A screenshot of chat response containing an image.")}}
 
 For security reasons, images will only be rendered if the URL is either:
 

--- a/docs/guides/advanced/schemas.md
+++ b/docs/guides/advanced/schemas.md
@@ -174,13 +174,13 @@ let PersonSchema = sdk.makeObjectSchema({
 
         When inspecting the property in the formula editor.
 
-        <img src="site:images/schemas_descriptions.png" srcset="site:images/schemas_descriptions_2x.png 2x" class="screenshot" alt="A schema property description being shown in the formula editor">
+        {{screenshot("images/schemas_descriptions.png", "A schema property description being shown in the formula editor")}}
 
     === "Column description"
 
         When used in sync tables or column formats, schema properties can be broken out into their own columns, and the property's description will be used as the initial value for the column's description. This column description is set once when the column is added to the table, and it can later be edited or removed by the user.
 
-        <img src="site:images/schemas_column_descriptions.png" srcset="site:images/schemas_column_descriptions_2x.png 2x" class="screenshot" alt="A column description being shown in a sync table">
+        {{screenshot("images/schemas_column_descriptions.png", "A column description being shown in a sync table")}}
 
 ??? tip "Add descriptions to object properties"
 
@@ -398,7 +398,7 @@ let TaskSchema = sdk.makeObjectSchema({
 });
 ```
 
-<img src="site:images/schemas_attribution.png" srcset="site:images/schemas_attribution_2x.png 2x" class="screenshot" alt="How attribution is displayed on hover">
+{{screenshot("images/schemas_attribution.png", "How attribution is displayed on hover")}}
 
 
 ## Schemas in sync tables
@@ -638,7 +638,7 @@ let MovieSchema = sdk.makeObjectSchema({
 });
 ```
 
-<img src="site:images/schemas_labels_default.png" srcset="site:images/schemas_labels_default_2x.png 2x" class="screenshot" alt="Default labels for subtitle properties">
+{{screenshot("images/schemas_labels_default.png", "Default labels for subtitle properties")}}
 
 However, there are times when the default label isn't a great fit. For instance you may want to put the property name after the value (`10 bugs` instead of `Bugs: 10`) or remove the label completely (`P1` instead of `Priority: P1`).
 
@@ -666,7 +666,7 @@ let MovieSchema = sdk.makeObjectSchema({
 });
 ```
 
-<img src="site:images/schemas_labels_custom.png" srcset="site:images/schemas_labels_custom_2x.png 2x" class="screenshot" alt="Custom labels for subtitle properties">
+{{screenshot("images/schemas_labels_custom.png", "Custom labels for subtitle properties")}}
 
 
 ### Property placeholders
@@ -686,7 +686,7 @@ let MovieSchema = sdk.makeObjectSchema({
 });
 ```
 
-<img src="site:images/schemas_placeholders.png" srcset="site:images/schemas_placeholders_2x.png 2x" class="screenshot" alt="Placeholders for subtitle properties">
+{{screenshot("images/schemas_placeholders.png", "Placeholders for subtitle properties")}}
 
 A property will be considered empty and fallback to the placeholder when its value is one of the following: `null`, `undefined`, `""`, `[]`, `{}`. The placeholder is only used to render the card, and when using the Superhuman formula language to access the property it will still return the original value. Placeholders are currently only supported on the following fields:
 

--- a/docs/guides/basics/authentication/aws.md
+++ b/docs/guides/basics/authentication/aws.md
@@ -23,7 +23,7 @@ pack.setUserAuthentication({
 
 When authenticating, the user will be prompted to enter their access key and secret.
 
-<img src="site:images/auth_aws_access_key.png" srcset="site:images/auth_aws_access_key_2x.png 2x" class="screenshot" alt="Prompting the user for their access key and secret">
+{{screenshot("images/auth_aws_access_key.png", "Prompting the user for their access key and secret")}}
 
 You can learn more about how to generate access keys in the [AWS documentation][awsdocs_accesskey].
 
@@ -45,7 +45,7 @@ pack.setUserAuthentication({
 
 When authenticating, the user will be prompted to enter the Amazon Resource Name (ARN) of the role to assume, as well as an associated external ID.
 
-<img src="site:images/auth_aws_assume_role.png" srcset="site:images/auth_aws_assume_role_2x.png 2x" class="screenshot" alt="Prompting the user for their role and external ID">
+{{screenshot("images/auth_aws_assume_role.png", "Prompting the user for their role and external ID")}}
 
 You can learn more about how to create roles in the [AWS documentation][awsdocs_createrole].
 

--- a/docs/guides/basics/authentication/index.md
+++ b/docs/guides/basics/authentication/index.md
@@ -49,13 +49,13 @@ When a building block uses authentication, you choose which connected account it
     In the formula editor the account is shown as the first parameter to the formula, and in the other dialogs the account to use is displayed as a dropdown list.
 
     === "In the formula editor"
-        <img src="site:images/auth_formula.png" srcset="site:images/auth_formula_2x.png 2x" class="screenshot" alt="Account selection in the formula editor">
+        {{screenshot("images/auth_formula.png", "Account selection in the formula editor")}}
     === "In the action builder"
-        <img src="site:images/auth_action.png" srcset="site:images/auth_action_2x.png 2x" class="screenshot" alt="Account selection in the action builder">
+        {{screenshot("images/auth_action.png", "Account selection in the action builder")}}
     === "In the column format settings"
-        <img src="site:images/auth_column_format.png" srcset="site:images/auth_column_format_2x.png 2x" class="screenshot" alt="Account selection in the column format settings">
+        {{screenshot("images/auth_column_format.png", "Account selection in the column format settings")}}
     === "In the sync table settings"
-        <img src="site:images/auth_sync_table.png" srcset="site:images/auth_sync_table_2x.png 2x" class="screenshot" alt="Account selection in the sync table settings">
+        {{screenshot("images/auth_sync_table.png", "Account selection in the sync table settings")}}
 
 
 ## Adding authentication to your Pack
@@ -90,7 +90,7 @@ pack.setSystemAuthentication({
 
 After adding the code, build a new version of your Pack and then navigate to the **Settings** tab. There you'll see an **Add system authentication** button you can use to set the credentials.
 
-<img src="site:images/auth_system.png" srcset="site:images/auth_system_2x.png 2x" class="screenshot" alt="Entering system credentials">
+{{screenshot("images/auth_system.png", "Entering system credentials")}}
 
 The types of authentication supported, as well as the additional settings, are described in the sections below.
 
@@ -219,7 +219,7 @@ Many APIs use tokens or keys for authentication. Per-user tokens are typically g
 
 When using per-user authentication, the user will be prompted to enter their token when connecting their account.
 
-<img src="site:images/auth_token.png" srcset="site:images/auth_token_2x.png 2x" class="screenshot" alt="Users entering an auth token">
+{{screenshot("images/auth_token.png", "Users entering an auth token")}}
 
 !!! tip "Set an instructions URL"
     It may not be obvious to users where they can find their API token. You can set the `instructionsUrl` field of the authentication configuration to a relevant help center article, or in some cases directly to the screen within the application that lists the API token. The platform will link to this URL in the dialog.
@@ -265,7 +265,7 @@ pack.setSystemAuthentication({
 
 Each token defined within the `params` array will result in an additional prompt in the authentication dialog:
 
-<img src="site:images/auth_custom.png" srcset="site:images/auth_custom_2x.png 2x" class="screenshot" alt="Entering tokens for custom authentication">
+{{screenshot("images/auth_custom.png", "Entering tokens for custom authentication")}}
 
 {% raw %}
 Unlike with other authentication types where the values are added to your fetch requests automatically, with `Custom` authentication you must manually add these tokens to your request. Wherever you need to inject one of these tokens enter a placeholder value instead, and before your request is sent the platform will replace it with the value of the corresponding token. The placeholder format is `{{<paramName>-<invocationToken>}}`, where `<paramName>` is the name of the token you defined and `<invocateToken>` is the unique ID generated for that execution of your Pack.
@@ -319,7 +319,7 @@ pack.setUserAuthentication({
 });
 ```
 
-<img src="site:images/auth_basic.png" srcset="site:images/auth_basic_2x.png 2x" class="screenshot" alt="Users entering their username and password">
+{{screenshot("images/auth_basic.png", "Users entering their username and password")}}
 
 [View Sample Code][sample_web_basic]{ .md-button }
 
@@ -483,7 +483,7 @@ pack.setUserAuthentication({
 
 When the user connects to their account they will now also be asked to provide the endpoint URL for their account.
 
-<img src="site:images/auth_endpoint.png" srcset="site:images/auth_endpoint_2x.png 2x" class="screenshot" alt="Setting the endpoint URL">
+{{screenshot("images/auth_endpoint.png", "Setting the endpoint URL")}}
 
 [View Sample Code][sample_manual_endpoint]{ .md-button }
 
@@ -545,7 +545,7 @@ pack.setUserAuthentication({
 
 The step's `getOptions` works like [dynamic autocomplete][autocomplete_dynamic], fetching the list of available endpoints and returning a display name and value for each. Note that the returned endpoints must be an object with a `display` and `value` field. Further, the `value` must be a valid URL. After the user enters their credentials they will be prompted to select one of the endpoints in a dialog.
 
-<img src="site:images/auth_setendpoint.png" srcset="site:images/auth_setendpoint_2x.png 2x" class="screenshot" alt="Selecting from a list of endpoints">
+{{screenshot("images/auth_setendpoint.png", "Selecting from a list of endpoints")}}
 
 [View Sample Code][sample_selected_endpoint]{ .md-button }
 

--- a/docs/guides/basics/authentication/oauth2.md
+++ b/docs/guides/basics/authentication/oauth2.md
@@ -79,7 +79,7 @@ However if the API provider deviates too far from the OAuth 2.0 specification it
 
 After you add the configuration code, build a new version of your Pack and then navigate to the **Settings** tab. There you'll see an **Add OAuth Credentials** button you can use to set the Pack's credentials.
 
-<img src="site:images/auth_oauth.png" srcset="site:images/auth_oauth_2x.png 2x" class="screenshot" alt="Setting the OAuth client ID and secret">
+{{screenshot("images/auth_oauth.png", "Setting the OAuth client ID and secret")}}
 
 These credentials identify your application and are the same for every user that uses your Pack. You need to obtain these credentials from the API provider, typically by registering your application in the provider's developer console or portal. These values are typically called the client ID and secret, but may in some cases be referred to using terms like "consumer" or "application".
 
@@ -180,7 +180,7 @@ pack.addFormula({
 
 When the Pack above is installed the user will only be required to grant access to the `read` scope. However, when they try to use the `UpdateItem` action formula and it fails they will then be prompted to grant additional access to the `write` scope. This prompt is displayed as a pop-up dialog at the bottom of the doc:
 
-<img src="site:images/auth_oauth_incremental.png" srcset="site:images/auth_oauth_incremental_2x.png 2x" class="screenshot" alt="Prompting the user for additional permissions">
+{{screenshot("images/auth_oauth_incremental.png", "Prompting the user for additional permissions")}}
 
 When the user signs in again they will be prompted to approve the additional scopes, after which they will be able to use the formula successfully.
 

--- a/docs/guides/basics/data-types.md
+++ b/docs/guides/basics/data-types.md
@@ -115,11 +115,11 @@ pack.addFormula({
 
 Objects are displayed in the doc as a "chip", a small rectangle with rounded corners. The display value is shown within the chip, with additional properties of object shown on hover.
 
-<img src="site:images/data_types_object_hover.png" srcset="site:images/data_types_object_hover_2x.png 2x" class="screenshot" alt="Hovering over an object chip">
+{{screenshot("images/data_types_object_hover.png", "Hovering over an object chip")}}
 
 Like Superhuman Docs tables, the fields within an object can be accessed using dot notation.
 
-<img src="site:images/data_types_object_dot.png" srcset="site:images/data_types_object_dot_2x.png 2x" class="screenshot" alt="Using dot notation to access the properties of the object">
+{{screenshot("images/data_types_object_dot.png", "Using dot notation to access the properties of the object")}}
 
 
 ### Arrays

--- a/docs/guides/basics/fetcher.md
+++ b/docs/guides/basics/fetcher.md
@@ -460,7 +460,7 @@ If there isn't enough time left for a retry (it would exceed the 1 minute execut
 
 There are cases where you may want to enforce your own rate limit, for example if you are calling an expensive API. To configure these, open the Pack Studio and click on **Settings** > **Add rate limits**.
 
-<img src="site:images/rate_limits.png" srcset="site:images/rate_limits_2x.png 2x" class="screenshot" alt="Rate limit dialog.">
+{{screenshot("images/rate_limits.png", "Rate limit dialog.")}}
 
 You can set a total rate limit across all users of your Pack, or if your Pack uses [authentication][authentication] you can also set a per-user rate limit. When the limit is reached a synthetic 429 response will be generated, triggering the [retry logic](#429) mentioned above.
 

--- a/docs/guides/basics/parameters/autocomplete.md
+++ b/docs/guides/basics/parameters/autocomplete.md
@@ -15,11 +15,11 @@ If you have a parameter that accepts a defined set of values it's usually best t
 In the formula editor, parameter options show up in the same pane used for the autocompletion of built-in elements of the Superhuman formula language. In the actions builder and sync table settings options are presented in a drop down.
 
 === "In the formula editor"
-    <img src="site:images/autocomplete_formula.png" srcset="site:images/autocomplete_formula_2x.png 2x" class="screenshot" alt="Autocomplete in the formula editor">
+    {{screenshot("images/autocomplete_formula.png", "Autocomplete in the formula editor")}}
 === "In the action builder"
-    <img src="site:images/autocomplete_action.png" srcset="site:images/autocomplete_action_2x.png 2x" class="screenshot" alt="Autocomplete in the action builder">
+    {{screenshot("images/autocomplete_action.png", "Autocomplete in the action builder")}}
 === "In the sync table settings"
-    <img src="site:images/autocomplete_sync.png" srcset="site:images/autocomplete_sync_2x.png 2x" class="screenshot" alt="Autocomplete in the sync table settings">
+    {{screenshot("images/autocomplete_sync.png", "Autocomplete in the sync table settings")}}
 
 
 ## Simple options
@@ -123,7 +123,7 @@ const GreetingParameter = sdk.makeParameter({
 !!! warning "Manual refresh required for `StringArray` parameters"
     When using `StringArray` parameters in the builder UIs, the autocomplete values are only fetched once when the parameter UI is loaded. The autocomplete options can be manually refreshed by the user with a menu item, but this limitation doesn't make them a great fit for use cases where the options depend on the values of previous parameters. <!-- o/bug/25402 -->
 
-    <img src="site:images/autocomplete_list_refresh.png" srcset="site:images/autocomplete_list_refresh_2x.png 2x" class="screenshot" alt="Autocomplete of list parameters requires manual refresh">
+    {{screenshot("images/autocomplete_list_refresh.png", "Autocomplete of list parameters requires manual refresh")}}
 
 !!! bug "Previous vararg values not available"
     When using [vararg parameters][parameters_vararg] in the builder UIs, the autocomplete function will not be able to access the values of previous vararg parameters. This means it isn't possible to build a set of key/value vararg parameters where the possible values depend on the key selected. <!-- o/bug/25373 -->

--- a/docs/guides/basics/parameters/index.md
+++ b/docs/guides/basics/parameters/index.md
@@ -18,20 +18,20 @@ Before a formula, action, or sync table can be run, values must be supplied for 
     For formulas the agent fills in the parameter values automatically as it calls the tool, guided by each parameter's name and description. However, parameters are shown to users in a UI in two cases: when an action requires approval, and when a connector with sync tables is being set up.
 
     === "In an action approval card"
-        <img src="site:images/parameter_go_action.png" srcset="site:images/parameter_go_action_2x.png 2x" class="screenshot" alt="Parameters in a Go action approval card">
+        {{screenshot("images/parameter_go_action.png", "Parameters in a Go action approval card")}}
     === "On the connector install screen"
-        <img src="site:images/parameter_go_sync.png" srcset="site:images/parameter_go_sync_2x.png 2x" class="screenshot" alt="Sync table parameters on the connector install screen">
+        {{screenshot("images/parameter_go_sync.png", "Sync table parameters on the connector install screen")}}
 
 === ":superhuman-docs: Docs"
 
     In the formula editor parameters are entered as comma-separated values, while in the action dialog or sync table side panel they presented as input boxes.
 
     === "In the formula editor"
-        <img src="site:images/parameter_formula.png" srcset="site:images/parameter_formula_2x.png 2x" class="screenshot" alt="Parameters in the formula editor">
+        {{screenshot("images/parameter_formula.png", "Parameters in the formula editor")}}
     === "In the action builder"
-        <img src="site:images/parameter_action.png" srcset="site:images/parameter_action_2x.png 2x" class="screenshot" alt="Parameters in the action builder">
+        {{screenshot("images/parameter_action.png", "Parameters in the action builder")}}
     === "In the sync table settings"
-        <img src="site:images/parameter_sync.png" srcset="site:images/parameter_sync_2x.png 2x" class="screenshot" alt="Parameters in the sync table settings">
+        {{screenshot("images/parameter_sync.png", "Parameters in the sync table settings")}}
 
 ## Defining parameters
 
@@ -492,7 +492,7 @@ pack.addFormula({
 
 Parameters of the type `DateArray` are often used for date ranges, with the first date representing the start of the range and the second date representing the end. When a `DateArray` parameter is used in an action or sync table, the input box displays a date range picker to make it easier for the user to select a range.
 
-<img src="site:images/parameter_daterange.png" srcset="site:images/parameter_daterange_2x.png 2x" class="screenshot" alt="Date array parameters displayed as a date range picker">
+{{screenshot("images/parameter_daterange.png", "Date array parameters displayed as a date range picker")}}
 
 These parameters also support a special set of [suggested values](#suggested) that represent date ranges relative to the current date. These are available in the [`PrecannedDateRange`][PrecannedDateRange] enumeration.
 

--- a/docs/guides/blocks/actions.md
+++ b/docs/guides/blocks/actions.md
@@ -18,18 +18,18 @@ Once your Pack is installed, its actions are available for users to run.
 
     An action is exposed as a tool that the agent can call while completing a task. Because actions typically create, update, or delete data, :superhuman-go: Go prompts the user to confirm before running one.
 
-    <img src="site:images/actions_go_approval.png" srcset="site:images/actions_go_approval_2x.png 2x" class="screenshot" alt="Action approval prompt in Superhuman Go">
+    {{screenshot("images/actions_go_approval.png", "Action approval prompt in Superhuman Go")}}
 
 === ":superhuman-docs: Docs"
 
     Actions provided by Packs appear as choices in the button and automation dialogs along-side built-in actions. Actions can also be used in the formula editor for those buttons and automations.
 
     === "In a button"
-        <img src="site:images/actions_button.png" srcset="site:images/actions_button_2x.png 2x" class="screenshot" alt="Selecting an action for a button">
+        {{screenshot("images/actions_button.png", "Selecting an action for a button")}}
     === "In an automation"
-        <img src="site:images/actions_automation.png" srcset="site:images/actions_automation_2x.png 2x" class="screenshot" alt="Selecting an action for an automation">
+        {{screenshot("images/actions_automation.png", "Selecting an action for an automation")}}
     === "In the formula editor"
-        <img src="site:images/actions_formula.png" srcset="site:images/actions_formula_2x.png 2x" class="screenshot" alt="Using actions in the formula editor.">
+        {{screenshot("images/actions_formula.png", "Using actions in the formula editor.")}}
 
 
 ## Creating actions
@@ -104,7 +104,7 @@ In some cases there is no meaningful result, in which case the convention is to 
 
 Like other building blocks, an action has an account parameter where you can select any account connected to the document. Actions can additionally use the special option "User's private account". When that option is selected, each user who presses the button takes the action using one of their own connected accounts, or is prompted to create one if they haven't set one up already.
 
-<img src="site:images/actions_private_account.png" srcset="site:images/actions_private_account_2x.png 2x" class="screenshot" alt="Private account option for actions">
+{{screenshot("images/actions_private_account.png", "Private account option for actions")}}
 
 
 ## Caching & recalculation

--- a/docs/guides/blocks/cards.md
+++ b/docs/guides/blocks/cards.md
@@ -11,11 +11,11 @@ description: Display structured information as rich cards.
 
 Pack formulas can return structured data as [objects][data_types_objects], allowing a single call to return a variety of related information. By default these objects are presented as "mentions", shown as chips in the document that you can hover over to get the full set of information.
 
-<img src="site:images/cards_demo_mention.png" srcset="site:images/cards_demo_mention_2x.png 2x" alt="Schema shown as a mention">
+{{screenshot("images/cards_demo_mention.png", "Schema shown as a mention", shadow=False)}}
 
 Cards are an alternative, more visual display format for objects that allow the user to easily consume key information. Additionally URLs pasted into a document can be automatically shown as cards, providing an easy way for users to discover and use your Pack.
 
-<img src="site:images/cards_demo_card.png" srcset="site:images/cards_demo_card_2x.png 2x" alt="Schema shown as a card">
+{{screenshot("images/cards_demo_card.png", "Schema shown as a card", shadow=False)}}
 
 [View Sample Code][samples]{ .md-button }
 
@@ -25,13 +25,13 @@ Cards are an alternative, more visual display format for objects that allow the 
 Cards are shown as distinct type of building block, but any formula returning a compatible object can be displayed as a card. It will also be shown as an option for [matching links](#display).
 
 === "Pack side panel"
-    <img src="site:images/cards_use_side_panel.png" srcset="site:images/cards_use_side_panel_2x.png 2x" class="screenshot" alt="Cards shown in the Pack side panel">
+    {{screenshot("images/cards_use_side_panel.png", "Cards shown in the Pack side panel")}}
 === "Object menu"
-    <img src="site:images/cards_use_display_as.png" srcset="site:images/cards_use_display_as_2x.png 2x" class="screenshot" alt="Changing a mention to show as a card in the display as menu">
+    {{screenshot("images/cards_use_display_as.png", "Changing a mention to show as a card in the display as menu")}}
 === "Link menu"
-    <img src="site:images/cards_link_installed.png" srcset="site:images/cards_link_installed_2x.png 2x" class="screenshot" alt="Changing a mention to show as a card in the display as menu">
+    {{screenshot("images/cards_link_installed.png", "Changing a mention to show as a card in the display as menu")}}
 === "Link menu (Pack not installed)"
-    <img src="site:images/cards_link_prompt.png" srcset="site:images/cards_link_prompt_2x.png 2x" class="screenshot" alt="Changing a mention to show as a card in the display as menu">
+    {{screenshot("images/cards_link_prompt.png", "Changing a mention to show as a card in the display as menu")}}
 
 
 
@@ -53,7 +53,7 @@ See the sections below for how to configure specific attributes of the card.
 
 The card's title appears at the top of the card, and is required.
 
-<img src="site:images/cards_parts_title.png" srcset="site:images/cards_parts_title_2x.png 2x" alt="The card's title">
+{{screenshot("images/cards_parts_title.png", "The card's title", shadow=False)}}
 
 Many object schemas already define a [display value][schemas_display_value] (via `displayProperty`) which determines which property value is shown in the mention chip for the object. The same display value will be shown as the title of the card, but can be overridden by defining a `titleProperty`. This is useful if you want to use a different property specifically for cards, for example that is longer.
 
@@ -77,7 +77,7 @@ const ProductSchema = sdk.makeObjectSchema({
 
 The card can include a subtitle that highlights key properties, which appears under the title.
 
-<img src="site:images/cards_parts_subtitle.png" srcset="site:images/cards_parts_subtitle_2x.png 2x" alt="The card's subtitle">
+{{screenshot("images/cards_parts_subtitle.png", "The card's subtitle", shadow=False)}}
 
 The properties displayed in the subtitle are determined via the `subtitleProperties` field of the schema, which lists the subset of properties to show and the order to show them.
 
@@ -105,7 +105,7 @@ The subtitle shows a label for each property, which defaults to `{Name}: {Value}
 
 The card body can include a snippet of content, which appears under the title (and subtitle if defined).
 
-<img src="site:images/cards_parts_snippet.png" srcset="site:images/cards_parts_snippet_2x.png 2x" alt="The card's body">
+{{screenshot("images/cards_parts_snippet.png", "The card's body", shadow=False)}}
 
 The snippet is meant to contain a limited amount of text, although there is no size limit enforced. Which property's content to use for the snippet is defined by the field `snippetProperty`, and it can only refer to properties of type `String` or `Array` of `String`. These properties can contain rich text, such as [Markdown][data_types_markdown] and [HTML][data_types_html].
 
@@ -125,7 +125,7 @@ const ProductSchema = sdk.makeObjectSchema({
 
 The card can include an image, which appears to the left of the other content.
 
-<img src="site:images/cards_parts_image.png" srcset="site:images/cards_parts_image_2x.png 2x" alt="The card's image">
+{{screenshot("images/cards_parts_image.png", "The card's image", shadow=False)}}
 
 Which property's content to use for the image is defined by the field `imageProperty`, and it can only refer to properties of type `String` with a hint of  `ImageReference`.
 <!-- TODO(spencer): Include ImageAttachment above once the post-processing work is complete. -->
@@ -152,7 +152,7 @@ const ProductSchema = sdk.makeObjectSchema({
 
 The card can include a link, which will be opened when the card is clicked. The domain of the link is also shown at the bottom of the card.
 
-<img src="site:images/cards_parts_link.png" srcset="site:images/cards_parts_link_2x.png 2x" alt="The card's link">
+{{screenshot("images/cards_parts_link.png", "The card's link", shadow=False)}}
 
 Which property's content to use for the link is defined by the field `linkProperty`, and it can only refer to properties of type `String` with a hint of `Url`.
 
@@ -177,7 +177,7 @@ One of the most common uses for cards is to display information about an item fr
 
 To make it easier to discover these cards, when a user pastes a link into a doc Superhuman Docs will show a list of compatible Packs. Clicking one of these will install the Pack and display the link as a card.
 
-<img src="site:images/cards_link_prompt.png" srcset="site:images/cards_link_prompt_2x.png 2x" class="screenshot" alt="Dialog showing cards that can be used to display a link">
+{{screenshot("images/cards_link_prompt.png", "Dialog showing cards that can be used to display a link")}}
 
 !!! info "Built-in card option"
     The link "Display as" menu may include an option for "Card", which displays a fix set of metadata for public URLs. This is distinct from Pack cards, which are shown as additional options below that.

--- a/docs/guides/blocks/column-formats.md
+++ b/docs/guides/blocks/column-formats.md
@@ -18,7 +18,7 @@ A column format is a custom column type that you can apply to any column in any 
 
 Column formats provided by Packs appear as choices in the **Column type** menu.
 
-<img src="site:images/column_format_menu.png" srcset="site:images/column_format_menu_2x.png 2x" class="screenshot" alt="Pack column formats in the column type menu">
+{{screenshot("images/column_format_menu.png", "Pack column formats in the column type menu")}}
 
 
 ## Creating column formats
@@ -78,7 +78,7 @@ Column formats can return any supported data type, and it will become the effect
 
 Column formats can use authentication to access private resources. The account used by the column format is configured within the options menu of the column.
 
-<img src="site:images/column_format_options.png" srcset="site:images/column_format_options_2x.png 2x" class="screenshot" alt="Selecting the account in the column format options">
+{{screenshot("images/column_format_options.png", "Selecting the account in the column format options")}}
 
 
 ## Automatic formatting {: #matchers}
@@ -107,7 +107,7 @@ Only Packs already installed in the document will have their matchers used. If m
 
 If your column format has [matchers](#matchers) defined it can also affect how links are displayed on the canvas. When editing the display settings for a link, if it matches a column format there will be a new option to display it using the Pack.
 
-<img src="site:images/column_format_canvas.png" srcset="site:images/column_format_canvas_2x.png 2x" class="screenshot" alt="Selecting the account in the column format options">
+{{screenshot("images/column_format_canvas.png", "Selecting the account in the column format options")}}
 
 When selected, this will wrap the link in a call to the formula that backs the column format. For example, using the Todoist column format above, a Todoist URL would be wrapped in a `=Task()` formula.
 

--- a/docs/guides/blocks/formulas.md
+++ b/docs/guides/blocks/formulas.md
@@ -18,7 +18,7 @@ Formulas are one of the most basic building blocks in Superhuman Docs; used to c
 
 A formula definition consists of a set of key-value pairs, which specify the various settings for the formula. Most of these settings are metadata, such as the name, description, parameters and result type. The actual code that is run each time the formula recalculated is specified using in the `execute` key.
 
-<img src="site:images/formula_structure.png" srcset="site:images/formula_structure_2x.png 2x" class="screenshot" alt="Mapping of formula code to formula editor.">
+{{screenshot("images/formula_structure.png", "Mapping of formula code to formula editor.")}}
 
 
 ## Naming
@@ -38,7 +38,7 @@ The name of a formula can only contain letters, numbers, and underscores. This r
 
 Formula names must be unique within a Pack, but can be the same as built-in formulas or those in other Packs. When a doc has access to multiple formulas with the same name the Pack's icon is used to distinguish them.
 
-<img src="site:images/formula_disambiguation.png" srcset="site:images/formula_disambiguation_2x.png 2x" class="screenshot" alt="Icons used to disambiguate formulas">
+{{screenshot("images/formula_disambiguation.png", "Icons used to disambiguate formulas")}}
 
 !!! warning
     Changing the name of a formula will break any existing docs that use it. When creating your Pack select your names carefully.
@@ -59,7 +59,7 @@ All formulas must return a result, which is a single value matching the type spe
 Formulas can use [authentication][authentication] to fetch private data. When using [system authentication][system_auth] there is no change to the user experience, but when you use [user authentication][user_auth] the formula editor will be automatically updated to prompt for a connected account. The connected account will appear as the first parameter of the formula, but its value is not passed to your formula's `execute` function.
 
 === "Formula editor"
-    <img src="site:images/formula_account.png" srcset="site:images/formula_account_2x.png 2x" class="screenshot" alt="Account parameter in formula editor">
+    {{screenshot("images/formula_account.png", "Account parameter in formula editor")}}
 
 === "Code"
     ```ts
@@ -105,7 +105,7 @@ After a formula is run its value is stored in the document model. Reloading the 
 
 Building or releasing a new version of your Pack doesn't automatically cause existing formulas to recalculate, so users may still see old results for a while. In the **Settings** tab of the Pack's side panel there is a "Refresh now" button (**⟳**) that allows users to recalculate all formulas using the Pack, as well as options to cause them to recalculate on a regular schedule.
 
-<img src="site:images/settings_recalc.png" srcset="site:images/settings_recalc_2x.png 2x" class="screenshot" alt="Recalculation settings in the Pack side panel">
+{{screenshot("images/settings_recalc.png", "Recalculation settings in the Pack side panel")}}
 
 Pack makers also have access to additional options in the [Pack maker tools][navigation_connector_maker_tools]{ data-preview }:
 
@@ -121,7 +121,7 @@ Superhuman Docs automatically generates user documentation for your formulas bas
 
 === "Formula documentation"
 
-    <img src="site:images/formula_examples.png" srcset="site:images/formula_examples_2x.png 2x" class="screenshot" alt="Formula examples in the generated documentation">
+    {{screenshot("images/formula_examples.png", "Formula examples in the generated documentation")}}
 
 === "Code"
 

--- a/docs/guides/blocks/sync-tables/dynamic.md
+++ b/docs/guides/blocks/sync-tables/dynamic.md
@@ -373,9 +373,9 @@ The `getSchema` function is first run when the table is initially dragged into t
 Instead of returning a flat list of datasets in the `listDynamicUrls` function, you can instead organize them into folders.
 
 === ":superhuman-go: Go"
-    <img src="site:images/dynamic_sync_table_folder_go.png" srcset="site:images/dynamic_sync_table_folder_go_2x.png 2x" class="screenshot" alt="Dataset list organized into folders in Superhuman Go">
+    {{screenshot("images/dynamic_sync_table_folder_go.png", "Dataset list organized into folders in Superhuman Go")}}
 === ":superhuman-docs: Docs"
-    <img src="site:images/dynamic_sync_table_folder.png" srcset="site:images/dynamic_sync_table_folder_2x.png 2x" class="screenshot" alt="Organize the URL list into folders">
+    {{screenshot("images/dynamic_sync_table_folder.png", "Organize the URL list into folders")}}
 
 To create a folder, return a [`MetadataFormulaObjectResultType`][MetadataFormulaObjectResultType] with `hasChildren: true`. When a user clicks on a folder, the `listDynamicUrls` function will be re-run, passing in the URL of the parent folder as the second parameter.
 
@@ -401,9 +401,9 @@ Folders can be nested inside of other folders, allowing you to represent complex
 Finding the desired dataset, even when [organized into folders](#folders), can be difficult when the there are many options to select from. If the underlying API supports it you can allow users to search for the dataset instead.
 
 === ":superhuman-go: Go"
-    <img src="site:images/dynamic_sync_table_search_go.png" srcset="site:images/dynamic_sync_table_search_go_2x.png 2x" class="screenshot" alt="Searching for a dataset in Superhuman Go">
+    {{screenshot("images/dynamic_sync_table_search_go.png", "Searching for a dataset in Superhuman Go")}}
 === ":superhuman-docs: Docs"
-    <img src="site:images/dynamic_sync_table_search.png" srcset="site:images/dynamic_sync_table_search_2x.png 2x" class="screenshot" alt="Searching for a dataset.">
+    {{screenshot("images/dynamic_sync_table_search.png", "Searching for a dataset.")}}
 
  To enable this search feature, add a `searchDynamicUrls` function to your sync table definition. This function works identically to `listDynamicUrls`, except that the 2nd parameter contains the user-entered search term instead of the folder URL.
 
@@ -429,7 +429,7 @@ pack.addDynamicSyncTable({
 
 In some cases it's not feasible to generate a list of all possible datasets the user can select from. In these cases you can omit the `listDynamicUrls` function and instead have your users directly enter the URL of the dataset.
 
-<img src="site:images/dynamic_sync_table_url.png" srcset="site:images/dynamic_sync_table_url_2x.png 2x" class="screenshot" alt="Manually entering the dynamic URL">
+{{screenshot("images/dynamic_sync_table_url.png", "Manually entering the dynamic URL")}}
 
 When using this approach you should use a user-facing URL as the dynamic URL, as that is what users will have access to. You'll need some way to translate those URLs into something you can use with the API, typically by extracting an ID.
 

--- a/docs/guides/blocks/sync-tables/index.md
+++ b/docs/guides/blocks/sync-tables/index.md
@@ -23,7 +23,7 @@ Before a sync table can pull in data it must be added and configured.
 
     Sync tables are configured when installing the connector, during which time the user can also set parameters. Once the connector is installed, the platform will begin indexing the data into the knowledge layer. See the [Indexing guide][indexing] for more information.
 
-    <img src="site:images/sync_table_usage_go.png" srcset="site:images/sync_table_usage_go_2x.png 2x" class="screenshot" alt="Sync table setup in Go.">
+    {{screenshot("images/sync_table_usage_go.png", "Sync table setup in Go.")}}
 
 === ":superhuman-docs: Docs"
 
@@ -55,13 +55,13 @@ A single sync table can be populated by more than one sync, letting you pull in 
 
     You add additional syncs while configuring the connector on the installation screen. With the table selected, click **Options** > **Add sync setting** to create additional syncs.
 
-    <img src="site:images/sync_table_multiple_go.png" srcset="site:images/sync_table_multiple_go_2x.png 2x" class="screenshot" alt="Configuring multiple syncs in Superhuman Go">
+    {{screenshot("images/sync_table_multiple_go.png", "Configuring multiple syncs in Superhuman Go")}}
 
 === ":superhuman-docs: Docs"
 
     A sync table can only be added to a document once, so to add more you open the table's **Options** pane and click **Add another sync**. The rows from each sync are appended to the same table, and you can use views and filters to display them separately.
 
-    <img src="site:images/sync_table_multiple_docs.png" srcset="site:images/sync_table_multiple_docs_2x.png 2x" class="screenshot" alt="Adding another sync in Superhuman Docs">
+    {{screenshot("images/sync_table_multiple_docs.png", "Adding another sync in Superhuman Docs")}}
 
 !!! info "Not supported for dynamic sync tables"
     Multiple syncs are only available for regular sync tables, not [dynamic sync tables][dynamic_sync_tables].
@@ -280,7 +280,7 @@ It's often the case that the different synced items in a Pack are related to eac
 
 A reference must specify the identity of the target table as well as the ID of the target row. If that row has already been synced to the doc, then the reference is replaced with the data from that row. Otherwise a grayed out chip is displayed, indicating that the referenced row hasn't been synced yet.
 
-<img src="site:images/sync_table_reference.png" srcset="site:images/sync_table_reference_2x.png 2x" class="screenshot" alt="How sync table references look in the doc">
+{{screenshot("images/sync_table_reference.png", "How sync table references look in the doc")}}
 
 See the [Schemas guide][schema_references] for more information on how to create references in your table schema.
 
@@ -315,7 +315,7 @@ Although only [featured columns][schemas_featured_columns] are shown in the tabl
 
 For very large schemas all of these unused properties can come with a performance cost however, so users have the option to choose the exact set of columns they want to sync. This can be done by clicking the **Sync more properties** button in the sync table settings, and is launched automatically when creating the sync table with a very large schema.
 
-<img src="site:images/sync_table_select_columns.png" srcset="site:images/sync_table_select_columns_2x.png 2x" class="screenshot" alt="Selecting columns of a sync table">
+{{screenshot("images/sync_table_select_columns.png", "Selecting columns of a sync table")}}
 
 Users can choose from top-level properties in the schema, and only those they select will be persisted in the document during the sync.
 

--- a/docs/guides/blocks/sync-tables/two-way.md
+++ b/docs/guides/blocks/sync-tables/two-way.md
@@ -20,7 +20,7 @@ description: Allow users to edit the contents of a sync table and push those cha
 
 To enable two-way sync on a sync table that supports it you need to toggle on the option **Enable Edits** in the sync table settings. Doing so reveals additional options that control when updates are sent and which account is used.
 
-<img src="site:images/two_way_enable.png" srcset="site:images/two_way_enable_2x.png 2x" class="screenshot" alt="Enabling edits on a sync table.">
+{{screenshot("images/two_way_enable.png", "Enabling edits on a sync table.")}}
 
 Certain columns of the table will now be editable, and you can change cell values them as you would for a normal Superhuman Docs table. Use the **Update rows** link to push the changes back to the data source.
 
@@ -312,7 +312,7 @@ When processing updates in batches be sure to return the same number of results 
 
 Similar to [parameter autocomplete][parameters_autocomplete], you can provide a suggested set of options for mutable properties, which will be shown to the user when they are editing a corresponding cell.
 
-<img src="site:images/two_way_autocomplete.png" srcset="site:images/two_way_autocomplete_2x.png 2x" class="screenshot" alt="Suggested property options in a cell.">
+{{screenshot("images/two_way_autocomplete.png", "Suggested property options in a cell.")}}
 
 !!! info "The hint `SelectList` or `Reference` is required"
 
@@ -445,7 +445,7 @@ The `allowNewValues` setting can only be enabled for `String` properties, as the
 
 When a row fails to update Superhuman Docs will show an error message attached to that row. The pending edits will be retained, so that users can adjust them and try again.
 
-<img src="site:images/two_way_error.png" srcset="site:images/two_way_error_2x.png 2x" class="screenshot" alt="Error attached to a row.">
+{{screenshot("images/two_way_error.png", "Error attached to a row.")}}
 
 To associate an error with a row return it at the corresponding index in the `result` array. For tables that use single row updates (`maxUpdateBatchSize == 1`) if you throw a `UserVisibleError` it will be associated with the row automatically. In all other cases a thrown error will be treated as a failure of the entire sync and cancel any remaining row updates.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ Connectors are listed in the [Superhuman Go Store][store] and the [Superhuman Do
 </div>
 
 <div class="landing-item" markdown>
-<img src="site:images/store_connectors.png" srcset="site:images/store_connectors_2x.png 2x" class="screenshot" alt="Connectors listed in the Superhuman Go Store.">
+{{screenshot("images/store_connectors.png", "Connectors listed in the Superhuman Go Store.")}}
 </div>
 
 </section>

--- a/docs/support/migration/superhuman-go.md
+++ b/docs/support/migration/superhuman-go.md
@@ -7,7 +7,7 @@ description: Information on how to update an existing Pack to work with Superhum
 
 If you've already built a Pack for Superhuman Docs, the good news is that it can also work as a connector in Superhuman Go.
 
-<img src="site:images/agent_upgrade.png" srcset="site:images/agent_upgrade_2x.png 2x" alt="A screenshot of the action confirmation UX." class="screenshot">
+{{screenshot("images/agent_upgrade.png", "A screenshot of the action confirmation UX.")}}
 
 In the screenshot above, you can see a user accessing data from the [Weather Pack][weather_pack], which hasn't had any code changes. The LLM knows all the formulas and actions in the Pack, calls them as needed, and displays the results in a human-friendly way.
 

--- a/docs/tutorials/build/fetcher.md
+++ b/docs/tutorials/build/fetcher.md
@@ -240,7 +240,7 @@ If everything is working correctly you should get back the currency value conver
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_fetcher_result.png" srcset="site:images/tutorial_fetcher_result_2x.png 2x" class="screenshot" alt="The formula working in a doc.">
+{{screenshot("images/tutorial_fetcher_result.png", "The formula working in a doc.")}}
 
 </div>
 </section>
@@ -300,7 +300,7 @@ The platform logs every API request that your Pack makes, and examining those lo
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_fetcher_panel.png" srcset="site:images/tutorial_fetcher_panel_2x.png 2x" class="screenshot" alt="Where to fine the open logs button in the panel">
+    {{screenshot("images/tutorial_fetcher_panel.png", "Where to fine the open logs button in the panel")}}
 
     </div>
     </section>
@@ -318,7 +318,7 @@ The platform logs every API request that your Pack makes, and examining those lo
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_fetcher_logs.png" srcset="site:images/tutorial_fetcher_logs_2x.png 2x" class="screenshot" alt="The fetch request showing in the logs.">
+    {{screenshot("images/tutorial_fetcher_logs.png", "The fetch request showing in the logs.")}}
 
     </div>
     </section>
@@ -334,7 +334,7 @@ The platform logs every API request that your Pack makes, and examining those lo
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_fetcher_http.png" srcset="site:images/tutorial_fetcher_http_2x.png 2x" class="screenshot" alt="The raw HTTP request and response.">
+    {{screenshot("images/tutorial_fetcher_http.png", "The raw HTTP request and response.")}}
 
     </div>
     </section>

--- a/docs/tutorials/build/formula.md
+++ b/docs/tutorials/build/formula.md
@@ -343,7 +343,7 @@ You should see the name, description, and parameters in the help text, get back 
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_formula_scaffold.png" srcset="site:images/tutorial_formula_scaffold_2x.png 2x" class="screenshot" alt="Working scaffold">
+{{screenshot("images/tutorial_formula_scaffold.png", "Working scaffold")}}
 
 </div>
 </section>
@@ -442,7 +442,7 @@ Rebuild your Pack, and refresh the formula the formula in the doc. If everything
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_formula_logic.png" srcset="site:images/tutorial_formula_logic_2x.png 2x" class="screenshot" alt="The logic working.">
+{{screenshot("images/tutorial_formula_logic.png", "The logic working.")}}
 
 </div>
 </section>
@@ -601,7 +601,7 @@ Rebuild your Pack, and try out the new `byWord` parameter in a formula. If every
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_formula_feature.png" srcset="site:images/tutorial_formula_feature_2x.png 2x" class="screenshot" alt="The new feature working.">
+{{screenshot("images/tutorial_formula_feature.png", "The new feature working.")}}
 
 </div>
 </section>

--- a/docs/tutorials/build/mcp.md
+++ b/docs/tutorials/build/mcp.md
@@ -270,7 +270,7 @@ The connector now exists on the platform, so it's time to install it and see wha
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_mcp_search.png" srcset="site:images/tutorial_mcp_search_2x.png 2x" class="screenshot" alt="Searching for the connector in Go">
+    {{screenshot("images/tutorial_mcp_search.png", "Searching for the connector in Go")}}
 
     </div>
     </section>
@@ -286,7 +286,7 @@ The connector now exists on the platform, so it's time to install it and see wha
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_mcp_signin.png" srcset="site:images/tutorial_mcp_signin_2x.png 2x" class="screenshot" alt="Begin the signin process.">
+    {{screenshot("images/tutorial_mcp_signin.png", "Begin the signin process.")}}
 
     </div>
     </section>
@@ -302,7 +302,7 @@ The connector now exists on the platform, so it's time to install it and see wha
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_mcp_authorize.png" srcset="site:images/tutorial_mcp_authorize_2x.png 2x" class="screenshot" alt="Authorizing access to your Todoist account">
+    {{screenshot("images/tutorial_mcp_authorize.png", "Authorizing access to your Todoist account")}}
 
     </div>
     </section>
@@ -324,7 +324,7 @@ The connector now exists on the platform, so it's time to install it and see wha
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_mcp_tasks.png" srcset="site:images/tutorial_mcp_tasks_2x.png 2x" class="screenshot" alt="Go listing your tasks in Todoist.">
+    {{screenshot("images/tutorial_mcp_tasks.png", "Go listing your tasks in Todoist.")}}
 
     </div>
     </section>
@@ -348,7 +348,7 @@ The connector now exists on the platform, so it's time to install it and see wha
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_mcp_create_task.png" srcset="site:images/tutorial_mcp_create_task_2x.png 2x" class="screenshot" alt="Confirming an action before it runs">
+    {{screenshot("images/tutorial_mcp_create_task.png", "Confirming an action before it runs")}}
 
     </div>
     </section>

--- a/docs/tutorials/build/oauth.md
+++ b/docs/tutorials/build/oauth.md
@@ -55,7 +55,7 @@ Todoist describes their OAuth2 support [in their developer docs][todoist_oauth].
     <div markdown>
 
     <a href="https://developer.todoist.com/guides/#step-1-authorization-request">
-      <img src="site:images/tutorial_oauth_authorization_url.png" srcset="site:images/tutorial_oauth_authorization_url_2x.png 2x" class="screenshot" alt="The documentation for the authorization URL.">
+      {{screenshot("images/tutorial_oauth_authorization_url.png", "The documentation for the authorization URL.")}}
     </a>
 
     </div>
@@ -80,7 +80,7 @@ Todoist describes their OAuth2 support [in their developer docs][todoist_oauth].
     <div markdown>
 
     <a href="https://developer.todoist.com/guides/#step-3-token-exchange">
-      <img src="site:images/tutorial_oauth_token_url.png" srcset="site:images/tutorial_oauth_token_url_2x.png 2x" class="screenshot" alt="The documentation for the token URL.">
+      {{screenshot("images/tutorial_oauth_token_url.png", "The documentation for the token URL.")}}
     </a>
 
     </div>
@@ -100,7 +100,7 @@ Todoist describes their OAuth2 support [in their developer docs][todoist_oauth].
     <div markdown>
 
     <a href="https://developer.todoist.com/guides/#permission-scopes">
-      <img src="site:images/tutorial_oauth_scopes.png" srcset="site:images/tutorial_oauth_scopes_2x.png 2x" class="screenshot" alt="The documentation for the scopes.">
+      {{screenshot("images/tutorial_oauth_scopes.png", "The documentation for the scopes.")}}
     </a>
 
     </div>
@@ -119,7 +119,7 @@ Todoist describes their OAuth2 support [in their developer docs][todoist_oauth].
     <div markdown>
 
     <a href="https://developer.todoist.com/guides/#step-1-authorization-request">
-      <img src="site:images/tutorial_oauth_scope_comma.png" srcset="site:images/tutorial_oauth_scope_comma_2x.png 2x" class="screenshot" alt="The documentation for the scope separator.">
+      {{screenshot("images/tutorial_oauth_scope_comma.png", "The documentation for the scope separator.")}}
     </a>
 
     </div>
@@ -144,7 +144,7 @@ Most API providers host a developer console for creating and managing applicatio
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_console.png" srcset="site:images/tutorial_oauth_console_2x.png 2x" class="screenshot" alt="The Todoist app management console">
+    {{screenshot("images/tutorial_oauth_console.png", "The Todoist app management console")}}
 
     </div>
     </section>
@@ -164,7 +164,7 @@ Most API providers host a developer console for creating and managing applicatio
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_create.png" srcset="site:images/tutorial_oauth_create_2x.png 2x" class="screenshot" alt="Creating a new application in the console">
+    {{screenshot("images/tutorial_oauth_create.png", "Creating a new application in the console")}}
 
     </div>
     </section>
@@ -419,7 +419,7 @@ The code we've written so far includes only public information about the OAuth f
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_pack_settings.png" srcset="site:images/tutorial_oauth_pack_settings_2x.png 2x" class="screenshot" alt="The Pack settings">
+    {{screenshot("images/tutorial_oauth_pack_settings.png", "The Pack settings")}}
 
     </div>
     </section>
@@ -437,7 +437,7 @@ The code we've written so far includes only public information about the OAuth f
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_pack_redirect.png" srcset="site:images/tutorial_oauth_pack_redirect_2x.png 2x" class="screenshot" alt="The redirect URL shown in the OAuth settings">
+    {{screenshot("images/tutorial_oauth_pack_redirect.png", "The redirect URL shown in the OAuth settings")}}
 
     </div>
     </section>
@@ -457,7 +457,7 @@ The code we've written so far includes only public information about the OAuth f
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_settings.png" srcset="site:images/tutorial_oauth_settings_2x.png 2x" class="screenshot" alt="The settings for the new application">
+    {{screenshot("images/tutorial_oauth_settings.png", "The settings for the new application")}}
 
     </div>
     </section>
@@ -475,7 +475,7 @@ The code we've written so far includes only public information about the OAuth f
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_pack_credentials.png" srcset="site:images/tutorial_oauth_pack_credentials_2x.png 2x" class="screenshot" alt="Entering the OAuth credentials">
+    {{screenshot("images/tutorial_oauth_pack_credentials.png", "Entering the OAuth credentials")}}
 
     </div>
     </section>
@@ -499,7 +499,7 @@ Now that the Pack is built and the credentials set, we're finally ready to sign 
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_connect.png" srcset="site:images/tutorial_oauth_connect_2x.png 2x" class="screenshot" alt="Prompted to connect an account">
+    {{screenshot("images/tutorial_oauth_connect.png", "Prompted to connect an account")}}
 
     </div>
     </section>
@@ -515,7 +515,7 @@ Now that the Pack is built and the credentials set, we're finally ready to sign 
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_signin.png" srcset="site:images/tutorial_oauth_signin_2x.png 2x" class="screenshot" alt="Dialog to sign in with an account">
+    {{screenshot("images/tutorial_oauth_signin.png", "Dialog to sign in with an account")}}
 
     </div>
     </section>
@@ -533,7 +533,7 @@ Now that the Pack is built and the credentials set, we're finally ready to sign 
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_authorize.png" srcset="site:images/tutorial_oauth_authorize_2x.png 2x" class="screenshot" alt="Authorize access to your Todoist account">
+    {{screenshot("images/tutorial_oauth_authorize.png", "Authorize access to your Todoist account")}}
 
     </div>
     </section>
@@ -551,7 +551,7 @@ Now that the Pack is built and the credentials set, we're finally ready to sign 
     </div>
     <div markdown>
 
-    <img src="site:images/tutorial_oauth_complete.png" srcset="site:images/tutorial_oauth_complete_2x.png 2x" class="screenshot" alt="Complete the account connection">
+    {{screenshot("images/tutorial_oauth_complete.png", "Complete the account connection")}}
 
     </div>
     </section>
@@ -570,7 +570,7 @@ You'll notice that it takes in an account as a parameter, and it should auto-sel
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_oauth_formula.png" srcset="site:images/tutorial_oauth_formula_2x.png 2x" class="screenshot" alt="Use the formula in a doc">
+{{screenshot("images/tutorial_oauth_formula.png", "Use the formula in a doc")}}
 
 </div>
 </section>

--- a/docs/tutorials/build/sync-table.md
+++ b/docs/tutorials/build/sync-table.md
@@ -510,7 +510,7 @@ To filter to a specific topic, open the sync option for the table, click **Add c
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_sync_table_build1.png" srcset="site:images/tutorial_sync_table_build1_2x.png 2x" class="screenshot" alt="The resulting sync table with name and ID fields">
+{{screenshot("images/tutorial_sync_table_build1.png", "The resulting sync table with name and ID fields")}}
 
 </div>
 </section>
@@ -787,7 +787,7 @@ The author column displays as a chip, since it's a rich object itself, and hover
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_sync_table_build2.png" srcset="site:images/tutorial_sync_table_build2_2x.png 2x" class="screenshot" alt="The resulting sync table with more fields">
+{{screenshot("images/tutorial_sync_table_build2.png", "The resulting sync table with more fields")}}
 
 </div>
 </section>
@@ -936,7 +936,7 @@ The Pack maker tools will show multiple executions of the sync formula, with tho
 </div>
 <div markdown>
 
-<img src="site:images/tutorial_sync_table_build3.png" srcset="site:images/tutorial_sync_table_build3_2x.png 2x" class="screenshot" alt="The resulting sync table with more rows">
+{{screenshot("images/tutorial_sync_table_build3.png", "The resulting sync table with more rows")}}
 
 </div>
 </section>

--- a/documentation/scripts/mkdocs_macros.py
+++ b/documentation/scripts/mkdocs_macros.py
@@ -1,9 +1,43 @@
+import html
+import logging
 import os
 import socket
 from datetime import date
 from urllib.parse import urljoin
 
+log = logging.getLogger("mkdocs.plugins.macros")
+
 def define_env(env):
+  @env.macro
+  def screenshot(path, alt, shadow=True, **attributes):
+    """Generates an <img> tag for an image in the docs directory.
+
+    Screenshots are captured at 2x and downsized to create the 1x version (see
+    `make generate-1x-images`). Pass the path to the 1x image, relative to the
+    docs directory, and the matching `_2x` file is added as a srcset if present.
+
+    Set shadow=False for cropped fragments of the UI, which are shown inline
+    without the rounded corners and drop shadow of a full screenshot.
+    """
+    docsDir = env.conf["docs_dir"]
+    if path.startswith("/"):
+      path = path[1:]
+    if not os.path.isfile(os.path.join(docsDir, path)):
+      log.warning(f"Image not found: {path}")
+    root, extension = os.path.splitext(path)
+    retinaPath = f"{root}_2x{extension}"
+
+    # The site-urls plugin resolves the site: prefix into a relative URL.
+    parts = [f'src="site:{path}"']
+    if os.path.isfile(os.path.join(docsDir, retinaPath)):
+      parts.append(f'srcset="site:{retinaPath} 2x"')
+    if shadow:
+      parts.append('class="screenshot"')
+    parts.append(f'alt="{html.escape(alt)}"')
+    for name, value in attributes.items():
+      parts.append(f'{name}="{html.escape(str(value))}"')
+    return f"<img {' '.join(parts)}>"
+
   @env.macro
   def getRelativePath(page, rootPage):
     rootDirectory = os.path.dirname(rootPage.file.src_uri)

--- a/documentation/scripts/mkdocs_macros.py
+++ b/documentation/scripts/mkdocs_macros.py
@@ -19,10 +19,16 @@ def define_env(env):
     Set shadow=False for cropped fragments of the UI, which are shown inline
     without the rounded corners and drop shadow of a full screenshot.
     """
-    docsDir = env.conf["docs_dir"]
+    docsDir = os.path.normpath(env.conf["docs_dir"])
     if path.startswith("/"):
       path = path[1:]
-    if not os.path.isfile(os.path.join(docsDir, path)):
+
+    # The site: URL below can only resolve to something the site serves, so
+    # reject paths that point outside of the docs directory.
+    fullPath = os.path.normpath(os.path.join(docsDir, path))
+    if not fullPath.startswith(docsDir + os.sep):
+      raise ValueError(f"Image path is outside of the docs directory: {path}")
+    if not os.path.isfile(fullPath):
       log.warning(f"Image not found: {path}")
     root, extension = os.path.splitext(path)
     retinaPath = f"{root}_2x{extension}"

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-plugin-prefer-let": "3.0.1",
     "glob": "11.1.0",
     "globals": "^15.0.0",
+    "image-dimensions": "^2.5.1",
     "js-yaml": "4.2.0",
     "linkinator": "^7.6.1",
     "lint-staged": "15.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       globals:
         specifier: ^15.0.0
         version: 15.15.0
+      image-dimensions:
+        specifier: ^2.5.1
+        version: 2.5.1
       js-yaml:
         specifier: 4.2.0
         version: 4.2.0
@@ -3080,6 +3083,11 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  image-dimensions@2.5.1:
+    resolution: {integrity: sha512-It7CkTNp7IYA8jhvGgz8K18OAbHF3/Juk8RNEyTyMFfolJOIU1Y2wGDnzDQPbGCjyxVF/++pwIZE0BKJUEOb1g==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -8498,6 +8506,8 @@ snapshots:
   ignore@6.0.2: {}
 
   ignore@7.0.5: {}
+
+  image-dimensions@2.5.1: {}
 
   import-fresh@3.3.0:
     dependencies:


### PR DESCRIPTION
This PR adds a few improvements to make it easier to work with images in documentation:

- Adds a macro to generate the `<img>` tag, automatically generating the `srcset` attribute if a 2x image exists, and updates the documentation to use that new macro everywhere.
- Adds a Make rule to generate 1x images from the 2x source screenshots.

It also removes a Make rule to optimize images, which is no longer needed since automatic image optimization was added in #3346.