### PR TITLE
Consolidate doc publishing actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name != 'main' && github.ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  AWS_REGION: us-west-2
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -80,168 +77,37 @@ jobs:
       - name: Validate samples
         run: make validate-samples
 
-  build-docs-head:
-    runs-on: ubuntu-latest
+  publish-docs-head:
     if: github.ref_name == 'main'
-    environment:
-      name: head-documentation
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/setup_python
-
-      - name: Cache mkdocs
-        uses: actions/cache@v4
-        with:
-          path: .cache
-          key: mkdocs-${{ hashFiles('mkdocs.yml') }}
-
-      - name: Build docs
-        run: DOC_DISABLE_SOURCES=false DOC_GIT_REVISION="${{ github.sha }}" MK_DOCS_SITE_URL="https://docs.qa-sh.io/packs/build/latest/" make docs
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-head
-          path: site
-
-  push-head-docs:
-    runs-on: ubuntu-latest
-    environment:
-      name: head-documentation
-    needs: build-docs-head
     permissions:
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      env: head
+      site-url: https://docs.qa-sh.io/packs/build/latest/
+      role-to-assume: arn:aws:iam::020355488663:role/automation/CICDRole
 
-      - name: Download site artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: site-head
-          path: site
-
-      - name: Configure AWS credentials
-        uses: ./.github/actions/setup_aws_profile
-        with:
-          role-to-assume: arn:aws:iam::020355488663:role/automation/CICDRole
-          profile-name: head
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-packs-sdk-push-head-docs
-
-      - name: Deploy to Head
-        run: make publish-docs-head FLAGS=--forceUpload
-
-  build-docs-staging:
-    runs-on: ubuntu-latest
-    environment:
-      name: staging-documentation
+  publish-docs-staging:
     if: github.actor != 'github-actions[bot]'
-    needs: push-head-docs
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/setup_python
-
-      - name: Cache mkdocs
-        uses: actions/cache@v4
-        with:
-          path: .cache
-          key: mkdocs-${{ hashFiles('mkdocs.yml') }}
-
-      - name: Build docs
-        run: DOC_DISABLE_SOURCES=false DOC_GIT_REVISION="${{ github.sha }}" MK_DOCS_SITE_URL="https://docs.pp-sh.io/packs/build/latest/" make docs
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-staging
-          path: site
-
-  push-staging-docs:
-    runs-on: ubuntu-latest
-    environment:
-      name: staging-documentation
-    if: github.actor != 'github-actions[bot]'
-    needs: [push-head-docs, build-docs-staging]
+    needs: publish-docs-head
     permissions:
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      env: staging
+      site-url: https://docs.pp-sh.io/packs/build/latest/
+      role-to-assume: arn:aws:iam::053716345611:role/automation/CICDRole
 
-      - name: Download site artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: site-staging
-          path: site
-
-      - name: Configure AWS credentials
-        uses: ./.github/actions/setup_aws_profile
-        with:
-          role-to-assume: arn:aws:iam::053716345611:role/automation/CICDRole
-          profile-name: staging
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-packs-sdk-push-staging-docs
-
-      - name: Deploy to Staging
-        run: make publish-docs-staging FLAGS=--forceUpload
-
-  build-docs-prod:
-    runs-on: ubuntu-latest
-    environment:
-      name: prod-documentation
+  publish-docs-prod:
     if: github.actor != 'github-actions[bot]'
-    needs: push-staging-docs
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
-      - uses: ./.github/actions/setup_python
-
-      - name: Cache mkdocs
-        uses: actions/cache@v4
-        with:
-          path: .cache
-          key: mkdocs-${{ hashFiles('mkdocs.yml') }}
-
-      - name: Build docs
-        run: DOC_DISABLE_SOURCES=false DOC_GIT_REVISION="${{ github.sha }}" MK_DOCS_SITE_URL="https://docs.superhuman.com/packs/build/latest/" make docs
-
-      - name: Upload site artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: site-prod
-          path: site
-
-  push-prod-docs:
-    runs-on: ubuntu-latest
-    environment:
-      name: prod-documentation
-    if: github.actor != 'github-actions[bot]'
-    needs: [push-staging-docs, build-docs-prod]
+    needs: publish-docs-staging
     permissions:
       id-token: write
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_node
-
-      - name: Download site artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: site-prod
-          path: site
-
-      - name: Configure AWS credentials
-        uses: ./.github/actions/setup_aws_profile
-        with:
-          role-to-assume: arn:aws:iam::029208794193:role/automation/CICDRole
-          profile-name: prod
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-packs-sdk-push-prod-docs
-
-      - name: Deploy to Production
-        run: make publish-docs-prod FLAGS=--forceUpload
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      env: prod
+      site-url: https://docs.superhuman.com/packs/build/latest/
+      role-to-assume: arn:aws:iam::029208794193:role/automation/CICDRole

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,65 @@
+name: Publish Docs
+
+# Builds and publishes the documentation site to a single environment.
+
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: >-
+          Target environment. Drives the GitHub environment (<env>-documentation),
+          the AWS profile name, and the `publish-docs-<env>` make target.
+        required: true
+        type: string
+      site-url:
+        description: 'Base URL the site is built against (MK_DOCS_SITE_URL).'
+        required: true
+        type: string
+      role-to-assume:
+        description: 'ARN of the IAM role to assume for the upload.'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region for the profile.'
+        required: false
+        type: string
+        default: us-west-2
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.env }}-documentation
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup_node
+      - uses: ./.github/actions/setup_python
+
+      - name: Cache mkdocs
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: mkdocs-${{ hashFiles('mkdocs.yml') }}
+
+      - name: Build docs
+        run: DOC_DISABLE_SOURCES=false DOC_GIT_REVISION="${{ github.sha }}" MK_DOCS_SITE_URL="${{ inputs.site-url }}" make docs
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-${{ inputs.env }}
+          path: site
+
+      - name: Configure AWS credentials
+        uses: ./.github/actions/setup_aws_profile
+        with:
+          role-to-assume: ${{ inputs.role-to-assume }}
+          profile-name: ${{ inputs.env }}
+          aws-region: ${{ inputs.aws-region }}
+          role-session-name: github-actions-packs-sdk-push-${{ inputs.env }}-docs
+
+      - name: Publish
+        run: make publish-docs-${{ inputs.env }} FLAGS=--forceUpload


### PR DESCRIPTION
This PR makes two changes:

- Consolidates the "build" and "push" stages of doc publishing into one action.
- Uses a template for the doc publishing rules, since so much of it is duplicative.

The impetus was to simplify the doc publishing experience, as I currently need to approve the build and push separately, creating unnecessary touchpoints without adding value. It also added extra total compute time, since build and push each needed to spin up an environment.