### PR TITLE
Make the Packs CLI usable from agents and pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ## [Unreleased]
 
+### Changed
+
+- CLI commands now fail immediately in non-interactive environments instead of waiting on confirmation prompts. Use `--yes` to skip confirmations on `clone`, `link`, `register`, and `release`. `register` requires `--apiToken` (or a pasted token on a TTY). `release` accepts `--use-latest` when the manifest has no version. `--help` for each command includes copy-pasteable examples.
+
 ## [1.17.5] - 2026-09-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog keeps track of all changes to the Packs SDK. We follow convention
 
 ### Changed
 
-- CLI commands now fail immediately in non-interactive environments instead of waiting on confirmation prompts. Use `--yes` to skip confirmations on `clone`, `link`, `register`, and `release`. `register` requires `--apiToken` (or a pasted token on a TTY). `release` accepts `--use-latest` when the manifest has no version. `--help` for each command includes copy-pasteable examples.
+- CLI commands now fail immediately in non-interactive environments instead of waiting on confirmation prompts. Use `--yes` to skip confirmations on `clone`, `link`, `register`, and `release`. `register` requires `--apiToken` (or a pasted token on a TTY). `release` accepts `--use-latest` when the manifest has no version. `--help` for each command includes examples ready to run.
 
 ## [1.17.5] - 2026-09-08
 

--- a/cli/clone.ts
+++ b/cli/clone.ts
@@ -2,6 +2,7 @@ import type {ArgumentsCamelCase} from 'yargs';
 import type {Client} from '../helpers/external-api/coda';
 import {assertApiToken} from './helpers';
 import {assertPackIdOrUrl} from './helpers';
+import {confirmOrFail} from './confirm';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import fs from 'fs-extra';
@@ -10,16 +11,16 @@ import {isResponseError} from '../helpers/external-api/coda';
 import path from 'path';
 import {print} from '../testing/helpers';
 import {printAndExit} from '../testing/helpers';
-import {promptForInput} from '../testing/helpers';
 import {storePackId} from './config_storage';
 
 interface CloneArgs {
   packIdOrUrl: string;
   apiEndpoint: string;
   apiToken?: string;
+  yes?: boolean;
 }
 
-export async function handleClone({packIdOrUrl, apiEndpoint, apiToken}: ArgumentsCamelCase<CloneArgs>) {
+export async function handleClone({packIdOrUrl, apiEndpoint, apiToken, yes}: ArgumentsCamelCase<CloneArgs>) {
   const manifestDir = process.cwd();
   const packId = assertPackIdOrUrl(packIdOrUrl);
   const formattedEndpoint = formatEndpoint(apiEndpoint);
@@ -27,12 +28,11 @@ export async function handleClone({packIdOrUrl, apiEndpoint, apiToken}: Argument
 
   const codeAlreadyExists = fs.existsSync(path.join(manifestDir, 'pack.ts'));
   if (codeAlreadyExists) {
-    const shouldOverwrite = promptForInput('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
-      yesOrNo: true,
+    confirmOrFail({
+      yes,
+      prompt: 'A pack.ts file already exists. Do you want to overwrite it? (y/N)?',
+      example: `packs clone ${packIdOrUrl} --yes`,
     });
-    if (shouldOverwrite.toLocaleLowerCase() !== 'yes') {
-      return printAndExit('Aborting');
-    }
   }
 
   const client = createCodaClient(apiToken, formattedEndpoint);
@@ -59,13 +59,11 @@ export async function handleClone({packIdOrUrl, apiEndpoint, apiToken}: Argument
   if (!sourceCode) {
     print(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
 
-    const shouldInitializeWithoutDownload = promptForInput(
-      'Do you want to continue initializing with template starter code instead (y/N)?',
-      {yesOrNo: true},
-    );
-    if (shouldInitializeWithoutDownload !== 'yes') {
-      return process.exit(1);
-    }
+    confirmOrFail({
+      yes,
+      prompt: 'Do you want to continue initializing with template starter code instead (y/N)?',
+      example: `packs clone ${packIdOrUrl} --yes`,
+    });
 
     await handleInit();
     storePackId(manifestDir, packId, apiEndpoint);
@@ -78,7 +76,7 @@ export async function handleClone({packIdOrUrl, apiEndpoint, apiToken}: Argument
   storePackId(manifestDir, packId, apiEndpoint);
 
   fs.writeFileSync(path.join(manifestDir, 'pack.ts'), sourceCode);
-  printAndExit("Successfully updated pack.ts with the Pack's code!", 0);
+  printAndExit(`cloned pack_id: ${packId}\nversion: ${packVersion}\nfile: pack.ts`, 0);
 }
 
 function maybeHandleClientError(err: any) {

--- a/cli/confirm.ts
+++ b/cli/confirm.ts
@@ -1,0 +1,38 @@
+import {printAndExit} from '../testing/helpers';
+import {promptForInput} from '../testing/helpers';
+
+export function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY);
+}
+
+export function confirmOrFail({
+  yes,
+  prompt,
+  example,
+  interactive = isInteractive(),
+}: {
+  yes?: boolean;
+  prompt: string;
+  example: string;
+  interactive?: boolean;
+}): void {
+  if (yes) {
+    return;
+  }
+  if (interactive) {
+    const answer = promptForInput(prompt, {yesOrNo: true});
+    if (answer !== 'yes') {
+      printAndExit('Aborted.');
+    }
+    return;
+  }
+  printAndExit(`${prompt.trim()}\nPass --yes to continue without a prompt.\n  ${example}`);
+}
+
+export function missingFlagError(message: string, example: string, extra?: string): never {
+  const lines = [`Error: ${message}`, `  ${example}`];
+  if (extra) {
+    lines.push(extra);
+  }
+  return printAndExit(lines.join('\n'));
+}

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -61,7 +61,7 @@ export async function createPack(
     const response = await codaClient.createPack({}, {name, description, workspaceId: parseWorkspace(workspace)});
     const packId = response.packId;
     storePackId(manifestDir, packId, apiEndpoint);
-    return printAndExit(`Pack created successfully! You can manage pack settings at ${apiEndpoint}/p/${packId}`, 0);
+    return printAndExit(`created pack_id: ${packId}\nurl: ${apiEndpoint}/p/${packId}`, 0);
   } catch (err: any) {
     if (isResponseError(err)) {
       return printAndExit(`Unable to create your pack, received error: ${await formatResponseError(err)}`);

--- a/cli/helpers.ts
+++ b/cli/helpers.ts
@@ -68,7 +68,9 @@ export function assertApiToken(codaApiEndpoint: string, cliApiToken?: string): s
   }
   const apiKey = getApiKey(codaApiEndpoint);
   if (!apiKey) {
-    return printAndExit('Missing API token. Please run `packs register` to register one.');
+    return printAndExit(
+      'Error: Missing API token.\n' + '  packs register --apiToken <token>\n' + 'Create a token: packs register --help',
+    );
   }
   return apiKey;
 }
@@ -77,7 +79,9 @@ export function assertPackId(manifestDir: string, codaApiEndpoint: string): numb
   const packId = getPackId(manifestDir, codaApiEndpoint);
   if (!packId) {
     return printAndExit(
-      `Could not find a Pack id in directory ${manifestDir}. You may need to run "packs create" first if this is a brand new pack.`,
+      `Error: Could not find a Pack id in directory ${manifestDir}.\n` +
+        `  packs create <manifestFile>\n` +
+        `  packs link <manifestDir> <packIdOrUrl>`,
     );
   }
   return packId;
@@ -86,7 +90,11 @@ export function assertPackId(manifestDir: string, codaApiEndpoint: string): numb
 export function assertPackIdOrUrl(packIdOrUrl: string): number {
   const packId = parsePackIdOrUrl(packIdOrUrl);
   if (!packId) {
-    return printAndExit(`Not a valid pack ID or URL: ${packIdOrUrl}`);
+    return printAndExit(
+      `Error: Not a valid pack ID or URL: ${packIdOrUrl}\n` +
+        `  packs clone 1234\n` +
+        `  packs clone https://coda.io/p/1234`,
+    );
   }
   return packId;
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import type {Argv} from 'yargs';
 import {DEFAULT_API_ENDPOINT} from './config_storage';
 import {DEFAULT_GIT_TAG} from './config_storage';
 import {DEFAULT_MAX_ROWS} from '../testing/execution';
@@ -40,6 +41,65 @@ const TimerStrategyArg = {
   string: true,
   desc: `Options: none, error, fake (default: ${DEFAULT_TIMER_STRATEGY}).`,
 };
+
+const YesArg = {
+  boolean: true,
+  alias: 'y',
+  default: false,
+  desc: 'Skip confirmation prompts. Required in non-interactive environments.',
+};
+
+const CommandExamples: Record<string, Array<[string, string]>> = {
+  execute: [
+    ['$0 execute pack.ts MyFormula "arg1"', 'Run a formula with mocked or live HTTP as configured.'],
+    ['$0 execute pack.ts MySyncTable --maxRows 10', 'Sync a table and cap the number of rows.'],
+  ],
+  auth: [['$0 auth pack.ts', 'Start local auth setup for the Pack.']],
+  init: [['$0 init', 'Scaffold pack.ts and related starter files in the current directory.']],
+  extensions: [['$0 extensions vscode', 'Install VS Code snippets for Packs.']],
+  clone: [
+    ['$0 clone 1234', 'Download the latest Pack Studio source into this directory.'],
+    ['$0 clone https://coda.io/p/1234 --yes', 'Overwrite pack.ts without prompting.'],
+  ],
+  register: [
+    ['$0 register --apiToken <token>', 'Validate and store a Pack API token.'],
+    ['$0 register --open', 'Open the token creation page, then pass --apiToken to store it.'],
+  ],
+  whoami: [['$0 whoami', 'Print the account and token currently registered.']],
+  build: [
+    ['$0 build pack.ts', 'Compile the Pack bundle locally.'],
+    ['$0 build pack.ts --outputDir dist', 'Write the bundle to a directory.'],
+  ],
+  upload: [
+    ['$0 upload pack.ts', 'Build and upload a new Pack version.'],
+    ['$0 upload pack.ts --notes "Fix formula errors"', 'Upload with version notes.'],
+  ],
+  create: [
+    ['$0 create pack.ts --name "My Pack"', 'Create a Pack and write its id to .coda-pack.json.'],
+    ['$0 create pack.ts --workspace ws-abc123', 'Create the Pack in a specific workspace.'],
+  ],
+  link: [
+    ['$0 link . 1234', 'Associate this directory with an existing Pack.'],
+    ['$0 link . 5678 --yes', 'Overwrite an existing Pack id without prompting.'],
+  ],
+  validate: [['$0 validate pack.ts', 'Validate the Pack definition without uploading.']],
+  release: [
+    ['$0 release pack.ts 1.2.3 --notes "Bug fixes"', 'Release a specific uploaded version.'],
+    ['$0 release pack.ts --notes "Bug fixes" --yes', 'Release from a non-main branch without prompting.'],
+    ['$0 release pack.ts --use-latest --notes "Bug fixes"', 'Release the latest uploaded version.'],
+  ],
+  setOption: [
+    ['$0 setOption pack.ts gitTag true', 'Create git tags on future releases.'],
+    ['$0 setOption pack.ts apiEndpoint https://my-company.coda.io', 'Pin a single-tenant API endpoint.'],
+  ],
+};
+
+function withExamples(argv: Argv, examples: Array<[string, string]>): Argv {
+  for (const [command, description] of examples) {
+    argv.example(command, description);
+  }
+  return argv;
+}
 
 export const commands: yargs.CommandModule[] = [
   {
@@ -105,7 +165,7 @@ export const commands: yargs.CommandModule[] = [
   {
     command: 'extensions <tools..>',
     describe: 'Installs developer extensions for working with Packs.',
-    builder: (yargs: yargs.Argv) => {
+    builder: (yargs: Argv) => {
       yargs.positional('tools', {
         type: 'string',
         choices: Object.values(Tools),
@@ -121,6 +181,7 @@ export const commands: yargs.CommandModule[] = [
     builder: {
       apiToken: ApiTokenArg,
       apiEndpoint: ApiEndpointArg,
+      yes: YesArg,
     },
     handler: handleClone as any,
   },
@@ -129,6 +190,12 @@ export const commands: yargs.CommandModule[] = [
     describe: 'Register API token to publish a Pack',
     builder: {
       apiEndpoint: ApiEndpointArg,
+      open: {
+        boolean: true,
+        default: false,
+        desc: 'Open the API token creation page in a browser.',
+      },
+      yes: YesArg,
     },
     handler: handleRegister as any,
   },
@@ -218,6 +285,7 @@ export const commands: yargs.CommandModule[] = [
     builder: {
       apiToken: ApiTokenArg,
       apiEndpoint: ApiEndpointArg,
+      yes: YesArg,
     },
     handler: handleLink as any,
   },
@@ -253,19 +321,18 @@ export const commands: yargs.CommandModule[] = [
       },
       apiToken: ApiTokenArg,
       apiEndpoint: ApiEndpointArg,
+      yes: YesArg,
+      useLatest: {
+        boolean: true,
+        default: false,
+        desc: 'Release the latest uploaded version when the manifest has no version.',
+      },
     },
     handler: handleRelease as any,
   },
   {
     command: 'setOption <manifestFile> <option> <value>',
-    describe:
-      'Set a persistent build option for the pack. This will store the option alongside the pack id in ' +
-      'the .coda-pack.json file and it will be used for all builds of the pack.\n\n' +
-      'Supported options:\n' +
-      '  - timerStrategy: Valid values are "none", "error", or "fake".\n' +
-      '  - gitTag: Valid values are "true" or "false". When true, the release command will create git tags.\n' +
-      '  - apiEndpoint: A URL for the API endpoint, required for single-tenant instances (e.g. "https://my-company.coda.io"). When set, all commands will use this endpoint by default.\n\n' +
-      'Usage: packs setOption path/to/pack.ts timerStrategy fake',
+    describe: 'Set a persistent build option for the pack (.coda-pack.json)',
     handler: handleSetOption as any,
   },
 ];
@@ -273,7 +340,19 @@ export const commands: yargs.CommandModule[] = [
 if (require.main === module) {
   let cli = yargs.parserConfiguration({'parse-numbers': false}).middleware(backfillFromPackConfig);
   for (const cmd of commands) {
-    cli = cli.command(cmd);
+    const name = (cmd.command as string).split(' ')[0];
+    cli = cli.command({
+      ...cmd,
+      builder: (argv: Argv) => {
+        let next = argv;
+        if (typeof cmd.builder === 'function') {
+          next = cmd.builder(argv) as Argv;
+        } else if (cmd.builder) {
+          next = argv.options(cmd.builder);
+        }
+        return withExamples(next, CommandExamples[name] ?? []);
+      },
+    });
   }
   void cli.demandCommand().strict().help().argv;
 }

--- a/cli/link.ts
+++ b/cli/link.ts
@@ -1,12 +1,12 @@
 import type {ArgumentsCamelCase} from 'yargs';
 import {assertApiToken} from './helpers';
 import {assertPackIdOrUrl} from './helpers';
+import {confirmOrFail} from './confirm';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
 import {getPackId} from './config_storage';
 import {isResponseError} from '../helpers/external-api/coda';
 import {printAndExit} from '../testing/helpers';
-import {promptForInput} from '../testing/helpers';
 import {storePackId} from './config_storage';
 
 // Regular expression that matches coda.io/p/<packId> or <packId>.
@@ -20,9 +20,10 @@ interface LinkArgs {
   apiEndpoint: string;
   packIdOrUrl: string;
   apiToken?: string;
+  yes?: boolean;
 }
 
-export async function handleLink({manifestDir, apiEndpoint, packIdOrUrl, apiToken}: ArgumentsCamelCase<LinkArgs>) {
+export async function handleLink({manifestDir, apiEndpoint, packIdOrUrl, apiToken, yes}: ArgumentsCamelCase<LinkArgs>) {
   // TODO(dweitzman): Add a download command to fetch the latest code from
   // the server and ask people if they want to download after linking.
   const formattedEndpoint = formatEndpoint(apiEndpoint);
@@ -50,20 +51,21 @@ export async function handleLink({manifestDir, apiEndpoint, packIdOrUrl, apiToke
   const existingPackId = getPackId(manifestDir, apiEndpoint);
   if (existingPackId) {
     if (existingPackId === packId) {
-      return printAndExit(`Already associated with pack ${existingPackId}. No change needed`, 0);
+      return printAndExit(
+        `already linked pack_id: ${existingPackId}\nurl: ${formattedEndpoint}/p/${existingPackId}`,
+        0,
+      );
     }
 
-    const input = promptForInput(
-      `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `,
-      {yesOrNo: true},
-    );
-    if (input.toLocaleLowerCase() !== 'yes') {
-      return process.exit(1);
-    }
+    confirmOrFail({
+      yes,
+      prompt: `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `,
+      example: `packs link ${manifestDir} ${packId} --yes`,
+    });
   }
 
   storePackId(manifestDir, packId, apiEndpoint);
-  return printAndExit(`Linked successfully!`, 0);
+  return printAndExit(`linked pack_id: ${packId}\nurl: ${formattedEndpoint}/p/${packId}`, 0);
 }
 
 export function parsePackIdOrUrl(packIdOrUrl: string): number | null {

--- a/cli/register.ts
+++ b/cli/register.ts
@@ -1,8 +1,11 @@
 import type {ArgumentsCamelCase} from 'yargs';
 import {DEFAULT_API_ENDPOINT} from './config_storage';
+import {confirmOrFail} from './confirm';
 import {createCodaClient} from './helpers';
 import {formatEndpoint} from './helpers';
+import {isInteractive} from './confirm';
 import {isResponseError} from '../helpers/external-api/coda';
+import {missingFlagError} from './confirm';
 import open from 'open';
 import {printAndExit} from '../testing/helpers';
 import {promptForInput} from '../testing/helpers';
@@ -12,6 +15,8 @@ import {tryParseSystemError} from './errors';
 interface RegisterArgs {
   apiToken?: string;
   apiEndpoint: string;
+  open?: boolean;
+  yes?: boolean;
 }
 
 const DEFAULT_ACCOUNT_ENDPOINT = 'https://docs.superhuman.com';
@@ -22,19 +27,35 @@ export function getApiTokenCreationUrl(apiEndpoint: string): string {
   return `${accountEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`;
 }
 
-export async function handleRegister({apiToken, apiEndpoint}: ArgumentsCamelCase<RegisterArgs>) {
+export async function handleRegister({
+  apiToken,
+  apiEndpoint,
+  open: openBrowser,
+  yes,
+}: ArgumentsCamelCase<RegisterArgs>) {
   const formattedEndpoint = formatEndpoint(apiEndpoint);
+  const tokenUrl = getApiTokenCreationUrl(formattedEndpoint);
   if (!apiToken) {
-    // TODO: deal with auto-open on devbox setups
-    const shouldOpenBrowser = promptForInput(
-      'No API token provided. Do you want to open your account page to create one (y/N)? ',
-      {yesOrNo: true},
-    );
-    if (shouldOpenBrowser !== 'yes') {
-      return process.exit(1);
+    if (openBrowser || (isInteractive() && !yes)) {
+      if (!openBrowser) {
+        confirmOrFail({
+          yes,
+          prompt: 'No API token provided. Do you want to open your account page to create one (y/N)? ',
+          example: 'packs register --apiToken <token>',
+        });
+      }
+      await open(tokenUrl);
     }
-    await open(getApiTokenCreationUrl(formattedEndpoint));
-    apiToken = promptForInput('Please paste the token here: ', {mask: true});
+    if (isInteractive()) {
+      apiToken = promptForInput('Please paste the token here: ', {mask: true});
+    }
+    if (!apiToken) {
+      return missingFlagError(
+        'No API token specified.',
+        'packs register --apiToken <token>',
+        `Create a token at ${tokenUrl}`,
+      );
+    }
   }
 
   const client = createCodaClient(apiToken, formattedEndpoint);
@@ -51,5 +72,5 @@ export async function handleRegister({apiToken, apiEndpoint}: ArgumentsCamelCase
   }
 
   storeCodaApiKey(apiToken, process.env.PWD, apiEndpoint);
-  printAndExit(`API key validated and stored successfully!`, 0);
+  printAndExit(`registered\nendpoint: ${formattedEndpoint}`, 0);
 }

--- a/cli/release.ts
+++ b/cli/release.ts
@@ -4,6 +4,7 @@ import type {PackVersionDefinition} from '..';
 import {assertApiToken} from './helpers';
 import {assertPackId} from './helpers';
 import {build} from './build';
+import {confirmOrFail} from './confirm';
 import {createCodaClient} from './helpers';
 import {createGitTag} from './git_helpers';
 import {formatEndpoint} from './helpers';
@@ -13,10 +14,10 @@ import {getGitState} from './git_helpers';
 import {gitTagExists} from './git_helpers';
 import {importManifest} from './helpers';
 import {isResponseError} from '../helpers/external-api/coda';
+import {missingFlagError} from './confirm';
 import path from 'path';
 import {print} from '../testing/helpers';
 import {printAndExit} from '../testing/helpers';
-import {promptForInput} from '../testing/helpers';
 import {tryParseSystemError} from './errors';
 
 interface ReleaseArgs {
@@ -26,6 +27,8 @@ interface ReleaseArgs {
   notes: string;
   apiToken?: string;
   gitTag?: boolean;
+  yes?: boolean;
+  useLatest?: boolean;
 }
 
 export async function handleRelease({
@@ -35,6 +38,8 @@ export async function handleRelease({
   notes,
   apiToken,
   gitTag,
+  yes,
+  useLatest,
 }: ArgumentsCamelCase<ReleaseArgs>) {
   const manifestDir = path.dirname(manifestFile);
   const formattedEndpoint = formatEndpoint(apiEndpoint);
@@ -57,13 +62,13 @@ export async function handleRelease({
 
     // Warn if not on main/master branch
     if (gitState.currentBranch && !['main', 'master'].includes(gitState.currentBranch)) {
-      const shouldContinue = promptForInput(
-        `Warning: You are releasing from branch '${gitState.currentBranch}', not 'main'.\n` + `Continue anyway? (y/N) `,
-        {yesOrNo: true},
-      );
-      if (shouldContinue !== 'yes') {
-        return process.exit(1);
-      }
+      confirmOrFail({
+        yes,
+        prompt:
+          `Warning: You are releasing from branch '${gitState.currentBranch}', not 'main'.\n` +
+          `Continue anyway? (y/N) `,
+        example: `packs release ${manifestFile} --notes "<notes>" --yes`,
+      });
     }
   }
 
@@ -89,12 +94,12 @@ export async function handleRelease({
 
     const [latestPackVersionData] = versions;
     const {packVersion: latestPackVersion} = latestPackVersionData;
-    const shouldReleaseLatestPackVersion = promptForInput(
-      `No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`,
-      {yesOrNo: true},
-    );
-    if (shouldReleaseLatestPackVersion !== 'yes') {
-      return process.exit(1);
+    if (!useLatest) {
+      return missingFlagError(
+        'No pack version specified.',
+        `packs release ${manifestFile} ${latestPackVersion} --notes "<notes>"`,
+        `Release the latest uploaded version: packs release ${manifestFile} --use-latest --notes "<notes>"`,
+      );
     }
     packVersion = latestPackVersion;
   }
@@ -104,7 +109,10 @@ export async function handleRelease({
     codaClient.createPackRelease(packId, {}, {packVersion, releaseNotes: notes}),
   );
 
-  print(`Pack version ${packVersion} released successfully (release #${releaseResponse.releaseId}).`);
+  print(`released ${packVersion}`);
+  print(`pack_id: ${packId}`);
+  print(`release_id: ${releaseResponse.releaseId}`);
+  print(`url: ${formattedEndpoint}/p/${packId}`);
 
   // Create git tag if enabled
   if (gitTag && gitState.isGitRepo) {

--- a/cli/set_option.ts
+++ b/cli/set_option.ts
@@ -24,7 +24,10 @@ export async function handleSetOption({manifestFile, option, value}: ArgumentsCa
 function validateOption(option: string, value: string): PackOptions {
   const validOptions = Object.values(PackOptionKey) as string[];
   if (!validOptions.includes(option)) {
-    return printAndExit(`Unsupported option "${option}". Valid options are: ${validOptions.join(', ')}`);
+    return printAndExit(
+      `Error: Unsupported option "${option}". Valid options: ${validOptions.join(', ')}\n` +
+        `  packs setOption pack.ts gitTag true`,
+    );
   }
   const key = option as PackOptionKey;
   switch (key) {

--- a/cli/whoami.ts
+++ b/cli/whoami.ts
@@ -17,7 +17,7 @@ export async function handleWhoami({apiToken, apiEndpoint}: ArgumentsCamelCase<W
   if (!apiToken) {
     apiToken = getApiKey(apiEndpoint);
     if (!apiToken) {
-      return printAndExit('Missing API token. Please run `packs register` to register one.');
+      return printAndExit('Error: Missing API token.\n  packs register --apiToken <token>');
     }
   }
 

--- a/dist/cli/clone.d.ts
+++ b/dist/cli/clone.d.ts
@@ -3,6 +3,7 @@ interface CloneArgs {
     packIdOrUrl: string;
     apiEndpoint: string;
     apiToken?: string;
+    yes?: boolean;
 }
-export declare function handleClone({ packIdOrUrl, apiEndpoint, apiToken }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
+export declare function handleClone({ packIdOrUrl, apiEndpoint, apiToken, yes }: ArgumentsCamelCase<CloneArgs>): Promise<undefined>;
 export {};

--- a/dist/cli/clone.js
+++ b/dist/cli/clone.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleClone = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const confirm_1 = require("./confirm");
 const helpers_3 = require("./helpers");
 const helpers_4 = require("./helpers");
 const fs_extra_1 = __importDefault(require("fs-extra"));
@@ -14,21 +15,19 @@ const coda_1 = require("../helpers/external-api/coda");
 const path_1 = __importDefault(require("path"));
 const helpers_5 = require("../testing/helpers");
 const helpers_6 = require("../testing/helpers");
-const helpers_7 = require("../testing/helpers");
 const config_storage_1 = require("./config_storage");
-async function handleClone({ packIdOrUrl, apiEndpoint, apiToken }) {
+async function handleClone({ packIdOrUrl, apiEndpoint, apiToken, yes }) {
     const manifestDir = process.cwd();
     const packId = (0, helpers_2.assertPackIdOrUrl)(packIdOrUrl);
     const formattedEndpoint = (0, helpers_4.formatEndpoint)(apiEndpoint);
     apiToken = (0, helpers_1.assertApiToken)(apiEndpoint, apiToken);
     const codeAlreadyExists = fs_extra_1.default.existsSync(path_1.default.join(manifestDir, 'pack.ts'));
     if (codeAlreadyExists) {
-        const shouldOverwrite = (0, helpers_7.promptForInput)('A pack.ts file already exists. Do you want to overwrite it? (y/N)?', {
-            yesOrNo: true,
+        (0, confirm_1.confirmOrFail)({
+            yes,
+            prompt: 'A pack.ts file already exists. Do you want to overwrite it? (y/N)?',
+            example: `packs clone ${packIdOrUrl} --yes`,
         });
-        if (shouldOverwrite.toLocaleLowerCase() !== 'yes') {
-            return (0, helpers_6.printAndExit)('Aborting');
-        }
     }
     const client = (0, helpers_3.createCodaClient)(apiToken, formattedEndpoint);
     let packVersion;
@@ -52,10 +51,11 @@ async function handleClone({ packIdOrUrl, apiEndpoint, apiToken }) {
     }
     if (!sourceCode) {
         (0, helpers_5.print)(`Unable to download source for Pack version ${packVersion}. Packs built using the CLI can't be cloned.`);
-        const shouldInitializeWithoutDownload = (0, helpers_7.promptForInput)('Do you want to continue initializing with template starter code instead (y/N)?', { yesOrNo: true });
-        if (shouldInitializeWithoutDownload !== 'yes') {
-            return process.exit(1);
-        }
+        (0, confirm_1.confirmOrFail)({
+            yes,
+            prompt: 'Do you want to continue initializing with template starter code instead (y/N)?',
+            example: `packs clone ${packIdOrUrl} --yes`,
+        });
         await (0, init_1.handleInit)();
         (0, config_storage_1.storePackId)(manifestDir, packId, apiEndpoint);
         return;
@@ -64,7 +64,7 @@ async function handleClone({ packIdOrUrl, apiEndpoint, apiToken }) {
     await (0, init_1.handleInit)();
     (0, config_storage_1.storePackId)(manifestDir, packId, apiEndpoint);
     fs_extra_1.default.writeFileSync(path_1.default.join(manifestDir, 'pack.ts'), sourceCode);
-    (0, helpers_6.printAndExit)("Successfully updated pack.ts with the Pack's code!", 0);
+    (0, helpers_6.printAndExit)(`cloned pack_id: ${packId}\nversion: ${packVersion}\nfile: pack.ts`, 0);
 }
 exports.handleClone = handleClone;
 function maybeHandleClientError(err) {

--- a/dist/cli/confirm.d.ts
+++ b/dist/cli/confirm.d.ts
@@ -1,0 +1,8 @@
+export declare function isInteractive(): boolean;
+export declare function confirmOrFail({ yes, prompt, example, interactive, }: {
+    yes?: boolean;
+    prompt: string;
+    example: string;
+    interactive?: boolean;
+}): void;
+export declare function missingFlagError(message: string, example: string, extra?: string): never;

--- a/dist/cli/confirm.js
+++ b/dist/cli/confirm.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.missingFlagError = exports.confirmOrFail = exports.isInteractive = void 0;
+const helpers_1 = require("../testing/helpers");
+const helpers_2 = require("../testing/helpers");
+function isInteractive() {
+    return Boolean(process.stdin.isTTY);
+}
+exports.isInteractive = isInteractive;
+function confirmOrFail({ yes, prompt, example, interactive = isInteractive(), }) {
+    if (yes) {
+        return;
+    }
+    if (interactive) {
+        const answer = (0, helpers_2.promptForInput)(prompt, { yesOrNo: true });
+        if (answer !== 'yes') {
+            (0, helpers_1.printAndExit)('Aborted.');
+        }
+        return;
+    }
+    (0, helpers_1.printAndExit)(`${prompt.trim()}\nPass --yes to continue without a prompt.\n  ${example}`);
+}
+exports.confirmOrFail = confirmOrFail;
+function missingFlagError(message, example, extra) {
+    const lines = [`Error: ${message}`, `  ${example}`];
+    if (extra) {
+        lines.push(extra);
+    }
+    return (0, helpers_1.printAndExit)(lines.join('\n'));
+}
+exports.missingFlagError = missingFlagError;

--- a/dist/cli/create.js
+++ b/dist/cli/create.js
@@ -62,7 +62,7 @@ async function createPack(manifestFile, apiEndpoint, { name, description, worksp
         const response = await codaClient.createPack({}, { name, description, workspaceId: parseWorkspace(workspace) });
         const packId = response.packId;
         (0, config_storage_3.storePackId)(manifestDir, packId, apiEndpoint);
-        return (0, helpers_4.printAndExit)(`Pack created successfully! You can manage pack settings at ${apiEndpoint}/p/${packId}`, 0);
+        return (0, helpers_4.printAndExit)(`created pack_id: ${packId}\nurl: ${apiEndpoint}/p/${packId}`, 0);
     }
     catch (err) {
         if ((0, coda_1.isResponseError)(err)) {

--- a/dist/cli/helpers.js
+++ b/dist/cli/helpers.js
@@ -92,7 +92,7 @@ function assertApiToken(codaApiEndpoint, cliApiToken) {
     }
     const apiKey = (0, config_storage_6.getApiKey)(codaApiEndpoint);
     if (!apiKey) {
-        return (0, helpers_2.printAndExit)('Missing API token. Please run `packs register` to register one.');
+        return (0, helpers_2.printAndExit)('Error: Missing API token.\n' + '  packs register --apiToken <token>\n' + 'Create a token: packs register --help');
     }
     return apiKey;
 }
@@ -100,7 +100,9 @@ exports.assertApiToken = assertApiToken;
 function assertPackId(manifestDir, codaApiEndpoint) {
     const packId = (0, config_storage_7.getPackId)(manifestDir, codaApiEndpoint);
     if (!packId) {
-        return (0, helpers_2.printAndExit)(`Could not find a Pack id in directory ${manifestDir}. You may need to run "packs create" first if this is a brand new pack.`);
+        return (0, helpers_2.printAndExit)(`Error: Could not find a Pack id in directory ${manifestDir}.\n` +
+            `  packs create <manifestFile>\n` +
+            `  packs link <manifestDir> <packIdOrUrl>`);
     }
     return packId;
 }
@@ -108,7 +110,9 @@ exports.assertPackId = assertPackId;
 function assertPackIdOrUrl(packIdOrUrl) {
     const packId = (0, link_1.parsePackIdOrUrl)(packIdOrUrl);
     if (!packId) {
-        return (0, helpers_2.printAndExit)(`Not a valid pack ID or URL: ${packIdOrUrl}`);
+        return (0, helpers_2.printAndExit)(`Error: Not a valid pack ID or URL: ${packIdOrUrl}\n` +
+            `  packs clone 1234\n` +
+            `  packs clone https://coda.io/p/1234`);
     }
     return packId;
 }

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -42,6 +42,62 @@ const TimerStrategyArg = {
     string: true,
     desc: `Options: none, error, fake (default: ${config_storage_3.DEFAULT_TIMER_STRATEGY}).`,
 };
+const YesArg = {
+    boolean: true,
+    alias: 'y',
+    default: false,
+    desc: 'Skip confirmation prompts. Required in non-interactive environments.',
+};
+const CommandExamples = {
+    execute: [
+        ['$0 execute pack.ts MyFormula "arg1"', 'Run a formula with mocked or live HTTP as configured.'],
+        ['$0 execute pack.ts MySyncTable --maxRows 10', 'Sync a table and cap the number of rows.'],
+    ],
+    auth: [['$0 auth pack.ts', 'Start local auth setup for the Pack.']],
+    init: [['$0 init', 'Scaffold pack.ts and related starter files in the current directory.']],
+    extensions: [['$0 extensions vscode', 'Install VS Code snippets for Packs.']],
+    clone: [
+        ['$0 clone 1234', 'Download the latest Pack Studio source into this directory.'],
+        ['$0 clone https://coda.io/p/1234 --yes', 'Overwrite pack.ts without prompting.'],
+    ],
+    register: [
+        ['$0 register --apiToken <token>', 'Validate and store a Pack API token.'],
+        ['$0 register --open', 'Open the token creation page, then pass --apiToken to store it.'],
+    ],
+    whoami: [['$0 whoami', 'Print the account and token currently registered.']],
+    build: [
+        ['$0 build pack.ts', 'Compile the Pack bundle locally.'],
+        ['$0 build pack.ts --outputDir dist', 'Write the bundle to a directory.'],
+    ],
+    upload: [
+        ['$0 upload pack.ts', 'Build and upload a new Pack version.'],
+        ['$0 upload pack.ts --notes "Fix formula errors"', 'Upload with version notes.'],
+    ],
+    create: [
+        ['$0 create pack.ts --name "My Pack"', 'Create a Pack and write its id to .coda-pack.json.'],
+        ['$0 create pack.ts --workspace ws-abc123', 'Create the Pack in a specific workspace.'],
+    ],
+    link: [
+        ['$0 link . 1234', 'Associate this directory with an existing Pack.'],
+        ['$0 link . 5678 --yes', 'Overwrite an existing Pack id without prompting.'],
+    ],
+    validate: [['$0 validate pack.ts', 'Validate the Pack definition without uploading.']],
+    release: [
+        ['$0 release pack.ts 1.2.3 --notes "Bug fixes"', 'Release a specific uploaded version.'],
+        ['$0 release pack.ts --notes "Bug fixes" --yes', 'Release from a non-main branch without prompting.'],
+        ['$0 release pack.ts --use-latest --notes "Bug fixes"', 'Release the latest uploaded version.'],
+    ],
+    setOption: [
+        ['$0 setOption pack.ts gitTag true', 'Create git tags on future releases.'],
+        ['$0 setOption pack.ts apiEndpoint https://my-company.coda.io', 'Pin a single-tenant API endpoint.'],
+    ],
+};
+function withExamples(argv, examples) {
+    for (const [command, description] of examples) {
+        argv.example(command, description);
+    }
+    return argv;
+}
 exports.commands = [
     {
         command: 'execute <manifestPath> <formulaName> [params..]',
@@ -120,6 +176,7 @@ exports.commands = [
         builder: {
             apiToken: ApiTokenArg,
             apiEndpoint: ApiEndpointArg,
+            yes: YesArg,
         },
         handler: clone_1.handleClone,
     },
@@ -128,6 +185,12 @@ exports.commands = [
         describe: 'Register API token to publish a Pack',
         builder: {
             apiEndpoint: ApiEndpointArg,
+            open: {
+                boolean: true,
+                default: false,
+                desc: 'Open the API token creation page in a browser.',
+            },
+            yes: YesArg,
         },
         handler: register_1.handleRegister,
     },
@@ -216,6 +279,7 @@ exports.commands = [
         builder: {
             apiToken: ApiTokenArg,
             apiEndpoint: ApiEndpointArg,
+            yes: YesArg,
         },
         handler: link_1.handleLink,
     },
@@ -250,25 +314,39 @@ exports.commands = [
             },
             apiToken: ApiTokenArg,
             apiEndpoint: ApiEndpointArg,
+            yes: YesArg,
+            useLatest: {
+                boolean: true,
+                default: false,
+                desc: 'Release the latest uploaded version when the manifest has no version.',
+            },
         },
         handler: release_1.handleRelease,
     },
     {
         command: 'setOption <manifestFile> <option> <value>',
-        describe: 'Set a persistent build option for the pack. This will store the option alongside the pack id in ' +
-            'the .coda-pack.json file and it will be used for all builds of the pack.\n\n' +
-            'Supported options:\n' +
-            '  - timerStrategy: Valid values are "none", "error", or "fake".\n' +
-            '  - gitTag: Valid values are "true" or "false". When true, the release command will create git tags.\n' +
-            '  - apiEndpoint: A URL for the API endpoint, required for single-tenant instances (e.g. "https://my-company.coda.io"). When set, all commands will use this endpoint by default.\n\n' +
-            'Usage: packs setOption path/to/pack.ts timerStrategy fake',
+        describe: 'Set a persistent build option for the pack (.coda-pack.json)',
         handler: set_option_1.handleSetOption,
     },
 ];
 if (require.main === module) {
     let cli = yargs_1.default.parserConfiguration({ 'parse-numbers': false }).middleware(helpers_1.backfillFromPackConfig);
     for (const cmd of exports.commands) {
-        cli = cli.command(cmd);
+        const name = cmd.command.split(' ')[0];
+        cli = cli.command({
+            ...cmd,
+            builder: (argv) => {
+                var _a;
+                let next = argv;
+                if (typeof cmd.builder === 'function') {
+                    next = cmd.builder(argv);
+                }
+                else if (cmd.builder) {
+                    next = argv.options(cmd.builder);
+                }
+                return withExamples(next, (_a = CommandExamples[name]) !== null && _a !== void 0 ? _a : []);
+            },
+        });
     }
     void cli.demandCommand().strict().help().argv;
 }

--- a/dist/cli/link.d.ts
+++ b/dist/cli/link.d.ts
@@ -4,7 +4,8 @@ interface LinkArgs {
     apiEndpoint: string;
     packIdOrUrl: string;
     apiToken?: string;
+    yes?: boolean;
 }
-export declare function handleLink({ manifestDir, apiEndpoint, packIdOrUrl, apiToken }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
+export declare function handleLink({ manifestDir, apiEndpoint, packIdOrUrl, apiToken, yes }: ArgumentsCamelCase<LinkArgs>): Promise<never>;
 export declare function parsePackIdOrUrl(packIdOrUrl: string): number | null;
 export {};

--- a/dist/cli/link.js
+++ b/dist/cli/link.js
@@ -3,19 +3,19 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parsePackIdOrUrl = exports.handleLink = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const confirm_1 = require("./confirm");
 const helpers_3 = require("./helpers");
 const helpers_4 = require("./helpers");
 const config_storage_1 = require("./config_storage");
 const coda_1 = require("../helpers/external-api/coda");
 const helpers_5 = require("../testing/helpers");
-const helpers_6 = require("../testing/helpers");
 const config_storage_2 = require("./config_storage");
 // Regular expression that matches coda.io/p/<packId> or <packId>.
 const PackEditUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/p\/([0-9]+)(:?[^0-9].*)?$/;
 const PackGalleryUrlRegex = /^https:\/\/(?:[^/]*)coda.io(?:\:[0-9]+)?\/packs\/[^/]*-([0-9]+)$/;
 const PackPlainIdRegex = /^([0-9]+)$/;
 const PackRegexes = [PackEditUrlRegex, PackGalleryUrlRegex, PackPlainIdRegex];
-async function handleLink({ manifestDir, apiEndpoint, packIdOrUrl, apiToken }) {
+async function handleLink({ manifestDir, apiEndpoint, packIdOrUrl, apiToken, yes }) {
     // TODO(dweitzman): Add a download command to fetch the latest code from
     // the server and ask people if they want to download after linking.
     const formattedEndpoint = (0, helpers_4.formatEndpoint)(apiEndpoint);
@@ -41,15 +41,16 @@ async function handleLink({ manifestDir, apiEndpoint, packIdOrUrl, apiToken }) {
     const existingPackId = (0, config_storage_1.getPackId)(manifestDir, apiEndpoint);
     if (existingPackId) {
         if (existingPackId === packId) {
-            return (0, helpers_5.printAndExit)(`Already associated with pack ${existingPackId}. No change needed`, 0);
+            return (0, helpers_5.printAndExit)(`already linked pack_id: ${existingPackId}\nurl: ${formattedEndpoint}/p/${existingPackId}`, 0);
         }
-        const input = (0, helpers_6.promptForInput)(`Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `, { yesOrNo: true });
-        if (input.toLocaleLowerCase() !== 'yes') {
-            return process.exit(1);
-        }
+        (0, confirm_1.confirmOrFail)({
+            yes,
+            prompt: `Overwrite existing deploy to pack https://coda.io/p/${existingPackId} with https://coda.io/p/${packId} instead? (y/N): `,
+            example: `packs link ${manifestDir} ${packId} --yes`,
+        });
     }
     (0, config_storage_2.storePackId)(manifestDir, packId, apiEndpoint);
-    return (0, helpers_5.printAndExit)(`Linked successfully!`, 0);
+    return (0, helpers_5.printAndExit)(`linked pack_id: ${packId}\nurl: ${formattedEndpoint}/p/${packId}`, 0);
 }
 exports.handleLink = handleLink;
 function parsePackIdOrUrl(packIdOrUrl) {

--- a/dist/cli/register.d.ts
+++ b/dist/cli/register.d.ts
@@ -2,7 +2,9 @@ import type { ArgumentsCamelCase } from 'yargs';
 interface RegisterArgs {
     apiToken?: string;
     apiEndpoint: string;
+    open?: boolean;
+    yes?: boolean;
 }
 export declare function getApiTokenCreationUrl(apiEndpoint: string): string;
-export declare function handleRegister({ apiToken, apiEndpoint }: ArgumentsCamelCase<RegisterArgs>): Promise<never>;
+export declare function handleRegister({ apiToken, apiEndpoint, open: openBrowser, yes, }: ArgumentsCamelCase<RegisterArgs>): Promise<never>;
 export {};

--- a/dist/cli/register.js
+++ b/dist/cli/register.js
@@ -5,9 +5,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.handleRegister = exports.getApiTokenCreationUrl = void 0;
 const config_storage_1 = require("./config_storage");
+const confirm_1 = require("./confirm");
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
+const confirm_2 = require("./confirm");
 const coda_1 = require("../helpers/external-api/coda");
+const confirm_3 = require("./confirm");
 const open_1 = __importDefault(require("open"));
 const helpers_3 = require("../testing/helpers");
 const helpers_4 = require("../testing/helpers");
@@ -20,16 +23,26 @@ function getApiTokenCreationUrl(apiEndpoint) {
     return `${accountEndpoint}/account?openDialog=CREATE_API_TOKEN&scopeType=pack#apiSettings`;
 }
 exports.getApiTokenCreationUrl = getApiTokenCreationUrl;
-async function handleRegister({ apiToken, apiEndpoint }) {
+async function handleRegister({ apiToken, apiEndpoint, open: openBrowser, yes, }) {
     const formattedEndpoint = (0, helpers_2.formatEndpoint)(apiEndpoint);
+    const tokenUrl = getApiTokenCreationUrl(formattedEndpoint);
     if (!apiToken) {
-        // TODO: deal with auto-open on devbox setups
-        const shouldOpenBrowser = (0, helpers_4.promptForInput)('No API token provided. Do you want to open your account page to create one (y/N)? ', { yesOrNo: true });
-        if (shouldOpenBrowser !== 'yes') {
-            return process.exit(1);
+        if (openBrowser || ((0, confirm_2.isInteractive)() && !yes)) {
+            if (!openBrowser) {
+                (0, confirm_1.confirmOrFail)({
+                    yes,
+                    prompt: 'No API token provided. Do you want to open your account page to create one (y/N)? ',
+                    example: 'packs register --apiToken <token>',
+                });
+            }
+            await (0, open_1.default)(tokenUrl);
         }
-        await (0, open_1.default)(getApiTokenCreationUrl(formattedEndpoint));
-        apiToken = (0, helpers_4.promptForInput)('Please paste the token here: ', { mask: true });
+        if ((0, confirm_2.isInteractive)()) {
+            apiToken = (0, helpers_4.promptForInput)('Please paste the token here: ', { mask: true });
+        }
+        if (!apiToken) {
+            return (0, confirm_3.missingFlagError)('No API token specified.', 'packs register --apiToken <token>', `Create a token at ${tokenUrl}`);
+        }
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);
     try {
@@ -43,6 +56,6 @@ async function handleRegister({ apiToken, apiEndpoint }) {
         return (0, helpers_3.printAndExit)(errors.join('\n'));
     }
     (0, config_storage_2.storeCodaApiKey)(apiToken, process.env.PWD, apiEndpoint);
-    (0, helpers_3.printAndExit)(`API key validated and stored successfully!`, 0);
+    (0, helpers_3.printAndExit)(`registered\nendpoint: ${formattedEndpoint}`, 0);
 }
 exports.handleRegister = handleRegister;

--- a/dist/cli/release.d.ts
+++ b/dist/cli/release.d.ts
@@ -6,6 +6,8 @@ interface ReleaseArgs {
     notes: string;
     apiToken?: string;
     gitTag?: boolean;
+    yes?: boolean;
+    useLatest?: boolean;
 }
-export declare function handleRelease({ manifestFile, packVersion: explicitPackVersion, apiEndpoint, notes, apiToken, gitTag, }: ArgumentsCamelCase<ReleaseArgs>): Promise<never>;
+export declare function handleRelease({ manifestFile, packVersion: explicitPackVersion, apiEndpoint, notes, apiToken, gitTag, yes, useLatest, }: ArgumentsCamelCase<ReleaseArgs>): Promise<never>;
 export {};

--- a/dist/cli/release.js
+++ b/dist/cli/release.js
@@ -7,6 +7,7 @@ exports.handleRelease = void 0;
 const helpers_1 = require("./helpers");
 const helpers_2 = require("./helpers");
 const build_1 = require("./build");
+const confirm_1 = require("./confirm");
 const helpers_3 = require("./helpers");
 const git_helpers_1 = require("./git_helpers");
 const helpers_4 = require("./helpers");
@@ -16,12 +17,12 @@ const git_helpers_2 = require("./git_helpers");
 const git_helpers_3 = require("./git_helpers");
 const helpers_5 = require("./helpers");
 const coda_1 = require("../helpers/external-api/coda");
+const confirm_2 = require("./confirm");
 const path_1 = __importDefault(require("path"));
 const helpers_6 = require("../testing/helpers");
 const helpers_7 = require("../testing/helpers");
-const helpers_8 = require("../testing/helpers");
 const errors_3 = require("./errors");
-async function handleRelease({ manifestFile, packVersion: explicitPackVersion, apiEndpoint, notes, apiToken, gitTag, }) {
+async function handleRelease({ manifestFile, packVersion: explicitPackVersion, apiEndpoint, notes, apiToken, gitTag, yes, useLatest, }) {
     const manifestDir = path_1.default.dirname(manifestFile);
     const formattedEndpoint = (0, helpers_4.formatEndpoint)(apiEndpoint);
     apiToken = (0, helpers_1.assertApiToken)(apiEndpoint, apiToken);
@@ -37,10 +38,12 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, a
         }
         // Warn if not on main/master branch
         if (gitState.currentBranch && !['main', 'master'].includes(gitState.currentBranch)) {
-            const shouldContinue = (0, helpers_8.promptForInput)(`Warning: You are releasing from branch '${gitState.currentBranch}', not 'main'.\n` + `Continue anyway? (y/N) `, { yesOrNo: true });
-            if (shouldContinue !== 'yes') {
-                return process.exit(1);
-            }
+            (0, confirm_1.confirmOrFail)({
+                yes,
+                prompt: `Warning: You are releasing from branch '${gitState.currentBranch}', not 'main'.\n` +
+                    `Continue anyway? (y/N) `,
+                example: `packs release ${manifestFile} --notes "<notes>" --yes`,
+            });
         }
     }
     // Resolve pack version
@@ -64,15 +67,17 @@ async function handleRelease({ manifestFile, packVersion: explicitPackVersion, a
         }
         const [latestPackVersionData] = versions;
         const { packVersion: latestPackVersion } = latestPackVersionData;
-        const shouldReleaseLatestPackVersion = (0, helpers_8.promptForInput)(`No version specified in your manifest. Do you want to release the latest version of the Pack (${latestPackVersion})? (y/N)\n`, { yesOrNo: true });
-        if (shouldReleaseLatestPackVersion !== 'yes') {
-            return process.exit(1);
+        if (!useLatest) {
+            return (0, confirm_2.missingFlagError)('No pack version specified.', `packs release ${manifestFile} ${latestPackVersion} --notes "<notes>"`, `Release the latest uploaded version: packs release ${manifestFile} --use-latest --notes "<notes>"`);
         }
         packVersion = latestPackVersion;
     }
     // Create release via API
     const releaseResponse = await handleResponse(codaClient.createPackRelease(packId, {}, { packVersion, releaseNotes: notes }));
-    (0, helpers_6.print)(`Pack version ${packVersion} released successfully (release #${releaseResponse.releaseId}).`);
+    (0, helpers_6.print)(`released ${packVersion}`);
+    (0, helpers_6.print)(`pack_id: ${packId}`);
+    (0, helpers_6.print)(`release_id: ${releaseResponse.releaseId}`);
+    (0, helpers_6.print)(`url: ${formattedEndpoint}/p/${packId}`);
     // Create git tag if enabled
     if (gitTag && gitState.isGitRepo) {
         const releaseGitTag = `pack/${packId}/v${packVersion}`;

--- a/dist/cli/set_option.js
+++ b/dist/cli/set_option.js
@@ -41,7 +41,8 @@ exports.handleSetOption = handleSetOption;
 function validateOption(option, value) {
     const validOptions = Object.values(config_storage_1.PackOptionKey);
     if (!validOptions.includes(option)) {
-        return (0, helpers_2.printAndExit)(`Unsupported option "${option}". Valid options are: ${validOptions.join(', ')}`);
+        return (0, helpers_2.printAndExit)(`Error: Unsupported option "${option}". Valid options: ${validOptions.join(', ')}\n` +
+            `  packs setOption pack.ts gitTag true`);
     }
     const key = option;
     switch (key) {

--- a/dist/cli/whoami.js
+++ b/dist/cli/whoami.js
@@ -12,7 +12,7 @@ async function handleWhoami({ apiToken, apiEndpoint }) {
     if (!apiToken) {
         apiToken = (0, config_storage_1.getApiKey)(apiEndpoint);
         if (!apiToken) {
-            return (0, helpers_3.printAndExit)('Missing API token. Please run `packs register` to register one.');
+            return (0, helpers_3.printAndExit)('Error: Missing API token.\n  packs register --apiToken <token>');
         }
     }
     const client = (0, helpers_1.createCodaClient)(apiToken, formattedEndpoint);

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -74,6 +74,11 @@ Clone an existing Pack that was created using Pack Studio
 
     **Type:** string
 
+`--yes`, `-y`
+:   Skip confirmation prompts. Required in non-interactive environments.
+
+    **Type:** boolean | **Default:** `false`
+
 ---
 
 ## create
@@ -185,6 +190,11 @@ Link to a pre-existing Pack ID on the server
 
     **Type:** string
 
+`--yes`, `-y`
+:   Skip confirmation prompts. Required in non-interactive environments.
+
+    **Type:** boolean | **Default:** `false`
+
 ---
 
 ## register
@@ -199,6 +209,16 @@ Register API token to publish a Pack
 :   API endpoint to use for the operation (default: https://coda.io). Required for single-tenant instances. Can also be set persistently via `packs setOption <manifestFile> apiEndpoint <url>`.
 
     **Type:** string
+
+`--open`
+:   Open the API token creation page in a browser.
+
+    **Type:** boolean | **Default:** `false`
+
+`--yes`, `-y`
+:   Skip confirmation prompts. Required in non-interactive environments.
+
+    **Type:** boolean | **Default:** `false`
 
 ---
 
@@ -230,18 +250,21 @@ Set the Pack version that is installable for users. You may specify a specific v
 
     **Type:** string
 
+`--yes`, `-y`
+:   Skip confirmation prompts. Required in non-interactive environments.
+
+    **Type:** boolean | **Default:** `false`
+
+`--useLatest`
+:   Release the latest uploaded version when the manifest has no version.
+
+    **Type:** boolean | **Default:** `false`
+
 ---
 
 ## setOption
 
-Set a persistent build option for the pack. This will store the option alongside the pack id in the .coda-pack.json file and it will be used for all builds of the pack.<br>
-<br>
-Supported options:<br>
-  - timerStrategy: Valid values are "none", "error", or "fake".<br>
-  - gitTag: Valid values are "true" or "false". When true, the release command will create git tags.<br>
-  - apiEndpoint: A URL for the API endpoint, required for single-tenant instances (e.g. "https://my-company.coda.io"). When set, all commands will use this endpoint by default.<br>
-<br>
-Usage: packs setOption path/to/pack.ts timerStrategy fake
+Set a persistent build option for the pack (.coda-pack.json)
 
 **Usage:** `packs setOption <manifestFile> <option> <value>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codahq/packs-sdk",
-  "version": "1.17.6-prerelease.2",
+  "version": "1.17.6-prerelease.3",
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0",

--- a/test/cli_headless_test.ts
+++ b/test/cli_headless_test.ts
@@ -1,0 +1,156 @@
+import './test_helper';
+import * as confirm from '../cli/confirm';
+import {confirmOrFail} from '../cli/confirm';
+import * as gitHelpers from '../cli/git_helpers';
+import {handleRegister} from '../cli/register';
+import {handleRelease} from '../cli/release';
+import * as helpers from '../cli/helpers';
+import mockFs from 'mock-fs';
+import sinon from 'sinon';
+import * as testingHelpers from '../testing/helpers';
+
+describe('Headless CLI', () => {
+  let exitMessage: string | undefined;
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    exitMessage = undefined;
+    exitCode = undefined;
+    sinon.stub(testingHelpers, 'print');
+    sinon.stub(testingHelpers, 'printAndExit').callsFake((msg: string, code: number = 1) => {
+      exitMessage = msg;
+      exitCode = code;
+      const error = new Error(msg);
+      (error as any).exitCode = code;
+      throw error;
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+    sinon.restore();
+  });
+
+  describe('confirmOrFail', () => {
+    it('returns immediately when --yes is set', () => {
+      confirmOrFail({
+        yes: true,
+        prompt: 'Overwrite? (y/N)',
+        example: 'packs clone 1234 --yes',
+        interactive: false,
+      });
+    });
+
+    it('fails with an example invocation when not interactive', () => {
+      try {
+        confirmOrFail({
+          yes: false,
+          prompt: 'Overwrite pack.ts? (y/N)',
+          example: 'packs clone 1234 --yes',
+          interactive: false,
+        });
+        assert.fail('expected printAndExit');
+      } catch {
+        assert.equal(exitCode, 1);
+        assert.include(exitMessage, 'Pass --yes to continue without a prompt.');
+        assert.include(exitMessage, 'packs clone 1234 --yes');
+      }
+    });
+  });
+
+  describe('register', () => {
+    it('fails fast without a token in non-interactive mode', async () => {
+      sinon.stub(confirm, 'isInteractive').returns(false);
+      try {
+        await handleRegister({
+          apiEndpoint: 'https://coda.io',
+          $0: 'packs',
+          _: ['register'],
+        });
+      } catch {
+        // printAndExit
+      }
+      assert.equal(exitCode, 1);
+      assert.include(exitMessage, 'No API token specified.');
+      assert.include(exitMessage, 'packs register --apiToken <token>');
+    });
+  });
+
+  describe('release', () => {
+    const PROJECT_DIR = '/myproject';
+    const MANIFEST_FILE = `${PROJECT_DIR}/pack.ts`;
+
+    beforeEach(() => {
+      mockFs({
+        [PROJECT_DIR]: {
+          'pack.ts': 'export const pack = {};',
+          '.coda-pack.json': JSON.stringify({packId: 12345}),
+        },
+      });
+      sinon.stub(helpers, 'createCodaClient').returns({
+        createPackRelease: sinon.stub().resolves({
+          packId: 12345,
+          packVersion: '1.0.0',
+          releaseId: 42,
+          releaseNotes: 'Test release',
+        }),
+        listPackVersions: sinon.stub().resolves({items: [{packVersion: '1.0.0'}]}),
+      } as any);
+    });
+
+    it('requires --yes when releasing from a non-main branch without a TTY', async () => {
+      sinon.stub(confirm, 'isInteractive').returns(false);
+      sinon.stub(gitHelpers, 'getGitState').returns({
+        isGitRepo: true,
+        isDirty: false,
+        currentBranch: 'feature',
+        commitSha: 'abc123',
+      });
+
+      try {
+        await handleRelease({
+          manifestFile: MANIFEST_FILE,
+          packVersion: '1.0.0',
+          apiEndpoint: 'https://coda.io',
+          notes: 'Test release',
+          apiToken: 'test-token',
+          gitTag: false,
+          $0: '',
+          _: [],
+        });
+      } catch {
+        // printAndExit
+      }
+
+      assert.equal(exitCode, 1);
+      assert.include(exitMessage, '--yes');
+    });
+
+    it('releases from a non-main branch when --yes is set', async () => {
+      sinon.stub(gitHelpers, 'getGitState').returns({
+        isGitRepo: true,
+        isDirty: false,
+        currentBranch: 'feature',
+        commitSha: 'abc123',
+      });
+
+      try {
+        await handleRelease({
+          manifestFile: MANIFEST_FILE,
+          packVersion: '1.0.0',
+          apiEndpoint: 'https://coda.io',
+          notes: 'Test release',
+          apiToken: 'test-token',
+          gitTag: false,
+          yes: true,
+          $0: '',
+          _: [],
+        });
+      } catch {
+        // printAndExit
+      }
+
+      assert.equal(exitCode, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fail immediately in non-interactive environments instead of hanging on `y/N` prompts (`register`, `clone`, `link`, `release`). Use `--yes` to skip confirmations.
- Add copy-pasteable Examples to every subcommand `--help`, plus `register --open`, `release --use-latest`, and success output with pack/release ids.

## Test plan
- [ ] `npx ts-node cli/index.ts --help` lists commands without dumping `setOption` details
- [ ] `npx ts-node cli/index.ts register --help` and `release --help` show Examples
- [ ] `npx ts-node cli/index.ts register` (no TTY/token) exits with `packs register --apiToken <token>`
- [ ] `TS_NODE_TRANSPILE_ONLY=1 TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' npx mocha test/cli_headless_test.ts test/release_test.ts test/cli_test.ts`