### PR TITLE
packs-sdk: release v1.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+## [1.17.4] - 2026-09-01
+
+### Fixed
+
+- Fixed a security vulnerability related to Pack sandboxing. All injected closures now run in strict mode.
+
 ## [1.17.3] - 2026-08-31
 
 ### Changed
@@ -1093,7 +1099,7 @@ await myHelper(context);
 
 - Beginning of alpha versioning.
 
-[unreleased]: https://github.com/coda/packs-sdk/compare/v1.17.3...HEAD
+[unreleased]: https://github.com/coda/packs-sdk/compare/v1.17.4...HEAD
 [1.7.5]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.5
 [1.7.4]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.4
 [1.7.3]: https://github.com/coda/packs-sdk/compare/v1.7.1...v1.7.3
@@ -1175,3 +1181,4 @@ await myHelper(context);
 [1.17.1]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.1
 [1.17.2]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.2
 [1.17.3]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.3
+[1.17.4]: https://github.com/coda/packs-sdk/compare/v1.7.8...v1.17.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codahq/packs-sdk",
-      "version": "1.17.3",
+      "version": "1.17.4",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.4-prerelease.1",
+  "version": "1.17.4",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
### Fixed

- Fixed a security vulnerability related to Pack sandboxing. All injected closures now run in strict mode.