### PR TITLE
Require an agent's instructions in the type

### DIFF
--- a/builder.ts
+++ b/builder.ts
@@ -651,7 +651,7 @@ export class AgentDefinitionBuilder extends BaseDefinitionBuilder {
   /**
    * See {@link PackVersionDefinition.agent}.
    */
-  agent: AgentDefinition = {};
+  agent: Partial<AgentDefinition> = {};
 
   /**
    * Sets this agent's instructions.

--- a/dist/builder.d.ts
+++ b/dist/builder.d.ts
@@ -421,7 +421,7 @@ export declare class AgentDefinitionBuilder extends BaseDefinitionBuilder {
     /**
      * See {@link PackVersionDefinition.agent}.
      */
-    agent: AgentDefinition;
+    agent: Partial<AgentDefinition>;
     /**
      * Sets this agent's instructions.
      *

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -6128,7 +6128,7 @@ export interface SuggestedPrompt {
  */
 export interface AgentDefinition {
 	/**
-	 * What the agent is told to do.
+	 * What the agent is told to do. A missing `setInstructions()` fails at `packs validate`.
 	 */
 	instructions: string;
 	/**

--- a/dist/bundle.d.ts
+++ b/dist/bundle.d.ts
@@ -6130,7 +6130,7 @@ export interface AgentDefinition {
 	/**
 	 * What the agent is told to do.
 	 */
-	instructions?: string;
+	instructions: string;
 	/**
 	 * The tools the agent may use.
 	 */
@@ -6682,7 +6682,7 @@ declare class AgentDefinitionBuilder extends BaseDefinitionBuilder {
 	/**
 	 * See {@link PackVersionDefinition.agent}.
 	 */
-	agent: AgentDefinition;
+	agent: Partial<AgentDefinition>;
 	/**
 	 * Sets this agent's instructions.
 	 *

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1828,9 +1828,10 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         models: z.array(skillModelConfigurationSchema).optional(),
     });
     const chatSkillSchema = skillSchema.partial();
-    // The listing owns the display fields, so only the instructions are required here.
+    // Missing and empty are separate Zod failures, so both carry the same message.
+    const MissingInstructions = 'An agent must have instructions. Call setInstructions() on the agent.';
     const agentSchema = zodCompleteStrictObject({
-        instructions: z.string().min(1).max(exports.Limits.PromptLength),
+        instructions: z.string({ error: MissingInstructions }).min(1, MissingInstructions).max(exports.Limits.PromptLength),
         tools: z
             .array(toolSchema)
             .optional()
@@ -2565,8 +2566,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
         });
     })
         .superRefine((data, context) => {
-        // Agents don't ship connector building blocks. The agent builder can't add them, but a
-        // hand-written manifest can, so check here too.
+        // The builder can't add these to an agent, but a hand-written manifest can.
         if (!data.agent) {
             return;
         }

--- a/dist/testing/upload_validation.js
+++ b/dist/testing/upload_validation.js
@@ -1830,7 +1830,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
     const chatSkillSchema = skillSchema.partial();
     // The listing owns the display fields, so only the instructions are required here.
     const agentSchema = zodCompleteStrictObject({
-        instructions: z.string().min(1).max(exports.Limits.PromptLength).optional(),
+        instructions: z.string().min(1).max(exports.Limits.PromptLength),
         tools: z
             .array(toolSchema)
             .optional()
@@ -1843,14 +1843,6 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
                 });
             }
         }),
-    }).superRefine((data, context) => {
-        if (!data.instructions) {
-            context.addIssue({
-                code: 'custom',
-                path: ['instructions'],
-                message: 'An agent must have instructions. Call setInstructions() on the agent.',
-            });
-        }
     });
     const skillEntrypointConfigSchema = zodCompleteStrictObject({
         skillName: z.string(),

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1576,7 +1576,7 @@ export interface AgentDefinition {
     /**
      * What the agent is told to do.
      */
-    instructions?: string;
+    instructions: string;
     /**
      * The tools the agent may use.
      */

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1574,7 +1574,7 @@ export interface SuggestedPrompt {
  */
 export interface AgentDefinition {
     /**
-     * What the agent is told to do.
+     * What the agent is told to do. A missing `setInstructions()` fails at `packs validate`.
      */
     instructions: string;
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.2-prerelease.2",
+  "version": "1.17.2-prerelease.3",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -8087,12 +8087,24 @@ describe('Pack metadata Validation', async () => {
       assert.deepEqual(result.agent, {instructions: 'You help a team run async standups.'});
     });
 
-    // The builder can't produce this — `instructions` is required on `AgentDefinition` — but a
-    // hand-written manifest can.
+    // Neither is reachable through the builder, but a hand-written manifest can produce both.
     it('rejects an agent that declared itself but never set instructions', async () => {
       const err = await validateJsonAndAssertFails(createFakeAgentMetadata({agent: {} as any}));
       assert.deepEqual(err.validationErrors, [
-        {path: 'agent.instructions', message: 'Missing required field agent.instructions.'},
+        {
+          path: 'agent.instructions',
+          message: 'An agent must have instructions. Call setInstructions() on the agent.',
+        },
+      ]);
+    });
+
+    it('rejects an agent whose instructions are empty', async () => {
+      const err = await validateJsonAndAssertFails(createFakeAgentMetadata({agent: {instructions: ''}}));
+      assert.deepEqual(err.validationErrors, [
+        {
+          path: 'agent.instructions',
+          message: 'An agent must have instructions. Call setInstructions() on the agent.',
+        },
       ]);
     });
 

--- a/test/upload_validation_test.ts
+++ b/test/upload_validation_test.ts
@@ -8087,23 +8087,12 @@ describe('Pack metadata Validation', async () => {
       assert.deepEqual(result.agent, {instructions: 'You help a team run async standups.'});
     });
 
+    // The builder can't produce this — `instructions` is required on `AgentDefinition` — but a
+    // hand-written manifest can.
     it('rejects an agent that declared itself but never set instructions', async () => {
-      const err = await validateJsonAndAssertFails(createFakeAgentMetadata({agent: {}}));
+      const err = await validateJsonAndAssertFails(createFakeAgentMetadata({agent: {} as any}));
       assert.deepEqual(err.validationErrors, [
-        {
-          path: 'agent.instructions',
-          message: 'An agent must have instructions. Call setInstructions() on the agent.',
-        },
-      ]);
-    });
-
-    it('rejects an agent with an empty definition', async () => {
-      const err = await validateJsonAndAssertFails(createFakeAgentMetadata({agent: {}}));
-      assert.deepEqual(err.validationErrors, [
-        {
-          path: 'agent.instructions',
-          message: 'An agent must have instructions. Call setInstructions() on the agent.',
-        },
+        {path: 'agent.instructions', message: 'Missing required field agent.instructions.'},
       ]);
     });
 

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2375,7 +2375,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
 
   // The listing owns the display fields, so only the instructions are required here.
   const agentSchema = zodCompleteStrictObject<AgentDefinition>({
-    instructions: z.string().min(1).max(Limits.PromptLength).optional(),
+    instructions: z.string().min(1).max(Limits.PromptLength),
     tools: z
       .array(toolSchema)
       .optional()
@@ -2388,14 +2388,6 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
           });
         }
       }),
-  }).superRefine((data, context) => {
-    if (!data.instructions) {
-      context.addIssue({
-        code: 'custom',
-        path: ['instructions'],
-        message: 'An agent must have instructions. Call setInstructions() on the agent.',
-      });
-    }
   });
 
   const skillEntrypointConfigSchema = zodCompleteStrictObject<SkillEntrypointConfig>({

--- a/testing/upload_validation.ts
+++ b/testing/upload_validation.ts
@@ -2373,9 +2373,11 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
   });
   const chatSkillSchema = skillSchema.partial();
 
-  // The listing owns the display fields, so only the instructions are required here.
+  // Missing and empty are separate Zod failures, so both carry the same message.
+  const MissingInstructions = 'An agent must have instructions. Call setInstructions() on the agent.';
+
   const agentSchema = zodCompleteStrictObject<AgentDefinition>({
-    instructions: z.string().min(1).max(Limits.PromptLength),
+    instructions: z.string({error: MissingInstructions}).min(1, MissingInstructions).max(Limits.PromptLength),
     tools: z
       .array(toolSchema)
       .optional()
@@ -3193,8 +3195,7 @@ ${endpointKey ? 'endpointKey is set' : `requiresEndpointUrl is ${requiresEndpoin
       });
     })
     .superRefine((data, context) => {
-      // Agents don't ship connector building blocks. The agent builder can't add them, but a
-      // hand-written manifest can, so check here too.
+      // The builder can't add these to an agent, but a hand-written manifest can.
       if (!(data as PackVersionMetadata).agent) {
         return;
       }

--- a/types.ts
+++ b/types.ts
@@ -1737,7 +1737,7 @@ export interface SuggestedPrompt {
  */
 export interface AgentDefinition {
   /**
-   * What the agent is told to do.
+   * What the agent is told to do. A missing `setInstructions()` fails at `packs validate`.
    */
   instructions: string;
   /**

--- a/types.ts
+++ b/types.ts
@@ -1739,7 +1739,7 @@ export interface AgentDefinition {
   /**
    * What the agent is told to do.
    */
-  instructions?: string;
+  instructions: string;
   /**
    * The tools the agent may use.
    */


### PR DESCRIPTION
`AgentDefinition.instructions` is required now, so a definition without one is a compile error rather than something validation catches later.

The builder holds a `Partial<AgentDefinition>`, since it starts as an empty object and fills in as the author calls methods — same split as `version`, which `PackVersionDefinition` requires and `BaseDefinitionBuilder` doesn't. The empty object is still what marks a pack as an agent.

That also drops the hand-written check for missing instructions: zod covers it now, so the error is the standard "Missing required field".